### PR TITLE
Feature/paas cf support

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/paas/PaasLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/location/paas/PaasLocationConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.paas;
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+/**
+ * It contains the parameters needed to configure an PaasLocation. For example, the ConfigKey
+ * {@link #REQUIRED_MEMORY} allows to specify a initial memory amount used in a location.
+ */
+
+public interface PaasLocationConfig {
+
+    @SetFromFlag("profile.instances")
+    ConfigKey<Integer> REQUIRED_INSTANCES = ConfigKeys.newIntegerConfigKey(
+            "instances", "Required instances to deploy the application", 1);
+
+    @SetFromFlag("profile.instances")
+    ConfigKey<Integer> REQUIRED_MEMORY = ConfigKeys.newIntegerConfigKey(
+            "memory", "Required memory to deploy the application (MB)", 512);
+
+    @SetFromFlag("profile.instances")
+    ConfigKey<Integer> REQUIRED_DISK = ConfigKeys.newIntegerConfigKey(
+            "disk", "Required disk to deploy the application (MB)", 1024);
+
+
+}

--- a/locations/cloudfoundry/pom.xml
+++ b/locations/cloudfoundry/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <cloudfoundry.client.version>1.1.2</cloudfoundry.client.version>
-        <springframework-webmvn.version>4.0.5.RELEASE</springframework-webmvn.version>
+        <springframework-webmvc.version>4.1.4.RELEASE</springframework-webmvc.version>
         <springframework-security.version>2.0.4.RELEASE</springframework-security.version>
     </properties>
 
@@ -78,12 +78,16 @@
                     <groupId>org.springframework.security.oauth</groupId>
                     <artifactId>spring-security-oauth2</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>${springframework-webmvn.version}</version>
