### PR TITLE
Make destroy on stop configurable for apps

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
@@ -294,8 +294,9 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 2); // sample + defaultDisplayName
-        assertEquals(ImmutableSet.copyOf(params), ImmutableSet.copyOf(BasicSpecParameter.fromClass(mgmt(), ConfigAppForTest.class)));
+        assertEquals(params.size(), 3, "Wrong number of params: "+params); // sample + defaultDisplayName + destroy_on_stop
+        assertEquals(ImmutableSet.copyOf(params), 
+            ImmutableSet.copyOf(BasicSpecParameter.fromClass(mgmt(), ConfigAppForTest.class)));
     }
 
     @Test

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
@@ -215,7 +215,9 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
         ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(this, Attributes.SERVICE_STATE_ACTUAL, "Application stopped");
         setExpectedStateAndRecordLifecycleEvent(Lifecycle.STOPPED);
 
-        if (getParent()==null) {
+        logApplicationLifecycle("Stopped");
+        
+        if (getParent()==null && Boolean.TRUE.equals(getConfig(DESTROY_ON_STOP))) {
             synchronized (this) {
                 //TODO review mgmt destroy lifecycle
                 //  we don't necessarily want to forget all about the app on stop, 
@@ -226,8 +228,6 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
                 getEntityManager().unmanage(this);
             }
         }
-
-        logApplicationLifecycle("Stopped");
     }
 
     protected void doStop() {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/StartableApplication.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/StartableApplication.java
@@ -19,7 +19,14 @@
 package org.apache.brooklyn.core.entity;
 
 import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Startable;
 
 public interface StartableApplication extends Application, Startable {
+    
+    ConfigKey<Boolean> DESTROY_ON_STOP = ConfigKeys.newBooleanConfigKey("application.stop.shouldDestroy",
+        "Whether the app should be removed from management after a successful stop (if it is a root); "
+        + "true by default.", true);
+    
 }

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/BasicStartableTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/BasicStartableTest.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -148,6 +149,8 @@ public class BasicStartableTest {
     @Test
     public void testTransitionsThroughLifecycles() throws Exception {
         startable = app.addChild(EntitySpec.create(BasicStartable.class));
+        EntityAsserts.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        
         RecordingSensorEventListener<Lifecycle> listener = new RecordingSensorEventListener<Lifecycle>(true);
         managementContext.getSubscriptionContext(startable)
                 .subscribe(startable, Attributes.SERVICE_STATE_ACTUAL, listener);

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/BasicStartableTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/BasicStartableTest.java
@@ -34,15 +34,13 @@ import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
-import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.location.Locations.LocationsFilter;
+import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.entity.stock.BasicEntity;
-import org.apache.brooklyn.entity.stock.BasicStartable;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -68,7 +66,7 @@ public class BasicStartableTest {
         managementContext = LocalManagementContextForTests.newInstance();
         loc1 = managementContext.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
         loc2 = managementContext.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
-        app = ApplicationBuilder.newManagedApp(TestApplication.class, managementContext);
+        app = TestApplication.Factory.newManagedInstanceForTests(managementContext);
     }
     
     @AfterMethod(alwaysRun=true)
@@ -100,6 +98,7 @@ public class BasicStartableTest {
         final List<Object> contexts = Lists.newCopyOnWriteArrayList();
         
         LocationsFilter filter = new LocationsFilter() {
+            private static final long serialVersionUID = 7078046521812992013L;
             @Override public List<Location> filterForContext(List<Location> locations, Object context) {
                 contexts.add(context);
                 assertEquals(locations, ImmutableList.of(loc1, loc2));
@@ -132,6 +131,7 @@ public class BasicStartableTest {
     public void testIgnoresUnstartableEntities() throws Exception {
         final AtomicReference<Exception> called = new AtomicReference<Exception>();
         LocationsFilter filter = new LocationsFilter() {
+            private static final long serialVersionUID = -5625121945234751178L;
             @Override public List<Location> filterForContext(List<Location> locations, Object context) {
                 called.set(new Exception());
                 return locations;
@@ -156,6 +156,7 @@ public class BasicStartableTest {
                 .subscribe(startable, Attributes.SERVICE_STATE_ACTUAL, listener);
 
         app.start(ImmutableList.of(loc1));
+        app.config().set(StartableApplication.DESTROY_ON_STOP, false);
         app.stop();
 
         ArrayList<Lifecycle> expected = Lists.newArrayList(


### PR DESCRIPTION
should fix https://issues.apache.org/jira/browse/BROOKLYN-203 and BasicStartableTest.testTransitionsThroughLifecycles (https://builds.apache.org/job/brooklyn-master-build/16/console) failure