### PR TITLE
change cert signature hashing algorithm from md5 to sha256

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/crypto/FluentKeySigner.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/crypto/FluentKeySigner.java
@@ -50,7 +50,7 @@ public class FluentKeySigner {
     protected Date validityStartDate, validityEndDate;
     protected BigInteger serialNumber;
     
-    protected String signatureAlgorithm = "MD5WithRSAEncryption";
+    protected String signatureAlgorithm = "SHA256WithRSAEncryption";
     protected AuthorityKeyIdentifier authorityKeyIdentifier;
     protected X509Certificate authorityCertificate;
 


### PR DESCRIPTION
- md5 use with certs has been disabled by default in Java 8u71+
- http://www.oracle.com/technetwork/java/javase/8u71-relnotes-2773756.html

self-signed certs generated by brooklyn observed to work in Chrome 48/Safari 9.0.3/Firefox 44 on OSX 10.11.3
```
Signature Algorithm: SHA-256 with RSA Encryption ( 1.2.840.113549.1.1.11 )
```