### PR TITLE
for local address when used in tests, ports not contactable on some build machines; try loop back instead

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
@@ -113,7 +113,7 @@ public class JmxFeedTest {
     
     public static class TestEntityWithJmx extends TestEntityImpl {
         @Override public void init() {
-            sensors().set(Attributes.HOSTNAME, "localhost");
+            sensors().set(Attributes.HOSTNAME, JmxHelperTest.LOCALHOST_NAME);
             sensors().set(UsesJmx.JMX_PORT, 
                     LocalhostMachineProvisioningLocation.obtainPort(PortRanges.fromString(
                         // just doing "40123+" was not enough to avoid collisions (on 40125),

--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxHelperTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxHelperTest.java
@@ -35,9 +35,7 @@ import javax.management.StandardEmitterMBean;
 
 import org.apache.brooklyn.entity.software.base.test.jmx.GeneralisedDynamicMBean;
 import org.apache.brooklyn.entity.software.base.test.jmx.JmxService;
-import org.apache.brooklyn.feed.jmx.JmxHelper;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.TestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.jclouds.util.Throwables2;
@@ -56,7 +54,9 @@ public class JmxHelperTest {
 
     private static final Logger log = LoggerFactory.getLogger(JmxHelperTest.class);
     
-    private static final String LOCALHOST_NAME = "localhost";
+    // NB: "localhost" resolves to the public-facing IP often which on the occasional box
+    // (eg ubuntu-us1 at apache) makes the ports not locally accessible.  so use loopback explicitly.
+    static final String LOCALHOST_NAME = "127.0.0.1";
     
     private static final int TIMEOUT_MS = 5000;
     private static final int SHORT_WAIT_MS = 250;

--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
@@ -58,7 +58,7 @@ public class RebindJmxFeedTest extends RebindTestFixtureWithApp {
 
     private static final Logger log = LoggerFactory.getLogger(RebindJmxFeedTest.class);
 
-    private static final String LOCALHOST_NAME = "localhost";
+    private static final String LOCALHOST_NAME = JmxHelperTest.LOCALHOST_NAME;
 
     static final AttributeSensor<String> SENSOR_STRING = Sensors.newStringSensor("aString", "");
     static final AttributeSensor<Integer> SENSOR_INT = Sensors.newIntegerSensor( "aLong", "");

--- a/utils/common/src/main/java/org/apache/brooklyn/test/http/TestHttpServer.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/http/TestHttpServer.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.List;
 
@@ -128,11 +127,9 @@ public class TestHttpServer {
     }
 
     private InetAddress getLocalAddress() {
-        try {
-            return InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            throw Exceptions.propagate(e);
-        }
+//        return Networking.getLocalHost();
+        // above sometimes not contactable; loopback may be more portable
+        return InetAddress.getLoopbackAddress();
     }
 
     public String getUrl() {


### PR DESCRIPTION
see if this fixes failed PR builds on `ubuntu-us-1` eg as described at #47 