### PR TITLE
Fix SoftwareProcessPersisterInMemorySizeIntegrationTest

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessPersisterInMemorySizeIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessPersisterInMemorySizeIntegrationTest.java
@@ -33,7 +33,7 @@ public class SoftwareProcessPersisterInMemorySizeIntegrationTest extends Brookly
 
     public SoftwareProcessPersisterInMemorySizeIntegrationTest() {
         pass1MaxFiles = 80;
-        pass1MaxKb = 150;
+        pass1MaxKb = 200;
         pass2MaxFiles = 100;
         pass2MaxKb = 150;
         pass3MaxKb = 50;


### PR DESCRIPTION
Seen a failure where 153397 bytes were written, increase maximum. The test is not deterministic.