### PR TITLE
[OSGi] Streamline ManagementContext injection in REST resources

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/org.ops4j.pax.web.cfg
+++ b/karaf/apache-brooklyn/src/main/resources/etc/org.ops4j.pax.web.cfg
@@ -1,0 +1,19 @@
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# TODO use the PortService - ${port:8081,8200}
+org.osgi.service.http.port=8081
+

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -164,7 +164,7 @@
 
         <feature>brooklyn-camp-base</feature>
         <feature>brooklyn-utils-rest-swagger</feature>
-        <feature>jetty</feature> <!-- TODO: pax-jetty??? -->
+        <feature>pax-jetty</feature>
     </feature>
 
     <feature name="brooklyn-rest-resources" version="${project.version}" description="Brooklyn REST Resources">
@@ -188,6 +188,8 @@
     </feature>
 
     <feature name="brooklyn-jsgui" version="${project.version}" description="Brooklyn REST JavaScript Web GUI">
+        <feature>pax-jetty</feature> <!-- jaas bundle -->
+        <bundle>mvn:org.apache.brooklyn/brooklyn-karaf-jetty-config/${project.version}</bundle>
         <bundle>mvn:org.apache.brooklyn/brooklyn-jsgui/${project.version}/war</bundle>
         <feature>war</feature>
     </feature>

--- a/karaf/itest/pom.xml
+++ b/karaf/itest/pom.xml
@@ -30,6 +30,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <includedTestGroups />
+        <excludedTestGroups>org.apache.brooklyn.test.IntegrationTest</excludedTestGroups>
+    </properties>
+
     <dependencies>
         <!-- Pax Exam Dependencies -->
         <dependency>
@@ -155,6 +160,15 @@
 
         <!-- project deps -->
         <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>brooklyn-features</artifactId>
+          <version>${project.version}</version>
+          <type>xml</type>
+          <classifier>features</classifier>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apache-brooklyn</artifactId>
             <version>${project.version}</version>
