### PR TITLE
does not create a localhost named location automatically

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
@@ -23,7 +23,10 @@ import java.util.Map;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
 import org.apache.brooklyn.api.location.LocationResolver;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocationResolver;
+import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.LocationConfigUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
@@ -40,6 +43,10 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
  */
 public class LocalhostLocationResolver extends AbstractLocationResolver implements LocationResolver.EnableableLocationResolver {
 
+    private static String BROOKLYN_LOCATION_LOCALHOST_PREFIX = "brooklyn.location.localhost";
+    
+    public static ConfigKey<Boolean> LOCALHOST_ENABLED = ConfigKeys.newConfigKeyWithPrefix(BROOKLYN_LOCATION_LOCALHOST_PREFIX+".", LocationConfigKeys.ENABLED);
+    
     public static final String LOCALHOST = "localhost";
 
     @Override
@@ -49,7 +56,7 @@ public class LocalhostLocationResolver extends AbstractLocationResolver implemen
 
     @Override
     public boolean isEnabled() {
-        return LocationConfigUtils.isEnabled(managementContext, "brooklyn.location.localhost");
+        return LocationConfigUtils.isEnabled(managementContext, BROOKLYN_LOCATION_LOCALHOST_PREFIX);
     }
 
     @Override

--- a/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
+++ b/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
@@ -75,7 +75,7 @@ public class ApplicationResourceIntegrationTest {
         if (manager == null) {
             manager = new LocalManagementContext();
             BrooklynRestApiLauncherTest.forceUseOfDefaultCatalogWithJavaClassPath(manager);
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             BrooklynRestApiLauncherTest.enableAnyoneLogin(manager);
         }
         return manager;

--- a/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
+++ b/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
@@ -65,7 +65,7 @@ public class BrooklynApiRestClientTest {
         if (manager == null) {
             manager = new LocalManagementContext();
             BrooklynRestApiLauncherTest.forceUseOfDefaultCatalogWithJavaClassPath(manager);
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             BrooklynRestApiLauncherTest.enableAnyoneLogin(manager);
         }
         return manager;

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -146,7 +146,7 @@ public abstract class BrooklynRestApiTest {
                 manager = new LocalManagementContextForTests();
             }
             manager.getHighAvailabilityManager().disabled();
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             
             new BrooklynCampPlatformLauncherNoServer()
                 .useManagementContext(manager)

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -85,7 +85,7 @@ public abstract class BrooklynRestApiTest {
                 manager = new LocalManagementContextForTests();
             }
             manager.getHighAvailabilityManager().disabled();
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             
             new BrooklynCampPlatformLauncherNoServer()
                 .useManagementContext(manager)


### PR DESCRIPTION
the location-add-wizard which @tbouron is working on will make it easy for users to do this, and there is no reason `localhost` should be added specially (and good reasons why it shouldn't as it is not representative and it is error-prone!)

i suggest this be tested and reviewed as part of @tbouron's WIP, and merged only at the same time as his.  (if this lands in time for 090 great but not needed.  probably confusing for a user to merge this PR without the wizard.)

we should also update the release notes with something like the following explaining the compatibility break:

```
6. The named location `localhost` is no longer automatically added by default on a fresh Brooklyn install.
Instead UI users are directed to a location wizard where they can configure their targets, including localhost. 
If you require `localhost` to be available on boot, define it as a named location in `brooklyn.properties`
or the default catalog. (The property `brooklyn.location.name.localhost=localhost` is usually sufficient.)
If you want a location named `localhost` afterwards, simply add it to your local catalog using the wizard.
```