### PR TITLE
[OSGi] JAAS LoginModule delegating to Brooklyn's SecurityProviders 

### DIFF
--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -30,6 +30,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <includedTestGroups />
+        <excludedTestGroups>org.apache.brooklyn.test.IntegrationTest</excludedTestGroups>
+    </properties>
+
     <dependencies>
         <!-- Pax Exam Dependencies -->
         <dependency>
@@ -155,6 +160,15 @@
 
         <!-- project deps -->
         <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>brooklyn-features</artifactId>
+          <version>${project.version}</version>
+          <type>xml</type>
+          <classifier>features</classifier>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apache-brooklyn</artifactId>
             <version>${project.version}</version>
@@ -171,6 +185,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>brooklyn-rest-resources</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-rest-resources</artifactId>
+            <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -180,6 +200,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.tinybundles</groupId>
+            <artifactId>tinybundles</artifactId>
+            <version>${tinybundles.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -187,7 +214,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -211,12 +237,23 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                   <systemPropertyVariables>
-                       <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}</org.ops4j.pax.url.mvn.localRepository>
-                   </systemPropertyVariables>
+                    <groups>${includedTestGroups}</groups>
+                    <excludedGroups>${excludedTestGroups}</excludedGroups>
+                    <systemPropertyVariables>
+                        <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}</org.ops4j.pax.url.mvn.localRepository>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>Integration</id>
+            <properties>
+              <includedTestGroups>org.apache.brooklyn.test.IntegrationTest</includedTestGroups>
+              <excludedTestGroups />
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -18,20 +18,9 @@
  */
 package org.apache.brooklyn;
 
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 import javax.inject.Inject;
 