@@ -171,6 +185,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>brooklyn-rest-resources</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>brooklyn-rest-resources</artifactId>
+            <version>${project.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -180,6 +200,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.tinybundles</groupId>
+            <artifactId>tinybundles</artifactId>
+            <version>${tinybundles.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -187,7 +214,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -211,12 +237,23 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                   <systemPropertyVariables>
-                       <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}</org.ops4j.pax.url.mvn.localRepository>
-                   </systemPropertyVariables>
+                    <groups>${includedTestGroups}</groups>
+                    <excludedGroups>${excludedTestGroups}</excludedGroups>
+                    <systemPropertyVariables>
+                        <org.ops4j.pax.url.mvn.localRepository>${settings.localRepository}</org.ops4j.pax.url.mvn.localRepository>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>Integration</id>
+            <properties>
+              <includedTestGroups>org.apache.brooklyn.test.IntegrationTest</includedTestGroups>
+              <excludedTestGroups />
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -18,20 +18,9 @@
  */
 package org.apache.brooklyn;
 
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 import javax.inject.Inject;
 
@@ -42,9 +31,6 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
-import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
-import org.ops4j.pax.exam.options.MavenUrlReference;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.util.Filter;
@@ -52,6 +38,8 @@ import org.osgi.framework.BundleContext;
 
 /**
  * Tests the apache-brooklyn karaf runtime assembly.
+ * 
+ * Keeping it a non-integration test so we have at least a basic OSGi sanity check. (takes 14 sec)
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -73,43 +61,10 @@ public class AssemblyTest {
 
     @Configuration
     public static Option[] configuration() throws Exception {
-        return new Option[]{
-            karafDistributionConfiguration()
-            .frameworkUrl(brooklynKarafDist())
-            .unpackDirectory(new File("target/paxexam/unpack/"))
-            .useDeployFolder(false),
-            configureConsole().ignoreLocalConsole(),
-            logLevel(LogLevel.INFO),
-            keepRuntimeFolder(),
-            features(karafStandardFeaturesRepository(), "eventadmin"),
-            junitBundles()
-        };
-    }
-
-    public static MavenArtifactUrlReference brooklynKarafDist() {
-        return maven()
-                .groupId("org.apache.brooklyn")
-                .artifactId("apache-brooklyn")
-                .type("zip")
-                .versionAsInProject();
-    }
-
-    public static MavenUrlReference karafStandardFeaturesRepository() {
-        return maven()
-                .groupId("org.apache.karaf.features")
-                .artifactId("standard")
-                .type("xml")
-                .classifier("features")
-                .versionAsInProject();
-    }
-
-    public static MavenUrlReference brooklynFeaturesRepository() {
-        return maven()
-                .groupId("org.apache.brooklyn")
-                .artifactId("brooklyn-features")
-                .type("xml")
-                .classifier("features")
-                .versionAsInProject();
+        return defaultOptionsWith(
+            // Uncomment this for remote debugging the tests on port 5005
+            // KarafDistributionOption.debugConfiguration()
+        );
     }
 
     @Test

--- a/karaf/itest/src/test/java/org/apache/brooklyn/KarafTestUtils.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/KarafTestUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn;
+
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
+
+import java.io.File;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+
+import com.google.common.collect.ObjectArrays;
+
+public class KarafTestUtils {
+    public static final Option[] DEFAULT_OPTIONS = {
+        karafDistributionConfiguration()
+            .frameworkUrl(brooklynKarafDist())
+            .unpackDirectory(new File("target/paxexam/unpack/"))
+            .useDeployFolder(false),
+        configureConsole().ignoreLocalConsole(),
+        logLevel(LogLevel.INFO),
+        features(karafStandardFeaturesRepository(), "eventadmin"),
+        junitBundles()
+    };
+
+    public static MavenUrlReference karafStandardFeaturesRepository() {
+        return maven()
+                .groupId("org.apache.karaf.features")
+                .artifactId("standard")
+                .type("xml")
+                .classifier("features")
+                .version(asInProject());
+    }
+
+
+    public static MavenArtifactUrlReference brooklynKarafDist() {
+        return maven()
+                .groupId("org.apache.brooklyn")
+                .artifactId("apache-brooklyn")
+                .type("zip")
+                .version(asInProject());
+    }
+
+    public static Option[] defaultOptionsWith(Option... options) {
+        return ObjectArrays.concat(DEFAULT_OPTIONS, options, Option.class);
+    }
+
+    public static MavenUrlReference brooklynFeaturesRepository() {
+        return maven()
+                .groupId("org.apache.brooklyn")
+                .artifactId("brooklyn-features")
+                .type("xml")
+                .classifier("features")
+                .versionAsInProject();
+    }
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.brooklyn.rest;
 
-import java.io.File;
-import java.util.concurrent.Callable;
-import org.apache.brooklyn.AssemblyTest;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.KarafTestUtils;
+import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
@@ -31,15 +34,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
@@ -53,22 +49,12 @@ public class BrooklynRestApiLauncherTest {
 
     @Configuration
     public static Option[] configuration() throws Exception {
-        return new Option[]{
-            karafDistributionConfiguration()
-            .frameworkUrl(AssemblyTest.brooklynKarafDist())
-            .unpackDirectory(new File("target/paxexam/unpack/"))
-            .useDeployFolder(false),
+        return defaultOptionsWith(
             editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", HTTP_PORT),
-            configureConsole().ignoreLocalConsole(),
-            logLevel(LogLevelOption.LogLevel.INFO),
-//            features(AssemblyTest.karafStandardFeaturesRepository(), "eventadmin"),
-            features(AssemblyTest.brooklynFeaturesRepository(), "brooklyn-software-base"),
-            junitBundles()
-
-            // for debugging
-//            , keepRuntimeFolder()
-//            , debugConfiguration()
-        };
+            features(KarafTestUtils.brooklynFeaturesRepository(), "brooklyn-software-base")
+            // Uncomment this for remote debugging the tests on port 5005
+            // ,KarafDistributionOption.debugConfiguration()
+        );
     }
 
     @Test

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProvider.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import javax.servlet.http.HttpSession;
+
+import org.apache.brooklyn.rest.security.provider.AbstractSecurityProvider;
+import org.apache.brooklyn.rest.security.provider.SecurityProvider;
+
+public class CustomSecurityProvider extends AbstractSecurityProvider implements SecurityProvider {
+
+    @Override
+    public boolean authenticate(HttpSession session, String user, String password) {
+        return "custom".equals(user);
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.IntegrationTest;
+import org.apache.karaf.features.BootFinished;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.tinybundles.core.TinyBundles;
+import org.osgi.framework.Constants;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IntegrationTest.class)
+public class CustomSecurityProviderTest {
+    private static final String WEBCONSOLE_REALM = "webconsole";
+
+    /**
+     * To make sure the tests run only when the boot features are fully
+     * installed
+     */
+    @Inject
+    BootFinished bootFinished;
+    
+    @Inject
+    ManagementContext managementContext;
+
+    @Configuration
+    public static Option[] configuration() throws Exception {
+        return defaultOptionsWith(
+            streamBundle(TinyBundles.bundle()
+                .add(CustomSecurityProvider.class)
+                .add("OSGI-INF/blueprint/security.xml", CustomSecurityProviderTest.class.getResource("/custom-security-bp.xml"))
+                .set(Constants.BUNDLE_MANIFESTVERSION, "2") // defaults to 1 which doesn't work
+                .set(Constants.BUNDLE_SYMBOLICNAME, "org.apache.brooklyn.test.security")
+                .set(Constants.BUNDLE_VERSION, "1.0.0")
+                .set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+                .set(Constants.EXPORT_PACKAGE, CustomSecurityProvider.class.getPackage().getName())
+                .build())
+            // Uncomment this for remote debugging the tests on port 5005
+            // ,KarafDistributionOption.debugConfiguration()
+        );
+    }
+
+    @Before
+    public void setUp() {
+        // Works only before initializing the security provider (i.e. before first use)
+        // TODO Dirty hack to inject the needed properties. Improve once managementContext is configurable.
+        // Alternatively re-register a test managementContext service (how?)
+        BrooklynProperties brooklynProperties = (BrooklynProperties)managementContext.getConfig();
+        brooklynProperties.put(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName(), CustomSecurityProvider.class.getCanonicalName());
+    }
+
+    @Test(expected = FailedLoginException.class)
+    public void checkLoginFails() throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        doLogin("invalid", "auth");
+    }
+
+    @Test
+    public void checkLoginSucceeds() throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = doLogin("custom", "password");
+        assertNotNull(lc.getSubject());
+    }
+
+    private LoginContext doLogin(final String username, final String password) throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (int i = 0; i < callbacks.length; i++) {
+                    Callback callback = callbacks[i];
+                    if (callback instanceof PasswordCallback) {
+                        PasswordCallback passwordCallback = (PasswordCallback)callback;
+                        passwordCallback.setPassword(password.toCharArray());
+                    } else if (callback instanceof NameCallback) {
+                        NameCallback nameCallback = (NameCallback)callback;
+                        nameCallback.setName(username);
+                    }
+                }
+            }
+        });
+        lc.login();
+        return lc;
+    }
+
+    private void assertRealmRegisteredEventually(final String userPassRealm) {
+        // Need to wait a bit for the realm to get registered, any OSGi way to do this?
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                javax.security.auth.login.Configuration initialConfig = javax.security.auth.login.Configuration.getConfiguration();
+                AppConfigurationEntry[] realm = initialConfig.getAppConfigurationEntry(userPassRealm);
+                assertNotNull(realm);
+            }
+        });
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.security;
+
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import javax.inject.Inject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.provider.ExplicitUsersSecurityProvider;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.IntegrationTest;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.karaf.features.BootFinished;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IntegrationTest.class)
+public class StockSecurityProviderTest {
+
+    private static final String WEBCONSOLE_REALM = "webconsole";
+    private static final String USER = "admin";
+    private static final String PASSWORD = "password";
+
+    /**
+     * To make sure the tests run only when the boot features are fully
+     * installed
+     */
+    @Inject
+    BootFinished bootFinished;
+    
+    @Inject
+    ManagementContext managementContext;
+
+    @Configuration
+    public static Option[] configuration() throws Exception {
+        return defaultOptionsWith(
+            // Uncomment this for remote debugging the tests on port 5005
+            // KarafDistributionOption.debugConfiguration()
+        );
+    }
+
+    @Before
+    public void setUp() {
+        //Works only before initializing the security provider (i.e. before first use)
+        addUser(USER, PASSWORD);
+    }
+
+    @Test(expected = FailedLoginException.class)
+    public void checkLoginFails() throws LoginException {
+        doLogin("invalid", "auth");
+    }
+
+    @Test
+    public void checkLoginSucceeds() throws LoginException {
+        LoginContext lc = doLogin(USER, PASSWORD);
+        assertNotNull(lc.getSubject());
+    }
+
+    @Test
+    public void checkRestSecurityFails() throws IOException {
+        checkRestSecurity(null, null, HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void checkRestSecuritySucceeds() throws IOException {
+        checkRestSecurity(USER, PASSWORD, HttpStatus.SC_OK);
+    }
+
+    private void checkRestSecurity(String username, String password, final int code) throws IOException {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        if (username != null && password != null) {
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+        }
+        try(CloseableHttpClient client =
+            HttpClientBuilder.create().setDefaultCredentialsProvider(credentialsProvider).build()) {
+            Asserts.succeedsEventually(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    assertResponseEquals(client, code);
+                    return null;
+                }
+            });
+        }
+    }
+
+    private void assertResponseEquals(CloseableHttpClient httpclient, int code) throws IOException, ClientProtocolException {
+        // TODO get this dynamically (from CXF service?)
+        // TODO port is static, should make it dynamic
+        HttpGet httpGet = new HttpGet("http://localhost:8181/v1/server/ha/state");
+        try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
+            assertEquals(code, response.getStatusLine().getStatusCode());
+        }
+    }
+    
+
+    private void addUser(String username, String password) {
+        // TODO Dirty hack to inject the needed properties. Improve once managementContext is configurable.
+        // Alternatively re-register a test managementContext service (how?)
+        BrooklynProperties brooklynProperties = (BrooklynProperties)managementContext.getConfig();
+        brooklynProperties.put(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName(), ExplicitUsersSecurityProvider.class.getCanonicalName());
+        brooklynProperties.put(BrooklynWebConfig.USERS.getName(), username);
+        brooklynProperties.put(BrooklynWebConfig.PASSWORD_FOR_USER(username), password);
+    }
+
+    private LoginContext doLogin(final String username, final String password) throws LoginException {
+        assertRealmRegisteredEventually(WEBCONSOLE_REALM);
+        LoginContext lc = new LoginContext(WEBCONSOLE_REALM, new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (int i = 0; i < callbacks.length; i++) {
+                    Callback callback = callbacks[i];
+                    if (callback instanceof PasswordCallback) {
+                        PasswordCallback passwordCallback = (PasswordCallback)callback;
+                        passwordCallback.setPassword(password.toCharArray());
+                    } else if (callback instanceof NameCallback) {
+                        NameCallback nameCallback = (NameCallback)callback;
+                        nameCallback.setName(username);
+                    }
+                }
+            }
+        });
+        lc.login();
+        return lc;
+    }
+
+    private void assertRealmRegisteredEventually(final String userPassRealm) {
+        // Need to wait a bit for the realm to get registered, any OSGi way to do this?
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                javax.security.auth.login.Configuration initialConfig = javax.security.auth.login.Configuration.getConfiguration();
+                AppConfigurationEntry[] realm = initialConfig.getAppConfigurationEntry(userPassRealm);
+                assertNotNull(realm);
+            }
+        });
+    }
+
+}

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
@@ -137,7 +137,7 @@ public class StockSecurityProviderTest {
     private void assertResponseEquals(CloseableHttpClient httpclient, int code) throws IOException, ClientProtocolException {
         // TODO get this dynamically (from CXF service?)
         // TODO port is static, should make it dynamic
-        HttpGet httpGet = new HttpGet("http://localhost:8181/v1/server/ha/state");
+        HttpGet httpGet = new HttpGet("http://localhost:8081/v1/server/ha/state");
         try (CloseableHttpResponse response = httpclient.execute(httpGet)) {
             assertEquals(code, response.getStatusLine().getStatusCode());
         }

--- a/karaf/itest/src/test/java/org/apache/brooklyn/test/IntegrationTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/test/IntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test;
+
+/**
+ * Used by junit for grouping tests
+ */
+public class IntegrationTest {
+
+}

--- a/karaf/itest/src/test/resources/custom-security-bp.xml
+++ b/karaf/itest/src/test/resources/custom-security-bp.xml
@@ -34,6 +34,7 @@ limitations under the License.
                      flags="required">
             brooklyn.webconsole.security.provider.symbolicName=org.apache.brooklyn.test.security
             brooklyn.webconsole.security.provider.version=1.0.0
+            brooklyn.webconsole.security.provider.role=users
         </jaas:module>
     </jaas:config>
 </blueprint>

--- a/karaf/itest/src/test/resources/custom-security-bp.xml
+++ b/karaf/itest/src/test/resources/custom-security-bp.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2015 The Apache Software Foundation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+           xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
+           xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
+           xmlns:cxf="http://cxf.apache.org/blueprint/core"
+           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
+           xsi:schemaLocation="
+             http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+             http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
+             http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0
+             ">
+
+    <jaas:config name="webconsole" rank="1">
+        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+                     flags="required">
+            brooklyn.webconsole.security.provider.symbolicName=org.apache.brooklyn.test.security
+            brooklyn.webconsole.security.provider.version=1.0.0
+        </jaas:module>
+    </jaas:config>
+</blueprint>

--- a/karaf/jetty-config/pom.xml
+++ b/karaf/jetty-config/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn-karaf</artifactId>
+    <version>0.9.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brooklyn-karaf-jetty-config</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>Jetty config fragment</name>
+  <description>
+    An OSGi fragment to extend the jetty classpath (Import-Packaaes) so it is
+    able to load all classes in the included jetty.xml.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <!-- TODO re-use pluginManagement to brooklyn-parent -->
+        <version>2.5.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Fragment-Host>org.ops4j.pax.web.pax-web-jetty</Fragment-Host>
+            <Import-Package>
+                org.eclipse.jetty.jaas,
+                org.apache.brooklyn.rest.security.jaas,
+                *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/karaf/jetty-config/src/main/resources/jetty.xml
+++ b/karaf/jetty-config/src/main/resources/jetty.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+        <Arg>
+            <New class="org.eclipse.jetty.jaas.JAASLoginService">
+                <Set name="name">karaf</Set>
+                <Set name="loginModuleName">karaf</Set>
+                <Set name="roleClassNames">
+                    <Array type="java.lang.String">
+                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
+                    </Array>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+    <Call name="addBean">
+        <Arg>
+            <New class="org.eclipse.jetty.jaas.JAASLoginService">
+                <Set name="name">default</Set>
+                <Set name="loginModuleName">karaf</Set>
+                <Set name="roleClassNames">
+                    <Array type="java.lang.String">
+                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
+                    </Array>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+    <Call name="addBean">
+        <Arg>
+            <New class="org.eclipse.jetty.jaas.JAASLoginService">
+                <Set name="name">webconsole</Set>
+                <Set name="loginModuleName">webconsole</Set>
+                <Set name="roleClassNames">
+                    <Array type="java.lang.String">
+                        <Item>org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule$RolePrincipal</Item>
+                    </Array>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+
+</Configure>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -55,6 +55,7 @@
 
   <modules>
     <module>init</module>
+    <module>jetty-config</module>
     <module>features</module>
     <module>apache-brooklyn</module>
     <module>commands</module>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -40,9 +40,10 @@
     <lifecycle-mapping-plugin.version>1.0.0</lifecycle-mapping-plugin.version>
 
     <!-- pax-exam -->
-    <pax.exam.version>4.6.0</pax.exam.version>
+    <pax.exam.version>4.7.0</pax.exam.version>
     <pax.url.version>2.4.3</pax.url.version>
     <ops4j.base.version>1.5.0</ops4j.base.version>
+    <tinybundles.version>1.0.0</tinybundles.version>
 
     <!-- feature repositories -->
     <servicemix.version>6.0.0</servicemix.version>
@@ -142,6 +143,22 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+                <excludes combine.children="append">
+                    <!-- Exclude sandbox because not part of distribution: not in tgz, and not uploaded to maven-central -->
+                    <exclude>sandbox/**</exclude>
+                    <!-- Exclude release because not part of distribution: not in tgz, and not uploaded to maven-central -->
+                    <exclude>release/**</exclude>
+                    <exclude>README.md</exclude>
+                    <!-- Exclude netbeans config files (not part of the project, but often on users' drives -->
+                    <exclude>**/nbactions.xml</exclude>
+                    <exclude>**/nb-configuration.xml</exclude>
+                </excludes>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -45,7 +45,6 @@ import org.apache.brooklyn.launcher.common.BasicLauncher;
 import org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelper;
 import org.apache.brooklyn.launcher.config.StopWhichAppsOnShutdown;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
-import org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
 import org.apache.brooklyn.rest.security.provider.BrooklynUserWithRandomPasswordSecurityProvider;
 import org.apache.brooklyn.rest.util.ShutdownHandler;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -308,9 +307,7 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
             if (useHttps!=null) webServer.setHttpsEnabled(useHttps);
             webServer.setShutdownHandler(shutdownHandler);
             webServer.putAttributes(brooklynProperties);
-            if (skipSecurityFilter != Boolean.TRUE) {
-                webServer.setSecurityFilter(BrooklynPropertiesSecurityFilter.class);
-            }
+            webServer.skipSecurity(Boolean.TRUE.equals(skipSecurityFilter));
             for (WebAppContextProvider webapp : webApps) {
                 webServer.addWar(webapp);
             }

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.launcher.common.BasicLauncher;
 import org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelper;
 import org.apache.brooklyn.launcher.config.StopWhichAppsOnShutdown;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import org.apache.brooklyn.rest.security.provider.BrooklynUserWithRandomPasswordSecurityProvider;
 import org.apache.brooklyn.rest.util.ShutdownHandler;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -273,7 +274,16 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
         BrooklynProperties brooklynProperties = (BrooklynProperties) managementContext.getConfig();
 
         // No security options in properties and no command line options overriding.
-        if (Boolean.TRUE.equals(skipSecurityFilter) && bindAddress==null) {
+        Boolean skipSecurity = skipSecurityFilter;
+        if (skipSecurity == null) {
+            String securityProvider = managementContext.getConfig().getConfig(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME);
+            // The security provider will let anyone in, but still require a password to be entered.
+            // Skip password request dialog if we know the provider will let users through.
+            if (AnyoneSecurityProvider.class.getName().equals(securityProvider)) {
+                skipSecurity = true;
+            }
+        }
+        if (Boolean.TRUE.equals(skipSecurity) && bindAddress==null) {
             LOG.info("Starting Brooklyn web-console on loopback because security is explicitly disabled and no bind address specified");
             bindAddress = Networking.LOOPBACK;
         } else if (BrooklynWebConfig.hasNoSecurityOptions(managementContext.getConfig())) {
@@ -307,7 +317,7 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
             if (useHttps!=null) webServer.setHttpsEnabled(useHttps);
             webServer.setShutdownHandler(shutdownHandler);
             webServer.putAttributes(brooklynProperties);
-            webServer.skipSecurity(Boolean.TRUE.equals(skipSecurityFilter));
+            webServer.skipSecurity(Boolean.TRUE.equals(skipSecurity));
             for (WebAppContextProvider webapp : webApps) {
                 webServer.addWar(webapp);
             }

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -49,7 +49,6 @@ import org.apache.brooklyn.launcher.config.CustomResourceLocator;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.rest.RestApiSetup;
-import org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
 import org.apache.brooklyn.rest.filter.EntitlementContextFilter;
 import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.filter.LoggingFilter;
@@ -203,7 +202,7 @@ public class BrooklynWebServer {
      * {@link BrooklynLoginModule} used by default.
      */
     @Deprecated
-    private Class<BrooklynPropertiesSecurityFilter> securityFilterClazz;
+    private Class<org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter> securityFilterClazz;
     
     @SetFromFlag
     private boolean skipSecurity = false;
@@ -240,7 +239,7 @@ public class BrooklynWebServer {
 
     /** @deprecated since 0.9.0, use {@link #skipSecurity} or {@link BrooklynLoginModule} */
     @Deprecated
-    public void setSecurityFilter(Class<BrooklynPropertiesSecurityFilter> filterClazz) {
+    public void setSecurityFilter(Class<org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter> filterClazz) {
         this.securityFilterClazz = filterClazz;
     }
 

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -434,8 +434,10 @@ public class BrooklynWebServer {
         RestApiSetup.installRest(context,
                 new ManagementContextProvider(),
                 new ShutdownHandlerProvider(shutdownHandler),
+                new RequestTaggingRsFilter(),
                 new NoCacheFilter(),
-                new HaHotCheckResourceFilter());
+                new HaHotCheckResourceFilter(),
+                new EntitlementContextFilter());
         RestApiSetup.installServletFilters(context,
                 RequestTaggingFilter.class,
                 LoggingFilter.class);

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -432,7 +432,7 @@ public class BrooklynWebServer {
 
     private WebAppContext deployRestApi(WebAppContext context) {
         RestApiSetup.installRest(context,
-                new ManagementContextProvider(managementContext),
+                new ManagementContextProvider(),
                 new ShutdownHandlerProvider(shutdownHandler),
                 new NoCacheFilter(),
                 new HaHotCheckResourceFilter());

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -244,8 +244,13 @@ public class BrooklynWebServer {
         this.securityFilterClazz = filterClazz;
     }
 
-    public void skipSecurity(boolean skipSecurity) {
+    public BrooklynWebServer skipSecurity() {
+        return skipSecurity(true);
+    }
+
+    public BrooklynWebServer skipSecurity(boolean skipSecurity) {
         this.skipSecurity = skipSecurity;
+        return this;
     }
 
     public void setShutdownHandler(@Nullable ShutdownHandler shutdownHandler) {

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -438,8 +438,7 @@ public class BrooklynWebServer {
                 new HaHotCheckResourceFilter());
         RestApiSetup.installServletFilters(context,
                 RequestTaggingFilter.class,
-                LoggingFilter.class,
-                HaMasterCheckFilter.class);
+                LoggingFilter.class);
         if (securityFilterClazz != null) {
             RestApiSetup.installServletFilters(context, securityFilterClazz);
         }

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/NopSecurityHandler.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/NopSecurityHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.launcher;
+
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+
+/**
+ * Ignores <security-constraint> elements from web.xml, so
+ * we can skip configuration even if requested by web app.
+ */
+public class NopSecurityHandler extends ConstraintSecurityHandler {
+
+    @Override
+    public void addConstraintMapping(ConstraintMapping mapping) {
+    }
+
+}

--- a/launcher/src/main/resources/web-security.xml
+++ b/launcher/src/main/resources/web-security.xml
@@ -1,0 +1,51 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+     http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>Logout</web-resource-name>
+      <url-pattern>/v1/logout</url-pattern>
+    </web-resource-collection>
+  </security-constraint>
+
+  <!-- Ignored programmatically if noConsoleSecurity -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>All</web-resource-name>
+      <url-pattern>/</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>webconsole</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>webconsole</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>webconsole</role-name>
+  </security-role>
+
+</web-app>

--- a/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorIntegrationTest.java
@@ -83,13 +83,13 @@ public class BrooklynEntityMirrorIntegrationTest {
     protected void setUpServer() {
         setUpServer(new LocalManagementContextForTests(), false);
     }
-    protected void setUpServer(ManagementContext mgmt, boolean useSecurityFilter) {
+    protected void setUpServer(ManagementContext mgmt, boolean skipSecurity) {
         try {
             if (serverMgmt!=null) throw new IllegalStateException("server already set up");
             
             serverMgmt = mgmt;
             server = new BrooklynWebServer(mgmt);
-            if (useSecurityFilter) server.setSecurityFilter(BrooklynPropertiesSecurityFilter.class);
+            server.skipSecurity(skipSecurity);
             server.start();
             
             serverMgmt.getHighAvailabilityManager().disabled();

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynWebServerTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynWebServerTest.java
@@ -88,6 +88,7 @@ public class BrooklynWebServerTest {
     @Test
     public void verifyHttp() throws Exception {
         webServer = new BrooklynWebServer(newManagementContext(brooklynProperties));
+        webServer.skipSecurity();
         try {
             webServer.start();
 
@@ -114,7 +115,7 @@ public class BrooklynWebServerTest {
                 .put("keystorePassword", "password")
                 .build();
         webServer = new BrooklynWebServer(flags, newManagementContext(brooklynProperties));
-        webServer.start();
+        webServer.skipSecurity().start();
         
         try {
             KeyStore keyStore = load("client.ks", "password");
@@ -172,6 +173,7 @@ public class BrooklynWebServerTest {
 
     private void verifyHttpsFromConfig(BrooklynProperties brooklynProperties) throws Exception {
         webServer = new BrooklynWebServer(MutableMap.of(), newManagementContext(brooklynProperties));
+        webServer.skipSecurity();
         webServer.start();
         
         try {

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/WebAppRunnerTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/WebAppRunnerTest.java
@@ -18,20 +18,16 @@
  */
 package org.apache.brooklyn.launcher;
 
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.internal.BrooklynProperties;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
-import org.apache.brooklyn.launcher.BrooklynWebServer;
-import org.apache.brooklyn.launcher.BrooklynLauncher;
-import org.apache.brooklyn.launcher.BrooklynServerDetails;
-
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
 
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -75,9 +71,9 @@ public class WebAppRunnerTest {
 
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
         brooklynProperties.putAll(bigProps);
-        brooklynProperties.put("brooklyn.webconsole.security.provider","org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider");
         brooklynProperties.put("brooklyn.webconsole.security.https.required","false");
-        return new BrooklynWebServer(bigProps, newManagementContext(brooklynProperties));
+        return new BrooklynWebServer(bigProps, newManagementContext(brooklynProperties))
+                .skipSecurity();
     }
     
     @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -157,6 +157,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jaas</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
                 <version>${jetty.version}</version>
             </dependency>

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.api;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/logout")
+@Api("Logout")
+public interface LogoutApi {
+
+    @POST
+    @ApiOperation(value = "Logout and clean session")
+    Response logout();
+
+}

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -20,17 +20,30 @@ package org.apache.brooklyn.rest.api;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/logout")
 @Api("Logout")
 public interface LogoutApi {
 
     @POST
-    @ApiOperation(value = "Logout and clean session")
+    @ApiOperation(value = "Request a logout and clean session")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Redirect to /logout/user, keeping the request method")
+    })
     Response logout();
 
+    @POST
+    @Path("/{user}")
+    @ApiOperation(value = "Logout and clean session if matching user logged")
+    Response logoutUser(
+        @ApiParam(value = "User to log out", required = true)
+        @PathParam("user") final String user);
 }

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -205,5 +205,19 @@
                 <directory>${basedir}/src/main/webapp</directory>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            org.apache.karaf.jaas.config,
+                            *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -109,6 +109,15 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-test-support</artifactId>
             <version>${project.version}</version>

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynRestApi.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynRestApi.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.rest.resources.EffectorResource;
 import org.apache.brooklyn.rest.resources.EntityConfigResource;
 import org.apache.brooklyn.rest.resources.EntityResource;
 import org.apache.brooklyn.rest.resources.LocationResource;
+import org.apache.brooklyn.rest.resources.LogoutResource;
 import org.apache.brooklyn.rest.resources.PolicyConfigResource;
 import org.apache.brooklyn.rest.resources.PolicyResource;
 import org.apache.brooklyn.rest.resources.ScriptResource;
@@ -67,6 +68,7 @@ public class BrooklynRestApi {
         resources.add(new ServerResource());
         resources.add(new UsageResource());
         resources.add(new VersionResource());
+        resources.add(new LogoutResource());
         return resources;
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
+
+@Provider
+@Priority(400)
+public class EntitlementContextFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    @Context
+    private HttpServletRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        SecurityContext securityContext = requestContext.getSecurityContext();
+        Principal user = securityContext.getUserPrincipal();
+
+        if (user != null) {
+           String uri = request.getRequestURI();
+           String remoteAddr = request.getRemoteAddr();
+   
+           String uid = RequestTaggingRsFilter.getTag();
+           WebEntitlementContext entitlementContext = new WebEntitlementContext(user.getName(), remoteAddr, uri, uid);
+           Entitlements.setEntitlementContext(entitlementContext);
+        }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        Entitlements.clearEntitlementContext();
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/NoCacheFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/NoCacheFilter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.rest.filter;
 
+import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -26,6 +27,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
 @Provider
+@Priority(200)
 public class NoCacheFilter implements ContainerResponseFilter {
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.brooklyn.util.text.Identifiers;
+
+/**
+ * Tags each request with a probabilistically unique id. Should be included before other
+ * filters to make sense.
+ */
+@Provider
+@Priority(100)
+public class RequestTaggingRsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    public static final String ATT_REQUEST_ID = RequestTaggingRsFilter.class.getName() + ".id";
+
+    @Context
+    private HttpServletRequest req;
+
+    private static ThreadLocal<String> tag = new ThreadLocal<String>();
+
+    protected static String getTag() {
+        // Alternatively could use
+        // PhaseInterceptorChain.getCurrentMessage().getId()
+
+        return checkNotNull(tag.get());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String requestId = getRequestId();
+        tag.set(requestId);
+    }
+
+    private String getRequestId() {
+        Object id = req.getAttribute(ATT_REQUEST_ID);
+        if (id != null) {
+            return id.toString();
+        } else {
+            return Identifiers.makeRandomId(6);
+        }
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        tag.remove();
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
@@ -120,7 +120,7 @@ public class EntityConfigResource extends AbstractBrooklynRestResource implement
                     continue;
                 }
                 result.put(key.getName(), 
-                    resource.resolving(value).preferJson(true).asJerseyOutermostReturnValue(false).raw(raw).context(entity).timeout(Duration.ZERO).renderAs(key).resolve());
+                    resource.resolving(value, mgmt).preferJson(true).asJerseyOutermostReturnValue(false).raw(raw).context(entity).timeout(Duration.ZERO).renderAs(key).resolve()); 
             }
             return result;
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.resources;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.brooklyn.rest.api.LogoutApi;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+
+public class LogoutResource extends AbstractBrooklynRestResource implements LogoutApi {
+    @Context HttpServletRequest req;
+
+    @Override
+    public Response logout() {
+        try {
+            req.logout();
+        } catch (ServletException e) {
+            Exceptions.propagate(e);
+        }
+
+        req.getSession().invalidate();
+        return Response.status(Status.UNAUTHORIZED)
+                .header("WWW-Authenticate", "Basic realm=\"webconsole\"")
+                .build();
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -52,6 +52,7 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
 import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
@@ -132,13 +133,13 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
         final AtomicBoolean completed = new AtomicBoolean();
         final AtomicBoolean hasAppErrorsOrTimeout = new AtomicBoolean();
 
-        //shutdownHandler is thread local
+        //shutdownHandler & mgmt is thread local
         final ShutdownHandler handler = shutdownHandler.getContext(ShutdownHandler.class);
+        final ManagementContext mgmt = mgmt();
         new Thread("shutdown") {
             @Override
             public void run() {
                 boolean terminateTried = false;
-                ManagementContext mgmt = mgmt();
                 try {
                     if (stopAppsFirst) {
                         CountdownTimer shutdownTimeoutTimer = null;
@@ -189,7 +190,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
                     }
 
                     terminateTried = true;
-                    mgmtInternal().terminate(); 
+                    ((ManagementContextInternal)mgmt).terminate(); 
 
                 } catch (Throwable e) {
                     Throwable interesting = Exceptions.getFirstInteresting(e);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import javax.servlet.http.HttpSession;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.StringConfigMap;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.provider.DelegatingSecurityProvider;
+import org.apache.brooklyn.rest.security.provider.SecurityProvider;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// http://docs.oracle.com/javase/7/docs/technotes/guides/security/jaas/JAASLMDevGuide.html
+
+/**
+ * <p>
+ * JAAS module delegating authentication to the {@link SecurityProvider} implementation 
+ * configured in {@literal brooklyn.properties}, key {@literal brooklyn.webconsole.security.provider}.
+ * 
+ * <p>
+ * If used in an OSGi environment only implementations visible from {@literal brooklyn-rest-server} are usable by default.
+ * To use a custom security provider add the following configuration to the its bundle in {@literal src/main/resources/OSGI-INF/bundle/security-provider.xml}:
+ * 
+ * <pre>
+ * {@code
+ *<?xml version="1.0" encoding="UTF-8"?>
+ *<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+ *           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.1.0"
+ *           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0">
+ *
+ *    <jaas:config name="karaf" rank="1">
+ *        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+ *                     flags="required">
+ *            brooklyn.webconsole.security.provider.symbolicName=BUNDLE_SYMBOLIC_NAME
+ *            brooklyn.webconsole.security.provider.version=BUNDLE_VERSION
+ *        </jaas:module>
+ *    </jaas:config>
+ *
+ *</blueprint>
+ *}
+ * </pre>
+ */
+// Needs an explicit "org.apache.karaf.jaas.config" Import-Package in the manifest!
+public class BrooklynLoginModule implements LoginModule {
+    private static final Logger log = LoggerFactory.getLogger(BrooklynLoginModule.class);
+
+    private static class BrooklynPrincipal implements Principal {
+        private String name;
+        public BrooklynPrincipal(String name) {
+            this.name = checkNotNull(name, "name");
+        }
+        @Override
+        public String getName() {
+            return name;
+        }
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof BrooklynPrincipal) {
+                return name.equals(((BrooklynPrincipal)obj).name);
+            }
+            return false;
+        }
+        @Override
+        public String toString() {
+            return "BrooklynPrincipal[" +name + "]";
+        }
+    }
+    private static final Principal DEFAULT_PRINCIPAL = new BrooklynPrincipal("brooklyn");
+    public static final String PROPERTY_BUNDLE_SYMBOLIC_NAME = BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName() + ".symbolicName";
+    public static final String PROPERTY_BUNDLE_VERSION = BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName() + ".version";
+
+    private Map<String, ?> options;
+    private BundleContext bundleContext;
+
+    private static DelegatingSecurityProvider defaultProvider;
+    private HttpSession providerSession;
+
+    private SecurityProvider provider;
+    private Subject subject;
+    private CallbackHandler callbackHandler;
+    private boolean loginSuccess;
+    private boolean commitSuccess;
+
+    public BrooklynLoginModule() {
+    }
+
+    private SecurityProvider getDefaultProvider() {
+        if (defaultProvider == null) {
+            createDefaultSecurityProvider(getManagementContext());
+        }
+        return defaultProvider;
+    }
+
+    private synchronized static SecurityProvider createDefaultSecurityProvider(ManagementContext mgmt) {
+        if (defaultProvider == null) {
+            defaultProvider = new DelegatingSecurityProvider(mgmt);
+        }
+        return defaultProvider;
+    }
+
+    private ManagementContext getManagementContext() {
+        return ManagementContextHolder.getManagementContext();
+    }
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+        this.options = options;
+
+        this.bundleContext = (BundleContext) options.get(BundleContext.class.getName());
+
+        loginSuccess = false;
+        commitSuccess = false;
+
+        initProvider();
+    }
+
+    private void initProvider() {
+        StringConfigMap brooklynProperties = getManagementContext().getConfig();
+        provider = brooklynProperties.getConfig(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE);
+        String symbolicName = (String) options.get(PROPERTY_BUNDLE_SYMBOLIC_NAME);
+        String version = (String) options.get(PROPERTY_BUNDLE_VERSION);
+        String className = (String) options.get(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME.getName());
+        if (className != null && symbolicName == null) {
+            throw new IllegalStateException("Missing JAAS module property " + PROPERTY_BUNDLE_SYMBOLIC_NAME + " pointing at the bundle where to load the security provider from.");
+        }
+        if (provider != null) return;
+        if (symbolicName != null) {
+            if (className == null) {
+                className = brooklynProperties.getConfig(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME);
+            }
+            if (className != null) {
+                try {
+                    Collection<Bundle> bundles = getMatchingBundles(symbolicName, version);
+                    if (bundles.isEmpty()) {
+                        throw new IllegalStateException("No bundle " + symbolicName + ":" + version + " found");
+                    } else if (bundles.size() > 1) {
+                        log.warn("Found multiple bundles matching symbolicName " + symbolicName + " and version " + version + 
+                                " while trying to load security provider " + className + ". Will use first one that loads the class successfully.");
+                    }
+                    provider = tryLoadClass(className, bundles);
+                    if (provider == null) {
+                        throw new ClassNotFoundException("Unable to load class " + className + " from bundle " + symbolicName + ":" + version);
+                    }
+                } catch (Exception e) {
+                    Exceptions.propagateIfFatal(e);
+                    throw new IllegalStateException("Can not load or create security provider " + className + " for bundle " + symbolicName + ":" + version, e);
+                }
+            }
+        } else {
+            log.debug("Delegating security provider loading to Brooklyn.");
+            provider = getDefaultProvider();
+        }
+
+        log.debug("Using security provider " + provider);
+    }
+
+    private SecurityProvider tryLoadClass(String className, Collection<Bundle> bundles)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        for (Bundle b : bundles) {
+            try {
+                @SuppressWarnings("unchecked")
+                Class<? extends SecurityProvider> securityProviderType = (Class<? extends SecurityProvider>) b.loadClass(className);
+                return DelegatingSecurityProvider.createSecurityProviderInstance(getManagementContext(), securityProviderType);
+            } catch (ClassNotFoundException e) {
+            }
+        }
+        return null;
+    }
+
+    private Collection<Bundle> getMatchingBundles(final String symbolicName, final String version) {
+        Collection<Bundle> bundles = new ArrayList<>();
+        for (Bundle b : bundleContext.getBundles()) {
+            if (b.getSymbolicName().equals(symbolicName) &&
+                    (version == null || b.getVersion().toString().equals(version))) {
+                bundles.add(b);
+            }
+        }
+        return bundles;
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        if (callbackHandler == null) {
+            loginSuccess = false;
+            throw new FailedLoginException("Username and password not available");
+        }
+
+        NameCallback cbName = new NameCallback("Username: ");
+        PasswordCallback cbPassword = new PasswordCallback("Password: ", false);
+
+        Callback[] callbacks = {cbName, cbPassword};
+
+        try {
+            callbackHandler.handle(callbacks);
+        } catch (IOException ioe) {
+            throw new LoginException(ioe.getMessage());
+        } catch (UnsupportedCallbackException uce) {
+            throw new LoginException(uce.getMessage() + " not available to obtain information from user");
+        }
+        String user = cbName.getName();
+        String password = new String(cbPassword.getPassword());
+
+        providerSession = new SecurityProviderHttpSession();
+        if (!provider.authenticate(providerSession, user, password)) {
+            loginSuccess = false;
+            throw new FailedLoginException("Incorrect username or password");
+        }
+
+        loginSuccess = true;
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        if (loginSuccess) {
+            if (subject.isReadOnly()) {
+                throw new LoginException("Can't commit read-only subject");
+            }
+            subject.getPrincipals().add(DEFAULT_PRINCIPAL);
+        }
+
+        commitSuccess = true;
+        return loginSuccess;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        if (loginSuccess && commitSuccess) {
+            removePrincipal();
+        }
+        return loginSuccess;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        removePrincipal();
+
+        subject = null;
+        callbackHandler = null;
+
+        return true;
+    }
+
+    private void removePrincipal() throws LoginException {
+        if (subject.isReadOnly()) {
+            throw new LoginException("Read-only subject");
+        }
+        subject.getPrincipals().remove(DEFAULT_PRINCIPAL);
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/JaasUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/JaasUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import java.net.URL;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JaasUtils {
+    private static final Logger log = LoggerFactory.getLogger(JaasUtils.class);
+
+    private static final String JAAS_CONFIG = "java.security.auth.login.config";
+
+    public static void init(ManagementContext mgmt) {
+        ManagementContextHolder.setManagementContextStatic(mgmt);
+        String config = System.getProperty(JAAS_CONFIG);
+        if (config == null) {
+            URL configUrl = JaasUtils.class.getResource("/jaas.conf");
+            if (configUrl != null) {
+                log.debug("Using classpath JAAS config from " + configUrl.toExternalForm());
+                System.setProperty(JAAS_CONFIG, configUrl.toExternalForm());
+            } else {
+                log.error("Can't find " + JAAS_CONFIG + " on classpath. Web server authentication will fail.");
+            }
+        } else {
+            log.debug("Using externally configured JAAS at " + config);
+        }
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/ManagementContextHolder.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/ManagementContextHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+
+public class ManagementContextHolder {
+    private static ManagementContext mgmt;
+    public static ManagementContext getManagementContext() {
+        return checkNotNull(mgmt, "Management context not set yet");
+    }
+    public void setManagementContext(ManagementContext mgmt) {
+        setManagementContextStatic(mgmt);
+    }
+    public static void setManagementContextStatic(ManagementContext mgmt) {
+        ManagementContextHolder.mgmt = checkNotNull(mgmt, "mgmt");
+    }
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import java.util.Enumeration;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+
+public class SecurityProviderHttpSession implements HttpSession {
+
+    @Override
+    public long getCreationTime() {
+        return 0;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public void setMaxInactiveInterval(int interval) {
+    }
+
+    @Override
+    public int getMaxInactiveInterval() {
+        return 0;
+    }
+
+    @Override
+    public HttpSessionContext getSessionContext() {
+        return null;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Object getValue(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getValueNames() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+    }
+
+    @Override
+    public void putValue(String name, Object value) {
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+    }
+
+    @Override
+    public void removeValue(String name) {
+    }
+
+    @Override
+    public void invalidate() {
+    }
+
+    @Override
+    public boolean isNew() {
+        return false;
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
@@ -18,13 +18,20 @@
  */
 package org.apache.brooklyn.rest.security.jaas;
 
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionContext;
 
+import org.apache.brooklyn.util.text.Identifiers;
+
 public class SecurityProviderHttpSession implements HttpSession {
+    String id = Identifiers.makeRandomId(5);
+    Map<String, Object> attributes = new ConcurrentHashMap<>();
 
     @Override
     public long getCreationTime() {
@@ -33,7 +40,7 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public String getId() {
-        return null;
+        return id;
     }
 
     @Override
@@ -62,7 +69,7 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public Object getAttribute(String name) {
-        return null;
+        return attributes.get(name);
     }
 
     @Override
@@ -72,7 +79,7 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public Enumeration<String> getAttributeNames() {
-        return null;
+        return Collections.enumeration(attributes.keySet());
     }
 
     @Override
@@ -82,6 +89,7 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public void setAttribute(String name, Object value) {
+        attributes.put(name, value);
     }
 
     @Override
@@ -90,6 +98,7 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public void removeAttribute(String name) {
+        attributes.remove(name);
     }
 
     @Override
@@ -98,6 +107,8 @@ public class SecurityProviderHttpSession implements HttpSession {
 
     @Override
     public void invalidate() {
+        id = Identifiers.makeRandomId(5);
+        attributes.clear();
     }
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/ManagementContextProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/ManagementContextProvider.java
@@ -18,17 +18,28 @@
  */
 package org.apache.brooklyn.rest.util;
 
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
+
+import com.google.common.annotations.VisibleForTesting;
 
 @Provider
 // Needed by tests in rest-resources module and by main code in rest-server
 public class ManagementContextProvider implements ContextResolver<ManagementContext> {
+    @Context
+    private ServletContext context;
 
     private ManagementContext mgmt;
 
+    public ManagementContextProvider() {
+    }
+
+    @VisibleForTesting
     public ManagementContextProvider(ManagementContext mgmt) {
         this.mgmt = mgmt;
     }
@@ -36,7 +47,11 @@ public class ManagementContextProvider implements ContextResolver<ManagementCont
     @Override
     public ManagementContext getContext(Class<?> type) {
         if (type == ManagementContext.class) {
-            return mgmt;
+            if (mgmt != null) {
+                return mgmt;
+            } else {
+                return (ManagementContext) context.getAttribute(BrooklynServiceAttributes.BROOKLYN_MANAGEMENT_CONTEXT);
+            }
         } else {
             return null;
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/WebResourceUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/WebResourceUtils.java
@@ -26,10 +26,13 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.rest.domain.ApiError;
 import org.apache.brooklyn.rest.util.json.BrooklynJacksonJsonProvider;
+import org.apache.brooklyn.util.core.osgi.Compat;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.apache.brooklyn.util.net.Urls;
@@ -39,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import javax.ws.rs.core.UriBuilder;
 
 public class WebResourceUtils {
 
@@ -183,14 +185,20 @@ public class WebResourceUtils {
         }
     }
 
+    /** @deprecated since 0.9.0, use {@link #applyJsonResponse(ManagementContext, Response, HttpServletResponse)} */
+    @Deprecated
+    public static void applyJsonResponse(ServletContext servletContext, Response source, HttpServletResponse target) throws IOException {
+        applyJsonResponse(OsgiCompat.getManagementContext(servletContext), source, target);
+    }
+
     /** Sets the {@link HttpServletResponse} target (last argument) from the given source {@link Response};
      * useful in filters where we might have a {@link Response} and need to set up an {@link HttpServletResponse}.
      */
-    public static void applyJsonResponse(ServletContext servletContext, Response source, HttpServletResponse target) throws IOException {
+    public static void applyJsonResponse(ManagementContext mgmt, Response source, HttpServletResponse target) throws IOException {
         target.setStatus(source.getStatus());
         target.setContentType(MediaType.APPLICATION_JSON);
         target.setCharacterEncoding("UTF-8");
-        target.getWriter().write(BrooklynJacksonJsonProvider.findAnyObjectMapper(servletContext, null).writeValueAsString(source.getEntity()));
+        target.getWriter().write(BrooklynJacksonJsonProvider.findAnyObjectMapper(mgmt).writeValueAsString(source.getEntity()));
     }
 
     /**

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -36,8 +36,6 @@ limitations under the License.
     </cxf:bus>
 
     <reference id="localManagementContext"
-               interface="org.apache.brooklyn.api.mgmt.ManagementContext" />
-    <reference id="localManagementContextInternal"
                interface="org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal" />
 
     <jaas:config name="webconsole">
@@ -49,70 +47,23 @@ limitations under the License.
         <property name="managementContext" ref="localManagementContext" />
     </bean>
 
-    <bean id="accessResourceBean" class="org.apache.brooklyn.rest.resources.AccessResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="activityResourceBean" class="org.apache.brooklyn.rest.resources.ActivityResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
+    <bean id="accessResourceBean" class="org.apache.brooklyn.rest.resources.AccessResource" />
+    <bean id="activityResourceBean" class="org.apache.brooklyn.rest.resources.ActivityResource" />
     <!--<bean id="apidocResourceBean" class="org.apache.brooklyn.rest.resources.ApidocResource" />-->
-    <bean id="applicationResourceBean" class="org.apache.brooklyn.rest.resources.ApplicationResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="catalogResourceBean" class="org.apache.brooklyn.rest.resources.CatalogResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="effectorResourceBean" class="org.apache.brooklyn.rest.resources.EffectorResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="entityConfigResourceBean" class="org.apache.brooklyn.rest.resources.EntityConfigResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="entityResourceBean" class="org.apache.brooklyn.rest.resources.EntityResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="locationResourceBean" class="org.apache.brooklyn.rest.resources.LocationResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="policyConfigResourceBean" class="org.apache.brooklyn.rest.resources.PolicyConfigResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="policyResourceBean" class="org.apache.brooklyn.rest.resources.PolicyResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="scriptResourceBean" class="org.apache.brooklyn.rest.resources.ScriptResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="sensorResourceBean" class="org.apache.brooklyn.rest.resources.SensorResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="serverResourceBean" class="org.apache.brooklyn.rest.resources.ServerResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="usageResourceBean" class="org.apache.brooklyn.rest.resources.UsageResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="versionResourceBean" class="org.apache.brooklyn.rest.resources.VersionResource">
-        <property name="managementContext" ref="localManagementContext" />
-        <property name="managementContextInternal" ref="localManagementContextInternal" />
-    </bean>
-    <bean id="logoutResourceBean" class="org.apache.brooklyn.rest.resources.LogoutResource">
-        <property name="managementContext" ref="localManagementContext" />
-    </bean>
+    <bean id="applicationResourceBean" class="org.apache.brooklyn.rest.resources.ApplicationResource" />
+    <bean id="catalogResourceBean" class="org.apache.brooklyn.rest.resources.CatalogResource" />
+    <bean id="effectorResourceBean" class="org.apache.brooklyn.rest.resources.EffectorResource" />
+    <bean id="entityConfigResourceBean" class="org.apache.brooklyn.rest.resources.EntityConfigResource" />
+    <bean id="entityResourceBean" class="org.apache.brooklyn.rest.resources.EntityResource" />
+    <bean id="locationResourceBean" class="org.apache.brooklyn.rest.resources.LocationResource" />
+    <bean id="policyConfigResourceBean" class="org.apache.brooklyn.rest.resources.PolicyConfigResource" />
+    <bean id="policyResourceBean" class="org.apache.brooklyn.rest.resources.PolicyResource" />
+    <bean id="scriptResourceBean" class="org.apache.brooklyn.rest.resources.ScriptResource" />
+    <bean id="sensorResourceBean" class="org.apache.brooklyn.rest.resources.SensorResource" />
+    <bean id="serverResourceBean" class="org.apache.brooklyn.rest.resources.ServerResource" />
+    <bean id="usageResourceBean" class="org.apache.brooklyn.rest.resources.UsageResource" />
+    <bean id="versionResourceBean" class="org.apache.brooklyn.rest.resources.VersionResource" />
+    <bean id="logoutResourceBean" class="org.apache.brooklyn.rest.resources.LogoutResource" />
 
     <jaxrs:server id="brooklynRestApiV1" address="/">
         <jaxrs:serviceBeans>
@@ -143,7 +94,7 @@ limitations under the License.
                 <property name="contextName" value="webconsole"/>
             </bean>
             <bean class="org.apache.brooklyn.rest.util.ManagementContextProvider">
-                <argument ref="localManagementContextInternal" />
+                <argument ref="localManagementContext" />
             </bean>
             <!--
                 TODO ShutdownHandlerProvider, sync with init work.

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -20,11 +20,13 @@ limitations under the License.
            xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns:cxf="http://cxf.apache.org/blueprint/core"
+           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
            xsi:schemaLocation="
              http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
              http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
              http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
              http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0
              ">
 
     <cxf:bus>
@@ -37,6 +39,15 @@ limitations under the License.
                interface="org.apache.brooklyn.api.mgmt.ManagementContext" />
     <reference id="localManagementContextInternal"
                interface="org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal" />
+
+    <jaas:config name="webconsole">
+        <jaas:module className="org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule"
+                     flags="required" />
+    </jaas:config>
+
+    <bean class="org.apache.brooklyn.rest.security.jaas.ManagementContextHolder">
+        <property name="managementContext" ref="localManagementContext" />
+    </bean>
 
     <bean id="accessResourceBean" class="org.apache.brooklyn.rest.resources.AccessResource">
         <property name="managementContext" ref="localManagementContext" />
@@ -124,6 +135,10 @@ limitations under the License.
             <bean class="org.apache.brooklyn.rest.util.DefaultExceptionMapper"/>
             <bean class="com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider"/>
             <bean class="org.apache.brooklyn.rest.util.FormMapProvider"/>
+            <bean class="org.apache.cxf.jaxrs.security.JAASAuthenticationFilter">
+                <property name="contextName" value="webconsole"/>
+            </bean>
         </jaxrs:providers>
+
     </jaxrs:server>
 </blueprint>

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -110,6 +110,9 @@ limitations under the License.
         <property name="managementContext" ref="localManagementContext" />
         <property name="managementContextInternal" ref="localManagementContextInternal" />
     </bean>
+    <bean id="logoutResourceBean" class="org.apache.brooklyn.rest.resources.LogoutResource">
+        <property name="managementContext" ref="localManagementContext" />
+    </bean>
 
     <jaxrs:server id="brooklynRestApiV1" address="/">
         <jaxrs:serviceBeans>
@@ -129,6 +132,7 @@ limitations under the License.
             <ref component-id="serverResourceBean" />
             <ref component-id="usageResourceBean" />
             <ref component-id="versionResourceBean" />
+            <ref component-id="logoutResourceBean" />
         </jaxrs:serviceBeans>
 
         <jaxrs:providers>
@@ -138,6 +142,17 @@ limitations under the License.
             <bean class="org.apache.cxf.jaxrs.security.JAASAuthenticationFilter">
                 <property name="contextName" value="webconsole"/>
             </bean>
+            <bean class="org.apache.brooklyn.rest.util.ManagementContextProvider">
+                <argument ref="localManagementContextInternal" />
+            </bean>
+            <!--
+                TODO ShutdownHandlerProvider, sync with init work.
+                Needs to be custom OSGi implementation?
+            -->
+            <bean class="org.apache.brooklyn.rest.filter.RequestTaggingRsFilter" />
+            <bean class="org.apache.brooklyn.rest.filter.NoCacheFilter" />
+            <bean class="org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter" />
+            <bean class="org.apache.brooklyn.rest.filter.EntitlementContextFilter" />
         </jaxrs:providers>
 
     </jaxrs:server>

--- a/rest/rest-resources/src/main/resources/jaas.conf
+++ b/rest/rest-resources/src/main/resources/jaas.conf
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+webconsole {
+   org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule required;
+};

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/EntitlementContextFilterTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/EntitlementContextFilterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.jaas.JaasUtils;
+import org.apache.brooklyn.rest.security.provider.ExplicitUsersSecurityProvider;
+import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
+import org.apache.cxf.interceptor.security.JAASLoginInterceptor;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+public class EntitlementContextFilterTest extends BrooklynRestResourceTest {
+
+    private static final String USER_PASS = "admin";
+
+    public static class EntitlementResource {
+        @GET
+        @Path("/test")
+        public String test() {
+            WebEntitlementContext context = (WebEntitlementContext)Entitlements.getEntitlementContext();
+            return context.user();
+        }
+    }
+
+    @Override
+    protected void configureCXF(JAXRSServerFactoryBean sf) {
+        BrooklynProperties props = (BrooklynProperties)getManagementContext().getConfig();
+        props.put(BrooklynWebConfig.USERS, USER_PASS);
+        props.put(BrooklynWebConfig.PASSWORD_FOR_USER(USER_PASS), USER_PASS);
+        props.put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, new ExplicitUsersSecurityProvider(getManagementContext()));
+
+        super.configureCXF(sf);
+
+        JaasUtils.init(getManagementContext());
+
+        JAASLoginInterceptor jaas = new JAASLoginInterceptor();
+        jaas.setContextName("webconsole");
+        sf.getInInterceptors().add(jaas);
+
+    }
+
+    @Override
+    protected void addBrooklynResources() {
+        addResource(new RequestTaggingRsFilter());
+        addResource(new EntitlementContextFilter());
+        addResource(new EntitlementResource());
+    }
+
+    @Test
+    public void testEntitlementContextSet() {
+        Response response = fetch("/test");
+        assertEquals(response.getStatus(), HttpStatus.SC_OK);
+        String tag = (String) response.readEntity(String.class);
+        assertEquals(tag, USER_PASS);
+    }
+
+    protected Response fetch(String path) {
+        WebClient resource = WebClient.create(getEndpointAddress(), clientProviders, USER_PASS, USER_PASS, null)
+            .path(path)
+            .accept(MediaType.APPLICATION_JSON_TYPE);
+        Response response = resource.get();
+        return response;
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/HaHotCheckTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/HaHotCheckTest.java
@@ -29,9 +29,9 @@ import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
-import org.apache.brooklyn.rest.util.HaHotStateCheckClassResource;
-import org.apache.brooklyn.rest.util.HaHotStateCheckResource;
-import org.apache.brooklyn.rest.util.HaMasterCheckResource;
+import org.apache.brooklyn.rest.util.TestingHaHotStateCheckClassResource;
+import org.apache.brooklyn.rest.util.TestingHaHotStateCheckResource;
+import org.apache.brooklyn.rest.util.TestingHaMasterCheckResource;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.testng.annotations.Test;
 
@@ -40,9 +40,9 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
     @Override
     protected void addBrooklynResources() {
         addResource(new HaHotCheckResourceFilter());
-        addResource(new HaHotStateCheckResource());
-        addResource(new HaHotStateCheckClassResource());
-        addResource(new HaMasterCheckResource());
+        addResource(new TestingHaHotStateCheckResource());
+        addResource(new TestingHaHotStateCheckClassResource());
+        addResource(new TestingHaMasterCheckResource());
         
         ((LocalManagementContext)getManagementContext()).noteStartupComplete();
     }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilterTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+public class RequestTaggingRsFilterTest extends BrooklynRestResourceTest {
+
+    @Path("/tag")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class TagResource {
+        @GET
+        public String tag() {
+            return RequestTaggingRsFilter.getTag();
+        }
+    }
+
+    @Override
+    protected void addBrooklynResources() {
+        addResource(new RequestTaggingRsFilter());
+        addResource(new TagResource());
+    }
+
+    @Test
+    public void testTaggingFilter() {
+        String tag1 = fetchTag();
+        String tag2 = fetchTag();
+        assertNotEquals(tag1, tag2);
+    }
+
+    private String fetchTag() {
+        Response response = fetch("/tag");
+        assertEquals(response.getStatus(), HttpStatus.SC_OK);
+        String tag = (String) response.readEntity(String.class);
+        assertNotNull(tag);
+        return tag;
+    }
+
+    protected Response fetch(String path) {
+        WebClient resource = client().path(path)
+                .accept(MediaType.APPLICATION_JSON_TYPE);
+        Response response = resource.get();
+        return response;
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModuleTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModuleTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+// http://docs.oracle.com/javase/7/docs/technotes/guides/security/jaas/JAASLMDevGuide.html
+public class BrooklynLoginModuleTest extends BrooklynMgmtUnitTestSupport {
+    private static final String ACCEPTED_USER = "user";
+    private static final String ACCEPTED_PASSWORD = "password";
+    private CallbackHandler GOOD_CB_HANDLER = new TestCallbackHandler(
+            ACCEPTED_USER,
+            ACCEPTED_PASSWORD);
+    private CallbackHandler BAD_CB_HANDLER = new TestCallbackHandler(
+            ACCEPTED_USER + ".invalid",
+            ACCEPTED_PASSWORD + ".invalid");
+
+    private Subject subject;
+    private Map<String, ?> sharedState;
+    private Map<String, ?> options;
+
+    private BrooklynLoginModule module;
+
+    @Override
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() throws Exception {
+        BrooklynProperties properties = BrooklynProperties.Factory.newEmpty();
+        properties.addFrom(ImmutableMap.of(
+                BrooklynWebConfig.USERS, ACCEPTED_USER,
+                BrooklynWebConfig.PASSWORD_FOR_USER("user"), ACCEPTED_PASSWORD));
+        mgmt = LocalManagementContextForTests.builder(true).useProperties(properties).build();
+        ManagementContextHolder.setManagementContextStatic(mgmt);
+
+        super.setUp();
+
+        subject = new Subject();
+        sharedState = MutableMap.of();
+        options = ImmutableMap.of();
+
+        module = new BrooklynLoginModule();
+    }
+
+    @Test
+    public void testMissingCallback() throws LoginException {
+        module.initialize(subject, null, sharedState, options);
+        try {
+            module.login();
+            fail("Login is supposed to fail due to missing callback");
+        } catch (FailedLoginException e) {
+            // Expected, ignore
+        }
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginCommitAbort() throws LoginException {
+        badLogin();
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginCommitAbortReadOnly() throws LoginException {
+        subject.setReadOnly();
+        badLogin();
+        assertFalse(module.commit(), "commit");
+        assertEmptyPrincipals();
+        assertFalse(module.abort(), "abort");
+    }
+
+    @Test
+    public void testFailedLoginAbort() throws LoginException {
+        badLogin();
+        assertFalse(module.abort(), "abort");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitLogout() throws LoginException {
+        goodLogin();
+        assertTrue(module.commit(), "commit");
+        assertBrooklynPrincipal();
+        assertTrue(module.logout(), "logout");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitAbort() throws LoginException {
+        goodLogin();
+        assertTrue(module.commit(), "commit");
+        assertBrooklynPrincipal();
+        assertTrue(module.abort(), "logout");
+        assertEmptyPrincipals();
+    }
+
+    @Test
+    public void testSuccessfulLoginCommitAbortReadOnly() throws LoginException {
+        subject.setReadOnly();
+        goodLogin();
+        try {
+            module.commit();
+            fail("Commit expected to throw");
+        } catch (LoginException e) {
+            // Expected
+        }
+        assertTrue(module.abort());
+    }
+
+    @Test
+    public void testSuccessfulLoginAbort() throws LoginException {
+        goodLogin();
+        assertTrue(module.abort(), "abort");
+        assertEmptyPrincipals();
+    }
+
+    private void goodLogin() throws LoginException {
+        module.initialize(subject, GOOD_CB_HANDLER, sharedState, options);
+        assertTrue(module.login(), "login");
+        assertEmptyPrincipals();
+    }
+
+    private void badLogin() throws LoginException {
+        module.initialize(subject, BAD_CB_HANDLER, sharedState, options);
+        try {
+            module.login();
+            fail("Login is supposed to fail due to invalid username+password pair");
+        } catch (FailedLoginException e) {
+            // Expected, ignore
+        }
+    }
+
+    private void assertBrooklynPrincipal() {
+        Principal principal = Iterables.getOnlyElement(subject.getPrincipals());
+        assertEquals(principal.getName(), "brooklyn");
+    }
+
+    private void assertEmptyPrincipals() {
+        assertEquals(subject.getPrincipals().size(), 0);
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/TestCallbackHandler.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/jaas/TestCallbackHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.jaas;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+public class TestCallbackHandler implements CallbackHandler {
+    private String username;
+    private String password;
+
+    public TestCallbackHandler(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks)
+            throws IOException, UnsupportedCallbackException {
+        for (Callback cb : callbacks) {
+            if (cb instanceof NameCallback) {
+                ((NameCallback)cb).setName(username);
+            } else if (cb instanceof PasswordCallback) {
+                ((PasswordCallback)cb).setPassword(password.toCharArray());
+            }
+        }
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -160,7 +160,7 @@ public abstract class BrooklynRestApiTest {
     }
 
     protected ObjectMapper mapper() {
-        return BrooklynJacksonJsonProvider.findSharedObjectMapper(null, getManagementContext());
+        return BrooklynJacksonJsonProvider.findSharedObjectMapper(getManagementContext());
     }
 
     public LocationRegistry getLocationRegistry() {

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/HaMasterCheckResource.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/HaMasterCheckResource.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.util;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+public class HaMasterCheckResource {
+
+    @POST
+    @Path("/server/shutdown")
+    public void shutdown() {
+
+    }
+
+    @POST
+    @Path("/ha/post")
+    public void post() {
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckClassResource.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckClassResource.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.rest.filter.HaHotStateRequired;
 @Path("/ha/class")
 @Produces(MediaType.APPLICATION_JSON)
 @HaHotStateRequired
-public class HaHotStateCheckClassResource {
+public class TestingHaHotStateCheckClassResource {
 
     @GET
     @Path("fail")

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckResource.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckResource.java
@@ -18,23 +18,27 @@
  */
 package org.apache.brooklyn.rest.util;
 
-import javax.ws.rs.POST;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.apache.brooklyn.rest.filter.HaHotStateRequired;
+
+@Path("/ha/method")
 @Produces(MediaType.APPLICATION_JSON)
-public class HaMasterCheckResource {
+public class TestingHaHotStateCheckResource {
 
-    @POST
-    @Path("/server/shutdown")
-    public void shutdown() {
-
+    @GET
+    @Path("ok")
+    public String ok() {
+        return "OK";
     }
 
-    @POST
-    @Path("/ha/post")
-    public void post() {
+    @GET
+    @Path("fail")
+    @HaHotStateRequired
+    public String fail() {
+        return "FAIL";
     }
-
 }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaMasterCheckResource.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/TestingHaMasterCheckResource.java
@@ -23,9 +23,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-@Path("/")
 @Produces(MediaType.APPLICATION_JSON)
-public class HaMasterCheckResource {
+public class TestingHaMasterCheckResource {
 
     @POST
     @Path("/server/shutdown")

--- a/rest/rest-server-jersey/pom.xml
+++ b/rest/rest-server-jersey/pom.xml
@@ -259,6 +259,9 @@
                                 <exclude>**/HaHotCheckResourceFilter.java</exclude>
                                 <exclude>**/FormMapProvider.java</exclude>
                                 <exclude>**/ApidocResource.java</exclude>
+                                <exclude>**/RequestTaggingFilter.java</exclude>
+                                <exclude>**/EntitlementContextFilter.java</exclude>
+                                <exclude>**/RequestTaggingRsFilter.java</exclude>
                               </excludes>
                             </resource>
                             <resource>

--- a/rest/rest-server-jersey/pom.xml
+++ b/rest/rest-server-jersey/pom.xml
@@ -162,6 +162,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
@@ -267,6 +271,22 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>copy-rest-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                          <outputDirectory>target/generated-resources/rest-deps</outputDirectory>
+                          <resources>
+                            <resource>
+                              <directory>../rest-resources/src/main/resources</directory>
+                              <includes>
+                                <include>**/jaas.conf</include>
+                              </includes>
+                            </resource>
+                          </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-rest-test-resources</id>
                         <phase>generate-test-resources</phase>
                         <goals><goal>copy-resources</goal></goals>
@@ -300,6 +320,18 @@
                     </execution>
                     <execution>
                         <id>rest-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals><goal>add-resource</goal></goals>
+                        <configuration>
+                          <resources>
+                            <resource>
+                                <directory>target/generated-resources/rest-deps</directory>
+                            </resource>
+                          </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>rest-test-resources</id>
                         <phase>generate-test-resources</phase>
                         <goals><goal>add-test-resource</goal></goals>
                         <configuration>

--- a/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
+
+import com.sun.jersey.core.util.Priority;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+
+@Priority(400)
+public class EntitlementContextFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    @Context
+    private HttpServletRequest servletRequest;
+
+    @Override
+    public ContainerRequest filter(ContainerRequest request) {
+        SecurityContext securityContext = request.getSecurityContext();
+        Principal user = securityContext.getUserPrincipal();
+
+        if (user != null) {
+            String uri = servletRequest.getRequestURI();
+            String remoteAddr = servletRequest.getRemoteAddr();
+
+            String uid = RequestTaggingFilter.getTag();
+            WebEntitlementContext entitlementContext = new WebEntitlementContext(user.getName(), remoteAddr, uri, uid);
+            Entitlements.setEntitlementContext(entitlementContext);
+        }
+        return request;
+    }
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        Entitlements.clearEntitlementContext();
+        return response;
+    }
+
+}

--- a/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/HaHotCheckResourceFilter.java
+++ b/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/HaHotCheckResourceFilter.java
@@ -73,6 +73,11 @@ public class HaHotCheckResourceFilter implements ResourceFilterFactory {
         this.mgmt = mgmt;
     }
 
+    // mgmt doesn't get injected for some reason, instead of looking for the cause just pass it at init time
+    public void setManagementContext(ContextResolver<ManagementContext> mgmt) {
+        this.mgmt = mgmt;
+    }
+
     private ManagementContext mgmt() {
         return mgmt.getContext(ManagementContext.class);
     }

--- a/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/NoCacheFilter.java
+++ b/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/NoCacheFilter.java
@@ -21,10 +21,12 @@ package org.apache.brooklyn.rest.filter;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
 
+import com.sun.jersey.core.util.Priority;
 import com.sun.jersey.spi.container.ContainerRequest;
 import com.sun.jersey.spi.container.ContainerResponse;
 import com.sun.jersey.spi.container.ContainerResponseFilter;
 
+@Priority(200)
 public class NoCacheFilter implements ContainerResponseFilter {
 
     @Override

--- a/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilter.java
+++ b/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingRsFilter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+
+import org.apache.brooklyn.util.text.Identifiers;
+
+import com.sun.jersey.core.util.Priority;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+
+/**
+ * Tags each request with a probabilistically unique id. Should be included before other
+ * filters to make sense.
+ */
+@Priority(100)
+public class RequestTaggingRsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    public static final String ATT_REQUEST_ID = RequestTaggingRsFilter.class.getName() + ".id";
+
+    @Context
+    private HttpServletRequest req;
+
+    private static ThreadLocal<String> tag = new ThreadLocal<String>();
+
+    protected static String getTag() {
+        // Alternatively could use
+        // PhaseInterceptorChain.getCurrentMessage().getId()
+
+        return checkNotNull(tag.get());
+    }
+
+    @Override
+    public ContainerRequest filter(ContainerRequest request) {
+        String requestId = getRequestId();
+        tag.set(requestId);
+        return request;
+    }
+
+    private String getRequestId() {
+        Object id = req.getAttribute(ATT_REQUEST_ID);
+        if (id != null) {
+            return id.toString();
+        } else {
+            return Identifiers.makeRandomId(6);
+        }
+    }
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        tag.remove();
+        return response;
+    }
+
+}

--- a/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/SwaggerFilter.java
+++ b/rest/rest-server-jersey/src/main/java/org/apache/brooklyn/rest/filter/SwaggerFilter.java
@@ -18,9 +18,7 @@
  */
 package org.apache.brooklyn.rest.filter;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -29,7 +27,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.ws.rs.core.UriBuilder;
 
 import org.apache.brooklyn.rest.apidoc.RestApiResourceScanner;
 

--- a/rest/rest-server-jersey/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server-jersey/src/main/webapp/WEB-INF/web.xml
@@ -92,6 +92,11 @@
                 io.swagger.jaxrs.listing.SwaggerSerializers;
                 org.apache.brooklyn.rest.util.FormMapProvider;
                 com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+                org.apache.brooklyn.rest.filter.RequestTaggingRsFilter;
+                org.apache.brooklyn.rest.filter.NoCacheFilter;
+                org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
+                org.apache.brooklyn.rest.filter.EntitlementContextFilter;
+                org.apache.brooklyn.rest.util.ManagementContextProvider;
                 org.apache.brooklyn.rest.resources.AccessResource;
                 org.apache.brooklyn.rest.resources.ActivityResource;
                 org.apache.brooklyn.rest.resources.ApidocResource;

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -47,7 +47,6 @@ import org.apache.brooklyn.rest.filter.SwaggerFilter;
 import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import org.apache.brooklyn.rest.security.provider.SecurityProvider;
 import org.apache.brooklyn.rest.util.ManagementContextProvider;
-import org.apache.brooklyn.rest.util.NullServletConfigProvider;
 import org.apache.brooklyn.rest.util.ServerStoppingShutdownHandler;
 import org.apache.brooklyn.rest.util.ShutdownHandlerProvider;
 import org.apache.brooklyn.util.core.osgi.Compat;
@@ -251,7 +250,7 @@ public class BrooklynRestApiLauncher {
         ResourceConfig config = new DefaultResourceConfig();
         for (Object r: BrooklynRestApi.getAllResources())
             config.getSingletons().add(r);
-        config.getSingletons().add(new ManagementContextProvider(mgmt));
+        config.getSingletons().add(new ManagementContextProvider());
         addShutdownListener(config, mgmt);
 
 
@@ -382,7 +381,7 @@ public class BrooklynRestApiLauncher {
         context.addFilter(filterHolder, "/v1/*", EnumSet.allOf(DispatcherType.class));
 
         ManagementContext mgmt = getManagementContext(context);
-        config.getSingletons().add(new ManagementContextProvider(mgmt));
+        config.getSingletons().add(new ManagementContextProvider());
         addShutdownListener(config, mgmt);
     }
 

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/HaHotCheckTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/HaHotCheckTest.java
@@ -29,9 +29,9 @@ import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
-import org.apache.brooklyn.rest.util.HaHotStateCheckClassResource;
-import org.apache.brooklyn.rest.util.HaHotStateCheckResource;
-import org.apache.brooklyn.rest.util.HaMasterCheckResource;
+import org.apache.brooklyn.rest.util.TestingHaHotStateCheckClassResource;
+import org.apache.brooklyn.rest.util.TestingHaHotStateCheckResource;
+import org.apache.brooklyn.rest.util.TestingHaMasterCheckResource;
 import org.apache.brooklyn.rest.util.ManagementContextProvider;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -55,9 +55,9 @@ public class HaHotCheckTest extends BrooklynRestResourceTest {
     protected void addBrooklynResources() {
         config.getProperties().put(ResourceConfig.PROPERTY_RESOURCE_FILTER_FACTORIES,
             new HaHotCheckResourceFilter(new ManagementContextProvider(getManagementContext())));
-        addResource(new HaHotStateCheckResource());
-        addResource(new HaHotStateCheckClassResource());
-        addResource(new HaMasterCheckResource());
+        addResource(new TestingHaHotStateCheckResource());
+        addResource(new TestingHaHotStateCheckClassResource());
+        addResource(new TestingHaMasterCheckResource());
         
         ((LocalManagementContext)getManagementContext()).noteStartupComplete();
     }

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -95,7 +95,7 @@ public abstract class BrooklynRestApiTest {
     }
     
     protected ObjectMapper mapper() {
-        return BrooklynJacksonJsonProvider.findSharedObjectMapper(null, getManagementContext());
+        return BrooklynJacksonJsonProvider.findSharedObjectMapper(getManagementContext());
     }
     
     @AfterClass

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/HaMasterCheckResource.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/HaMasterCheckResource.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.util;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class HaMasterCheckResource {
+
+    @POST
+    @Path("/server/shutdown")
+    public void shutdown() {
+
+    }
+
+    @POST
+    @Path("/ha/post")
+    public void post() {
+    }
+
+}

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckClassResource.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckClassResource.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.rest.filter.HaHotStateRequired;
 @Path("/ha/class")
 @Produces(MediaType.APPLICATION_JSON)
 @HaHotStateRequired
-public class HaHotStateCheckClassResource {
+public class TestingHaHotStateCheckClassResource {
 
     @GET
     @Path("fail")

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckResource.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaHotStateCheckResource.java
@@ -27,7 +27,7 @@ import org.apache.brooklyn.rest.filter.HaHotStateRequired;
 
 @Path("/ha/method")
 @Produces(MediaType.APPLICATION_JSON)
-public class HaHotStateCheckResource {
+public class TestingHaHotStateCheckResource {
 
     @GET
     @Path("ok")

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaMasterCheckResource.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/TestingHaMasterCheckResource.java
@@ -18,27 +18,24 @@
  */
 package org.apache.brooklyn.rest.util;
 
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.brooklyn.rest.filter.HaHotStateRequired;
-
-@Path("/ha/method")
+@Path("/")
 @Produces(MediaType.APPLICATION_JSON)
-public class HaHotStateCheckResource {
+public class TestingHaMasterCheckResource {
 
-    @GET
-    @Path("ok")
-    public String ok() {
-        return "OK";
+    @POST
+    @Path("/server/shutdown")
+    public void shutdown() {
+
     }
 
-    @GET
-    @Path("fail")
-    @HaHotStateRequired
-    public String fail() {
-        return "FAIL";
+    @POST
+    @Path("/ha/post")
+    public void post() {
     }
+
 }

--- a/rest/rest-server/pom.xml
+++ b/rest/rest-server/pom.xml
@@ -113,6 +113,10 @@
             <artifactId>jetty-servlet</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/RestApiSetup.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/RestApiSetup.java
@@ -34,9 +34,6 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
 import io.swagger.config.ScannerFactory;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
-import org.apache.brooklyn.rest.util.ManagementContextProvider;
 
 public class RestApiSetup {
 
@@ -48,11 +45,6 @@ public class RestApiSetup {
             app.singleton(o);
         }
 
-        ManagementContext managementContext = extractManagementContext(providers);
-        for (Object o : app.getSingletons()) {
-            injectManagementContext(managementContext, o);
-        }
-
         CXFNonSpringJaxrsServlet servlet = new CXFNonSpringJaxrsServlet(app);
         servlet.setBus(BusFactory.newInstance().createBus());
         servlet.getBus().getInInterceptors().add(new GZIPInInterceptor());
@@ -61,21 +53,6 @@ public class RestApiSetup {
         final ServletHolder servletHolder = new ServletHolder(servlet);
 
         context.addServlet(servletHolder, "/v1/*");
-    }
-
-    private static void injectManagementContext(ManagementContext managementContext, Object o) {
-        if (managementContext != null && o instanceof ManagementContextInjectable) {
-            ((ManagementContextInjectable) o).setManagementContext(managementContext);
-        }
-    }
-
-    private static ManagementContext extractManagementContext(Object... providers) {
-        for (Object o : providers) {
-            if (o instanceof ManagementContextProvider) {
-                return ((ManagementContextProvider) o).getContext(ManagementContext.class);
-            }
-        }
-        return null;
     }
 
     @SafeVarargs

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/BrooklynPropertiesSecurityFilter.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/BrooklynPropertiesSecurityFilter.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule;
 import org.apache.brooklyn.rest.security.provider.DelegatingSecurityProvider;
 import org.apache.brooklyn.rest.util.OsgiCompat;
 import org.apache.brooklyn.util.text.Strings;
@@ -44,7 +45,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Provides basic HTTP authentication.
+ * 
+ * @deprecated since 0.9.0, use JAAS authentication instead, see {@link BrooklynLoginModule}.
  */
+@Deprecated
 public class BrooklynPropertiesSecurityFilter implements Filter {
 
     /**
@@ -53,7 +57,7 @@ public class BrooklynPropertiesSecurityFilter implements Filter {
      * the providers may impose additional criteria such as timeouts,
      * or a null user (no login) may be permitted)
      */
-    public static final String AUTHENTICATED_USER_SESSION_ATTRIBUTE = "brooklyn.user";
+    public static final String AUTHENTICATED_USER_SESSION_ATTRIBUTE = BrooklynLoginModule.AUTHENTICATED_USER_SESSION_ATTRIBUTE;
 
     /**
      * The session attribute set to indicate the remote address of the HTTP request.

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/BrooklynPropertiesSecurityFilter.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/BrooklynPropertiesSecurityFilter.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.resources.LogoutResource;
 import org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule;
 import org.apache.brooklyn.rest.security.provider.DelegatingSecurityProvider;
 import org.apache.brooklyn.rest.util.OsgiCompat;
@@ -46,7 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides basic HTTP authentication.
  * 
- * @deprecated since 0.9.0, use JAAS authentication instead, see {@link BrooklynLoginModule}.
+ * @deprecated since 0.9.0, use JAAS authentication instead, see {@link BrooklynLoginModule}, {@link LogoutResource}, {@link EntitlementContextFilter}.
  */
 @Deprecated
 public class BrooklynPropertiesSecurityFilter implements Filter {

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/HaMasterCheckFilter.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/HaMasterCheckFilter.java
@@ -88,7 +88,7 @@ public class HaMasterCheckFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String problem = lookForProblem(request);
         if (problem!=null) {
-            WebResourceUtils.applyJsonResponse(servletContext, helper.disallowResponse(problem, request.getParameterMap()), (HttpServletResponse)response);
+            WebResourceUtils.applyJsonResponse(mgmt, helper.disallowResponse(problem, request.getParameterMap()), (HttpServletResponse)response);
         } else {
             chain.doFilter(request, response);
         }

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/HaMasterCheckFilter.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/HaMasterCheckFilter.java
@@ -44,8 +44,10 @@ import com.google.common.collect.Sets;
  * <p>
  * Post POSTs and PUTs are assumed to need master state, with the exception of shutdown.
  * Requests with {@link #SKIP_CHECK_HEADER} set as a header skip this check.
+ * 
+ * @deprecated since 0.9.0. Use JAX-RS {@link HaHotCheckResourceFilter} instead.
  */
-// TODO Merge with HaHotCheckResourceFilter so the functionality is available in Karaf
+@Deprecated
 public class HaMasterCheckFilter implements Filter {
 
     private static final Set<String> SAFE_STANDBY_METHODS = Sets.newHashSet("GET", "HEAD");

--- a/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingFilter.java
+++ b/rest/rest-server/src/main/java/org/apache/brooklyn/rest/filter/RequestTaggingFilter.java
@@ -33,7 +33,7 @@ import org.apache.brooklyn.util.text.Identifiers;
  * Tags each request with a probabilistically unique id. Should be included before other
  * filters to make sense.
  */
-//TODO Re-implement as JAX-RS filter
+// TODO Deprecate after porting LoggingFilter
 public class RequestTaggingFilter implements Filter {
 
     private static ThreadLocal<String> tag = new ThreadLocal<String>();
@@ -45,6 +45,7 @@ public class RequestTaggingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String requestId = Identifiers.makeRandomId(6);
+        request.setAttribute(RequestTaggingRsFilter.ATT_REQUEST_ID, requestId);
         tag.set(requestId);
         try {
             chain.doFilter(request, response);

--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -30,29 +30,11 @@
     </filter-mapping>
 
     <filter>
-        <filter-name>Brooklyn Properties Authentication Filter</filter-name>
-        <filter-class>org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>Brooklyn Properties Authentication Filter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
-    <filter>
         <filter-name>Brooklyn Logging Filter</filter-name>
         <filter-class>org.apache.brooklyn.rest.filter.LoggingFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>Brooklyn Logging Filter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
-    <filter>
-        <filter-name>Brooklyn HA Master Filter</filter-name>
-        <filter-class>org.apache.brooklyn.rest.filter.HaMasterCheckFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>Brooklyn HA Master Filter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
@@ -95,7 +77,11 @@
             <param-value>
                 io.swagger.jaxrs.listing.SwaggerSerializers,
                 org.apache.brooklyn.rest.util.FormMapProvider,
-                com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
+                com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider,
+                org.apache.brooklyn.rest.filter.RequestTaggingRsFilter,
+                org.apache.brooklyn.rest.filter.NoCacheFilter,
+                org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter,
+                org.apache.brooklyn.rest.filter.EntitlementContextFilter,
                 org.apache.brooklyn.rest.util.ManagementContextProvider
                 <!-- org.apache.brooklyn.rest.util.ShutdownHandlerProvider -->
             </param-value>

--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -96,6 +96,8 @@
                 io.swagger.jaxrs.listing.SwaggerSerializers,
                 org.apache.brooklyn.rest.util.FormMapProvider,
                 com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
+                org.apache.brooklyn.rest.util.ManagementContextProvider
+                <!-- org.apache.brooklyn.rest.util.ShutdownHandlerProvider -->
             </param-value>
         </init-param>
 

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -36,10 +36,13 @@ import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
-import org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
-import org.apache.brooklyn.rest.filter.HaMasterCheckFilter;
+import org.apache.brooklyn.rest.filter.EntitlementContextFilter;
+import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.filter.LoggingFilter;
+import org.apache.brooklyn.rest.filter.NoCacheFilter;
 import org.apache.brooklyn.rest.filter.RequestTaggingFilter;
+import org.apache.brooklyn.rest.filter.RequestTaggingRsFilter;
+import org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule.RolePrincipal;
 import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import org.apache.brooklyn.rest.security.provider.SecurityProvider;
 import org.apache.brooklyn.rest.util.ManagementContextProvider;
@@ -51,6 +54,7 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.text.WildcardGlobs;
+import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -89,11 +93,9 @@ public class BrooklynRestApiLauncher {
         SERVLET, /** web-xml is not fully supported */ @Beta WEB_XML
     }
 
-    public static final List<Class<? extends Filter>> DEFAULT_FILTERS = ImmutableList.of(
+    public static final List<Class<? extends Filter>> DEFAULT_FILTERS = ImmutableList.<Class<? extends Filter>>of(
             RequestTaggingFilter.class,
-            BrooklynPropertiesSecurityFilter.class,
-            LoggingFilter.class,
-            HaMasterCheckFilter.class);
+            LoggingFilter.class);
 
     private boolean forceUseOfDefaultCatalogWithJavaClassPath = false;
     private Class<? extends SecurityProvider> securityProvider;
@@ -217,8 +219,12 @@ public class BrooklynRestApiLauncher {
 
         installWar(context);
         RestApiSetup.installRest(context,
-                new ManagementContextProvider(managementContext),
-                new ShutdownHandlerProvider(shutdownListener));
+                new ManagementContextProvider(),
+                new ShutdownHandlerProvider(shutdownListener),
+                new RequestTaggingRsFilter(),
+                new NoCacheFilter(),
+                new HaHotCheckResourceFilter(),
+                new EntitlementContextFilter());
         RestApiSetup.installServletFilters(context, this.filters);
 
         context.setContextPath("/");

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -245,7 +245,6 @@ public class BrooklynRestApiLauncher {
     /** NB: not fully supported; use one of the other {@link StartMode}s */
     private ContextHandler webXmlContextHandler(ManagementContext mgmt) {
         RestApiSetup.initSwagger();
-        // TODO add security to web.xml
         WebAppContext context;
         if (findMatchingFile("src/main/webapp")!=null) {
             // running in source mode; need to use special classpath
@@ -290,7 +289,9 @@ public class BrooklynRestApiLauncher {
     @Deprecated
     public static Server startServer(ContextHandler context, String summary, InetSocketAddress bindLocation) {
         Server server = new Server(bindLocation);
-        
+
+        initJaas(server);
+
         server.setHandler(context);
         try {
             server.start();
@@ -301,6 +302,15 @@ public class BrooklynRestApiLauncher {
         log.info("  http://localhost:"+((NetworkConnector)server.getConnectors()[0]).getLocalPort()+"/");
 
         return server;
+    }
+
+    // TODO Why parallel code for server init here and in BrooklynWebServer?
+    private static void initJaas(Server server) {
+        JAASLoginService loginService = new JAASLoginService();
+        loginService.setName("webconsole");
+        loginService.setLoginModuleName("webconsole");
+        loginService.setRoleClassNames(new String[] {RolePrincipal.class.getName()});
+        server.addBean(loginService);
     }
 
     public static BrooklynRestApiLauncher launcher() {


### PR DESCRIPTION
Makes `ManagementContextProvider` the single source of `ManagementContext` in REST code, abstracting away the different methods for accessing it.

Discussed in https://github.com/apache/brooklyn-server/pull/34
Depends on #41 
