### PR TITLE
Added start latch to BasicStartable and StartableApplication

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
@@ -294,9 +294,8 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 3, "Wrong number of params: "+params); // sample + defaultDisplayName + destroy_on_stop
-        assertEquals(ImmutableSet.copyOf(params), 
-            ImmutableSet.copyOf(BasicSpecParameter.fromClass(mgmt(), ConfigAppForTest.class)));
+        assertEquals(params.size(), 4, "Wrong number of params: "+params); // sample + defaultDisplayName + destroy_on_stop + start.latch
+        assertEquals(ImmutableSet.copyOf(params), ImmutableSet.copyOf(BasicSpecParameter.fromClass(mgmt(), ConfigAppForTest.class)));
     }
 
     @Test

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
@@ -149,6 +149,15 @@ public class ConfigKeys {
         return new BasicConfigKeyOverwriting<T>(parent, newDescription, defaultValue);
     }
 
+
+    public static <T> AttributeSensorAndConfigKey<T, T> newSensorAndConfigKeyWithDefault(AttributeSensorAndConfigKey<T, T> parent, T defaultValue) {
+        return new BasicAttributeSensorAndConfigKey(parent, defaultValue);
+    }
+
+    public static PortAttributeSensorAndConfigKey newPortSensorAndConfigKeyWithDefault(PortAttributeSensorAndConfigKey parent, Object defaultValue) {
+        return new PortAttributeSensorAndConfigKey(parent, defaultValue);
+    }
+
     public static <T> ConfigKey<T> newConfigKeyRenamed(String newName, ConfigKey<T> key) {
         return new BasicConfigKey<T>(key.getTypeToken(), newName, key.getDescription(), key.getDefaultValue());
     }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/StartableApplication.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/StartableApplication.java