@@ -42,9 +31,6 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
-import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
-import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.util.Filter;
@@ -52,6 +38,8 @@ import org.osgi.framework.BundleContext;
 
 /**
  * Tests the apache-brooklyn karaf runtime assembly.
+ * 
+ * Keeping it a non-integration test so we have at least a basic OSGi sanity check. (takes 14 sec)
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -73,43 +61,10 @@ public class AssemblyTest {
 
     @Configuration
     public static Option[] configuration() throws Exception {
-        return new Option[]{
-            karafDistributionConfiguration()
-            .frameworkUrl(brooklynKarafDist())
-            .unpackDirectory(new File("target/paxexam/unpack/"))
-            .useDeployFolder(false),
-            configureConsole().ignoreLocalConsole(),
-            logLevel(LogLevel.INFO),
-            keepRuntimeFolder(),
-            features(karafStandardFeaturesRepository(), "eventadmin"),
-            junitBundles()
-        };
-    }
-
-    public static MavenArtifactUrlReference brooklynKarafDist() {
-        return maven()
-                .groupId("org.apache.brooklyn")
-                .artifactId("apache-brooklyn")
-                .type("zip")
-                .versionAsInProject();
-    }
-
-    public static MavenUrlReference karafStandardFeaturesRepository() {
-        return maven()
-                .groupId("org.apache.karaf.features")
-                .artifactId("standard")
-                .type("xml")
-                .classifier("features")
-                .versionAsInProject();
-    }
-
-    public static MavenUrlReference brooklynFeaturesRepository() {
-        return maven()
-                .groupId("org.apache.brooklyn")
-                .artifactId("brooklyn-features")
-                .type("xml")
-                .classifier("features")
-                .versionAsInProject();
+        return defaultOptionsWith(
+            // Uncomment this for remote debugging the tests on port 5005
+            // KarafDistributionOption.debugConfiguration()
+        );
     }
 
     @Test

--- a/karaf/itest/src/test/java/org/apache/brooklyn/KarafTestUtils.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/KarafTestUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn;
+
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+
+import java.io.File;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+
+import com.google.common.collect.ObjectArrays;
+
+public class KarafTestUtils {
+    public static final Option[] DEFAULT_OPTIONS = {
+        karafDistributionConfiguration()
+            .frameworkUrl(brooklynKarafDist())
+            .unpackDirectory(new File("target/paxexam/unpack/"))
+            .useDeployFolder(false),
+        configureConsole().ignoreLocalConsole(),
+        logLevel(LogLevel.INFO),
+        features(karafStandardFeaturesRepository(), "eventadmin"),
+        junitBundles()
+    };
+
+    public static MavenUrlReference karafStandardFeaturesRepository() {
+        return maven()
+                .groupId("org.apache.karaf.features")
+                .artifactId("standard")
+                .type("xml")
+                .classifier("features")
+                .version(asInProject());
+    }
+
+
+    public static MavenArtifactUrlReference brooklynKarafDist() {
+        return maven()
+                .groupId("org.apache.brooklyn")
+                .artifactId("apache-brooklyn")
+                .type("zip")
+                .version(asInProject());
+    }
+
+    public static Option[] defaultOptionsWith(Option... options) {
+        return ObjectArrays.concat(DEFAULT_OPTIONS, options, Option.class);
+    }
+
+    public static MavenUrlReference brooklynFeaturesRepository() {
+        return maven()
+                .groupId("org.apache.brooklyn")
+                .artifactId("brooklyn-features")
+                .type("xml")
+                .classifier("features")
+                .versionAsInProject();
+    }
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.brooklyn.rest;
 
-import java.io.File;
-import java.util.concurrent.Callable;
-import org.apache.brooklyn.AssemblyTest;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.KarafTestUtils;
+import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
@@ -31,15 +34,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
@@ -53,22 +49,12 @@ public class BrooklynRestApiLauncherTest {
 
     @Configuration
     public static Option[] configuration() throws Exception {
-        return new Option[]{
-            karafDistributionConfiguration()
-            .frameworkUrl(AssemblyTest.brooklynKarafDist())
-            .unpackDirectory(new File("target/paxexam/unpack/"))
-            .useDeployFolder(false),
+        return defaultOptionsWith(
             editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", HTTP_PORT),
-            configureConsole().ignoreLocalConsole(),
-            logLevel(LogLevelOption.LogLevel.INFO),
-//            features(AssemblyTest.karafStandardFeaturesRepository(), "eventadmin"),
-            features(AssemblyTest.brooklynFeaturesRepository(), "brooklyn-software-base"),
-            junitBundles()
-
-            // for debugging
-//            , keepRuntimeFolder()
-//            , debugConfiguration()
-        };
+            features(KarafTestUtils.brooklynFeaturesRepository(), "brooklyn-software-base")
+            // Uncomment this for remote debugging the tests on port 5005
+            // ,KarafDistributionOption.debugConfiguration()
+        );
     }
 
     @Test

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProvider.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.brooklyn.rest.security.provider.AbstractSecurityProvider;
+import org.apache.brooklyn.rest.security.provider.SecurityProvider;
+
+public class CustomSecurityProvider extends AbstractSecurityProvider implements SecurityProvider {
+
+    @Override
+    public boolean authenticate(HttpSession session, String user, String password) {
+        return "custom".equals(user);
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.IntegrationTest;
+import org.apache.karaf.features.BootFinished;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.tinybundles.core.TinyBundles;
+import org.osgi.framework.Constants;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IntegrationTest.class)
+public class CustomSecurityProviderTest {
+    private static final String WEBCONSOLE_REALM = "webconsole";
+
+    /**
+     * To make sure the tests run only when the boot features are fully
+     * installed
+     */
+    @Inject
+    BootFinished bootFinished;
+    
+    @Inject
+    ManagementContext managementContext;
+
+    @Configuration
+    public static Option[] configuration() throws Exception {
+        return defaultOptionsWith(
+            streamBundle(TinyBundles.bundle()
+                .add(CustomSecurityProvider.class)
+                .add("OSGI-INF/blueprint/security.xml", CustomSecurityProviderTest.class.getResource("/custom-security-bp.xml"))
+                .set(Constants.BUNDLE_MANIFESTVERSION, "2") // defaults to 1 which doesn't work
+                .set(Constants.BUNDLE_SYMBOLICNAME, "org.apache.brooklyn.test.security")
+                .set(Constants.BUNDLE_VERSION, "1.0.0")
+                .set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+                .set(Constants.EXPORT_PACKAGE, CustomSecurityProvider.class.getPackage().getName())
+                .build())
+            // Uncomment this for remote debugging the tests on port 5005
+            // ,KarafDistributionOption.debugConfiguration()
+        );
+    }
+
+    @Before
+    public void setUp() {
+        // Works only before initializing the security provider (i.e. before first use)
+        // TODO Dirty hack to inject the needed properties. Improve once managementContext is configurable.
+        // Alternatively re-register a test managementContext service (how?)
+        BrooklynProperties brooklynProperties = (BrooklynProperties)managementContext.getConfig();
+        brooklynProperties.put(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName(), CustomSecurityProvider.class.getCanonicalName());
+    }
+
+    @Test(expected = FailedLoginException.class)
+    public void checkLoginFails() throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        doLogin("invalid", "auth");
+    }
+
+    @Test
+    public void checkLoginSucceeds() throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = doLogin("custom", "password");
+        assertNotNull(lc.getSubject());
+    }
+
+    private LoginContext doLogin(final String username, final String password) throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (int i = 0; i < callbacks.length; i++) {
+                    Callback callback = callbacks[i];
+                    if (callback instanceof PasswordCallback) {
+                        PasswordCallback passwordCallback = (PasswordCallback)callback;
+                        passwordCallback.setPassword(password.toCharArray());
+                    } else if (callback instanceof NameCallback) {
+                        NameCallback nameCallback = (NameCallback)callback;
+                        nameCallback.setName(username);
+                    }
+                }
+            }
+        });
+        lc.login();
+        return lc;
+    }
+
+    private void assertRealmRegisteredEventually(final String userPassRealm) {
+        // Need to wait a bit for the realm to get registered, any OSGi way to do this?
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                javax.security.auth.login.Configuration initialConfig = javax.security.auth.login.Configuration.getConfiguration();
+                AppConfigurationEntry[] realm = initialConfig.getAppConfigurationEntry(userPassRealm);
+                assertNotNull(realm);
+            }
+        });
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import javax.inject.Inject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.provider.ExplicitUsersSecurityProvider;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.IntegrationTest;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.karaf.features.BootFinished;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IntegrationTest.class)
+public class StockSecurityProviderTest {
+
+    private static final String WEBCONSOLE_REALM = "webconsole";
+    private static final String USER = "admin";
+    private static final String PASSWORD = "password";
+
+    /**
+     * To make sure the tests run only when the boot features are fully
+     * installed
+     */
+    @Inject
+    BootFinished bootFinished;
+    
+    @Inject
+    ManagementContext managementContext;
+
+    @Configuration
+    public static Option[] configuration() throws Exception {
+        return defaultOptionsWith(
+            // Uncomment this for remote debugging the tests on port 5005
+            // KarafDistributionOption.debugConfiguration()
+        );
+    }
+
+    @Before
+    public void setUp() {
+        //Works only before initializing the security provider (i.e. before first use)
+        addUser(USER, PASSWORD);
+    }
+
+    @Test(expected = FailedLoginException.class)
+    public void checkLoginFails() throws LoginException {
+        doLogin("invalid", "auth");
+    }
+
+    @Test
+    public void checkLoginSucceeds() throws LoginException {
+        LoginContext lc = doLogin(USER, PASSWORD);
+        assertNotNull(lc.getSubject());
+    }
+
+    @Test
+    public void checkRestSecurityFails() throws IOException {
+        checkRestSecurity(null, null, HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void checkRestSecuritySucceeds() throws IOException {
+        checkRestSecurity(USER, PASSWORD, HttpStatus.SC_OK);
+    }
+
+    private void checkRestSecurity(String username, String password, final int code) throws IOException {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        if (username != null && password != null) {
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+        }
+        try(CloseableHttpClient client =
+            HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build()) {
+            Asserts.succeedsEventually(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    assertResponseEquals(client, code);
+                    return null;
+                }
+            });
+        }
+    }
+
+    private void assertResponseEquals(CloseableHttpClient httpclient, int code) throws IOException, ClientProtocolException {
+        // TODO get this dynamically (from CXF service?)
+        // TODO port is static, should make it dynamic
+        HttpGet httpGet = new HttpGet("http://localhost:8181/v1/server/ha/state");
+        try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+            assertEquals(code, response.getStatusLine().getStatusCode());
+        }
+    }
+    
+
+    private void addUser(String username, String password) {
+        // TODO Dirty hack to inject the needed properties. Improve once managementContext is configurable.
+        // Alternatively re-register a test managementContext service (how?)
+        BrooklynProperties brooklynProperties = (BrooklynProperties)managementContext.getConfig();
+        brooklynProperties.put(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName(), ExplicitUsersSecurityProvider.class.getCanonicalName());
+        brooklynProperties.put(BrooklynWebConfig.USERS.getName(), username);
+        brooklynProperties.put(BrooklynWebConfig.PASSWORD_FOR_USER(username), password);
+    }
+
+    private LoginContext doLogin(final String username, final String password) throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (int i = 0; i < callbacks.length; i++) {
+                    Callback callback = callbacks[i];
+                    if (callback instanceof PasswordCallback) {
+                        PasswordCallback passwordCallback = (PasswordCallback)callback;
+                        passwordCallback.setPassword(password.toCharArray());
+                    } else if (callback instanceof NameCallback) {
+                        NameCallback nameCallback = (NameCallback)callback;
+                        nameCallback.setName(username);
+                    }
+                }
+            }
+        });
+        lc.login();
+        return lc;
+    }
+
+    private void assertRealmRegisteredEventually(final String userPassRealm) {
+        // Need to wait a bit for the realm to get registered, any OSGi way to do this?
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                javax.security.auth.login.Configuration initialConfig = javax.security.auth.login.Configuration.getConfiguration();
+                AppConfigurationEntry[] realm = initialConfig.getAppConfigurationEntry(userPassRealm);
+                assertNotNull(realm);
+            }
+        });
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/test/IntegrationTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/test/IntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test;
+
+/**
+ * Used by junit for grouping tests
+ */
+public class IntegrationTest {
+
+}

