### PR TITLE
winrm4j: exclude slf4j transitive dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -565,7 +565,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.4.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>

--- a/software/base/pom.xml
+++ b/software/base/pom.xml
@@ -46,11 +46,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.cloudsoft.windows</groupId>
-            <artifactId>winrm4j</artifactId>
-            <version>${winrm4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-jmxmp-agent</artifactId>
             <version>${project.version}</version>

--- a/software/winrm/pom.xml
+++ b/software/winrm/pom.xml
@@ -29,7 +29,6 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
-    <groupId>org.apache.brooklyn</groupId>
     <artifactId>brooklyn-software-winrm</artifactId>
 
     <name>Brooklyn WinRM Software Entities</name>
@@ -44,6 +43,26 @@
             <groupId>io.cloudsoft.windows</groupId>
             <artifactId>winrm4j</artifactId>
             <version>${winrm4j.version}</version>
+            <exclusions>
+                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                 <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!--
+            Excluded from winrm4j the wrong jcl-over-slf4j version; include the right one below.
+            Note use of explicit exclude, rather than wildcard, because maven-enforcer-plugin 1.4.1
+            does not support wildcards: https://issues.apache.org/jira/browse/MENFORCER-195
+         -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
Depends on org.slf4j 1.7.12 (via org.apache.cxf), whereas Brooklyn depends on 1.6.6