### PR TITLE
Pick up root wars when passed to BrooklynLauncher

### DIFF
--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -287,7 +287,7 @@ public class BrooklynWebServer {
     /** specifies a WAR to use at a given context path (only if server not yet started);
      * cf deploy(path, url) */
     public BrooklynWebServer addWar(String path, String warUrl) {
-        contextProviders.put(path, new WebAppContextProvider(path, warUrl));
+        addWar(new WebAppContextProvider(path, warUrl));
         return this;
     }
 
@@ -394,7 +394,7 @@ public class BrooklynWebServer {
             allWars.put(entry.getKey(), new WebAppContextProvider(entry.getKey(), entry.getValue()));
         }
 
-        WebAppContextProvider rootWar = allWars.remove("/");
+        WebAppContextProvider rootWar = allWars.remove(""); // leading slash stripped by WebAppContextProvider
         if (rootWar==null) rootWar = new WebAppContextProvider("/", war);
         
         for (WebAppContextProvider contextProvider : allWars.values()) {


### PR DESCRIPTION
wars passed to BrooklynLauncher get their context path stripped of the leading "/", resulting in empty string for root apps. The web server expects a "/" context path for a root war so it uses the default war instead.

/cc @sjcorbett 