### PR TITLE
[OSGi] Make EmbeddedFelixFramework pluggable

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
@@ -36,15 +36,16 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServerPaths;
-import org.apache.brooklyn.rt.felix.EmbeddedFelixFramework;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.osgi.Osgis;
 import org.apache.brooklyn.util.core.osgi.Osgis.BundleFinder;
+import org.apache.brooklyn.util.core.osgi.SystemFrameworkLoader;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.os.Os.DeletionResult;
+import org.apache.brooklyn.util.osgi.SystemFramework;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
@@ -192,15 +193,7 @@ public class OsgiManager {
                     Class<T> clazz;
                     //Extension bundles don't support loadClass.
                     //Instead load from the app classpath.
-                    if (EmbeddedFelixFramework.isExtensionBundle(b)) {
-                        @SuppressWarnings("unchecked")
-                        Class<T> c = (Class<T>)Class.forName(type);
-                        clazz = c;
-                    } else {
-                        @SuppressWarnings("unchecked")
-                        Class<T> c = (Class<T>)b.loadClass(type);
-                        clazz = c;
-                    }
+                    clazz = SystemFrameworkLoader.get().loadClassFromBundle(type, b);
                     return Maybe.of(clazz);
                 } else {
                     bundleProblems.put(osgiBundle, ((Maybe.Absent<?>)bundle).getException());

--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/ContainerFramework.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/ContainerFramework.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.core.osgi;
+
+import org.apache.brooklyn.util.osgi.SystemFramework;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.launch.Framework;
+
+public class ContainerFramework implements SystemFramework {
+
+    @Override
+    public Framework getFramework(String felixCacheDir, boolean clean) {
+        final Bundle bundle = FrameworkUtil.getBundle(Osgis.class);
+        return (Framework) bundle.getBundleContext().getBundle(0);
+    }
+
+    @Override
+    public void ungetFramework(Framework framework) {
+    }
+
+    @Override
+    public boolean isSystemBundle(Bundle bundle) {
+        return false;
+    }
+
+    @Override
+    public <T> Class<T> loadClassFromBundle(String type, Bundle b) throws ClassNotFoundException {
+        @SuppressWarnings("unchecked")
+        Class<T> c = (Class<T>)b.loadClass(type);
+        return c;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/SystemFrameworkLoader.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/SystemFrameworkLoader.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.core.osgi;
+
+import org.apache.brooklyn.api.framework.FrameworkLookup;
+import org.apache.brooklyn.util.osgi.SystemFramework;
+
+public class SystemFrameworkLoader {
+    private static SystemFramework framework;
+    public static SystemFramework get() {
+        if (framework == null) {
+            return createFramework();
+        } else {
+            return framework;
+        }
+    }
+    private synchronized static SystemFramework createFramework() {
+        if (framework == null) {
+            framework = FrameworkLookup.lookup(SystemFramework.class).get();
+        }
+        return framework;
+    }
+}

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -61,4 +61,8 @@ limitations under the License.
         <property name="persistPeriod" value="${persistPeriod}" />
     </bean>
 
+    <bean id="containerFramework"
+          class="org.apache.brooklyn.util.core.osgi.ContainerFramework" />
+    <service ref="containerFramework"
+          interface="org.apache.brooklyn.util.osgi.SystemFramework" />
 </blueprint>

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
@@ -20,11 +20,11 @@ package org.apache.brooklyn.core.mgmt.osgi;
 
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.rt.felix.EmbeddedFelixFramework;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.osgi.OsgiTestBase;
 import org.apache.brooklyn.util.core.osgi.Osgis;
+import org.apache.brooklyn.util.core.osgi.SystemFrameworkLoader;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.maven.MavenArtifact;
 import org.apache.brooklyn.util.maven.MavenRetriever;
@@ -106,7 +106,7 @@ public class OsgiStandaloneTest extends OsgiTestBase {
         //Make sure that we still get the initially loaded
         //bundle after trying to install the same version.
         Bundle bundle = install(url);
-        Assert.assertTrue(EmbeddedFelixFramework.isExtensionBundle(bundle));
+        Assert.assertTrue(SystemFrameworkLoader.get().isSystemBundle(bundle));
     }
 
     @Test

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -136,6 +136,7 @@
         <!-- TODO: don't use wrap -->
         <bundle dependency="true">wrap:mvn:com.google.http-client/google-http-client/1.18.0-rc</bundle> <!-- from geoip -->
         <bundle dependency="true">wrap:mvn:com.maxmind.geoip2/geoip2/${maxmind.version}</bundle> <!-- from geoip2 -->
+        <bundle dependency="true">wrap:mvn:com.maxmind.db/maxmind-db/${maxmind-db.version}</bundle>
         <bundle dependency="true">wrap:mvn:xpp3/xpp3_min/1.1.4c</bundle> <!-- from com.thoughtworks.xstream/xstream -->
 
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${reflections.bundle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <jsr311-api.version>1.1.1</jsr311-api.version>
         <jax-rs-api.version>2.0.1</jax-rs-api.version>
         <maxmind.version>0.8.1</maxmind.version>
+        <maxmind-db.version>0.3.4</maxmind-db.version>
         <jna.version>4.0.0</jna.version>
         <winrm4j.version>0.3.2</winrm4j.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->

--- a/utils/common/src/main/java/org/apache/brooklyn/util/osgi/SystemFramework.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/osgi/SystemFramework.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.osgi;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.launch.Framework;
+
+public interface SystemFramework {
+    /** 
+     * Provides an OSGI framework.
+     *
+     * When running inside an OSGi container, the container framework is returned.
+     * When running standalone a new Apache Felix container is created.
+     */
+    public Framework getFramework(String felixCacheDir, boolean clean);
+
+    /**
+     * Stops/ungets the OSGi framework, depending on the environment.
+     */
+    public void ungetFramework(Framework framework);
+
+    /**
+     * Whether the bundle is exporting classes from the application class path.
+     */
+    public boolean isSystemBundle(Bundle bundle);
+
+    /**
+     * Loads a class from the passed bundle. The embedded environment has some special
+     * requirements for loading classes so the implementation will abstract those.
+     */
+    public <T> Class<T> loadClassFromBundle(String type, Bundle b) throws ClassNotFoundException;
+}

--- a/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFramework.java
+++ b/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFramework.java
@@ -256,11 +256,6 @@ public class EmbeddedFelixFramework {
         return atts.containsKey(new Attributes.Name(Constants.BUNDLE_MANIFESTVERSION));
     }
 
-    public static boolean isSystemBundle(Bundle bundle) {
-        String versionedId = OsgiUtils.getVersionedId( bundle );
-        return SYSTEM_BUNDLES.contains(versionedId);
-    }
-
     public static boolean isExtensionBundle(Bundle bundle) {
         String location = bundle.getLocation();
         return location != null && 

--- a/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFramework.java
+++ b/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFramework.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.rt.felix;
+
+import org.apache.brooklyn.util.osgi.SystemFramework;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.launch.Framework;
+
+public class EmbeddedFramework implements SystemFramework {
+
+    @Override
+    public Framework getFramework(String felixCacheDir, boolean clean) {
+        return EmbeddedFelixFramework.newFrameworkStarted(felixCacheDir, clean, null);
+    }
+
+    @Override
+    public void ungetFramework(Framework framework) {
+        EmbeddedFelixFramework.stopFramework(framework);
+    }
+
+    @Override
+    public boolean isSystemBundle(Bundle bundle) {
+        return EmbeddedFelixFramework.isExtensionBundle(bundle);
+    }
+
+    @Override
+    public <T> Class<T> loadClassFromBundle(String type, Bundle b) throws ClassNotFoundException {
+        Class<T> clazz;
+        if (EmbeddedFelixFramework.isExtensionBundle(b)) {
+            @SuppressWarnings("unchecked")
+            Class<T> c = (Class<T>)Class.forName(type);
+            clazz = c;
+        } else {
+            @SuppressWarnings("unchecked")
+            Class<T> c = (Class<T>)b.loadClass(type);
+            clazz = c;
+        }
+        return clazz;
+    }
+
+}

--- a/utils/rt-felix/src/main/resources/META-INF/services/org.apache.brooklyn.util.osgi.SystemFramework
+++ b/utils/rt-felix/src/main/resources/META-INF/services/org.apache.brooklyn.util.osgi.SystemFramework
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.brooklyn.rt.felix.EmbeddedFramework


### PR DESCRIPTION
Needs different implementations depending on whether running in Karaf or classical. Can't have EmbeddedFelixFramework loaded in Karaf because felix bundle doesn't export org.apache.framework packages, just generic OSGi ones.

Needs to be rebased on master after merging #65  for a successful build.