### PR TITLE
WinRM operationTimeout parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <jax-rs-api.version>2.0.1</jax-rs-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
-        <winrm4j.version>0.3.1</winrm4j.version>
+        <winrm4j.version>0.3.2</winrm4j.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>
         <zookeeper.version>3.3.4</zookeeper.version>

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -77,6 +77,7 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
             "Address of the remote machine");
 
     public static final ConfigKey<Integer> WINRM_CONFIG_PORT = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.PROP_PORT);
+    public static final ConfigKey<String> OPERATION_TIMEOUT = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.OPERATION_TIMEOUT);
     public static final ConfigKey<Boolean> USE_HTTPS_WINRM = WinRmTool.USE_HTTPS_WINRM;
 
 
@@ -339,7 +340,6 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
             args.putAll(props);
             args.configure(SshTool.PROP_HOST, getAddress().getHostAddress());
             args.configure(WinRmTool.USE_NTLM, getConfig(WinRmMachineLocation.USE_NTLM));
-            args.configure(WinRmTool.USE_HTTPS_WINRM, getConfig(WinRmMachineLocation.USE_HTTPS_WINRM));
             args.configure(WinRmTool.PROP_PORT, getPort());
 
             if (LOG.isTraceEnabled()) LOG.trace("creating WinRM session for "+Sanitizer.sanitize(args));

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -57,12 +57,14 @@ public interface WinRmTool {
     ConfigKey<Boolean> USE_NTLM = ConfigKeys.newBooleanConfigKey("winrm.useNtlm", "The parameter configures tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", true);
     ConfigKey<String> PROP_USER = newStringConfigKey("user", "User to connect as", null);
     ConfigKey<String> PROP_PASSWORD = newStringConfigKey("password", "Password to use to connect", null);
+    ConfigKey<String> OPERATION_TIMEOUT = newStringConfigKey("winrm.operationTimeout", "WinRM OperationTimeout. If no output is available before the wsman:OperationTimeout expires, " +
+            "the server MUST return a WSManFault with the Code attribute equal to \"2150858793\". When the client receives this fault, it will issue another Receive request. winrm4j also sets the tcp socket timeout to a rounded up value", "1m");
 
     // TODO See SshTool#PROP_SSH_TRIES, where it was called "sshTries"; remove duplication? Merge into one well-named thing?
     ConfigKey<Integer> PROP_EXEC_TRIES = ConfigKeys.newIntegerConfigKey(
             "execTries", 
             "Max number of times to attempt WinRM operations", 
-            10);
+            1);
 
     ConfigKey<Duration> PROP_EXEC_RETRY_DELAY = newConfigKey(
             Duration.class,

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -70,6 +70,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
     private final boolean logCredentials;
     private final Boolean useSecureWinrm;
     private final String authenticationScheme;
+    private final String operationTimeout;
     
     public Winrm4jTool(Map<String,?> config) {
         this(ConfigBag.newInstance(config));
@@ -86,6 +87,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
         execTries = getRequiredConfig(config, PROP_EXEC_TRIES);
         execRetryDelay = getRequiredConfig(config, PROP_EXEC_RETRY_DELAY);
         logCredentials = getRequiredConfig(config, LOG_CREDENTIALS);
+        operationTimeout = config.get(OPERATION_TIMEOUT);
     }
     
     @Override
@@ -149,6 +151,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
             Duration execTimestamp = null;
             try {
                 WinRmTool tool = connect();
+                tool.setOperationTimeout(Duration.of(operationTimeout).toMilliseconds());
                 connectTimestamp = Duration.of(stopwatch);
                 WinRmToolResponse result = task.apply(tool);
                 execTimestamp = Duration.of(stopwatch);


### PR DESCRIPTION
* Configurable  operationTimeout. 1 minute by default as the new winrm4j does regular status polling when a command is executed.
* WinRM set default execTries
  This enables easier debugging and immidiate feedback when a problem occurs.