### PR TITLE
Add policy to stop applications after a period has elapsed

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DurationSinceSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DurationSinceSensor.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.sensor;
+
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.feed.function.FunctionFeed;
+import org.apache.brooklyn.feed.function.FunctionPollConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.time.Duration;
+
+import com.google.common.base.Supplier;
+import com.google.common.reflect.TypeToken;
+
+public class DurationSinceSensor extends AddSensor<Duration> {
+
+    private static final Supplier<Long> CURRENT_TIME_SUPPLIER = new CurrentTimeSupplier();
+
+    public static final ConfigKey<Supplier<Long>> EPOCH_SUPPLIER = ConfigKeys.builder(new TypeToken<Supplier<Long>>() {})
+            .name("duration.since.epochsupplier")
+            .description("The source of time from which durations are measured. Defaults to System.currentTimeMillis.")
+            .defaultValue(CURRENT_TIME_SUPPLIER)
+            .build();
+
+    public static final ConfigKey<Supplier<Long>> TIME_SUPPLIER = ConfigKeys.builder(new TypeToken<Supplier<Long>>() {})
+            .name("duration.since.timesupplier")
+            .description("The source of the current time. Defaults to System.currentTimeMillis.")
+            .defaultValue(CURRENT_TIME_SUPPLIER)
+            .build();
+
+    private final Supplier<Long> epochSupplier;
+    private final Supplier<Long> timeSupplier;
+    private final AttributeSensor<Long> epochSensor;
+
+    public DurationSinceSensor(ConfigBag params) {
+        super(params);
+        epochSupplier = params.get(EPOCH_SUPPLIER);
+        timeSupplier = params.get(TIME_SUPPLIER);
+        epochSensor = Sensors.newLongSensor(sensor.getName() + ".epoch");
+    }
+
+    @Override
+    public void apply(final EntityLocal entity) {
+        super.apply(entity);
+
+        if (entity.sensors().get(epochSensor) == null) {
+            entity.sensors().set(epochSensor, epochSupplier.get());
+        }
+
+        FunctionFeed feed = FunctionFeed.builder()
+                .entity(entity)
+                .poll(new FunctionPollConfig<>(sensor).callable(new UpdateTimeSince(entity)))
+                .period(period)
+                .build();
+
+        entity.addFeed(feed);
+    }
+
+    private static class CurrentTimeSupplier implements Supplier<Long> {
+        @Override
+        public Long get() {
+            return System.currentTimeMillis();
+        }
+    }
+
+    private class UpdateTimeSince implements Callable<Duration> {
+        private final Entity entity;
+
+        private UpdateTimeSince(Entity entity) {
+            this.entity = entity;
+        }
+
+        @Override
+        public Duration call() {
+            Long referencePoint = entity.sensors().get(epochSensor);
+            // Defensive check. Someone has done something silly if this is false.
+            if (referencePoint != null) {
+                return Duration.millis(timeSupplier.get() - referencePoint);
+            } else {
+                throw new IllegalStateException("Cannot calculate duration since sensor: " +
+                        entity + " missing required value for " + epochSensor);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
@@ -43,7 +43,6 @@ import com.google.common.base.Supplier;
  * {@link JSONObject} from a JSON response in order to populate the sensor with the data at the {@code jsonPath}.
  *
  * @see SshCommandSensor
- * @see JmxAttributeSensor
  */
 @Beta
 public final class HttpRequestSensor<T> extends AddSensor<T> {
@@ -88,10 +87,12 @@ public final class HttpRequestSensor<T> extends AddSensor<T> {
                 .onSuccess(HttpValueFunctions.<T>jsonContentsFromPath(jsonPath))
                 .period(period);
 
-        HttpFeed.builder().entity(entity)
+        HttpFeed feed = HttpFeed.builder().entity(entity)
                 .baseUri(uri)
                 .credentialsIfNotNull(username, password)
                 .poll(pollConfig)
                 .build();
+
+        entity.addFeed(feed);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/DurationSinceSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/DurationSinceSensorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.sensor;
+
+import static org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsContinually;
+import static org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsEventually;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+
+public class DurationSinceSensorTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testSensorAddedAndUpdated() {
+        final AtomicLong ticker = new AtomicLong(0);
+        Supplier<Long> timeSupplier = new Supplier<Long>() {
+            @Override
+            public Long get() {
+                return ticker.get();
+            }
+        };
+        Entity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .addInitializer(new DurationSinceSensor(ConfigBag.newInstance(ImmutableMap.of(
+                        AddSensor.SENSOR_NAME, "sensor",
+                        AddSensor.SENSOR_TYPE, Duration.class.getName(),
+                        AddSensor.SENSOR_PERIOD, Duration.ONE_MILLISECOND,
+                        DurationSinceSensor.EPOCH_SUPPLIER, Suppliers.ofInstance(0L),
+                        DurationSinceSensor.TIME_SUPPLIER, timeSupplier)))));
+
+        final Map<?, ?> timeout = ImmutableMap.of("timeout", Duration.millis(10));
+        final AttributeSensor<Duration> duration = Sensors.newSensor(Duration.class, "sensor");
+        assertAttributeEqualsEventually(entity, duration, Duration.millis(0));
+        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(0));
+        ticker.incrementAndGet();
+        assertAttributeEqualsEventually(entity, duration, Duration.millis(1));
+        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(1));
+        ticker.incrementAndGet();
+        assertAttributeEqualsEventually(entity, duration, Duration.millis(2));
+        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(2));
+    }
+
+}

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/WebAppContextProvider.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/WebAppContextProvider.java
@@ -112,4 +112,10 @@ public class WebAppContextProvider {
     public String getWarUrl() {
         return warUrl;
     }
+
+    @Override
+    public String toString() {
+        return warUrl + "@" + pathSpec;
+    }
+
 }

--- a/policy/src/main/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicy.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.policy.action;
+
+import java.util.Set;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.SensorEvent;
+import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.policy.AbstractPolicy;
+import org.apache.brooklyn.core.sensor.DurationSinceSensor;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+public class StopAfterDurationPolicy extends AbstractPolicy {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StopAfterDurationPolicy.class);
+
+    public static final ConfigKey<Duration> LIFETIME = ConfigKeys.builder(Duration.class)
+            .name("lifetime")
+            .description("The duration the entity is allowed to remain running")
+            .constraint(Predicates.notNull())
+            .build();
+
+    public static final ConfigKey<Lifecycle> STATE = ConfigKeys.builder(Lifecycle.class)
+            .name("state")
+            .description("The state the entity must enter before the stop-timer is started")
+            .defaultValue(Lifecycle.RUNNING)
+            .constraint(Predicates.notNull())
+            .build();
+
+    public static final ConfigKey<Duration> POLL_PERIOD = ConfigKeys.builder(Duration.class)
+            .name("pollPeriod")
+            .description("Period in which duration-since sensor should be updated")
+            .defaultValue(Duration.THIRTY_SECONDS)
+            .constraint(Predicates.notNull())
+            .build();
+
+    public static final ConfigKey<Boolean> HAS_STARTED_TIMER = ConfigKeys.builder(Boolean.class)
+            .name("timer-started")
+            .description("For internal use only")
+            .defaultValue(false)
+            .build();
+
+    public static final ConfigKey<Boolean> FIRED_STOP = ConfigKeys.builder(Boolean.class)
+            .name("fired-stop")
+            .description("For internal use only")
+            .defaultValue(false)
+            .build();
+
+    private final Object eventLock = new Object[0];
+
+    public void setEntity(final EntityLocal entity) {
+        super.setEntity(entity);
+        entity.subscriptions().subscribe(entity, Attributes.SERVICE_STATE_ACTUAL, new LifecycleListener());
+        entity.subscriptions().subscribe(entity, Sensors.newSensor(Duration.class, getSensorName()), new TimeIsUpListener());
+    }
+
+    @Override
+    protected <T> void doReconfigureConfig(ConfigKey<T> key, T val) {
+        Set<ConfigKey<?>> accepted = ImmutableSet.<ConfigKey<?>>of(
+                HAS_STARTED_TIMER,
+                FIRED_STOP,
+                LIFETIME);
+        if (!accepted.contains(key)) {
+            super.doReconfigureConfig(key, val);
+        }
+    }
+
+    private String getSensorName() {
+        return "duration.since.first-" + config().get(STATE).name().toLowerCase();
+    }
+
+    private class LifecycleListener implements SensorEventListener<Lifecycle> {
+        @Override
+        public void onEvent(SensorEvent<Lifecycle> event) {
+            synchronized (eventLock) {
+                if (!config().get(HAS_STARTED_TIMER) && config().get(STATE).equals(event.getValue())) {
+                    DurationSinceSensor sensor = new DurationSinceSensor(ConfigBag.newInstance(ImmutableMap.of(
+                            DurationSinceSensor.SENSOR_NAME, getSensorName(),
+                            DurationSinceSensor.SENSOR_PERIOD, config().get(POLL_PERIOD),
+                            DurationSinceSensor.SENSOR_TYPE, Duration.class.getName())));
+                    sensor.apply(entity);
+                    config().set(HAS_STARTED_TIMER, true);
+                }
+            }
+        }
+    }
+
+    private class TimeIsUpListener implements SensorEventListener<Duration> {
+        @Override
+        public void onEvent(SensorEvent<Duration> event) {
+            synchronized (eventLock) {
+                if (!config().get(FIRED_STOP)) {
+                    if (config().get(LIFETIME).subtract(event.getValue()).isNegative()) {
+                        LOG.debug("Stopping {}: lifetime ({}) has expired", entity, config().get(LIFETIME));
+                        entity.invoke(Startable.STOP, ImmutableMap.<String, Object>of());
+                        config().set(FIRED_STOP, true);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/policy/src/test/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicyTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.policy.action;
+
+import static org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsEventually;
+
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class StopAfterDurationPolicyTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testAppStoppedWhenDurationExpires() {
+        PolicySpec<StopAfterDurationPolicy> policy = PolicySpec.create(StopAfterDurationPolicy.class)
+                .configure(StopAfterDurationPolicy.LIFETIME, Duration.ONE_MILLISECOND)
+                .configure(StopAfterDurationPolicy.POLL_PERIOD, Duration.ONE_MILLISECOND);
+        app.policies().add(policy);
+        app.start(ImmutableList.of(app.newSimulatedLocation()));
+        assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+    }
+
+}

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
@@ -275,7 +275,11 @@ public class Duration implements Comparable<Duration>, Serializable {
     }
 
     public boolean isPositive() {
-        return nanos()>0;
+        return nanos() > 0;
+    }
+
+    public boolean isNegative() {
+        return nanos() < 0;
     }
 
     public boolean isLongerThan(Duration x) {


### PR DESCRIPTION
Aka "the money saver".

`DurationSinceSensor` records the duration since it as added to an entity.

`StopAfterDurationPolicy` waits for an entity to reach a lifecycle, adds a duration-since sensor to it, waits for the duration to be greater than the configured lifetime, then stops the entity.