+            <version>${springframework-webmvc.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/locations/cloudfoundry/pom.xml
+++ b/locations/cloudfoundry/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>brooklyn-locations-cloudfoundry</artifactId>
+    <packaging>jar</packaging>
+    <name>Brooklyn Cloudfoundry Locations Targets</name>
+    <description>
+        Support CloudFoundry PaaS services API for deploying applications
+    </description>
+
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-parent</artifactId>
+        <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../../parent/pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <cloudfoundry.client.version>1.1.2</cloudfoundry.client.version>
+        <springframework-webmvn.version>4.0.5.RELEASE</springframework-webmvn.version>
+        <springframework-security.version>2.0.4.RELEASE</springframework-security.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cloudfoundry-client-lib</artifactId>
+            <version>${cloudfoundry.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.security.oauth</groupId>
+                    <artifactId>spring-security-oauth2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>${springframework-webmvn.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security.oauth</groupId>
+            <artifactId>spring-security-oauth2</artifactId>
+            <version>${springframework-security.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-expression</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-beans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- includes testng and useful logging for tests -->
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-test-support</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-core</artifactId>
+            <version>${brooklyn.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-logback-xml</artifactId>
+            <version>${project.version}</version>
+            <!-- optional so that this project has logging; dependencies may redeclare or supply their own -->
+            <optional>true</optional>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/locations/cloudfoundry/src/main/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocation.java
+++ b/locations/cloudfoundry/src/main/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocation.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.cloudfoundry;
+
+
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.location.AbstractLocation;
+import org.apache.brooklyn.location.paas.PaasLocation;
+import org.apache.brooklyn.location.paas.PaasLocationConfig;
+import org.cloudfoundry.client.lib.CloudCredentials;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+
+public class CloudFoundryPaasLocation extends AbstractLocation
+        implements PaasLocation, PaasLocationConfig {
+
+    public static final Logger LOG = LoggerFactory.getLogger(CloudFoundryPaasLocation.class);
+
+    public static ConfigKey<String> CF_USER = ConfigKeys.newStringConfigKey("user");
+    public static ConfigKey<String> CF_PASSWORD = ConfigKeys.newStringConfigKey("password");
+    public static ConfigKey<String> CF_ORG = ConfigKeys.newStringConfigKey("org");
+    public static ConfigKey<String> CF_ENDPOINT = ConfigKeys.newStringConfigKey("endpoint");
+    public static ConfigKey<String> CF_SPACE = ConfigKeys.newStringConfigKey("space");
+
+    CloudFoundryClient client;
+
+    public CloudFoundryPaasLocation() {
+        super();
+    }
+
+    @Override
+    public void init() {
+        super.init();
+    }
+
+    public void setUpClient() {
+        if (client == null) {
+            CloudCredentials credentials =
+                    new CloudCredentials(getConfig(CF_USER), getConfig(CF_PASSWORD));
+            client = new CloudFoundryClient(credentials,
+                    getTargetURL(getConfig(CF_ENDPOINT)),
+                    getConfig(CF_ORG), getConfig(CF_SPACE), true);
+            client.login();
+        }
+    }
+
+    @Override
+    public String getPaasProviderName() {
+        return "CloudFoundry";
+    }
+
+    private static URL getTargetURL(String target) {
+        try {
+            return URI.create(target).toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("The target URL is not valid: " + e.getMessage());
+        }
+    }
+
+    public CloudFoundryClient getCloudFoundryClient() {
+        return client;
+    }
+
+
+
+
+
+
+}

--- a/locations/cloudfoundry/src/main/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationResolver.java
+++ b/locations/cloudfoundry/src/main/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationResolver.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.cloudfoundry;
+
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationRegistry;
+import org.apache.brooklyn.api.location.LocationResolver;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.location.BasicLocationRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class CloudFoundryPaasLocationResolver implements LocationResolver {
+
+    public static final Logger log = LoggerFactory
+            .getLogger(CloudFoundryPaasLocationResolver.class);
+
+    public static final String CLOUD_FOUNDRY = "cloudfoundry";
+
+    private ManagementContext managementContext;
+
+    @Override
+    public void init(ManagementContext managementContext) {
+        this.managementContext = checkNotNull(managementContext, "managementContext");
+    }
+
+    @Override
+    public String getPrefix() {
+        return CLOUD_FOUNDRY;
+    }
+
+    @Override
+    public boolean accepts(String spec, LocationRegistry registry) {
+        return BasicLocationRegistry.isResolverPrefixForSpec(this, spec, true);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Location newLocationFromString(Map locationFlags,
+                                          String spec,
+                                          LocationRegistry registry) {
+        return managementContext.getLocationManager().createLocation(
+                LocationSpec.create(locationFlags, CloudFoundryPaasLocation.class));
+    }
+
+
+}
+

--- a/locations/cloudfoundry/src/main/resources/META-INF/services/org.apache.brooklyn.api.location.LocationResolver
+++ b/locations/cloudfoundry/src/main/resources/META-INF/services/org.apache.brooklyn.api.location.LocationResolver
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocationResolver

--- a/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationLiveTest.java
+++ b/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationLiveTest.java
@@ -19,5 +19,59 @@
 package org.apache.brooklyn.location.cloudfoundry;
 
 
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
 public class CloudFoundryPaasLocationLiveTest {
+
+    protected final String LOCATION_SPEC_NAME = "cloudfoundry-instance";
+    protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
+    protected LocalManagementContext managementContext;
+    protected BrooklynProperties brooklynProperties;
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (managementContext != null){
+            Entities.destroyAll(managementContext);
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        managementContext = newLocalManagementContext();
+        brooklynProperties = new LocalManagementContext().getBrooklynProperties();
+        cloudFoundryPaasLocation = newSampleCloudFoundryLocationForTesting(LOCATION_SPEC_NAME);
+    }
+
+    @Test(groups = {"Live"})
+    public void testClientSetUp() {
+        cloudFoundryPaasLocation.setUpClient();
+        assertNotNull(cloudFoundryPaasLocation.getCloudFoundryClient());
+    }
+
+    @Test(groups = {"Live"})
+    public void testClientSetUpPerLocationInstance() {
+        cloudFoundryPaasLocation.setUpClient();
+        CloudFoundryClient client1 = cloudFoundryPaasLocation.getCloudFoundryClient();
+        cloudFoundryPaasLocation.setUpClient();
+        CloudFoundryClient client2 = cloudFoundryPaasLocation.getCloudFoundryClient();
+        assertEquals(client1, client2);
+    }
+
+    protected CloudFoundryPaasLocation newSampleCloudFoundryLocationForTesting(String spec) {
+        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().resolve(spec);
+    }
+
+    protected LocalManagementContext newLocalManagementContext() {
+        return new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+    }
 }

--- a/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationLiveTest.java
+++ b/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationLiveTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.cloudfoundry;
+
+
+public class CloudFoundryPaasLocationLiveTest {
+}

--- a/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationResolverTest.java
+++ b/locations/cloudfoundry/src/test/java/org/apache/brooklyn/location/cloudfoundry/CloudFoundryPaasLocationResolverTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.cloudfoundry;
+
+
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.location.paas.PaasLocationConfig;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class CloudFoundryPaasLocationResolverTest {
+
+    private LocalManagementContext managementContext;
+    private BrooklynProperties brooklynProperties;
+
+    private final String LOCATION_SPEC_NAME = "cloudfoundry-instance";
+
+    private final String USER = "user";
+    private final String PASSWORD = "password";
+    private final String ORG = "organization";
+    private final String SPACE = "space";
+    private final String ENDPOINT = "endpoint";
+    private final String ADDRESS = "run.pivotal.io";
+
+    @BeforeMethod
+    public void setUp() {
+        managementContext = new LocalManagementContext(BrooklynProperties.Factory.newEmpty());
+        brooklynProperties = managementContext.getBrooklynProperties();
+
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME, "cloudfoundry");
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".user", USER);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".password", PASSWORD);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".org", ORG);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".endpoint", ENDPOINT);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".space", SPACE);
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".address", ADDRESS);
+
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".disk",
+                PaasLocationConfig.REQUIRED_DISK.getDefaultValue());
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".memory",
+                PaasLocationConfig.REQUIRED_MEMORY.getDefaultValue());
+        brooklynProperties.put("brooklyn.location.named." + LOCATION_SPEC_NAME + ".instances",
+                PaasLocationConfig.REQUIRED_INSTANCES.getDefaultValue());
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (managementContext != null) {
+            managementContext.terminate();
+        }
+    }
+
+    @Test
+    public void cloudFoundryTakesProvidersScopedPropertiesTest() {
+        CloudFoundryPaasLocation cloudFoundryPaasLocation = resolve(LOCATION_SPEC_NAME);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_USER), USER);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_PASSWORD), PASSWORD);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_ENDPOINT), ENDPOINT);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_ORG), ORG);
+        assertEquals(cloudFoundryPaasLocation.getConfig(CloudFoundryPaasLocation.CF_SPACE), SPACE);
+
+        assertEquals(cloudFoundryPaasLocation.getConfig(PaasLocationConfig.REQUIRED_DISK),
+                PaasLocationConfig.REQUIRED_DISK.getDefaultValue());
+        assertEquals(cloudFoundryPaasLocation.getConfig(PaasLocationConfig.REQUIRED_MEMORY),
+                PaasLocationConfig.REQUIRED_MEMORY.getDefaultValue());
+        assertEquals(cloudFoundryPaasLocation.getConfig(PaasLocationConfig.REQUIRED_INSTANCES),
+                PaasLocationConfig.REQUIRED_INSTANCES.getDefaultValue());
+    }
+
+    @Test
+    void cloudFoundryClientInitilizedTest() {
+        CloudFoundryPaasLocation cloudFoundryPaasLocation = resolve(LOCATION_SPEC_NAME);
+        assertNull(cloudFoundryPaasLocation.getCloudFoundryClient());
+    }
+
+    private CloudFoundryPaasLocation resolve(String spec) {
+        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().resolve(spec);
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
         <module>policy</module>
 
         <module>locations/jclouds</module>
+        <module>locations/cloudfoundry</module>
 
         <module>software/base</module>
         <module>software/winrm</module>

--- a/software/base/pom.xml
+++ b/software/base/pom.xml
@@ -75,7 +75,11 @@
             <artifactId>brooklyn-policy</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-locations-cloudfoundry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractApplicationCloudFoundryDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractApplicationCloudFoundryDriver.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocation;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Beta
+public abstract class AbstractApplicationCloudFoundryDriver
+        extends AbstractSoftwareProcessCloudFoundryDriver
+        implements ApplicationCloudFoundryDriver {
+
+    public static final Logger log = LoggerFactory.getLogger(AbstractApplicationCloudFoundryDriver.class);
+
+
+    public AbstractApplicationCloudFoundryDriver(EntityLocal entity,
+                                                 CloudFoundryPaasLocation location) {
+        super(entity, location);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+    }
+
+    @Override
+    public SoftwareProcessImpl getEntity() {
+        return (SoftwareProcessImpl) super.getEntity();
+    }
+
+    protected abstract String getApplicationUrl();
+
+    protected abstract String getApplicationName();
+
+    public abstract String getBuildpack();
+
+    @Override
+    public boolean isRunning() {
+        CloudApplication app = getClient().getApplication(getApplicationName());
+        return (app != null)
+                && app.getState().equals(CloudApplication.AppState.STARTED);
+    }
+
+    @Override
+    public int getInstancesNumber() {
+        CloudApplication app = getClient().getApplication(getApplicationName());
+        return app.getInstances();
+    }
+
+    @Override
+    public int getDisk() {
+        CloudApplication app = getClient().getApplication(getApplicationName());
+        return app.getDiskQuota();
+    }
+
+    @Override
+    public int getMemory() {
+        CloudApplication app = getClient().getApplication(getApplicationName());
+        return app.getMemory();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+
+        preDeploy();
+        deploy();
+        preLaunch();
+        launch();
+        postLaunch();
+    }
+
+    public void preDeploy() {}
+
+    public abstract void deploy();
+
+    public void preLaunch() {}
+
+    public void launch() {
+        getClient().startApplication(getApplicationName());
+    }
+
+    public void postLaunch() {}
+
+    @Override
+    public void restart() {
+        // TODO: complete
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        getClient().stopApplication(getApplicationName());
+        deleteApplication();
+    }
+
+    @Override
+    public void deleteApplication() {
+        getClient().deleteApplication(getApplicationName());
+    }
+
+    protected String inferApplicationDomainUri(String name) {
+        String defaultDomainName = getClient().getDefaultDomain().getName();
+        return name + "-domain." + defaultDomainName;
+    }
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessCloudFoundryDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessCloudFoundryDriver.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocation;
+import org.cloudfoundry.client.lib.CloudFoundryClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * An abstract implementation of the {@link SoftwareProcessDriver} focus on PaaS.
+ * This class is equivalent to @{link AbstractSoftwareProcessSshDriver} and
+ * @{link AbstractSoftwareProcessDriver}.
+ */
+@Beta
+public abstract class AbstractSoftwareProcessCloudFoundryDriver implements SoftwareProcessDriver {
+
+
+    public static final Logger log = LoggerFactory
+            .getLogger(AbstractSoftwareProcessCloudFoundryDriver.class);
+
+    private final CloudFoundryPaasLocation location;
+    protected final EntityLocal entity;
+    CloudFoundryClient client;
+
+    public AbstractSoftwareProcessCloudFoundryDriver(EntityLocal entity,
+                                                     CloudFoundryPaasLocation location) {
+        this.entity = checkNotNull(entity, "entity");
+        this.location = checkNotNull(location, "location");
+        init();
+    }
+
+    protected void init() {
+    }
+
+    @Override
+    public EntityLocal getEntity() {
+        return entity;
+    }
+
+    @Override
+    public CloudFoundryPaasLocation getLocation() {
+        return location;
+    }
+
+    protected CloudFoundryClient getClient() {
+        return client;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return false;
+    }
+
+    @Override
+    public void rebind() {
+
+    }
+
+    @Override
+    public void start() {
+        setUpClient();
+    }
+
+    protected void setUpClient() {
+        if (client == null) {
+            location.setUpClient();
+            client = location.getCloudFoundryClient();
+            checkNotNull(client, "CloudFoundry client");
+        }
+    }
+
+    @Override
+    public void restart() {
+        //TODO: complete
+    }
+
+    @Override
+    public void stop() {
+        //TODO: complete
+    }
+
+    @Override
+    public void kill() {
+        stop();
+    }
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/ApplicationCloudFoundryDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/ApplicationCloudFoundryDriver.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public interface ApplicationCloudFoundryDriver extends SoftwareProcessDriver {
+
+    //TODO delete?
+    /**
+     * Kills the process, ungracefully and immediately where possible (e.g. with `kill -9`).
+     */
+    void deleteApplication();
+
+    /**
+     * Return the number of instances that are used for an application.
+     * @return
+     */
+    int getInstancesNumber();
+
+    /**
+     * Return the current disk quota used by the application.
+     * @return
+     */
+    int getDisk();
+
+    /**
+     * Return the current assigned memory to the application.
+     * @return
+     */
+    int getMemory();
+
+}
+

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/PaasLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/PaasLifecycleEffectorTasks.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.entity.software.base.lifecycle.AbstractLifecycleEffectorTasks;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+
+@Beta
+public class PaasLifecycleEffectorTasks extends AbstractLifecycleEffectorTasks {
+
+    private static final Logger log = LoggerFactory.getLogger(PaasLifecycleEffectorTasks.class);
+
+    @Override
+    protected SoftwareProcessImpl entity() {
+        return (SoftwareProcessImpl) super.entity();
+    }
+
+    @Override
+    public void start(Collection<? extends Location> locations) {
+        //TODO
+    }
+
+    /**
+     * Default restart implementation for an entity.
+     * <p>
+     * Stops processes if possible, then starts the entity again.
+     */
+    @Override
+    public void restart(ConfigBag parameters) {
+        //TODO
+    }
+    
+    @Override
+    public void stop(ConfigBag parameters) {
+        //TODO
+    }
+
+    @Override
+    public void suspend(ConfigBag parameters) {
+        //TODO
+    }
+
+
+}
+

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/PaasLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/PaasLifecycleEffectorTasks.java
@@ -21,13 +21,21 @@ package org.apache.brooklyn.entity.software.base;
 
 import com.google.common.annotations.Beta;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.entity.software.base.lifecycle.AbstractLifecycleEffectorTasks;
+import org.apache.brooklyn.location.paas.PaasLocation;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-
+import java.util.concurrent.Callable;
 
 @Beta
 public class PaasLifecycleEffectorTasks extends AbstractLifecycleEffectorTasks {
@@ -41,28 +49,156 @@ public class PaasLifecycleEffectorTasks extends AbstractLifecycleEffectorTasks {
 
     @Override
     public void start(Collection<? extends Location> locations) {
-        //TODO
+        ServiceStateLogic.setExpectedState(entity(), Lifecycle.STARTING);
+        try {
+
+            PaasLocation location = (PaasLocation) getLocation(locations);
+
+            preStartProcess(location);
+            startProcess();
+            postStartProcess();
+
+            ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
+        } catch (Throwable t) {
+            ServiceStateLogic.setExpectedState(entity(), Lifecycle.ON_FIRE);
+            log.error("Error error starting entity {}", entity());
+            throw Exceptions.propagate(t);
+        }
+    }
+
+    //TODO: This method could be uploaded to the super class.
+    protected void preStartProcess(PaasLocation location) {
+        createDriver(location);
+        entity().preStart();
+    }
+
+    /**
+     * Create the driver ensuring that the location is ready.
+     */
+    private void createDriver(PaasLocation location) {
+        if (location != null) {
+            entity().initDriver(location);
+        } else {
+            throw new ExceptionInInitializerError("Location should not be null in " + this +
+                    " the driver needs a initialized Location");
+        }
+    }
+
+    protected void startProcess() {
+        entity().getDriver().start();
+    }
+
+    protected void postStartProcess() {
+        entity().postDriverStart();
+        if (entity().connectedSensors) {
+            log.debug("skipping connecting sensors for " + entity() + " " +
+                    "in driver-tasks postStartCustom because already connected (e.g. restarting)");
+        } else {
+            log.debug("connecting sensors for " + entity() + " in driver-tasks postStartCustom because already connected (e.g. restarting)");
+            entity().connectSensors();
+        }
+        entity().waitForServiceUp();
+        entity().postStart();
     }
 
     /**
      * Default restart implementation for an entity.
-     * <p>
+     * <p/>
      * Stops processes if possible, then starts the entity again.
      */
     @Override
     public void restart(ConfigBag parameters) {
         //TODO
     }
-    
+
     @Override
     public void stop(ConfigBag parameters) {
-        //TODO
+
+        log.info("Stopping {} in {}", entity(), entity().getLocations());
+        try {
+
+            DynamicTasks.queue("pre-stop", new Callable<String>() {
+                public String call() {
+                    if (entity().getAttribute(SoftwareProcess.SERVICE_STATE_ACTUAL) == Lifecycle.STOPPED) {
+                        log.debug("Skipping stop of entity " + entity() + " when already stopped");
+                        return "Already stopped";
+                    }
+                    ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPING);
+                    entity().setAttribute(SoftwareProcess.SERVICE_UP, false);
+                    preStopProcess();
+                    return null;
+                }
+            });
+
+            stopProcess();
+            postStopProcess();
+            entity().setAttribute(SoftwareProcess.SERVICE_UP, false);
+            ServiceStateLogic.setExpectedState(entity(), Lifecycle.STOPPED);
+        } catch (Throwable t) {
+            ServiceStateLogic.setExpectedState(entity(), Lifecycle.ON_FIRE);
+            log.error("Error error starting entity {}", entity());
+            throw Exceptions.propagate(t);
+        }
     }
 
     @Override
     public void suspend(ConfigBag parameters) {
         //TODO
     }
+
+    protected void preStopProcess() {
+        entity().preStop();
+    }
+
+    protected String stopProcess() {
+        //TODO: This method was copied from SoftwareProcessDriverLifecycleEffectorTasks. It should
+        //be moved to any super class
+        String result;
+
+        SoftwareProcess.ChildStartableMode mode = getChildrenStartableModeEffective();
+        TaskAdaptable<?> children = null;
+        Exception childException = null;
+
+        if (!mode.isDisabled) {
+            children = StartableMethods.stoppingChildren(entity());
+
+            if (mode.isBackground || !mode.isLate) Entities.submit(entity(), children);
+            else {
+                DynamicTasks.queue(children);
+                try {
+                    DynamicTasks.waitForLast();
+                } catch (Exception e) {
+                    childException = e;
+                }
+            }
+        }
+
+        if (entity().getDriver() != null) {
+            entity().getDriver().stop();
+            result = "Driver stop completed";
+        } else {
+            result = "No driver (nothing to do here)";
+        }
+
+        if (!mode.isDisabled && !mode.isBackground) {
+            try {
+                children.asTask().get();
+            } catch (Exception e) {
+                childException = e;
+                log.debug("Error stopping children; continuing and will rethrow if no other errors", e);
+            }
+        }
+
+        if (childException != null)
+            throw new IllegalStateException(result + "; but error stopping child: " + childException, childException);
+
+        return result;
+    }
+
+    protected void postStopProcess() {
+        entity().postStop();
+    }
+
 
 
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -20,20 +20,14 @@ package org.apache.brooklyn.entity.software.base;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 
-import com.google.common.collect.Sets;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
-import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.MapConfigKey;
-import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -42,10 +36,7 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
-import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
@@ -258,6 +249,13 @@ public interface SoftwareProcess extends Entity, Startable {
     ConfigKey<SoftwareProcessDriverLifecycleEffectorTasks> LIFECYCLE_EFFECTOR_TASKS = ConfigKeys.newConfigKey(SoftwareProcessDriverLifecycleEffectorTasks.class,
             "softwareProcess.lifecycleTasks", "An object that handles lifecycle of an entity's associated machine.",
             new SoftwareProcessDriverLifecycleEffectorTasks());
+
+    @Beta
+    @SetFromFlag("paasLifecycleEffectorTasks")
+    ConfigKey<PaasLifecycleEffectorTasks> PAAS_LIFECYCLE_EFFECTOR_TASKS = ConfigKeys.newConfigKey(
+            PaasLifecycleEffectorTasks.class,
+            "softwareProcess.paaslifecycleTasks", "An object that handles lifecycle of an entity's associated machine.",
+            new PaasLifecycleEffectorTasks());
 
     ConfigKey<Boolean> RETRIEVE_USAGE_METRICS = ConfigKeys.newBooleanConfigKey(
             "metrics.usage.retrieve",

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -125,14 +125,6 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
         entity().preStart();
     }
 
-    /** returns how children startables should be handled (reporting none for efficiency if there are no children) */
-    protected ChildStartableMode getChildrenStartableModeEffective() {
-        if (entity().getChildren().isEmpty()) return ChildStartableMode.NONE;
-        ChildStartableMode result = entity().getConfig(SoftwareProcess.CHILDREN_STARTABLE_MODE);
-        if (result!=null) return result;
-        return ChildStartableMode.NONE;
-    }
-
     @Override
     protected String startProcessesAtMachine(final Supplier<MachineLocation> machineS) {
         ChildStartableMode mode = getChildrenStartableModeEffective();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -110,7 +110,7 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     
     @Override
     protected Map<String, Object> obtainProvisioningFlags(final MachineProvisioningLocation<?> location) {
-        return entity().obtainProvisioningFlags(location);
+        return entity().obtainFlagsForLocation(location);
     }
      
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -27,7 +27,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -36,12 +35,10 @@ import org.apache.brooklyn.api.entity.drivers.EntityDriverManager;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
-import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
-import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -59,11 +56,9 @@ import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.CountdownTimer;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -74,8 +69,6 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 /**
  * An {@link Entity} representing a piece of software which can be installed, run, and controlled.
@@ -121,7 +114,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         return driver;
     }
 
-    protected SoftwareProcessDriver newDriver(MachineLocation loc){
+    protected SoftwareProcessDriver newDriver(Location loc){
         EntityDriverManager entityDriverManager = getManagementContext().getEntityDriverManager();
         return (SoftwareProcessDriver)entityDriverManager.build(this, loc);
     }
@@ -515,10 +508,10 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         return ports;
     }
 
-    protected void initDriver(MachineLocation machine) {
-        SoftwareProcessDriver newDriver = doInitDriver(machine);
+    protected void initDriver(Location location) {
+        SoftwareProcessDriver newDriver = doInitDriver(location);
         if (newDriver == null) {
-            throw new UnsupportedOperationException("cannot start "+this+" on "+machine+": no driver available");
+            throw new UnsupportedOperationException("cannot start "+this+" on "+location+": no driver available");
         }
         driver = newDriver;
     }
@@ -527,16 +520,16 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      * Creates the driver (if does not already exist or needs replaced for some reason). Returns either the existing driver
      * or a new driver. Must not return null.
      */
-    protected SoftwareProcessDriver doInitDriver(MachineLocation machine) {
+    protected SoftwareProcessDriver doInitDriver(Location location) {
         if (driver!=null) {
-            if ((driver instanceof AbstractSoftwareProcessDriver) && machine.equals(((AbstractSoftwareProcessDriver)driver).getLocation())) {
+            if ((driver instanceof AbstractSoftwareProcessDriver) && location.equals(((AbstractSoftwareProcessDriver)driver).getLocation())) {
                 return driver; //just reuse
             } else {
-                log.warn("driver/location change is untested for {} at {}; changing driver and continuing", this, machine);
-                return newDriver(machine);
+                log.warn("driver/location change is untested for {} at {}; changing driver and continuing", this, location);
+                return newDriver(location);
             }
         } else {
-            return newDriver(machine);
+            return newDriver(location);
         }
     }
     

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -43,9 +43,9 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle.Transition;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
-import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplBehaviourFactory;
-import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplMachineBehaviourFactory;
-import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplPaasBehaviourFactory;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplBehaviorFactory;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplMachineBehaviorFactory;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.SoftwareProcessImplPaasBehaviorFactory;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.MachineProvisioningLocationFlagsSupplier;
 import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
@@ -88,7 +88,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
     protected boolean connectedSensors = false;
 
-    SoftwareProcessImplBehaviourFactory factory;
+    SoftwareProcessImplBehaviorFactory factory;
     public LocationFlagSupplier locationFlagSupplier;
     private LifecycleEffectorTasks LIFECYCLE_TASKS;
 
@@ -137,7 +137,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     @Beta
     protected void initBehavior(){
         locationFlagSupplier = new MachineProvisioningLocationFlagsSupplier(this);
-        factory =  new SoftwareProcessImplMachineBehaviourFactory(this);
+        factory =  new SoftwareProcessImplMachineBehaviorFactory(this);
         LIFECYCLE_TASKS = getLifecycleEffectorTasks();
         LIFECYCLE_TASKS.attachLifecycleEffectors(this);
     }
@@ -570,7 +570,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     }
 
     /**
-     * If custom behaviour is required by sub-classes, consider overriding {@link #preStart()} or {@link #postStart()})}.
+     * If custom behavior is required by sub-classes, consider overriding {@link #preStart()} or {@link #postStart()})}.
      * Also consider adding additional work via tasks, executed using {@link DynamicTasks#queue(String, Callable)}.
      */
     @Override
@@ -588,18 +588,18 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
     @Beta
     protected void updateFactoryAndBehavior(Location location){
-        if((factory == null) || (newBehaviourFactoryIsRequired(location))) {
+        if((factory == null) || (newBehaviorFactoryIsRequired(location))) {
             updateFactoryAndBehavior(createBehaviorFactory(location));
         }
     }
 
     @Beta
-    private boolean newBehaviourFactoryIsRequired(Location location){
+    private boolean newBehaviorFactoryIsRequired(Location location){
         return !factory.isASupportedLocation(location);
     }
 
     @Beta
-    protected void updateFactoryAndBehavior(SoftwareProcessImplBehaviourFactory newFactory){
+    protected void updateFactoryAndBehavior(SoftwareProcessImplBehaviorFactory newFactory){
         factory = newFactory;
         LIFECYCLE_TASKS = factory.getLifecycleEffectorTasks();
         log.info("Lifecycle {} was selected for {}", LIFECYCLE_TASKS, this);
@@ -608,19 +608,19 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     }
 
     @Beta
-    protected SoftwareProcessImplBehaviourFactory createBehaviorFactory(Location location){
-        SoftwareProcessImplBehaviourFactory result =null;
+    protected SoftwareProcessImplBehaviorFactory createBehaviorFactory(Location location){
+        SoftwareProcessImplBehaviorFactory result =null;
         if((location instanceof MachineProvisioningLocation) ||
                 (location instanceof MachineLocation)){
-            result =  new SoftwareProcessImplMachineBehaviourFactory(this);
+            result =  new SoftwareProcessImplMachineBehaviorFactory(this);
         } else if(location instanceof PaasLocation){
-            result =  new SoftwareProcessImplPaasBehaviourFactory(this);
+            result =  new SoftwareProcessImplPaasBehaviorFactory(this);
         }
         return result;
     }
 
     /**
-     * If custom behaviour is required by sub-classes, consider overriding  {@link #preStop()} or {@link #postStop()}.
+     * If custom behavior is required by sub-classes, consider overriding  {@link #preStop()} or {@link #postStop()}.
      * Also consider adding additional work via tasks, executed using {@link DynamicTasks#queue(String, Callable)}.
      */
     @Override
@@ -642,7 +642,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     }
 
     /**
-     * If custom behaviour is required by sub-classes, consider overriding {@link #preRestart()} or {@link #postRestart()}.
+     * If custom behavior is required by sub-classes, consider overriding {@link #preRestart()} or {@link #postRestart()}.
      * Also consider adding additional work via tasks, executed using {@link DynamicTasks#queue(String, Callable)}.
      */
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplBehaviorFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplBehaviorFactory.java
@@ -20,36 +20,13 @@ package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
 
 
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.entity.software.base.SoftwareProcess;
-import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
-import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.PaasLocationFlagsSupplier;
 import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
-import org.apache.brooklyn.location.paas.PaasLocation;
 
-public class SoftwareProcessImplPaasBehaviourFactory
-        implements SoftwareProcessImplBehaviourFactory {
+public interface SoftwareProcessImplBehaviorFactory {
 
-    SoftwareProcessImpl entity;
-
-    public SoftwareProcessImplPaasBehaviourFactory(SoftwareProcessImpl entity){
-        this.entity = entity;
-    }
-
-    @Override
-    public LocationFlagSupplier getLocationFlagSupplier() {
-        return new PaasLocationFlagsSupplier(entity);
-    }
-
-    @Override
-    public LifecycleEffectorTasks getLifecycleEffectorTasks() {
-        return entity.getConfig(SoftwareProcess.PAAS_LIFECYCLE_EFFECTOR_TASKS);
-    }
-
-    @Override
-    public boolean isASupportedLocation(Location location) {
-        return location instanceof PaasLocation;
-    }
-
+    public LocationFlagSupplier getLocationFlagSupplier();
+    public LifecycleEffectorTasks getLifecycleEffectorTasks();
+    public boolean isASupportedLocation(Location location);
 
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplBehaviourFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplBehaviourFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
+
+
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
+
+public interface SoftwareProcessImplBehaviourFactory {
+
+    public LocationFlagSupplier getLocationFlagSupplier();
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviorFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviorFactory.java
@@ -28,12 +28,12 @@ import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplie
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.MachineProvisioningLocationFlagsSupplier;
 import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
 
-public class SoftwareProcessImplMachineBehaviourFactory
-        implements SoftwareProcessImplBehaviourFactory {
+public class SoftwareProcessImplMachineBehaviorFactory
+        implements SoftwareProcessImplBehaviorFactory {
 
     SoftwareProcessImpl entity;
 
-    public SoftwareProcessImplMachineBehaviourFactory(SoftwareProcessImpl entity){
+    public SoftwareProcessImplMachineBehaviorFactory(SoftwareProcessImpl entity){
         this.entity = entity;
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviourFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviourFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
+
+
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.MachineProvisioningLocationFlagsSupplier;
+
+public class SoftwareProcessImplMachineBehaviourFactory
+        implements SoftwareProcessImplBehaviourFactory {
+
+    SoftwareProcessImpl entity;
+
+    public SoftwareProcessImplMachineBehaviourFactory(SoftwareProcessImpl entity){
+        this.entity = entity;
+    }
+
+    @Override
+    public LocationFlagSupplier getLocationFlagSupplier() {
+        return new MachineProvisioningLocationFlagsSupplier(entity);
+    }
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviourFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplMachineBehaviourFactory.java
@@ -19,9 +19,14 @@
 package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
 
 
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.MachineLocation;
+import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.MachineProvisioningLocationFlagsSupplier;
+import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
 
 public class SoftwareProcessImplMachineBehaviourFactory
         implements SoftwareProcessImplBehaviourFactory {
@@ -35,6 +40,17 @@ public class SoftwareProcessImplMachineBehaviourFactory
     @Override
     public LocationFlagSupplier getLocationFlagSupplier() {
         return new MachineProvisioningLocationFlagsSupplier(entity);
+    }
+
+    @Override
+    public LifecycleEffectorTasks getLifecycleEffectorTasks() {
+        return entity.getConfig(SoftwareProcess.LIFECYCLE_EFFECTOR_TASKS);
+    }
+
+    @Override
+    public boolean isASupportedLocation(Location location) {
+        return (location instanceof MachineProvisioningLocation) ||
+                (location instanceof MachineLocation);
     }
 
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviorFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviorFactory.java
@@ -20,13 +20,36 @@ package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
 
 
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.PaasLocationFlagsSupplier;
 import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
+import org.apache.brooklyn.location.paas.PaasLocation;
 
-public interface SoftwareProcessImplBehaviourFactory {
+public class SoftwareProcessImplPaasBehaviorFactory
+        implements SoftwareProcessImplBehaviorFactory {
 
-    public LocationFlagSupplier getLocationFlagSupplier();
-    public LifecycleEffectorTasks getLifecycleEffectorTasks();
-    public boolean isASupportedLocation(Location location);
+    SoftwareProcessImpl entity;
+
+    public SoftwareProcessImplPaasBehaviorFactory(SoftwareProcessImpl entity){
+        this.entity = entity;
+    }
+
+    @Override
+    public LocationFlagSupplier getLocationFlagSupplier() {
+        return new PaasLocationFlagsSupplier(entity);
+    }
+
+    @Override
+    public LifecycleEffectorTasks getLifecycleEffectorTasks() {
+        return entity.getConfig(SoftwareProcess.PAAS_LIFECYCLE_EFFECTOR_TASKS);
+    }
+
+    @Override
+    public boolean isASupportedLocation(Location location) {
+        return location instanceof PaasLocation;
+    }
+
 
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviourFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviourFactory.java
@@ -19,9 +19,13 @@
 package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
 
 
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
 import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.PaasLocationFlagsSupplier;
+import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
+import org.apache.brooklyn.location.paas.PaasLocation;
 
 public class SoftwareProcessImplPaasBehaviourFactory
         implements SoftwareProcessImplBehaviourFactory {
@@ -35,6 +39,16 @@ public class SoftwareProcessImplPaasBehaviourFactory
     @Override
     public LocationFlagSupplier getLocationFlagSupplier() {
         return new PaasLocationFlagsSupplier(entity);
+    }
+
+    @Override
+    public LifecycleEffectorTasks getLifecycleEffectorTasks() {
+        return entity.getConfig(SoftwareProcess.PAAS_LIFECYCLE_EFFECTOR_TASKS);
+    }
+
+    @Override
+    public boolean isASupportedLocation(Location location) {
+        return location instanceof PaasLocation;
     }
 
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviourFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/SoftwareProcessImplPaasBehaviourFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
+
+
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
+import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.PaasLocationFlagsSupplier;
+
+public class SoftwareProcessImplPaasBehaviourFactory
+        implements SoftwareProcessImplBehaviourFactory {
+
+    SoftwareProcessImpl entity;
+
+    public SoftwareProcessImplPaasBehaviourFactory(SoftwareProcessImpl entity){
+        this.entity = entity;
+    }
+
+    @Override
+    public LocationFlagSupplier getLocationFlagSupplier() {
+        return new PaasLocationFlagsSupplier(entity);
+    }
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/AbstractLocationFlagsSupplier.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/AbstractLocationFlagsSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+
+import java.util.Map;
+
+public abstract class AbstractLocationFlagsSupplier implements LocationFlagSupplier {
+
+    AbstractEntity entity;
+
+    public AbstractLocationFlagsSupplier(AbstractEntity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public AbstractEntity entity() {
+        return entity;
+    }
+
+    @Override
+    public abstract Map<String, Object> obtainFlagsForLocation(Location location);
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/LocationFlagSupplier.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/LocationFlagSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface LocationFlagSupplier {
+
+    public AbstractEntity entity();
+
+    public Map<String, Object> obtainFlagsForLocation(Location location);
+    public Collection<Integer> getRequiredOpenPorts();
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplier.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplier.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+
+import com.google.common.collect.ImmutableList;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.location.LocationConfigKeys;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.entity.software.base.InboundPortsUtils;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class MachineProvisioningLocationFlagsSupplier extends AbstractLocationFlagsSupplier {
+
+    private static final Logger log = LoggerFactory.getLogger(MachineProvisioningLocationFlagsSupplier.class);
+
+    public MachineProvisioningLocationFlagsSupplier(AbstractEntity entity) {
+        super(entity);
+    }
+
+    @Override
+    public Map<String,Object> obtainFlagsForLocation(Location location){
+        return obtainProvisioningFlags((MachineProvisioningLocation)location);
+    }
+
+    protected Map<String,Object> obtainProvisioningFlags(MachineProvisioningLocation location) {
+        ConfigBag result = ConfigBag.newInstance(location.getProvisioningFlags(ImmutableList.of(getClass().getName())));
+        result.putAll(entity().getConfig(SoftwareProcessImpl.PROVISIONING_PROPERTIES));
+        if (result.get(CloudLocationConfig.INBOUND_PORTS) == null) {
+            Collection<Integer> ports = getRequiredOpenPorts();
+            Object requiredPorts = result.get(CloudLocationConfig.ADDITIONAL_INBOUND_PORTS);
+            if (requiredPorts instanceof Integer) {
+                ports.add((Integer) requiredPorts);
+            } else if (requiredPorts instanceof Iterable) {
+                for (Object o : (Iterable<?>) requiredPorts) {
+                    if (o instanceof Integer) ports.add((Integer) o);
+                }
+            }
+            if (ports != null && ports.size() > 0) result.put(CloudLocationConfig.INBOUND_PORTS, ports);
+        }
+        result.put(LocationConfigKeys.CALLER_CONTEXT, entity());
+        return result.getAllConfigMutable();
+    }
+
+    /**
+     * Returns the ports that this entity wants to be opened.
+     * @see org.apache.brooklyn.entity.software.base.InboundPortsUtils#getRequiredOpenPorts(org.apache.brooklyn.api.entity.Entity, Set, Boolean, String)
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#REQUIRED_OPEN_LOGIN_PORTS
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#INBOUND_PORTS_AUTO_INFER
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#INBOUND_PORTS_CONFIG_REGEX
+     */
+    @SuppressWarnings("serial")
+    public Collection<Integer> getRequiredOpenPorts() {
+        Set<Integer> ports = MutableSet.copyOf(entity().getConfig(SoftwareProcessImpl.REQUIRED_OPEN_LOGIN_PORTS));
+        Boolean portsAutoInfer = entity().getConfig(SoftwareProcessImpl.INBOUND_PORTS_AUTO_INFER);
+        String portsRegex = entity().getConfig(SoftwareProcessImpl.INBOUND_PORTS_CONFIG_REGEX);
+        ports.addAll(InboundPortsUtils.getRequiredOpenPorts(entity(), entity().config().getBag().getAllConfigAsConfigKeyMap().keySet(), portsAutoInfer, portsRegex));
+        return ports;
+    }
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplier.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplier.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.software.base.InboundPortsUtils;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -49,9 +50,13 @@ public class MachineProvisioningLocationFlagsSupplier extends AbstractLocationFl
         return obtainProvisioningFlags((MachineProvisioningLocation)location);
     }
 
+    public SoftwareProcessImpl entity(){
+        return (SoftwareProcessImpl) super.entity();
+    }
+
     protected Map<String,Object> obtainProvisioningFlags(MachineProvisioningLocation location) {
         ConfigBag result = ConfigBag.newInstance(location.getProvisioningFlags(ImmutableList.of(getClass().getName())));
-        result.putAll(entity().getConfig(SoftwareProcessImpl.PROVISIONING_PROPERTIES));
+        result.putAll(entity().getConfig(SoftwareProcess.PROVISIONING_PROPERTIES));
         if (result.get(CloudLocationConfig.INBOUND_PORTS) == null) {
             Collection<Integer> ports = getRequiredOpenPorts();
             Object requiredPorts = result.get(CloudLocationConfig.ADDITIONAL_INBOUND_PORTS);
@@ -71,15 +76,15 @@ public class MachineProvisioningLocationFlagsSupplier extends AbstractLocationFl
     /**
      * Returns the ports that this entity wants to be opened.
      * @see org.apache.brooklyn.entity.software.base.InboundPortsUtils#getRequiredOpenPorts(org.apache.brooklyn.api.entity.Entity, Set, Boolean, String)
-     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#REQUIRED_OPEN_LOGIN_PORTS
-     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#INBOUND_PORTS_AUTO_INFER
-     * @see org.apache.brooklyn.entity.software.base.SoftwareProcessImpl#INBOUND_PORTS_CONFIG_REGEX
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcess#REQUIRED_OPEN_LOGIN_PORTS
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcess#INBOUND_PORTS_AUTO_INFER
+     * @see org.apache.brooklyn.entity.software.base.SoftwareProcess#INBOUND_PORTS_CONFIG_REGEX
      */
     @SuppressWarnings("serial")
     public Collection<Integer> getRequiredOpenPorts() {
-        Set<Integer> ports = MutableSet.copyOf(entity().getConfig(SoftwareProcessImpl.REQUIRED_OPEN_LOGIN_PORTS));
-        Boolean portsAutoInfer = entity().getConfig(SoftwareProcessImpl.INBOUND_PORTS_AUTO_INFER);
-        String portsRegex = entity().getConfig(SoftwareProcessImpl.INBOUND_PORTS_CONFIG_REGEX);
+        Set<Integer> ports = MutableSet.copyOf(entity().getConfig(SoftwareProcess.REQUIRED_OPEN_LOGIN_PORTS));
+        Boolean portsAutoInfer = entity().getConfig(SoftwareProcess.INBOUND_PORTS_AUTO_INFER);
+        String portsRegex = entity().getConfig(SoftwareProcess.INBOUND_PORTS_CONFIG_REGEX);
         ports.addAll(InboundPortsUtils.getRequiredOpenPorts(entity(), entity().config().getBag().getAllConfigAsConfigKeyMap().keySet(), portsAutoInfer, portsRegex));
         return ports;
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/PaasLocationFlagsSupplier.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/PaasLocationFlagsSupplier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaasLocationFlagsSupplier extends AbstractLocationFlagsSupplier {
+
+    private static final Logger log = LoggerFactory.getLogger(PaasLocationFlagsSupplier.class);
+
+    public PaasLocationFlagsSupplier(AbstractEntity entity) {
+        super(entity);
+    }
+
+    @Override
+         public Map<String,Object> obtainFlagsForLocation(Location location){
+        return new HashMap<>();
+    }
+
+    @Override
+    public Collection<Integer> getRequiredOpenPorts() {
+        return new ArrayList<>();
+    }
+
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/AbstractLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/AbstractLifecycleEffectorTasks.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.lifecycle;
+
+
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.MachineLocation;
+import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.entity.stock.EffectorStartableImpl;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public abstract class AbstractLifecycleEffectorTasks implements LifecycleEffectorTasks {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractLifecycleEffectorTasks.class);
+    public static final ConfigKey<Collection<? extends Location>> LOCATIONS = EffectorStartableImpl.StartParameters.LOCATIONS;
+
+    /** Attaches lifecycle effectors (start, restart, stop) to the given entity post-creation. */
+    public void attachLifecycleEffectors(Entity entity) {
+        //((EntityInternal) entity).getMutableEntityType().addEffector(newStartEffector());
+        ((EntityInternal) entity).getMutableEntityType().addEffector(newRestartEffector());
+        ((EntityInternal) entity).getMutableEntityType().addEffector(newStopEffector());
+    }
+
+    /**
+     * Return an effector suitable for setting in a {@code public static final} or attaching dynamically.
+     * <p>
+     * The effector overrides the corresponding effector from {@link org.apache.brooklyn.core.entity.trait.Startable} with
+     * the behaviour in this lifecycle class instance.
+     */
+    public Effector<Void> newStartEffector() {
+        return Effectors.effector(Startable.START).impl(newStartEffectorTask()).build();
+    }
+
+    /** @see {@link #newStartEffector()} */
+    public Effector<Void> newRestartEffector() {
+        return Effectors.effector(Startable.RESTART)
+                .parameter(SoftwareProcess.RestartSoftwareParameters.RESTART_CHILDREN)
+                .parameter(SoftwareProcess.RestartSoftwareParameters.RESTART_MACHINE)
+                .impl(newRestartEffectorTask())
+                .build();
+    }
+
+    /** @see {@link #newStartEffector()} */
+    public Effector<Void> newStopEffector() {
+        return Effectors.effector(Startable.STOP)
+                .parameter(SoftwareProcess.StopSoftwareParameters.STOP_PROCESS_MODE)
+                .parameter(SoftwareProcess.StopSoftwareParameters.STOP_MACHINE_MODE)
+                .impl(newStopEffectorTask())
+                .build();
+    }
+
+    /** @see {@link #newStartEffector()} */
+    public Effector<Void> newSuspendEffector() {
+        return Effectors.effector(Void.class, "suspend")
+                .description("Suspend the process/service represented by an entity")
+                .parameter(SoftwareProcess.StopSoftwareParameters.STOP_PROCESS_MODE)
+                .parameter(SoftwareProcess.StopSoftwareParameters.STOP_MACHINE_MODE)
+                .impl(newSuspendEffectorTask())
+                .build();
+    }
+
+    /**
+     * Returns the {@link org.apache.brooklyn.core.effector.EffectorBody} which supplies the implementation for the start effector.
+     * <p>
+     * Calls {@link #start(Collection)} in this class.
+     */
+    public EffectorBody<Void> newStartEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                Collection<? extends Location> locations  = null;
+
+                Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
+                locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+
+                if (locations==null) {
+                    // null/empty will mean to inherit from parent
+                    locations = Collections.emptyList();
+                }
+
+                start(locations);
+                return null;
+            }
+        };
+        return new StartEffectorBody();
+    }
+
+    private class StartEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            Collection<? extends Location> locations = null;
+
+            Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
+            locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+
+            if (locations == null) {
+                // null/empty will mean to inherit from parent
+                locations = Collections.emptyList();
+            }
+
+            start(locations);
+            return null;
+        }
+
+    }
+
+    /**
+     * Calls {@link #restart(ConfigBag)}.
+     *
+     * @see {@link #newStartEffectorTask()}
+     */
+    public EffectorBody<Void> newRestartEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                restart(parameters);
+                return null;
+            }
+        };
+        return new RestartEffectorBody();
+    }
+
+    private class RestartEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            restart(parameters);
+            return null;
+        }
+    }
+
+    /**
+     * Calls {@link #suspend(ConfigBag)}.
+     *
+     * @see {@link #newStartEffectorTask()}
+     */
+    public EffectorBody<Void> newSuspendEffectorTask() {
+        return new SuspendEffectorBody();
+    }
+
+    private class SuspendEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            suspend(parameters);
+            return null;
+        }
+    }
+
+    /**
+     * Calls {@link #stop(ConfigBag)}.
+     *
+     * @see {@link #newStartEffectorTask()}
+     */
+    public EffectorBody<Void> newStopEffectorTask() {
+        // TODO included anonymous inner class for backwards compatibility with persisted state.
+        new EffectorBody<Void>() {
+            @Override
+            public Void call(ConfigBag parameters) {
+                stop(parameters);
+                return null;
+            }
+        };
+        return new StopEffectorBody();
+    }
+
+    private class StopEffectorBody extends EffectorBody<Void> {
+        @Override
+        public Void call(ConfigBag parameters) {
+            stop(parameters);
+            return null;
+        }
+    }
+
+    protected EntityInternal entity() {
+        return (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
+    }
+
+    public Location getLocation(@Nullable Collection<? extends Location> locations) {
+        if (locations==null || locations.isEmpty()) locations = entity().getLocations();
+        if (locations.isEmpty()) {
+            MachineProvisioningLocation<?> provisioner = entity().getAttribute(SoftwareProcess.PROVISIONING_LOCATION);
+            if (provisioner!=null) locations = Arrays.<Location>asList(provisioner);
+        }
+        locations = Locations.getLocationsCheckingAncestors(locations, entity());
+
+        Maybe<MachineLocation> ml = Locations.findUniqueMachineLocation(locations);
+        if (ml.isPresent()) return ml.get();
+
+        if (locations.isEmpty())
+            throw new IllegalArgumentException("No locations specified when starting "+entity());
+        if (locations.size() != 1 || Iterables.getOnlyElement(locations)==null)
+            throw new IllegalArgumentException("Ambiguous locations detected when starting "+entity()+": "+locations);
+        return Iterables.getOnlyElement(locations);
+    }
+
+    /** returns how children startables should be handled (reporting none for efficiency if there are no children) */
+    protected SoftwareProcess.ChildStartableMode getChildrenStartableModeEffective() {
+        if (entity().getChildren().isEmpty()) return SoftwareProcess.ChildStartableMode.NONE;
+        SoftwareProcess.ChildStartableMode result = entity().getConfig(SoftwareProcess.CHILDREN_STARTABLE_MODE);
+        if (result!=null) return result;
+        return SoftwareProcess.ChildStartableMode.NONE;
+    }
+
+    /** @deprecated since 0.7.0 use {@link #restart(ConfigBag)} */
+    @Deprecated
+    public void restart() {
+        restart(ConfigBag.EMPTY);
+    }
+
+    /** @deprecated since 0.7.0 use {@link #stop(ConfigBag)} */
+    @Deprecated
+    public void stop() {
+        stop(ConfigBag.EMPTY);
+    }
+
+    @Override
+    public abstract void start(Collection<? extends Location> locations);
+
+    @Override
+    public abstract void restart(ConfigBag parameters);
+
+    @Override
+    public abstract void stop(ConfigBag parameters);
+
+    @Override
+    public abstract void suspend(ConfigBag parameters);
+
+
+}
+

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/LifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/LifecycleEffectorTasks.java
@@ -16,17 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.entity.software.base.behavior.softwareprocess;
+package org.apache.brooklyn.entity.software.base.lifecycle;
 
 
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier.LocationFlagSupplier;
-import org.apache.brooklyn.entity.software.base.lifecycle.LifecycleEffectorTasks;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 
-public interface SoftwareProcessImplBehaviourFactory {
+import javax.annotation.Nullable;
+import java.util.Collection;
 
-    public LocationFlagSupplier getLocationFlagSupplier();
-    public LifecycleEffectorTasks getLifecycleEffectorTasks();
-    public boolean isASupportedLocation(Location location);
+@Beta
+public interface LifecycleEffectorTasks {
 
+    void attachLifecycleEffectors(Entity entity);
+
+    void start(Collection<? extends Location> locations);
+
+    void restart(ConfigBag parameters);
+
+    void stop(ConfigBag paramters);
+
+    void suspend(ConfigBag paramters);
+
+    @Deprecated
+    void stop();
+
+    Location getLocation(@Nullable Collection<? extends Location> locations);
 }
+

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -128,7 +128,7 @@ public abstract class MachineLifecycleEffectorTasks {
     
     /** Attaches lifecycle effectors (start, restart, stop) to the given entity post-creation. */
     public void attachLifecycleEffectors(Entity entity) {
-        ((EntityInternal) entity).getMutableEntityType().addEffector(newStartEffector());
+        //((EntityInternal) entity).getMutableEntityType().addEffector(newStartEffector());
         ((EntityInternal) entity).getMutableEntityType().addEffector(newRestartEffector());
         ((EntityInternal) entity).getMutableEntityType().addEffector(newStopEffector());
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -19,16 +19,12 @@
 package org.apache.brooklyn.entity.software.base.lifecycle;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import javax.annotation.Nullable;
 
-import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineLocation;
@@ -40,8 +36,6 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.Sanitizer;
-import org.apache.brooklyn.core.effector.EffectorBody;
-import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
@@ -49,11 +43,9 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
-import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.AbstractLocation;
-import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
@@ -65,7 +57,6 @@ import org.apache.brooklyn.entity.software.base.SoftwareProcess.RestartSoftwareP
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.RestartSoftwareParameters.RestartMachineMode;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters.StopMode;
-import org.apache.brooklyn.entity.stock.EffectorStartableImpl.StartParameters;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,198 +104,18 @@ import org.apache.brooklyn.util.time.Duration;
  * @since 0.6.0
  */
 @Beta
-public abstract class MachineLifecycleEffectorTasks {
+public abstract class MachineLifecycleEffectorTasks extends AbstractLifecycleEffectorTasks{
 
     private static final Logger log = LoggerFactory.getLogger(MachineLifecycleEffectorTasks.class);
 
     public static final ConfigKey<Boolean> ON_BOX_BASE_DIR_RESOLVED = ConfigKeys.newBooleanConfigKey("onbox.base.dir.resolved",
         "Whether the on-box base directory has been resolved (for internal use)");
 
-    public static final ConfigKey<Collection<? extends Location>> LOCATIONS = StartParameters.LOCATIONS;
     public static final ConfigKey<Duration> STOP_PROCESS_TIMEOUT = ConfigKeys.newConfigKey(Duration.class,
             "process.stop.timeout", "How long to wait for the processes to be stopped; use null to mean forever", Duration.TWO_MINUTES);
 
     protected final MachineInitTasks machineInitTasks = new MachineInitTasks();
-    
-    /** Attaches lifecycle effectors (start, restart, stop) to the given entity post-creation. */
-    public void attachLifecycleEffectors(Entity entity) {
-        //((EntityInternal) entity).getMutableEntityType().addEffector(newStartEffector());
-        ((EntityInternal) entity).getMutableEntityType().addEffector(newRestartEffector());
-        ((EntityInternal) entity).getMutableEntityType().addEffector(newStopEffector());
-    }
 
-    /**
-     * Return an effector suitable for setting in a {@code public static final} or attaching dynamically.
-     * <p>
-     * The effector overrides the corresponding effector from {@link Startable} with
-     * the behaviour in this lifecycle class instance.
-     */
-    public Effector<Void> newStartEffector() {
-        return Effectors.effector(Startable.START).impl(newStartEffectorTask()).build();
-    }
-
-    /** @see {@link #newStartEffector()} */
-    public Effector<Void> newRestartEffector() {
-        return Effectors.effector(Startable.RESTART)
-                .parameter(RestartSoftwareParameters.RESTART_CHILDREN)
-                .parameter(RestartSoftwareParameters.RESTART_MACHINE)
-                .impl(newRestartEffectorTask())
-                .build();
-    }
-    
-    /** @see {@link #newStartEffector()} */
-    public Effector<Void> newStopEffector() {
-        return Effectors.effector(Startable.STOP)
-                .parameter(StopSoftwareParameters.STOP_PROCESS_MODE)
-                .parameter(StopSoftwareParameters.STOP_MACHINE_MODE)
-                .impl(newStopEffectorTask())
-                .build();
-    }
-
-    /** @see {@link #newStartEffector()} */
-    public Effector<Void> newSuspendEffector() {
-        return Effectors.effector(Void.class, "suspend")
-                .description("Suspend the process/service represented by an entity")
-                .parameter(StopSoftwareParameters.STOP_PROCESS_MODE)
-                .parameter(StopSoftwareParameters.STOP_MACHINE_MODE)
-                .impl(newSuspendEffectorTask())
-                .build();
-    }
-
-    /**
-     * Returns the {@link EffectorBody} which supplies the implementation for the start effector.
-     * <p>
-     * Calls {@link #start(Collection)} in this class.
-     */
-    public EffectorBody<Void> newStartEffectorTask() {
-        // TODO included anonymous inner class for backwards compatibility with persisted state.
-        new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                Collection<? extends Location> locations  = null;
-
-                Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
-                locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
-
-                if (locations==null) {
-                    // null/empty will mean to inherit from parent
-                    locations = Collections.emptyList();
-                }
-
-                start(locations);
-                return null;
-            }
-        };
-        return new StartEffectorBody();
-    }
-
-    private class StartEffectorBody extends EffectorBody<Void> {
-        @Override
-        public Void call(ConfigBag parameters) {
-            Collection<? extends Location> locations = null;
-
-            Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
-            locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
-
-            if (locations == null) {
-                // null/empty will mean to inherit from parent
-                locations = Collections.emptyList();
-            }
-
-            start(locations);
-            return null;
-        }
-
-    }
-
-    /**
-     * Calls {@link #restart(ConfigBag)}.
-     *
-     * @see {@link #newStartEffectorTask()}
-     */
-    public EffectorBody<Void> newRestartEffectorTask() {
-        // TODO included anonymous inner class for backwards compatibility with persisted state.
-        new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                restart(parameters);
-                return null;
-            }
-        };
-        return new RestartEffectorBody();
-    }
-
-    private class RestartEffectorBody extends EffectorBody<Void> {
-        @Override
-        public Void call(ConfigBag parameters) {
-            restart(parameters);
-            return null;
-        }
-    }
-
-    /**
-     * Calls {@link #stop(ConfigBag)}.
-     *
-     * @see {@link #newStartEffectorTask()}
-     */
-    public EffectorBody<Void> newStopEffectorTask() {
-        // TODO included anonymous inner class for backwards compatibility with persisted state.
-        new EffectorBody<Void>() {
-            @Override
-            public Void call(ConfigBag parameters) {
-                stop(parameters);
-                return null;
-            }
-        };
-        return new StopEffectorBody();
-    }
-
-    private class StopEffectorBody extends EffectorBody<Void> {
-        @Override
-        public Void call(ConfigBag parameters) {
-            stop(parameters);
-            return null;
-        }
-    }
-
-    /**
-     * Calls {@link #suspend(ConfigBag)}.
-     *
-     * @see {@link #newStartEffectorTask()}
-     */
-    public EffectorBody<Void> newSuspendEffectorTask() {
-        return new SuspendEffectorBody();
-    }
-
-    private class SuspendEffectorBody extends EffectorBody<Void> {
-        @Override
-        public Void call(ConfigBag parameters) {
-            suspend(parameters);
-            return null;
-        }
-    }
-
-    protected EntityInternal entity() {
-        return (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-    }
-
-    protected Location getLocation(@Nullable Collection<? extends Location> locations) {
-        if (locations==null || locations.isEmpty()) locations = entity().getLocations();
-        if (locations.isEmpty()) {
-            MachineProvisioningLocation<?> provisioner = entity().getAttribute(SoftwareProcess.PROVISIONING_LOCATION);
-            if (provisioner!=null) locations = Arrays.<Location>asList(provisioner);
-        }
-        locations = Locations.getLocationsCheckingAncestors(locations, entity());
-
-        Maybe<MachineLocation> ml = Locations.findUniqueMachineLocation(locations);
-        if (ml.isPresent()) return ml.get();
-
-        if (locations.isEmpty())
-            throw new IllegalArgumentException("No locations specified when starting "+entity());
-        if (locations.size() != 1 || Iterables.getOnlyElement(locations)==null)
-            throw new IllegalArgumentException("Ambiguous locations detected when starting "+entity()+": "+locations);
-        return Iterables.getOnlyElement(locations);
-    }
     
     /** runs the tasks needed to start, wrapped by setting {@link Attributes#SERVICE_STATE_EXPECTED} appropriately */ 
     public void start(Collection<? extends Location> locations) {
@@ -555,6 +366,7 @@ public abstract class MachineLifecycleEffectorTasks {
     }
 
     protected Map<String, Object> obtainProvisioningFlags(final MachineProvisioningLocation<?> location) {
+        //Fixme this if could be deleted, any entity implements this
         if (entity() instanceof ProvidesProvisioningFlags) {
             return ((ProvidesProvisioningFlags)entity()).obtainProvisioningFlags(location).getAllConfig();
         }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/EntityPollingTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/EntityPollingTest.java
@@ -22,13 +22,10 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.location.MachineLocation;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.java.UsesJmx;
-import org.apache.brooklyn.entity.java.VanillaJavaAppImpl;
-import org.apache.brooklyn.entity.java.VanillaJavaAppSshDriver;
 import org.apache.brooklyn.entity.java.UsesJmx.JmxAgentModes;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.test.jmx.JmxService;
@@ -98,7 +95,7 @@ public class EntityPollingTest {
         }
 
         @Override
-        public VanillaJavaAppSshDriver newDriver(MachineLocation loc) {
+        public VanillaJavaAppSshDriver newDriver(Location loc) {
             return new VanillaJavaAppSshDriver(this, (SshMachineLocation)loc) {
                 @Override public void install() {
                     // no-op

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/JavaOptsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/JavaOptsTest.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
-import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -150,7 +150,7 @@ public class JavaOptsTest extends BrooklynAppUnitTestSupport {
     }
     
     public static class TestingJavaOptsVanillaJavaAppImpl extends VanillaJavaAppImpl {
-        @Override public VanillaJavaAppSshDriver newDriver(MachineLocation loc) {
+        @Override public VanillaJavaAppSshDriver newDriver(Location loc) {
             return new VanillaJavaAppSshDriver(this, (SshMachineLocation)loc) {
                 @Override protected List<String> getCustomJavaConfigOptions() {
                     return MutableList.<String>builder()

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplierTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/MachineProvisioningLocationFlagsSupplierTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest;
+import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Beta
+public class MachineProvisioningLocationFlagsSupplierTest extends BrooklynAppUnitTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MachineProvisioningLocationFlagsSupplierTest.class);
+
+    private SshMachineLocation machine;
+    private FixedListMachineProvisioningLocation<SshMachineLocation> loc;
+    private MachineProvisioningLocationFlagsSupplier machineFlagsSupplier;
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        loc = getLocation();
+    }
+
+    @SuppressWarnings("unchecked")
+    private FixedListMachineProvisioningLocation<SshMachineLocation> getLocation() {
+        FixedListMachineProvisioningLocation<SshMachineLocation> loc = mgmt.getLocationManager().createLocation(LocationSpec.create(FixedListMachineProvisioningLocation.class));
+        machine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+                .configure("address", "localhost"));
+        loc.addMachine(machine);
+        return loc;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMachineDefaultAttributesGeneration() throws Exception {
+
+        SoftwareProcessEntityTest.MyServiceImpl entity =
+                new SoftwareProcessEntityTest.MyServiceImpl(app);
+        machineFlagsSupplier = new MachineProvisioningLocationFlagsSupplier(entity);
+
+        Map<String, Object> machineFlags = machineFlagsSupplier.obtainFlagsForLocation(loc);
+        assertNotNull(machineFlags);
+        assertEquals(machineFlags.size(), 2);
+        assertTrue(machineFlags.containsKey("inboundPorts"));
+        Set<Integer> inboundPorts = (Set<Integer>) machineFlags.get("inboundPorts");
+        assertEquals(inboundPorts.size(), 2);
+        Integer requiredOpenDefaultLoginPorts =
+                (Integer)SoftwareProcessEntityTest.MyService.REQUIRED_OPEN_LOGIN_PORTS
+                        .getDefaultValue().toArray()[0];
+        assertTrue(inboundPorts.contains(requiredOpenDefaultLoginPorts));
+        assertTrue(inboundPorts.contains(new Integer("8080")));
+    }
+
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/PaasLocationFlagsSupplierTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/behavior/softwareprocess/supplier/PaasLocationFlagsSupplierTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.software.base.behavior.softwareprocess.supplier;
+
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest;
+import org.apache.brooklyn.location.paas.TestPaasLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Beta
+public class PaasLocationFlagsSupplierTest extends BrooklynAppUnitTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MachineProvisioningLocationFlagsSupplierTest.class);
+
+    PaasLocationFlagsSupplier paasLocationFlagsSupplier;
+    TestPaasLocation loc;
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        loc = new TestPaasLocation();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPaasDefaultAttributesGeneration() throws Exception {
+        SoftwareProcessEntityTest.MyServiceImpl entity =
+                new SoftwareProcessEntityTest.MyServiceImpl(app);
+
+        paasLocationFlagsSupplier = new PaasLocationFlagsSupplier(entity);
+
+        Map<String, Object> paasLocationFlags = paasLocationFlagsSupplier.obtainFlagsForLocation(loc);
+        assertNotNull(paasLocationFlags);
+        assertTrue(paasLocationFlags.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Please, note that this PR is extended by [brooklyn-library#8](https://github.com/apache/brooklyn-library/pull/8).

For adding PaaS support, a `CloudFoundryLocation` is added which is based on `PaasLocation`.
This new location contains a API client for CloudFoundry Paas Services, (CloudFoundry Java Client), that allows to use the services of this provider.

Extracting ssh behaviour from `SoftwareProcessImpl`: provisioning flags
For adding paas support, `SoftwareProcess` entities should to be agnostics in order to allows to be deployed on SSH and PaaS locations. So, the machine behaviour and management should be decoupled of the entities and it should be moved to an isolate class.

`SoftwareProcessImpl` contained a pair of method for obtaining the needed flags to create and configure a VM. However as it was mentioned previously, this entity shouldn't contain any ssh (machine) behaviour. Then, this code is moved to an external class,  `MachineProvisioningLocationFlagsSupplier` that is managed in `SoftwareProcessImpl` as a `LocationFlagSupplier` interface. Moreover, an equivalent class is added to represent this behaviour (obtain flags location) for PaaS. `FlagsSuppliers` are used to separate some entity's logic to an external class but this object could be avoided and its logic could be moved to `MachineLifecycleEffectorTasks` or `PaasLifecycleEffectorTasks` .

`SoftwareProcessImpl` will select a behaviour for obtaining the flags depending on the selected location for deploying the entity.
Adding `BehaviourFactory` for selecting PaaS or SSH behaviour in run time.

Following the previous commits, `SoftwareProcessImpl` entities should select PaaS or SSH behaviour in run time, depending on the target location. An entity know the target location when it is started (calling to start effector), then just when this effector is called the entity will able to know the selected location, so in this moment the entity will able to find the required behaviour, SSH or PaaS.
The whole behaviour is composed by several classes, then `SoftwareProcessImpl` uses a factory (BehaviourFactory) which is selected according to the target location. This factory allows to select in run time all behavior focus in a location.

A new hierarchy of drivers is added to Brooklyn, these new drivers is oriented to PaaS but they follow the hierarchy defined for SSH. For example, `AbstractSoftwareProcessDriver`, `AbstractSoftwareProcessSshDriver` allow to `SoftwareProcess` entities use drivers for location based on  machines. Then, to enable the PaaS support for `SoftwareProcess` entities a set of drivers is added such as `AbstractSoftwareProcessCloudFoundryDriver` and `AbstractApplicationCloudFoundryDriver`.
Fixing dependency convergence.
