### PR TITLE
Fix hostname resolving for jclouds locations

### DIFF
--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -206,5 +206,15 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- 
+                jsr311 excluded above, this module is JAX-RS version independent. Version decided at user.
+                For tests running in the module still need to use a specific dependency - use JAX-RS 2.0 as
+                that's what is used in standard build.
+            -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -197,7 +197,6 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
         imageId = node.getImageId();
         privateAddresses = node.getPrivateAddresses();
         publicAddresses = node.getPublicAddresses();
-        hostname = node.getHostname();
         _node = Optional.of(node);
     }
 
@@ -281,7 +280,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
         // was wrong on some clouds (e.g. vcloud-director, where VMs are often given a random 
         // hostname that does not resolve on the VM and is not in any DNS).
         // Now delegates to jcloudsParent.getPublicHostname(node).
-        if (privateHostname == null) {
+        if (hostname == null) {
             Optional<NodeMetadata> node = getOptionalNode();
             if (node.isPresent()) {
                 HostAndPort sshHostAndPort = getSshHostAndPort();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
@@ -80,8 +80,8 @@ public class JcloudsAddressesLiveTest extends AbstractJcloudsLiveTest {
         Set<String> publicAddresses = machine.getPublicAddresses();
         Set<String> privateAddresses = machine.getPrivateAddresses();
         String subnetIp = machine.getSubnetIp();
-        String hostname = machine.getHostname();
         String subnetHostname = machine.getSubnetHostname();
+        String hostname = machine.getHostname();
         String msg = "locationAddress="+locationAddress+"; address="+address+"; publicAddrs="+publicAddresses+"; privateAddrs="+privateAddresses+"; subnetIp="+subnetIp+"; hostname="+hostname+"; subnetHostname="+subnetHostname;
         LOG.info("node: "+msg);
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
@@ -156,7 +156,8 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
         assertEquals(machine2.getPrivateAddresses(), ImmutableSet.of("10.144.66.5"), errmsg);
         assertEquals(machine2.getPublicAddresses(), ImmutableSet.of("54.254.23.53"), errmsg);
         assertEquals(machine2.getPrivateAddress(), Optional.of("10.144.66.5"), errmsg);
-        assertEquals(machine2.getHostname(), "ip-10-144-66-5", errmsg); // TODO would prefer the hostname that works inside and out
+        assertEquals(machine2.getSubnetHostname(), "10.144.66.5", errmsg);
+        assertEquals(machine2.getHostname(), "54.254.23.53", errmsg);
         assertEquals(machine2.getOsDetails().isWindows(), false, errmsg);
         assertEquals(machine2.getOsDetails().isLinux(), true, errmsg);
         assertEquals(machine2.getOsDetails().isMac(), false, errmsg);
@@ -188,7 +189,7 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
         assertEquals(machine3.getPrivateAddresses(), ImmutableSet.of("10.144.66.5"), errmsg);
         assertEquals(machine3.getPublicAddresses(), ImmutableSet.of("54.254.23.53"), errmsg);
         assertEquals(machine3.getPrivateAddress(), Optional.of("10.144.66.5"), errmsg);
-        assertEquals(machine3.getHostname(), "ip-10-144-66-5", errmsg); // TODO would prefer the hostname that works inside and out
+        assertEquals(machine3.getHostname(), "54.254.23.53", errmsg);
         
         // The VM is no longer running, so won't be able to infer OS Details.
         assertFalse(machine3.getOptionalOsDetails().isPresent(), errmsg);


### PR DESCRIPTION
* don't initialize hostname directly from the node
* correct lazy hostname initialization logic

According to [this comment](
https://github.com/apache/brooklyn-server/blob/master/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java#L280-L283) we shouldn’t use `node.getHostname()`. But in practice that’s exactly what happens, because `hostname` is [initialized here]( 
https://github.com/apache/brooklyn-server/blob/master/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java#L200) which is called both on location init and rebind.