### PR TITLE
BROOKLYN-231 fix race where updating and deleting can cause deleted item not to be deleted

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -200,7 +200,6 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
         this.persistFeedsEnabled = BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_FEED_PERSISTENCE_PROPERTY);
     }
     
-    @SuppressWarnings("unchecked")
     public void start() {
         synchronized (startStopMutex) {
             if (state==ListenerState.RUNNING || (scheduledTask!=null && !scheduledTask.isDone())) {
@@ -219,7 +218,7 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                 }
             };
             scheduledTask = (ScheduledTask) executionContext.submit(new ScheduledTask(MutableMap.of("displayName", "scheduled[periodic-persister]",
-                "tags", MutableSet.of(BrooklynTaskTags.TRANSIENT_TASK_TAG)), taskFactory).period(period));
+                "tags", MutableSet.of(BrooklynTaskTags.TRANSIENT_TASK_TAG)), taskFactory).period(period).delay(period));
         }
     }
 
@@ -317,7 +316,7 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
     }
     
     private void addReferencedObjects(DeltaCollector deltaCollector) {
-        Set<BrooklynObject> referencedObjects = Sets.newLinkedHashSet();
+        MutableSet<BrooklynObject> referencedObjects = MutableSet.of();
         
         // collect references
         for (Entity entity : deltaCollector.entities) {
@@ -327,10 +326,10 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                 referencedObjects.addAll(findLocationsInHierarchy);
             }
             if (persistPoliciesEnabled) {
-                referencedObjects.addAll(entity.getPolicies());
+                referencedObjects.addAll(entity.policies());
             }
             if (persistEnrichersEnabled) {
-                referencedObjects.addAll(entity.getEnrichers());
+                referencedObjects.addAll(entity.enrichers());
             }
             if (persistFeedsEnabled) {
                 referencedObjects.addAll(((EntityInternal)entity).feeds().getFeeds());


### PR DESCRIPTION
the persists and deletions run simultaneously; now, don't write things which are deleted.
also suppress the immediate delta write that was previously being done;
this may impact tests if there relying on an immediate checkpoint, but that's a bad test,
for in normal operation checkpointing should be started when the mgmt node starts and there should be nothing to persist.
if we support turning on persistence later that should trigger a full write not a delta write.