@@ -22,11 +22,15 @@ import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 public interface StartableApplication extends Application, Startable {
     
     ConfigKey<Boolean> DESTROY_ON_STOP = ConfigKeys.newBooleanConfigKey("application.stop.shouldDestroy",
         "Whether the app should be removed from management after a successful stop (if it is a root); "
         + "true by default.", true);
-    
+
+    @SetFromFlag("startLatch")
+    ConfigKey<Boolean> START_LATCH = BrooklynConfigKeys.START_LATCH;
+
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicApplicationImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicApplicationImpl.java
@@ -20,10 +20,8 @@ package org.apache.brooklyn.entity.stock;
 
 import org.apache.brooklyn.core.entity.AbstractApplication;
 
-
-
 public class BasicApplicationImpl extends AbstractApplication implements BasicApplication {
-    
+
     @Override
     public void init() {
         super.init();

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicEntityImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicEntityImpl.java
@@ -20,11 +20,8 @@ package org.apache.brooklyn.entity.stock;
 
 import org.apache.brooklyn.core.entity.AbstractEntity;
 
-
-
-
 public class BasicEntityImpl extends AbstractEntity implements BasicEntity {
-    
-    public BasicEntityImpl() {
-    }
+
+    public BasicEntityImpl() { }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
@@ -20,21 +20,29 @@ package org.apache.brooklyn.entity.stock;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.Locations;
-
-import com.google.common.collect.ImmutableList;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
  * Provides a pass-through Startable entity used for keeping hierarchies tidy. 
  */
 @ImplementedBy(BasicStartableImpl.class)
 public interface BasicStartable extends Entity, Startable {
+
+    @SetFromFlag("startLatch")
+    ConfigKey<Boolean> START_LATCH = BrooklynConfigKeys.START_LATCH;
+
+    ConfigKey<Locations.LocationsFilter> LOCATIONS_FILTER = ConfigKeys.newConfigKey(Locations.LocationsFilter.class,
+            "brooklyn.locationsFilter", "Provides a hook for customizing locations to be used for a given context");
 
     /** @deprecated since 0.7.0; use {@link Locations#LocationFilter} */
     @Deprecated
@@ -51,6 +59,4 @@ public interface BasicStartable extends Entity, Startable {
         };
     }
 
-    public static final ConfigKey<Locations.LocationsFilter> LOCATIONS_FILTER = ConfigKeys.newConfigKey(Locations.LocationsFilter.class,
-            "brooklyn.locationsFilter", "Provides a hook for customizing locations to be used for a given context");
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartableImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartableImpl.java
@@ -22,6 +22,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -35,12 +42,6 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Predicates;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 public class BasicStartableImpl extends AbstractEntity implements BasicStartable {
 
@@ -50,6 +51,10 @@ public class BasicStartableImpl extends AbstractEntity implements BasicStartable
     public void start(Collection<? extends Location> locations) {
         try {
             ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
+
+            // Opportunity to block startup until other dependent components are available
+            Object val = config().get(START_LATCH);
+            if (val != null) log.debug("{} finished waiting for start-latch; continuing...", this);
 
             addLocations(locations);
             locations = Locations.getLocationsCheckingAncestors(locations, this);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeSshDriver.java
@@ -88,8 +88,7 @@ public class BrooklynNodeSshDriver extends JavaSoftwareProcessSshDriver implemen
     }
 
     @Override
-    public void preInstall() {
-        resolver = Entities.newDownloader(this);
+    public String getArchiveNameFormat() {
         String subpath = entity.getConfig(BrooklynNode.SUBPATH_IN_ARCHIVE);
         if (subpath==null) {
             // assume the dir name is `basename-VERSION` where download link is `basename-VERSION-dist.tar.gz`
@@ -112,8 +111,8 @@ public class BrooklynNodeSshDriver extends JavaSoftwareProcessSshDriver implemen
                 }
             }
         }
-        if (subpath==null) subpath = format("brooklyn-dist-%s", getVersion());
-        setExpandedInstallDir(Os.mergePaths(getInstallDir(), resolver.getUnpackedDirectoryName(subpath)));
+        if (subpath==null) subpath = "brooklyn-dist-%s";
+        return subpath;
     }
 
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -108,23 +108,24 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         }
         if (!skipStart) {
             DynamicTasks.queue("install", new Runnable() { public void run() {
-
                 Optional<Boolean> locationInstalled = Optional.fromNullable(getLocation().getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
                 Optional<Boolean> entityInstalled = Optional.fromNullable(entity.getConfig(BrooklynConfigKeys.SKIP_ENTITY_INSTALLATION));
+
+                DynamicTasks.queue("copy-pre-install-resources", new Runnable() { public void run() {
+                    waitForConfigKey(BrooklynConfigKeys.PRE_INSTALL_RESOURCES_LATCH);
+                    copyPreInstallResources();
+                }});
+
+                DynamicTasks.queue("pre-install", new Runnable() { public void run() {
+                    preInstall();
+                }});
+
+                DynamicTasks.queue("pre-install-command", new Runnable() { public void run() {
+                    runPreInstallCommand();
+                }});
+
                 boolean skipInstall = locationInstalled.or(entityInstalled).or(false);
                 if (!skipInstall) {
-                    DynamicTasks.queue("copy-pre-install-resources", new Runnable() { public void run() {
-                        waitForConfigKey(BrooklynConfigKeys.PRE_INSTALL_RESOURCES_LATCH);
-                        copyPreInstallResources();
-                    }});
-
-                    DynamicTasks.queue("pre-install", new Runnable() { public void run() {
-                        preInstall();
-                    }});
-
-                    DynamicTasks.queue("pre-install-command", new Runnable() { public void run() {
-                        runPreInstallCommand();
-                    }});
                     DynamicTasks.queue("setup", new Runnable() { public void run() {
                         waitForConfigKey(BrooklynConfigKeys.SETUP_LATCH);
                         setup();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -29,6 +29,13 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -48,12 +55,6 @@ import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwareProcessDriver implements NativeWindowsScriptRunner {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractSoftwareProcessWinRmDriver.class);
@@ -176,6 +177,28 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     @Override
     public int executePsCommand(Map flags, String command, String phase) {
         return executeNativeOrPsCommand(flags, null, command, phase, true);
+    }
+    
+    /**
+     * @deprecated since 0.5.0; instead rely on {@link org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolverManager} to inc
+     *
+     * <pre>
+     * {@code
+     * DownloadResolver resolver = Entities.newDownloader(this);
+     * List<String> urls = resolver.getTargets();
+     * }
+     * </pre>
+     */
+    protected String getEntityVersionLabel() {
+        return getEntityVersionLabel("_");
+    }
+
+    /**
+     * @deprecated since 0.5.0; instead rely on {@link org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolverManager} to inc
+     */
+    protected String getEntityVersionLabel(String separator) {
+        return elvis(entity.getEntityType().getSimpleName(),
+               entity.getClass().getName())+(getVersion() != null ? separator+getVersion() : "");
     }
 
     @Override


### PR DESCRIPTION
Allows groups of components and applications to have their startup sequence controlled more easily. This includes only setting `service.isUp` to `true` on an `AbstractApplication` once it, and its children, have started. This is the same semantics as other entities, and allows a more consistent blueprint style.

Also reverts https://github.com/apache/brooklyn-server/commit/d7c3759a150f409d1674fdaf74117404d56a665d which prevents Clocker from re-using images.