--- a/karaf/itest/src/test/resources/custom-security-bp.xml
+++ b/karaf/itest/src/test/resources/custom-security-bp.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2015 The Apache Software Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+           xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xmlns:cxf="http://cxf.apache.org/blueprint/core"
+           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
+             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0
+             ">
+
+    <jaas:config name="webconsole" rank="1">
+        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+                     flags="required">
+            brooklyn.webconsole.security.provider.symbolicName=org.apache.brooklyn.test.security
+            brooklyn.webconsole.security.provider.version=1.0.0
+        </jaas:module>
+    </jaas:config>
+</blueprint>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -40,9 +40,10 @@
     <lifecycle-mapping-plugin.version>1.0.0</lifecycle-mapping-plugin.version>
 
     <!-- pax-exam -->
-    <pax.exam.version>4.6.0</pax.exam.version>
+    <pax.exam.version>4.7.0</pax.exam.version>
     <pax.url.version>2.4.3</pax.url.version>
     <ops4j.base.version>1.5.0</ops4j.base.version>
+    <tinybundles.version>1.0.0</tinybundles.version>
 
     <!-- feature repositories -->
     <servicemix.version>6.0.0</servicemix.version>
@@ -142,6 +143,22 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+                <excludes combine.children="append">
+                    <!-- Exclude sandbox because not part of distribution: not in tgz, and not uploaded to maven-central -->
+                    <exclude>sandbox/**</exclude>
+                    <!-- Exclude release because not part of distribution: not in tgz, and not uploaded to maven-central -->
+                    <exclude>release/**</exclude>
+                    <exclude>README.md</exclude>
+                    <!-- Exclude netbeans config files (not part of the project, but often on users' drives -->
+                    <exclude>**/nbactions.xml</exclude>
+                    <exclude>**/nb-configuration.xml</exclude>
+                </excludes>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -205,5 +205,19 @@
                 <directory>${basedir}/src/main/webapp</directory>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            org.apache.karaf.jaas.config,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import javax.servlet.http.HttpSession;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.StringConfigMap;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.provider.DelegatingSecurityProvider;
+import org.apache.brooklyn.rest.security.provider.SecurityProvider;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// http://docs.oracle.com/javase/7/docs/technotes/guides/security/jaas/JAASLMDevGuide.html
+
+/**
+ * <p>
+ * JAAS module delegating authentication to the {@link SecurityProvider} implementation 
+ * configured in {@literal brooklyn.properties}, key {@literal brooklyn.webconsole.security.provider}.
+ * 
+ * <p>
+ * If used in an OSGi environment only implementations visible from {@literal brooklyn-rest-server} are usable by default.
+ * To use a custom security provider add the following configuration to the its bundle in {@literal src/main/resources/OSGI-INF/bundle/security-provider.xml}:
+ * 
+ * <pre>
+ * {@code
+ *<?xml version="1.0" encoding="UTF-8"?>
+ *<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+ *           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.1.0"
+ *           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0">
+ *
+ *    <jaas:config name="karaf" rank="1">
+ *        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+ *                     flags="required">
+ *            brooklyn.webconsole.security.provider.symbolicName=BUNDLE_SYMBOLIC_NAME
+ *            brooklyn.webconsole.security.provider.version=BUNDLE_VERSION
+ *        </jaas:module>
+ *    </jaas:config>
+ *
+ *</blueprint>
+ *}
+ * </pre>
+ */
+// Needs an explicit "org.apache.karaf.jaas.config" Import-Package in the manifest!
+public class BrooklynLoginModule implements LoginModule {
+    private static final Logger log = LoggerFactory.getLogger(BrooklynLoginModule.class);
+
+    private static class BrooklynPrincipal implements Principal {
+        private String name;
+        public BrooklynPrincipal(String name) {
+            this.name = checkNotNull(name, "name");
+        }
+        @Override
+        public String getName() {
+            return name;
+        }
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof BrooklynPrincipal) {
+                return name.equals(((BrooklynPrincipal)obj).name);
+            }
+            return false;
+        }
+        @Override
+        public String toString() {
+            return "BrooklynPrincipal[" +name + "]";
+        }
+    }
+    private static final Principal DEFAULT_PRINCIPAL = new BrooklynPrincipal("brooklyn");
+    public static final String PROPERTY_BUNDLE_SYMBOLIC_NAME = BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName() + ".symbolicName";
+    public static final String PROPERTY_BUNDLE_VERSION = BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName() + ".version";
+
+    private Map<String, ?> options;
+    private BundleContext bundleContext;
+
+    private static DelegatingSecurityProvider defaultProvider;
+    private HttpSession providerSession;
+
+    private SecurityProvider provider;
+    private Subject subject;
+    private CallbackHandler callbackHandler;
+    private boolean loginSuccess;
+    private boolean commitSuccess;
+
+    public BrooklynLoginModule() {
+    }
+
+    private SecurityProvider getDefaultProvider() {
+        if (defaultProvider == null) {
+            createDefaultSecurityProvider(getManagementContext());
+        }
+        return defaultProvider;
+    }
+
+    private synchronized static SecurityProvider createDefaultSecurityProvider(ManagementContext mgmt) {
+        if (defaultProvider == null) {
+            defaultProvider = new DelegatingSecurityProvider(mgmt);
+        }
+        return defaultProvider;
+    }
+
+    private ManagementContext getManagementContext() {
+        return ManagementContextHolder.getManagementContext();
+    }
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+        this.options = options;
+
+        this.bundleContext = (BundleContext) options.get(BundleContext.class.getName());
+
+        loginSuccess = false;
+        commitSuccess = false;
+
+        initProvider();
+    }
+
+    private void initProvider() {
+        StringConfigMap brooklynProperties = getManagementContext().getConfig();
+        provider = brooklynProperties.getConfig(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE);
+        String symbolicName = (String) options.get(PROPERTY_BUNDLE_SYMBOLIC_NAME);
+        String version = (String) options.get(PROPERTY_BUNDLE_VERSION);
+        String className = (String) options.get(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName());
+        if (className != null && symbolicName == null) {
+            throw new IllegalStateException("Missing JAAS module property " + PROPERTY_BUNDLE_SYMBOLIC_NAME + " pointing at the bundle where to load the security provider from.");
+        }
+        if (provider != null) return;
+        if (symbolicName != null) {
+            if (className == null) {
+                className = brooklynProperties.getConfig(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME);
+            }
+            if (className != null) {
+                try {
+                    Collection<Bundle> bundles = getMatchingBundles(symbolicName, version);
+                    if (bundles.isEmpty()) {
+                        throw new IllegalStateException("No bundle " + symbolicName + ":" + version + " found");
+                    } else if (bundles.size() > 1) {
+                        log.warn("Found multiple bundles matching symbolicName " + symbolicName + " and version " + version + 
+                                " while trying to load security provider " + className + ". Will use first one that loads the class successfully.");
+                    }
+                    provider = tryLoadClass(className, bundles);
+                    if (provider == null) {
+                        throw new ClassNotFoundException("Unable to load class " + className + " from bundle " + symbolicName + ":" + version);
+                    }
+                } catch (Exception e) {
+                    Exceptions.propagateIfFatal(e);
+                    throw new IllegalStateException("Can not load or create security provider " + className + " for bundle " + symbolicName + ":" + version, e);
+                }
+            }
+        } else {
+            log.debug("Delegating security provider loading to Brooklyn.");
+            provider = getDefaultProvider();
+        }
+
+        log.debug("Using security provider " + provider);
+    }
+
+    private SecurityProvider tryLoadClass(String className, Collection<Bundle> bundles)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        for (Bundle b : bundles) {
+            try {
+                @SuppressWarnings("unchecked")
+                Class<? extends SecurityProvider> securityProviderType = (Class<? extends SecurityProvider>) b.loadClass(className);
+                return DelegatingSecurityProvider.createSecurityProviderInstance(getManagementContext(), securityProviderType);
+            } catch (ClassNotFoundException e) {
+            }
+        }
+        return null;
+    }
+
+    private Collection<Bundle> getMatchingBundles(final String symbolicName, final String version) {
+        Collection<Bundle> bundles = new ArrayList<>();
+        for (Bundle b : bundleContext.getBundles()) {
+            if (b.getSymbolicName().equals(symbolicName) &&
+                    (version == null || b.getVersion().toString().equals(version))) {
+                bundles.add(b);
+            }
+        }
+        return bundles;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        if (callbackHandler == null) {
+            loginSuccess = false;
+            throw new FailedLoginException("Username and password not available");
+        }
+
+        NameCallback cbName = new NameCallback("Username: ");
+        PasswordCallback cbPassword = new PasswordCallback("Password: ", false);
+
+        Callback[] callbacks = {cbName, cbPassword};
+
+        try {
+            callbackHandler.handle(callbacks);
+        } catch (IOException ioe) {
+            throw new LoginException(ioe.getMessage());
+        } catch (UnsupportedCallbackException uce) {
+            throw new LoginException(uce.getMessage() + " not available to obtain information from user");
+        }
+        String user = cbName.getName();
+        String password = new String(cbPassword.getPassword());
+
+        providerSession = new SecurityProviderHttpSession();
+        if (!provider.authenticate(providerSession, user, password)) {
+            loginSuccess = false;
+            throw new FailedLoginException("Incorrect username or password");
+        }
+
+        loginSuccess = true;
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        if (loginSuccess) {
+            if (subject.isReadOnly()) {
+                throw new LoginException("Can't commit read-only subject");
+            }
+            subject.getPrincipals().add(DEFAULT_PRINCIPAL);
+        }
+
+        commitSuccess = true;
+        return loginSuccess;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        if (loginSuccess && commitSuccess) {
+            removePrincipal();
+        }
+        return loginSuccess;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        removePrincipal();
+
+        subject = null;
+        callbackHandler = null;
+
+        return true;
+    }
+
+    private void removePrincipal() throws LoginException {
+        if (subject.isReadOnly()) {
+            throw new LoginException("Read-only subject");
+        }
+        subject.getPrincipals().remove(DEFAULT_PRINCIPAL);
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/ManagementContextHolder.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/ManagementContextHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+
+public class ManagementContextHolder {
+    private static ManagementContext mgmt;
+    public static ManagementContext getManagementContext() {
+        return checkNotNull(mgmt, "Management context not set yet");
+    }
+    public void setManagementContext(ManagementContext mgmt) {
+        setManagementContextStatic(mgmt);
+    }
+    public static void setManagementContextStatic(ManagementContext mgmt) {
+        ManagementContextHolder.mgmt = checkNotNull(mgmt, "mgmt");
+    }
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import java.util.Enumeration;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+
+public class SecurityProviderHttpSession implements HttpSession {
+
+    @Override
+    public long getCreationTime() {
+        return 0;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public void setMaxInactiveInterval(int interval) {
+    }
+
+    @Override
+    public int getMaxInactiveInterval() {
+        return 0;
+    }
+
+    @Override
+    public HttpSessionContext getSessionContext() {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Object getValue(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getValueNames() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+    }
+
+    @Override
+    public void putValue(String name, Object value) {
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+    }
+
+    @Override
+    public void removeValue(String name) {
+    }
+
+    @Override
+    public void invalidate() {
+    }
+
+    @Override
+    public boolean isNew() {
+        return false;
+    }
+
+}

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -20,11 +20,13 @@ limitations under the License.
            xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns:cxf="http://cxf.apache.org/blueprint/core"
+           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
            xsi:schemaLocation="
              http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
              http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
              http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
              http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0
              ">
 
     <cxf:bus>
@@ -37,6 +39,15 @@ limitations under the License.
                interface="org.apache.brooklyn.api.mgmt.ManagementContext" />
     <reference id="localManagementContextInternal"
                interface="org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal" />
+
+    <jaas:config name="webconsole">
+        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+                     flags="required" />
+    </jaas:config>
+
+    <bean class="org.apache.brooklyn.rest.security.jaas.ManagementContextHolder">
+        <property name="managementContext" ref="localManagementContext" />
+    </bean>
 
     <bean id="accessResourceBean" class="org.apache.brooklyn.rest.resources.AccessResource">
         <property name="managementContext" ref="localManagementContext" />
@@ -124,6 +135,10 @@ limitations under the License.
             <bean class="org.apache.brooklyn.rest.util.DefaultExceptionMapper"/>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
             <bean class="org.apache.brooklyn.rest.util.FormMapProvider"/>
+            <bean class="org.apache.cxf.jaxrs.security.JAASAuthenticationFilter">
+                <property name="contextName" value="webconsole"/>
+            </bean>
         </jaxrs:providers>
+
     </jaxrs:server>
 </blueprint>

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModuleTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModuleTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+// http://docs.oracle.com/javase/7/docs/technotes/guides/security/jaas/JAASLMDevGuide.html
+public class BrooklynLoginModuleTest extends BrooklynMgmtUnitTestSupport {
+    private static final String ACCEPTED_USER = "user";
+    private static final String ACCEPTED_PASSWORD = "password";
+    private CallbackHandler GOOD_CB_HANDLER = new TestCallbackHandler(
+            ACCEPTED_USER,
+            ACCEPTED_PASSWORD);
+    private CallbackHandler BAD_CB_HANDLER = new TestCallbackHandler(
+            ACCEPTED_USER + ".invalid",
+            ACCEPTED_PASSWORD + ".invalid");
+
+    private Subject subject;
+    private Map<String, ?> sharedState;
+    private Map<String, ?> options;
+
+    private BrooklynLoginModule module;
+
+    @Override
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() throws Exception {
+        BrooklynProperties properties = BrooklynProperties.Factory.newEmpty();
+        properties.addFrom(ImmutableMap.of(
+                BrooklynWebConfig.USERS, ACCEPTED_USER,
+                BrooklynWebConfig.PASSWORD_FOR_USER("user"), ACCEPTED_PASSWORD));
+        mgmt = LocalManagementContextForTests.builder(true).useProperties(properties).build();
+        ManagementContextHolder.setManagementContextStatic(mgmt);
+
+        super.setUp();
+
+        subject = new Subject();
+        sharedState = MutableMap.of();
+        options = ImmutableMap.of();
+
+        module = new BrooklynLoginModule();
+    }
+
+    @Test
+    public void testMissingCallback() throws LoginException {
+        module.initialize(subject, null, sharedState, options);
+        try {
+            module.login();
+            fail("Login is supposed to fail due to missing callback");
+        } catch (FailedLoginException e) {
+            // Expected, ignore
+        }
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginCommitAbort() throws LoginException {
+        badLogin();
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginCommitAbortReadOnly() throws LoginException {
+        subject.setReadOnly();
+        badLogin();
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginAbort() throws LoginException {
+        badLogin();
+        assertFalse(module.abort(), "abort");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitLogout() throws LoginException {
+        goodLogin();
+        assertTrue(module.commit(), "commit");
+        assertBrooklynPrincipal();
+        assertTrue(module.logout(), "logout");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitAbort() throws LoginException {
+        goodLogin();
+        assertTrue(module.commit(), "commit");
+        assertBrooklynPrincipal();
+        assertTrue(module.abort(), "logout");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitAbortReadOnly() throws LoginException {
+        subject.setReadOnly();
+        goodLogin();
+        try {
+            module.commit();
+            fail("Commit expected to throw");
+        } catch (LoginException e) {
+            // Expected
+        }
+        assertTrue(module.abort());
+    }
+
+    @Test
+    public void testSuccessfulLoginAbort() throws LoginException {
+        goodLogin();
+        assertTrue(module.abort(), "abort");
+        assertEmptyPrincipals();
+    }
+
+    private void goodLogin() throws LoginException {
+        module.initialize(subject, GOOD_CB_HANDLER, sharedState, options);
+        assertTrue(module.login(), "login");
+        assertEmptyPrincipals();
+    }
+
+    private void badLogin() throws LoginException {
+        module.initialize(subject, BAD_CB_HANDLER, sharedState, options);
+        try {
+            module.login();
+            fail("Login is supposed to fail due to invalid username+password pair");
+        } catch (FailedLoginException e) {
+            // Expected, ignore
+        }
+    }
+
+    private void assertBrooklynPrincipal() {
+        Principal principal = Iterables.getOnlyElement(subject.getPrincipals());
+        assertEquals(principal.getName(), "brooklyn");
+    }
+
+    private void assertEmptyPrincipals() {
+        assertEquals(subject.getPrincipals().size(), 0);
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/TestCallbackHandler.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/TestCallbackHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+public class TestCallbackHandler implements CallbackHandler {
+    private String username;
+    private String password;
+
+    public TestCallbackHandler(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks)
+            throws IOException, UnsupportedCallbackException {
+        for (Callback cb : callbacks) {
+            if (cb instanceof NameCallback) {
+                ((NameCallback)cb).setName(username);
+            } else if (cb instanceof PasswordCallback) {
+                ((PasswordCallback)cb).setPassword(password.toCharArray());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Depends on #15.

An implementation of a JAAS LoginModule, delegating to the SecurityProvider configured in brooklyn.properties. Used as the authentication mechanism for the REST API when running in Karaf.
Currently configured as a separate realm, used only for web.
