### PR TITLE
fix location leak - use LocationSpec wherever possible

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
@@ -108,6 +109,7 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
     private final List<Enricher> enrichers = Lists.newArrayList();
     private final List<EnricherSpec<?>> enricherSpecs = Lists.newArrayList();
     private final List<Location> locations = Lists.newArrayList();
+    private final List<LocationSpec<?>> locationSpecs = Lists.newArrayList();
     private final Set<Class<?>> additionalInterfaces = Sets.newLinkedHashSet();
     private final List<EntityInitializer> entityInitializers = Lists.newArrayList();
     private final List<EntitySpec<?>> children = Lists.newArrayList();
@@ -131,6 +133,7 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
                 .children(copyFromSpecs(otherSpec.getChildren()))
                 .members(otherSpec.getMembers())
                 .groups(otherSpec.getGroups())
+                .locationSpecs(otherSpec.getLocationSpecs())
                 .locations(otherSpec.getLocations());
         
         if (otherSpec.getParent() != null) parent(otherSpec.getParent());
@@ -207,6 +210,7 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         return policySpecs;
     }
     
+    /** @deprecated since 0.9.0 in future only {@link #getPolicySpecs()} will be supported */ @Deprecated
     public List<Policy> getPolicies() {
         return policies;
     }
@@ -215,10 +219,16 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         return enricherSpecs;
     }
     
+    /** @deprecated since 0.9.0 in future only {@link #getEnricherSpecs()} will be supported */ @Deprecated
     public List<Enricher> getEnrichers() {
         return enrichers;
     }
     
+    public List<LocationSpec<?>> getLocationSpecs() {
+        return locationSpecs;
+    }
+
+    /** @deprecated since 0.9.0 in future only {@link #getLocationSpecs()} will be supported */ @Deprecated
     public List<Location> getLocations() {
         return locations;
     }
@@ -311,7 +321,8 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         return this;
     }
 
-    /** adds a policy to the spec */
+    /** adds a policy to the spec 
+     * @deprecated since 0.9.0 pass a spec, using {@link #policy(EnricherSpec)} */ @Deprecated
     public <V> EntitySpec<T> policy(Policy val) {
         checkMutable();
         policies.add(checkNotNull(val, "policy"));
@@ -332,21 +343,23 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         return this;
     }
     
-    /** adds the supplied policies to the spec */
+    /** adds the supplied policies to the spec 
+     * @deprecated since 0.9.0 pass a spec, using {@link #policySpecs(Iterable)} */ @Deprecated
     public <V> EntitySpec<T> policies(Iterable<? extends Policy> val) {
         checkMutable();
         policies.addAll(MutableList.copyOf(checkNotNull(val, "policies")));
         return this;
     }
     
-    /** adds a policy to the spec */
+    /** adds an enricher to the spec 
+     * @deprecated since 0.9.0 pass a spec, using {@link #enricher(EnricherSpec)} */ @Deprecated
     public <V> EntitySpec<T> enricher(Enricher val) {
         checkMutable();
         enrichers.add(checkNotNull(val, "enricher"));
         return this;
     }
 
-    /** adds a policy to the spec */
+    /** adds an enricher to the spec */
     public <V> EntitySpec<T> enricher(EnricherSpec<?> val) {
         checkMutable();
         enricherSpecs.add(checkNotNull(val, "enricherSpec"));
@@ -360,34 +373,56 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         return this;
     }
     
-    /** adds the supplied policies to the spec */
+    /** adds the supplied policies to the spec 
+     * @deprecated since 0.9.0 pass a spec, using {@link #enricherSpecs(Iterable)} */ @Deprecated
     public <V> EntitySpec<T> enrichers(Iterable<? extends Enricher> val) {
         checkMutable();
         enrichers.addAll(MutableList.copyOf(checkNotNull(val, "enrichers")));
         return this;
     }
     
+     /** adds a location to the spec
+      * @deprecated since 0.9.0 pass a spec, using {@link #enricherSpecs(Iterable)} */ 
+     @Deprecated
+     // there are still many places in tests where we use this;
+     // in some we want to force the use of a given location.
+     // TODO we could perhaps introduce an ExistingLocation class which can generate a spec based on an ID to formalize this?
+     public <V> EntitySpec<T> location(Location val) {
+         checkMutable();
+         locations.add(checkNotNull(val, "location"));
+         return this;
+     }
+     
     /** adds a location to the spec */
-    public <V> EntitySpec<T> location(Location val) {
+    public <V> EntitySpec<T> location(LocationSpec<?> val) {
         checkMutable();
-        locations.add(checkNotNull(val, "location"));
+        locationSpecs.add(checkNotNull(val, "location"));
         return this;
     }
     
-    /** clears locations defined in the spec */
-    public <V> EntitySpec<T> clearLocations() {
+    /** adds the supplied locations to the spec */
+    public <V> EntitySpec<T> locationSpecs(Iterable<? extends LocationSpec<?>> val) {
         checkMutable();
-        locations.clear();
-        return this;        
+        locationSpecs.addAll(MutableList.copyOf(checkNotNull(val, "locations")));
+        return this;
     }
     
-    /** adds the supplied locations to the spec */
+    /** adds the supplied locations to the spec
+     * @deprecated since 0.9.0 pass a spec, using {@link #locationSpecs(Iterable)} */ @Deprecated
     public <V> EntitySpec<T> locations(Iterable<? extends Location> val) {
         checkMutable();
         locations.addAll(MutableList.copyOf(checkNotNull(val, "locations")));
         return this;
     }
 
+    /** clears locations defined in the spec */
+    public <V> EntitySpec<T> clearLocations() {
+        checkMutable();
+        locationSpecs.clear();
+        locations.clear();
+        return this;        
+    }
+    
     /** "seals" this spec, preventing any future changes */
     public EntitySpec<T> immutable() {
         immutable = true;

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -247,6 +247,11 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     /** strings inserted as flags, config keys inserted as config keys; 
      * if you want to force one or the other, create a ConfigBag and convert to the appropriate map type */
     public SpecT configure(Map<?,?> val) {
+        if (val==null) {
+            log.warn("Null supplied when configuring "+this);
+            log.debug("Source for null supplied when configuring "+this, new Throwable("Source for null supplied when configuring "+this));
+            return self();
+        }
         for (Map.Entry<?, ?> entry: val.entrySet()) {
             if (entry.getKey()==null) throw new NullPointerException("Null key not permitted");
             if (entry.getKey() instanceof CharSequence)

--- a/api/src/main/java/org/apache/brooklyn/api/location/LocationDefinition.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/LocationDefinition.java
@@ -30,7 +30,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
  * a name that matches a named location defined in the brooklyn poperties.
  * 
  * Users are not expected to implement this, or to use the interface directly. See
- * {@link LocationRegistry#resolve(String)} and {@link ManagementContext#getLocationRegistry()}.
+ * {@link ManagementContext#getLocationRegistry()}.
  */
 public interface LocationDefinition {
 

--- a/api/src/main/java/org/apache/brooklyn/api/location/LocationResolver.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/LocationResolver.java
@@ -22,8 +22,6 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 
-import com.google.common.annotations.Beta;
-
 /**
  * Provides a way of creating location instances of a particular type.
  */
@@ -37,21 +35,14 @@ public interface LocationResolver {
     /** whether the spec is something which should be passed to this resolver */
     boolean accepts(String spec, LocationRegistry registry);
 
-    /**
-     * Similar to {@link #newLocationFromString(Map, String)} 
-     * but passing in a reference to the registry itself (from which the base properties are discovered)
-     * and including flags (e.g. user, key, cloud credential) which are known to be for this location.
-     * <p>
-     * introduced to support locations which refer to other locations, e.g. NamedLocationResolver  
-     **/ 
-    @SuppressWarnings("rawtypes")
-    Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry);
+    /** whether the location is enabled */
+    boolean isEnabled();
 
-    /** @since 0.7.0 exploring this as a mechanism to disable locations */
-    @Beta
-    public interface EnableableLocationResolver extends LocationResolver {
-        /** whether the location is enabled */
-        boolean isEnabled();
-    }
-    
+    /**
+     * Creates a LocationSpec given a spec string, flags (e.g. user, key, cloud credential),
+     * and the registry itself from which the base properties are discovered
+     * and supporting locations which refer to other locations, e.g. NamedLocationResolver.
+     **/ 
+    LocationSpec<? extends Location> newLocationSpecFromString(String spec, Map<?,?> locationFlags, LocationRegistry registry);
+
 }

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/LocationManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/LocationManager.java
@@ -31,6 +31,9 @@ public interface LocationManager {
 
     /**
      * Creates a new location, which is tracked by the management context.
+     * <p>
+     * Some sub-interfaces may expose an option to suppress management
+     * (e.g. <code>CREATE_UNMANAGED</code> on the Brooklyn LocationManagerInternal sub-interface). 
      * 
      * @param spec
      */
@@ -41,7 +44,9 @@ public interface LocationManager {
      * Equivalent to {@code createLocation(LocationSpec.create(type).configure(config))}
      * 
      * @see #createLocation(LocationSpec)
+     * @deprecated in 0.9.0, use {@link LocationSpec} instead
      */
+    @Deprecated
     <T extends Location> T createLocation(Map<?,?> config, Class<T> type);
 
     /**

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -224,6 +224,7 @@ public class BrooklynComponentTemplateResolver {
         if (planId != null)
             spec.configure(BrooklynCampConstants.PLAN_ID, planId);
 
+        // XXX use location spec
         List<Location> locations = new BrooklynYamlLocationResolver(mgmt).resolveLocations(attrs.getAllConfig(), true);
         if (locations != null) {
             // override locations defined in the type if locations are specified here

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
@@ -224,13 +224,12 @@ public class BrooklynComponentTemplateResolver {
         if (planId != null)
             spec.configure(BrooklynCampConstants.PLAN_ID, planId);
 
-        // XXX use location spec
-        List<Location> locations = new BrooklynYamlLocationResolver(mgmt).resolveLocations(attrs.getAllConfig(), true);
+        List<LocationSpec<?>> locations = new BrooklynYamlLocationResolver(mgmt).resolveLocations(attrs.getAllConfig(), true);
         if (locations != null) {
             // override locations defined in the type if locations are specified here
             // empty list can be used by caller to clear, so they are inherited
             spec.clearLocations();
-            spec.locations(locations);
+            spec.locationSpecs(locations);
         }
 
         decorateSpec(spec, encounteredRegisteredTypeIds);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
@@ -200,7 +200,7 @@ public class ByonLocationsYamlTest extends AbstractYamlTest {
 
         Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
         FixedListMachineProvisioningLocation<MachineLocation> loc = (FixedListMachineProvisioningLocation<MachineLocation>) Iterables.get(app.getLocations(), 0);
-        PortForwardManager pfm = (PortForwardManager) mgmt().getLocationRegistry().resolve("portForwardManager(scope=global)");
+        PortForwardManager pfm = (PortForwardManager) mgmt().getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
         
         Set<MachineLocation> machines = loc.getAvailable();
         assertEquals(machines.size(), 2, "machines="+machines);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
@@ -29,7 +29,6 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.Jsonya;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
@@ -85,7 +85,7 @@ public class ExternalConfigBrooklynPropertiesTest extends AbstractYamlTest {
         props.put("brooklyn.location.jclouds.aws-ec2.identity", "$brooklyn:external(\"myprovider\", \"mykey\")");
         props.put("brooklyn.location.jclouds.aws-ec2.credential", "$brooklyn:external(\"myprovider\", \"mykey2\")");
         
-        JcloudsLocation loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve("jclouds:aws-ec2:us-east-1");
+        JcloudsLocation loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-east-1");
         assertEquals(loc.getIdentity(), "myval");
         assertEquals(loc.getCredential(), "myval2");
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/LocationsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/LocationsYamlTest.java
@@ -263,7 +263,7 @@ public class LocationsYamlTest extends AbstractYamlTest {
         Entity app = createStartWaitAndLogApplication(new StringReader(yaml));
         Entity child = Iterables.getOnlyElement(app.getChildren());
         MultiLocation<?> loc = (MultiLocation<?>) Iterables.getOnlyElement(Entities.getAllInheritedLocations(child));
-        Assert.assertEquals(loc.getSubLocations().size(), 2);
+        Assert.assertEquals(loc.getSubLocationsAsLocations().size(), 2);
         
         assertUserAddress((SshMachineLocation)loc.obtain(), "root", "127.0.0.1");
         assertUserAddress((SshMachineLocation)loc.obtain(), "root", "127.0.0.2");

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/LocationsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/LocationsYamlTest.java
@@ -281,5 +281,5 @@ public class LocationsYamlTest extends AbstractYamlTest {
     protected Logger getLogger() {
         return log;
     }
-    
+
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReloadBrooklynPropertiesTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReloadBrooklynPropertiesTest.java
@@ -23,13 +23,11 @@ import java.io.Reader;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.camp.CampPlatform;
-import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
-import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
 import org.apache.brooklyn.camp.spi.Assembly;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.stream.Streams;
@@ -78,7 +76,7 @@ public class ReloadBrooklynPropertiesTest {
             final Entity app = brooklynMgmt.getEntityManager().getEntity(assembly.getId());
             LOG.info("App - " + app);
             Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
-            EntityTestUtils.assertAttributeEqualsEventually(app, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(app, Startable.SERVICE_UP, true);
         } catch (Exception e) {
             LOG.warn("Unable to instantiate " + template + " (rethrowing): " + e);
             throw Exceptions.propagate(e);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/TestSensorAndEffectorInitializer.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/TestSensorAndEffectorInitializer.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.EntityInitializer;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.effector.Effectors;
@@ -42,7 +41,7 @@ public class TestSensorAndEffectorInitializer implements EntityInitializer {
 
     protected String helloWord() { return "Hello"; }
     
-    public void apply(EntityLocal entity) {
+    public void apply(@SuppressWarnings("deprecation") org.apache.brooklyn.api.entity.EntityLocal entity) {
         Effector<String> eff = Effectors.effector(String.class, EFFECTOR_SAY_HELLO).parameter(String.class, "name").impl(
             new EffectorBody<String>() {
                 @Override

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaBashNetcatYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaBashNetcatYamlTest.java
@@ -22,14 +22,13 @@ import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.text.StringPredicates;
@@ -68,7 +67,7 @@ public class VanillaBashNetcatYamlTest extends AbstractYamlTest {
         Entity netcat = Iterables.getOnlyElement(netcatI);
         
         // make sure netcat is running
-        EntityTestUtils.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.equalTo(Lifecycle.RUNNING));
+        EntityAsserts.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.equalTo(Lifecycle.RUNNING));
         
         // find the pinger, now comparing by name
         Iterable<Entity> pingerI = Iterables.filter(app.getChildren(), EntityPredicates.displayNameEqualTo("Simple Pinger"));
@@ -80,26 +79,26 @@ public class VanillaBashNetcatYamlTest extends AbstractYamlTest {
         ping = pinger.invoke(EFFECTOR_SAY_HI, MutableMap.<String,Object>of());
         Assert.assertEquals(ping.get().trim(), "hello");
         // and check we get the right result 
-        EntityTestUtils.assertAttributeEventually(netcat, SENSOR_OUTPUT_ALL, StringPredicates.containsLiteral("hi netcat"));
+        EntityAsserts.assertAttributeEventually(netcat, SENSOR_OUTPUT_ALL, StringPredicates.containsLiteral("hi netcat"));
         log.info("invoked ping from "+pinger+" to "+netcat+", 'all' sensor shows:\n"+
                 netcat.getAttribute(SENSOR_OUTPUT_ALL));
 
         // netcat should now fail and restart
-        EntityTestUtils.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.not(Predicates.equalTo(Lifecycle.RUNNING)));
+        EntityAsserts.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.not(Predicates.equalTo(Lifecycle.RUNNING)));
         log.info("detected failure, state is: "+netcat.getAttribute(Attributes.SERVICE_STATE_ACTUAL));
-        EntityTestUtils.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.equalTo(Lifecycle.RUNNING));
+        EntityAsserts.assertAttributeEventually(netcat, Attributes.SERVICE_STATE_ACTUAL, Predicates.equalTo(Lifecycle.RUNNING));
         log.info("detected recovery, state is: "+netcat.getAttribute(Attributes.SERVICE_STATE_ACTUAL));
 
         // invoke effector again, now with a parameter
         ping = pinger.invoke(EFFECTOR_SAY_HI, MutableMap.<String,Object>of("message", "yo yo yo"));
         Assert.assertEquals(ping.get().trim(), "hello");
         // checking right result
-        EntityTestUtils.assertAttributeEventually(netcat, SENSOR_OUTPUT_ALL, StringPredicates.containsLiteral("yo yo yo"));
+        EntityAsserts.assertAttributeEventually(netcat, SENSOR_OUTPUT_ALL, StringPredicates.containsLiteral("yo yo yo"));
         log.info("invoked ping again from "+pinger+" to "+netcat+", 'all' sensor shows:\n"+
                 netcat.getAttribute(SENSOR_OUTPUT_ALL));
         
         // and it's propagated to the app
-        EntityTestUtils.assertAttributeEventually(app, Sensors.newStringSensor("output.last"), StringPredicates.containsLiteral("yo yo yo"));
+        EntityAsserts.assertAttributeEventually(app, Sensors.newStringSensor("output.last"), StringPredicates.containsLiteral("yo yo yo"));
         
         log.info("after all is said and done, app is:");
         Entities.dumpInfo(app);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
@@ -34,13 +34,13 @@ import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.VanillaWindowsProcess;
 import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.task.TaskPredicates;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.apache.brooklyn.util.text.Strings;
@@ -301,7 +301,7 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
             
             VanillaWindowsProcess entity = (VanillaWindowsProcess) app.getChildren().iterator().next();
             
-            EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
             assertStreams(entity, stdouts);
             
         } else if (cmdFailed.equals("stop-command")) {
@@ -310,7 +310,7 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
             log.info("App started:");
             Entities.dumpInfo(app);
             VanillaWindowsProcess entity = (VanillaWindowsProcess) app.getChildren().iterator().next();
-            EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
             
             entity.stop();
             assertSubTaskFailures(entity, ImmutableMap.of(taskRegexFailed, StringPredicates.containsLiteral("for "+cmdFailed)));

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -266,7 +266,7 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
         assertCatalogCount(1);
         assertLocationManagerInstancesCount(0);
 
-        Location loc = mgmt().getLocationRegistry().resolve("lh1");
+        Location loc = mgmt().getLocationRegistry().getLocationManaged("lh1");
 
         assertLocationRegistryCount(1);
         assertCatalogCount(1);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -36,8 +36,11 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
+import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.text.StringFunctions;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -248,6 +251,67 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
 
     private int countCatalogLocations() {
         return Iterables.size(mgmt().getTypeRegistry().getMatching(RegisteredTypePredicates.IS_LOCATION));
+    }
+
+    @Test
+    public void testManagedLocationsCreateAndCleanup() {
+        assertLocationRegistryCount(0);
+        assertLocationManagerInstancesCount(0);
+        assertCatalogCount(0);
+        
+        String symbolicName = "lh1";
+        addCatalogLocation(symbolicName, LOCALHOST_LOCATION_TYPE, null);
+
+        assertLocationRegistryCount(1);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(0);
+
+        Location loc = mgmt().getLocationRegistry().resolve("lh1");
+
+        assertLocationRegistryCount(1);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(1);
+
+        mgmt().getLocationManager().unmanage(loc);
+        
+
+        assertLocationRegistryCount(1);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(0);
+
+        deleteCatalogEntity("lh1");
+        
+        assertLocationRegistryCount(0);
+        assertCatalogCount(0);
+        assertLocationManagerInstancesCount(0);
+    }
+    
+    private void assertLocationRegistryCount(int size) {
+        Asserts.assertThat(mgmt().getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(size));
+    }
+    private void assertLocationManagerInstancesCount(int size) {
+        Asserts.assertThat(mgmt().getLocationManager().getLocations(), CollectionFunctionals.sizeEquals(size));
+    }
+    private void assertCatalogCount(int size) {
+        Asserts.assertThat(mgmt().getCatalog().getCatalogItems(), CollectionFunctionals.sizeEquals(size));
+    }
+    
+    @Test
+    public void testLocationPartOfBlueprintDoesntLeak() {
+        String symbolicName = "my.catalog.app.id.load";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  id: " + symbolicName,
+            "  version: " + TEST_VERSION,
+            "  item:",
+            "    type: "+ BasicEntity.class.getName(),
+            "    location:",
+            "      jclouds:aws-ec2: { identity: ignore, credential: ignore }"
+            );
+        
+        assertLocationRegistryCount(0);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(0);
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
@@ -151,7 +151,7 @@ public class ConfigKeys {
 
 
     public static <T> AttributeSensorAndConfigKey<T, T> newSensorAndConfigKeyWithDefault(AttributeSensorAndConfigKey<T, T> parent, T defaultValue) {
-        return new BasicAttributeSensorAndConfigKey(parent, defaultValue);
+        return new BasicAttributeSensorAndConfigKey<T>(parent, defaultValue);
     }
 
     public static PortAttributeSensorAndConfigKey newPortSensorAndConfigKeyWithDefault(PortAttributeSensorAndConfigKey parent, Object defaultValue) {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/trait/Startable.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/trait/Startable.java
@@ -52,7 +52,7 @@ public interface Startable {
             "The location or locations to start in, as a string, a location object, a list of strings, "
             + "or a list of location objects");
         @Override public Void call(ConfigBag parameters) {
-            parameters.put(LOCATIONS, entity().getManagementContext().getLocationRegistry().resolveList(parameters.get(LOCATIONS)));
+            parameters.put(LOCATIONS, entity().getManagementContext().getLocationRegistry().getListOfLocationsManaged(parameters.get(LOCATIONS)));
             return new MethodEffector<Void>(Startable.class, "start").call(entity(), parameters.getAllConfig());
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocationResolver.java
@@ -52,7 +52,6 @@ import com.google.common.collect.ImmutableList;
  * 
  * @author aled
  */
-@SuppressWarnings({"unchecked","rawtypes"})
 public abstract class AbstractLocationResolver implements LocationResolver {
 
     public static final Logger log = LoggerFactory.getLogger(AbstractLocationResolver.class);
@@ -77,22 +76,29 @@ public abstract class AbstractLocationResolver implements LocationResolver {
     }
 
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public boolean isEnabled() {
+        return LocationConfigUtils.isResolverPrefixEnabled(managementContext, getPrefix());
+    }
+
+    @Override
+    public LocationSpec<?> newLocationSpecFromString(String spec, Map<?,?> locationFlags, LocationRegistry registry) {
         ConfigBag config = extractConfig(locationFlags, spec, registry);
-        Map globalProperties = registry.getProperties();
+        @SuppressWarnings("unchecked")
+        Map<String,?> globalProperties = registry.getProperties();
         String namedLocation = (String) locationFlags.get(LocationInternal.NAMED_SPEC_NAME.getName());
         
         if (registry != null) {
             LocationPropertiesFromBrooklynProperties.setLocalTempDir(globalProperties, config);
         }
 
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(getLocationType())
+        return LocationSpec.create(getLocationType())
             .configure(config.getAllConfig())
-            .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation)));
+            .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation));        
     }
 
     protected ConfigBag extractConfig(Map<?,?> locationFlags, String spec, LocationRegistry registry) {
-        Map globalProperties = registry.getProperties();
+        @SuppressWarnings("unchecked")
+        Map<String,?> globalProperties = registry.getProperties();
         ParsedSpec parsedSpec = specParser.parse(spec);
         String namedLocation = (String) locationFlags.get(LocationInternal.NAMED_SPEC_NAME.getName());
         

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
@@ -118,8 +118,20 @@ import com.google.common.collect.Sets;
  *     </ol>
  * </ol>
  * 
- * TODO There is no concept of a location version in this registry. The version
- * in the catalog is generally ignored.
+ * TODO we should change the registry to be a pass-through facade on top of the catalog,
+ * and shift to preferring catalog access mechanisms.
+ * this brings it in line with how we do other things;
+ * also this does not understand versions.
+ * to do this we will need to:
+ * <li> update the catalog on addition, setting a plan (ensuring serialization);
+ *      in case of a definition CHANGED in brooklyn.properties give an error if it means the plan has changed
+ *      (user could then remove from brooklyn.properties, if persistence on, or apply the update in the catalog;
+ *      ie similar semantics to defining an initial catalog via the CLI)
+ * <li> find and return the RegisteredType from the type-registry/catalog here
+ * <p>
+ * Once done, update the UI use /v1/catalog/locations instead of /v1/locations
+ * (currently the latter is the only way to list locations known in the LocationRegistry 
+ * ie those from brookln.properties.)
  */
 @SuppressWarnings({"rawtypes","unchecked"})
 public class BasicLocationRegistry implements LocationRegistry {
@@ -218,7 +230,7 @@ public class BasicLocationRegistry implements LocationRegistry {
     public void updateDefinedLocation(CatalogItem<Location, LocationSpec<?>> item) {
         String id = item.getCatalogItemId();
         String symbolicName = item.getSymbolicName();
-        String spec = CatalogLocationResolver.NAME + ":" + id;
+        String spec = CatalogLocationResolver.createLegacyWrappedReference(id);
         Map<String, Object> config = ImmutableMap.<String, Object>of();
         BasicLocationDefinition locDefinition = new BasicLocationDefinition(symbolicName, symbolicName, spec, config);
         
@@ -233,7 +245,7 @@ public class BasicLocationRegistry implements LocationRegistry {
     public void updateDefinedLocation(RegisteredType item) {
         String id = item.getId();
         String symbolicName = item.getSymbolicName();
-        String spec = CatalogLocationResolver.NAME + ":" + id;
+        String spec = CatalogLocationResolver.createLegacyWrappedReference(id);
         Map<String, Object> config = ImmutableMap.<String, Object>of();
         BasicLocationDefinition locDefinition = new BasicLocationDefinition(symbolicName, symbolicName, spec, config);
         

--- a/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
@@ -28,8 +28,11 @@ import org.apache.brooklyn.api.location.LocationResolver;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
 
 /**
  * Given a location spec in the form {@code brooklyn.catalog:<symbolicName>:<version>}, 
@@ -74,7 +77,7 @@ public class CatalogLocationResolver implements LocationResolver {
     }
     
     /**
-     * accepts anything that looks like it will be a YAML catalog item (e.g. starting "brooklyn.locations")
+     * accepts anything that looks like it will be a YAML catalog item (e.g. starting "brooklyn.catalog:")
      */
     @Override
     public boolean accepts(String spec, LocationRegistry registry) {
@@ -83,4 +86,18 @@ public class CatalogLocationResolver implements LocationResolver {
         return false;
     }
 
+    @Beta /** for transitioning away from LocationDefinition */
+    public static boolean isLegacyWrappedReference(String spec) {
+        if (spec==null) return false;
+        if (spec.startsWith(NAME+":")) return true;
+        return false;
+    }
+    @Beta /** for transitioning away from LocationDefinition */
+    public static String createLegacyWrappedReference(String id) {
+        return NAME + ":" + id;
+    }
+    @Beta /** for transitioning away from LocationDefinition */
+    public static String unwrapLegacyWrappedReference(String id) {
+        return Strings.removeFromStart(id, NAME+":");
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
@@ -49,8 +49,12 @@ public class CatalogLocationResolver implements LocationResolver {
     }
     
     @Override
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public boolean isEnabled() {
+        return true;
+    }
+    
+    @Override
+    public LocationSpec<? extends Location> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         String id = spec.substring(NAME.length()+1);
         RegisteredType item = managementContext.getTypeRegistry().get(id);
         if (item.isDisabled()) {
@@ -59,10 +63,9 @@ public class CatalogLocationResolver implements LocationResolver {
             log.warn("Use of deprecated catalog item "+item.getSymbolicName()+":"+item.getVersion());
         }
         
-        LocationSpec<?> origLocSpec = (LocationSpec) managementContext.getTypeRegistry().createSpec(item, null, LocationSpec.class);
-        LocationSpec locSpec = LocationSpec.create(origLocSpec)
-                .configure(locationFlags);
-        return managementContext.getLocationManager().createLocation(locSpec);
+        LocationSpec<?> origLocSpec = (LocationSpec<?>) managementContext.getTypeRegistry().createSpec(item, null, LocationSpec.class);
+        LocationSpec<?> locSpec = LocationSpec.create(origLocSpec).configure(locationFlags);
+        return locSpec;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/location/DefinedLocationByIdResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/DefinedLocationByIdResolver.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.location.LocationRegistry;
 import org.apache.brooklyn.api.location.LocationResolver;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,16 +47,20 @@ public class DefinedLocationByIdResolver implements LocationResolver {
         this.managementContext = checkNotNull(managementContext, "managementContext");
     }
     
-    @SuppressWarnings({ "rawtypes" })
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public boolean isEnabled() {
+        return true;
+    }
+    
+    @Override
+    public LocationSpec<? extends Location> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         String id = spec;
         if (spec.toLowerCase().startsWith(ID+":")) {
             id = spec.substring( (ID+":").length() );
         }
         LocationDefinition ld = registry.getDefinedLocationById(id);
         ld.getSpec();
-        return ((BasicLocationRegistry)registry).resolveLocationDefinition(ld, locationFlags, null);
+        return ((BasicLocationRegistry)registry).getLocationSpec(ld, locationFlags).get();
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/location/LocationConfigUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/LocationConfigUtils.java
@@ -60,6 +60,8 @@ public class LocationConfigUtils {
 
     private static final Logger log = LoggerFactory.getLogger(LocationConfigUtils.class);
 
+    public static String BROOKLYN_LOCATION_PREFIX = "brooklyn.location";
+    
     /** Creates an instance of {@link OsCredential} by inspecting {@link LocationConfigKeys#PASSWORD}; 
      * {@link LocationConfigKeys#PRIVATE_KEY_DATA} and {@link LocationConfigKeys#PRIVATE_KEY_FILE};
      * {@link LocationConfigKeys#PRIVATE_KEY_PASSPHRASE} if needed, and
@@ -548,9 +550,14 @@ public class LocationConfigUtils {
         return result;
     }
 
-    public static boolean isEnabled(ManagementContext mgmt, String prefix) {
-        ConfigKey<Boolean> key = ConfigKeys.newConfigKeyWithPrefix(prefix+".", LocationConfigKeys.ENABLED);
-        Boolean enabled = mgmt.getConfig().getConfig(key);
+    public static boolean isResolverPrefixEnabled(ManagementContext mgmt, String resolverIdPrefix) {
+        return isEnabled(mgmt, BROOKLYN_LOCATION_PREFIX+"."+resolverIdPrefix);
+    }
+    
+    /** checks enablement, by looking at <code>key + ".enabled"</code> */
+    public static boolean isEnabled(ManagementContext mgmt, String key) {
+        ConfigKey<Boolean> k = ConfigKeys.newConfigKeyWithPrefix(key+".", LocationConfigKeys.ENABLED);
+        Boolean enabled = mgmt.getConfig().getConfig(k);
         if (enabled!=null) return enabled.booleanValue();
         return true;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerImpl.java
@@ -75,7 +75,6 @@ import com.google.common.net.HostAndPort;
  *        such as the jcloudsMachine.getJcloudsId().
  * </ul>
  */
-@SuppressWarnings("serial")
 public class PortForwardManagerImpl extends AbstractLocation implements PortForwardManager {
 
     private static final Logger log = LoggerFactory.getLogger(PortForwardManagerImpl.class);

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolver.java
@@ -20,16 +20,23 @@ package org.apache.brooklyn.core.location.access;
 
 import java.util.Map;
 
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocationResolver;
 import org.apache.brooklyn.core.location.LocationConfigUtils;
 import org.apache.brooklyn.core.location.LocationPredicates;
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
+import org.apache.brooklyn.core.objs.proxy.SpecialBrooklynObjectConstructor;
+import org.apache.brooklyn.core.objs.proxy.SpecialBrooklynObjectConstructor.Config;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
@@ -49,27 +56,15 @@ public class PortForwardManagerLocationResolver extends AbstractLocationResolver
     @Override
     public LocationSpec<?> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         ConfigBag config = extractConfig(locationFlags, spec, registry);
-        Map globalProperties = registry.getProperties();
+        Map<?,?> globalProperties = registry.getProperties();
         String namedLocation = (String) locationFlags.get(LocationInternal.NAMED_SPEC_NAME.getName());
         String scope = config.get(PortForwardManager.SCOPE);
 
-        Optional<Location> result = Iterables.tryFind(managementContext.getLocationManager().getLocations(), 
-                Predicates.and(
-                        Predicates.instanceOf(PortForwardManager.class), 
-                        LocationPredicates.configEqualTo(PortForwardManager.SCOPE, scope)));
-        
-        if (result.isPresent()) {
-            // XXX
-//            return result.get();
-            return null;
-        } else {
-            LocationSpec<PortForwardManagerImpl> loc = LocationSpec.create(PortForwardManagerImpl.class)
-                    .configure(config.getAllConfig())
-                    .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation));
-            
-            if (LOG.isDebugEnabled()) LOG.debug("Created "+loc+" for scope "+scope);
-            return loc;
-        }
+        return LocationSpec.create(PortForwardManagerImpl.class)
+            .configure(config.getAllConfig())
+            .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation))
+            .configure(PortForwardManagerConstructor.SCOPE, scope)
+            .configure(Config.SPECIAL_CONSTRUCTOR, PortForwardManagerConstructor.class);
     }
 
     @Override
@@ -87,5 +82,45 @@ public class PortForwardManagerLocationResolver extends AbstractLocationResolver
         ConfigBag config = super.extractConfig(locationFlags, spec, registry);
         config.putAsStringKeyIfAbsent("name", "localhost");
         return config;
+    }
+    
+    public static class PortForwardManagerConstructor implements SpecialBrooklynObjectConstructor {
+
+        public static ConfigKey<String> SCOPE = ConfigKeys.newConfigKeyWithPrefix("brooklyn.object.constructor.portforward.",
+            PortForwardManager.SCOPE);
+        
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T create(ManagementContext mgmt, Class<T> type, AbstractBrooklynObjectSpec<?, ?> spec) {
+            ConfigBag config = ConfigBag.newInstance(spec.getConfig());
+            String scope = config.get(SCOPE);
+            
+            Optional<Location> result = findPortForwardManager(mgmt, scope);
+            if (result.isPresent()) return (T) result.get();
+            
+            // have to create it, but first check again with synch lock
+            synchronized (PortForwardManager.class) {
+                result = findPortForwardManager(mgmt, scope);
+                if (result.isPresent()) return (T) result.get();
+
+                Object callerContext = config.get(CloudLocationConfig.CALLER_CONTEXT);
+                LOG.info("Creating PortForwardManager(scope="+scope+")"+(callerContext!=null ? " for "+callerContext : ""));
+                
+                spec = LocationSpec.create((LocationSpec<?>)spec);
+                // clear the special instruction to actually create it
+                spec.configure(Config.SPECIAL_CONSTRUCTOR, (Class<SpecialBrooklynObjectConstructor>) null);
+                spec.configure(PortForwardManager.SCOPE, scope);
+                
+                return (T) mgmt.getLocationManager().createLocation((LocationSpec<?>) spec);
+            }
+        }
+
+        private Optional<Location> findPortForwardManager(ManagementContext mgmt, String scope) {
+            return Iterables.tryFind(mgmt.getLocationManager().getLocations(), 
+                Predicates.and(
+                        Predicates.instanceOf(PortForwardManager.class), 
+                        LocationPredicates.configEqualTo(PortForwardManager.SCOPE, scope)));
+        }
+        
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolver.java
@@ -47,7 +47,7 @@ public class PortForwardManagerLocationResolver extends AbstractLocationResolver
     }
 
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public LocationSpec<?> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         ConfigBag config = extractConfig(locationFlags, spec, registry);
         Map globalProperties = registry.getProperties();
         String namedLocation = (String) locationFlags.get(LocationInternal.NAMED_SPEC_NAME.getName());
@@ -59,11 +59,13 @@ public class PortForwardManagerLocationResolver extends AbstractLocationResolver
                         LocationPredicates.configEqualTo(PortForwardManager.SCOPE, scope)));
         
         if (result.isPresent()) {
-            return result.get();
+            // XXX
+//            return result.get();
+            return null;
         } else {
-            PortForwardManager loc = managementContext.getLocationManager().createLocation(LocationSpec.create(PortForwardManagerImpl.class)
+            LocationSpec<PortForwardManagerImpl> loc = LocationSpec.create(PortForwardManagerImpl.class)
                     .configure(config.getAllConfig())
-                    .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation)));
+                    .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation));
             
             if (LOG.isDebugEnabled()) LOG.debug("Created "+loc+" for scope "+scope);
             return loc;

--- a/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationInternal.java
@@ -37,11 +37,8 @@ import com.google.common.annotations.Beta;
  */
 public interface LocationInternal extends BrooklynObjectInternal, Location {
 
-    @Beta
     public static final ConfigKey<String> ORIGINAL_SPEC = ConfigKeys.newStringConfigKey("spec.original", "The original spec used to instantiate a location");
-    @Beta
     public static final ConfigKey<String> FINAL_SPEC = ConfigKeys.newStringConfigKey("spec.final", "The actual spec (in a chain) which instantiates a location");
-    @Beta
     public static final ConfigKey<String> NAMED_SPEC_NAME = ConfigKeys.newStringConfigKey("spec.named.name", "The name on the (first) named spec in a chain");
     
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -249,6 +249,7 @@ public class EntityManagementUtils {
             wrappedChild.displayName(wrapperParent.getDisplayName());
         }
         
+        wrappedChild.locationSpecs(wrapperParent.getLocationSpecs());
         wrappedChild.locations(wrapperParent.getLocations());
         
         if (!wrapperParent.getParameters().isEmpty())
@@ -310,8 +311,9 @@ public class EntityManagementUtils {
             spec.getInitializers().isEmpty() &&
             spec.getPolicies().isEmpty() &&
             spec.getPolicySpecs().isEmpty() &&
-            // these items prevent merge only if they are defined at both levels
-            (spec.getLocations().isEmpty() || Iterables.getOnlyElement(spec.getChildren()).getLocations().isEmpty())
+            // prevent merge only if a location is defined at both levels
+            ((spec.getLocations().isEmpty() && spec.getLocationSpecs().isEmpty()) || 
+                (Iterables.getOnlyElement(spec.getChildren()).getLocations().isEmpty()) && Iterables.getOnlyElement(spec.getChildren()).getLocationSpecs().isEmpty())
             // TODO what should we do with parameters? currently clobbers due to EntitySpec.parameters(...) behaviour.
 //            && (spec.getParameters().isEmpty() || Iterables.getOnlyElement(spec.getChildren()).getParameters().isEmpty())
             ;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalLocationManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalLocationManager.java
@@ -29,35 +29,28 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.location.ProvisioningLocation;
 import org.apache.brooklyn.api.mgmt.AccessController;
-import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.BrooklynLogging;
 import org.apache.brooklyn.core.BrooklynLogging.LoggingLevel;
-import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.internal.storage.BrooklynStorage;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.objs.proxy.InternalLocationFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.apache.brooklyn.util.stream.Streams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
 public class LocalLocationManager implements LocationManagerInternal {
-
-    @Beta /* expect to remove when API returns LocationSpec or similar */
-    public static final ConfigKey<Boolean> CREATE_UNMANAGED = ConfigKeys.newBooleanConfigKey("brooklyn.internal.location.createUnmanaged",
-        "If set on a location or spec, causes the manager to create it in an unmanaged state (for peeking)", false);
     
     private static final Logger log = LoggerFactory.getLogger(LocalLocationManager.class);
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocationManagerInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocationManagerInternal.java
@@ -19,9 +19,17 @@
 package org.apache.brooklyn.core.mgmt.internal;
 
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.LocationManager;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 
 public interface LocationManagerInternal extends LocationManager, BrooklynObjectManagerInternal<Location> {
+
+    /** Indicates that a call to {@link #createLocation(LocationSpec)} should create a location instance not
+     * linked to the management context. This allows clients to peek at the result but not to use it. */
+    public static final ConfigKey<Boolean> CREATE_UNMANAGED = ConfigKeys.newBooleanConfigKey("brooklyn.internal.location.createUnmanaged",
+        "If set on a location or spec, causes the manager to create it in an unmanaged state (for peeking)", false);
 
     public Iterable<String> getLocationIds();
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -80,19 +80,18 @@ public class BrooklynPersistenceUtils {
     
     /** Creates a {@link PersistenceObjectStore} for use with a specified set of modes. */
     public static PersistenceObjectStore newPersistenceObjectStore(ManagementContext managementContext,
-            String locationSpec, String locationContainer, PersistMode persistMode, HighAvailabilityMode highAvailabilityMode) {
+            String locationSpecString, String locationContainer, PersistMode persistMode, HighAvailabilityMode highAvailabilityMode) {
         PersistenceObjectStore destinationObjectStore;
-        locationContainer = BrooklynServerPaths.newMainPersistencePathResolver(managementContext).location(locationSpec).dir(locationContainer).resolve();
+        locationContainer = BrooklynServerPaths.newMainPersistencePathResolver(managementContext).location(locationSpecString).dir(locationContainer).resolve();
 
-        Location location = null;
-        if (Strings.isBlank(locationSpec)) {
-            location = managementContext.getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.class)
+        LocationSpec<?> locationSpec = Strings.isBlank(locationSpecString) ?
+            LocationSpec.create(LocalhostMachineProvisioningLocation.class) :
+                managementContext.getLocationRegistry().getLocationSpec(locationSpecString).get();
+            
+        Location location = managementContext.getLocationManager().createLocation(locationSpec
                 .configure(LocalLocationManager.CREATE_UNMANAGED, true));
-        } else {
-            location = managementContext.getLocationRegistry().resolve(locationSpec, false, null).get();
-            if (!(location instanceof LocationWithObjectStore)) {
-                throw new IllegalArgumentException("Destination location "+location+" does not offer a persistent store");
-            }
+        if (!(location instanceof LocationWithObjectStore)) {
+            throw new IllegalArgumentException("Destination location "+location+" does not offer a persistent store");
         }
         destinationObjectStore = ((LocationWithObjectStore)location).newPersistenceObjectStore(locationContainer);
         

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -34,6 +33,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.EntityTypeRegistry;
 import org.apache.brooklyn.api.entity.Group;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
@@ -326,6 +326,10 @@ public class InternalEntityFactory extends InternalFactory {
             public void run() {
                 ((AbstractEntity)entity).init();
 
+                for (LocationSpec<?> locationSpec : spec.getLocationSpecs()) {
+                    ((AbstractEntity)entity).addLocations(MutableList.of(
+                        managementContext.getLocationManager().createLocation(locationSpec)));
+                }
                 ((AbstractEntity)entity).addLocations(spec.getLocations());
 
                 for (EntityInitializer initializer: spec.getInitializers()) {

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -372,9 +372,11 @@ public class InternalEntityFactory extends InternalFactory {
      * The new-style no-arg constructor is preferred, and   
      * configuration from the {@link EntitySpec} is <b>not</b> normally applied,
      * although for old-style entities flags from the spec are passed to the constructor.
-     */
+     * <p>
+     * @deprecated since 0.9.0 becoming private
+     */ @Deprecated
     public <T extends Entity> T constructEntity(Class<? extends T> clazz, EntitySpec<T> spec) {
-        T entity = constructEntityImpl(clazz, spec.getFlags());
+        T entity = constructEntityImpl(clazz, spec, null, null);
         if (((AbstractEntity)entity).getProxy() == null) ((AbstractEntity)entity).setProxy(createEntityProxy(spec, entity));
         return entity;
     }
@@ -383,9 +385,9 @@ public class InternalEntityFactory extends InternalFactory {
      * Constructs a new-style entity (fails if no no-arg constructor).
      * Sets the entity's id and proxy.
      * <p>
-     * As {@link #constructEntity(Class, EntitySpec)} but when no spec is used.
+     * For use during rebind.
      */
-    // TODO would it be cleaner to have callers just create a spec? and deprecate this?
+    // TODO would it be cleaner to have rebind create a spec and deprecate this?
     public <T extends Entity> T constructEntity(Class<T> clazz, Iterable<Class<?>> interfaces, String entityId) {
         if (!isNewStyle(clazz)) {
             throw new IllegalStateException("Cannot construct old-style entity "+clazz);
@@ -393,7 +395,7 @@ public class InternalEntityFactory extends InternalFactory {
         checkNotNull(entityId, "entityId");
         checkState(interfaces != null && !Iterables.isEmpty(interfaces), "must have at least one interface for entity %s:%s", clazz, entityId);
         
-        T entity = constructEntityImpl(clazz, ImmutableMap.<String, Object>of(), entityId);
+        T entity = constructEntityImpl(clazz, null, null, entityId);
         if (((AbstractEntity)entity).getProxy() == null) {
             Entity proxy = managementContext.getEntityManager().getEntity(entity.getId());
             if (proxy==null) {
@@ -408,15 +410,11 @@ public class InternalEntityFactory extends InternalFactory {
         return entity;
     }
 
-    protected <T extends Entity> T constructEntityImpl(Class<? extends T> clazz, Map<String, ?> constructionFlags) {
-        return constructEntityImpl(clazz, constructionFlags, null);
-    }
-    
-    protected <T extends Entity> T constructEntityImpl(Class<? extends T> clazz, Map<String, ?> constructionFlags, String entityId) {
-        T entity = super.construct(clazz, constructionFlags);
+    private <T extends Entity> T constructEntityImpl(Class<? extends T> clazz, EntitySpec<?> optionalSpec, Map<String, ?> optionalConstructorFlags, String optionalEntityId) {
+        T entity = construct(clazz, optionalSpec, optionalConstructorFlags);
         
-        if (entityId != null) {
-            FlagUtils.setFieldsFromFlags(ImmutableMap.of("id", entityId), entity);
+        if (optionalEntityId != null) {
+            FlagUtils.setFieldsFromFlags(ImmutableMap.of("id", optionalEntityId), entity);
         }
         if (entity instanceof AbstractApplication) {
             FlagUtils.setFieldsFromFlags(ImmutableMap.of("mgmt", managementContext), entity);

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalLocationFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalLocationFactory.java
@@ -94,7 +94,7 @@ public class InternalLocationFactory extends InternalFactory {
         try {
             Class<? extends T> clazz = spec.getType();
             
-            T loc = construct(clazz, spec.getFlags());
+            T loc = construct(clazz, spec, null);
 
             if (spec.getId() != null) {
                 FlagUtils.setFieldsFromFlags(ImmutableMap.of("id", spec.getId()), loc);

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalPolicyFactory.java
@@ -20,10 +20,7 @@ package org.apache.brooklyn.core.objs.proxy;
 
 import java.util.Map;
 
-import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.objs.BrooklynObject;
-import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
@@ -32,7 +29,6 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
-import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -106,7 +102,7 @@ public class InternalPolicyFactory extends InternalFactory {
         try {
             Class<? extends T> clazz = spec.getType();
 
-            T pol = construct(clazz, spec.getFlags());
+            T pol = construct(clazz, spec, null);
 
             if (spec.getDisplayName()!=null) {
                 ((AbstractPolicy)pol).setDisplayName(spec.getDisplayName());
@@ -148,7 +144,7 @@ public class InternalPolicyFactory extends InternalFactory {
         try {
             Class<? extends T> clazz = spec.getType();
             
-            T enricher = construct(clazz, spec.getFlags());
+            T enricher = construct(clazz, spec, null);
             
             if (spec.getDisplayName()!=null)
                 ((AbstractEnricher)enricher).setDisplayName(spec.getDisplayName());

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/SpecialBrooklynObjectConstructor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/SpecialBrooklynObjectConstructor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs.proxy;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+
+import com.google.common.annotations.Beta;
+import com.google.common.reflect.TypeToken;
+
+/** Marker interface for use when a spec needs something special to create the object under management. 
+ * Set the {@link Config#SPECIAL_CONSTRUCTOR} config key in the spec pointing to the class;
+ * it will be instantiated and {@link #create(Class, AbstractBrooklynObjectSpec)} invoked to create the class.
+ * The type of course must be consistent with the spec.
+ * <p>
+ * This entire mechanism is beta; it is introduced for a few special cases where some type of dynamicism is currently required.
+ * In most cases the {@link AbstractBrooklynObjectSpec} should correspond directly to the object created.
+ * Some use cases are:
+ * <li>PortForwarderManager, shared global record
+ * <li>Choosing a different entity type smartly based on the location (e.g. deploying to PaaS vs IaaS) 
+ * <li>Referencing an existing location (optionally, and there are MAJOR issues with this in general; see below)
+ * <li>Clocker (?) - newly defined docker locations (although these may all point at entities)
+ * <p>
+ * See implementations of this interface.
+ * <p>
+ * Note that the caller may typically do additional configuration on the resulting object,
+ * such as setting a catalog item ID etc. That behaviour may merit adjustment and is subject to change.
+ * <p>
+ * Where this returns an existing item we must be VERY careful around *unmanaging*,
+ * both when this reference is unmanaged (but the original is still in use) 
+ * and when the target is unmanaged (but this reference is still in use).
+ * <p>
+ * Some possible improvements to the simple approach here are:
+ * <li>Return a delegate impl of the {@link Location} or {@link Entity} interface pointing at the target.
+ *     (This would work fine for sensors/effectors but it would fail any java type checks or casts.
+ *     We could switch to a brooklyn-managed type system, which would also allow for explicit yaml inheritance,
+ *     but that's not a small task.)
+ * <li>Return a java reflections proxy impl (we have this for entity already;
+ *     but for many Location types interfaces are not currently defined;
+ *     adding them would be nice to make Locations more like Entities)
+ * <li>Require the appropriate {@link Entity} or {@link Location} type, on a case-by-case basis,
+ *     where the lifecycle is as normal, and the logic for initializing and delegating is done 
+ *     in the init.  (Possibly this is better than the current implementation!?  It is certainly
+ *     simpler than allowing multiple links to existing items, and would be feasible in many
+ *     cases, e.g. a `same-machine-as` type (assuming we made SshMachineEntity an interface);
+ *     but it would not allow choosing an entity type smartly based on location.)
+ */
+@Beta
+public interface SpecialBrooklynObjectConstructor {
+    
+    /** Method to implement to create the given type from the given spec. */
+    public <T> T create(ManagementContext mgmt, Class<T> type, AbstractBrooklynObjectSpec<?,?> spec);
+    
+    public static class Config {
+        @Beta @SuppressWarnings("serial")
+        public static ConfigKey<Class<? extends SpecialBrooklynObjectConstructor>> SPECIAL_CONSTRUCTOR =
+            ConfigKeys.newConfigKey(new TypeToken<Class<? extends SpecialBrooklynObjectConstructor>>() {}, "brooklyn.object.constructor.special");
+    }
+    
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -728,15 +728,19 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
 
         // choose locations to be deployed to
         List<Location> chosenLocations;
-        List<Location> memberLocations = getMemberSpec() == null ? null : getMemberSpec().getLocations();
-        if (memberLocations != null && memberLocations.size() > 0) {
+
+        EntitySpec<?> memberSpec = getMemberSpec();
+        boolean memberSpecHasLocation = memberSpec!=null && (!memberSpec.getLocationSpecs().isEmpty() || !memberSpec.getLocations().isEmpty());
+        if (memberSpecHasLocation) {
             // The memberSpec overrides the location passed to cluster.start(); use
             // the location defined on the member.
             if (isAvailabilityZoneEnabled()) {
                 LOG.warn("Cluster {} has availability-zone enabled, but memberSpec overrides location with {}; using "
-                        + "memberSpec's location; availability-zone behaviour will not apply", this, memberLocations);
+                        + "memberSpec's location; availability-zone behaviour will not apply", this, 
+                        ""+memberSpec.getLocationSpecs()+"+"+memberSpec.getLocations());
             }
-            chosenLocations = Collections.nCopies(delta, memberLocations.get(0));
+            // null means create an instance but don't set a location
+            chosenLocations = Collections.nCopies(delta, null);
         } else if (isAvailabilityZoneEnabled()) {
             List<Location> subLocations = getNonFailedSubLocations();
             Multimap<Location, Entity> membersByLocation = getMembersByLocation();

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicRegionsFabricImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicRegionsFabricImpl.java
@@ -42,7 +42,7 @@ public class DynamicRegionsFabricImpl extends DynamicFabricImpl implements Dynam
     @Override
     public String addRegion(String location) {
         Preconditions.checkNotNull(location, "location");
-        Location l = getManagementContext().getLocationRegistry().resolve(location);
+        Location l = getManagementContext().getLocationRegistry().getLocationManaged(location);
         addLocations(Arrays.asList(l));
         
         Entity e = addCluster(l);

--- a/core/src/main/java/org/apache/brooklyn/location/byon/HostLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/HostLocationResolver.java
@@ -40,9 +40,8 @@ public class HostLocationResolver extends AbstractLocationResolver {
     
     private static final String HOST = "host";
     
-    @SuppressWarnings("rawtypes")
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public LocationSpec<?> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         // Extract args from spec
         ParsedSpec parsedSpec = specParser.parse(spec);
         Map<String, String> argsMap = parsedSpec.argsMap;
@@ -64,16 +63,16 @@ public class HostLocationResolver extends AbstractLocationResolver {
 
         // Generate target spec
         String target = "byon("+KeyValueParser.toLine(argsMap)+")";
-        Maybe<Location> testResolve = managementContext.getLocationRegistry().resolve(target, false, null);
+        Maybe<LocationSpec<?>> testResolve = managementContext.getLocationRegistry().getLocationSpec(target);
         if (!testResolve.isPresent()) {
             throw new IllegalArgumentException("Invalid target location '" + target + "' for location '"+HOST+"': "+
                 Exceptions.collapseText( ((Absent<?>)testResolve).getException() ), ((Absent<?>)testResolve).getException());
         }
         
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(SingleMachineProvisioningLocation.class)
+        return LocationSpec.create(SingleMachineProvisioningLocation.class)
                 .configure("location", target)
                 .configure("locationFlags", flags.getAllConfig())
-                .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation)));
+                .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation));
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineLocationResolver.java
@@ -36,10 +36,10 @@ public class SingleMachineLocationResolver extends AbstractLocationResolver {
     
     private static final String SINGLE = "single";
     
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public LocationSpec<?> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         ConfigBag config = extractConfig(locationFlags, spec, registry);
+        @SuppressWarnings("rawtypes")
         Map globalProperties = registry.getProperties();
         String namedLocation = (String) locationFlags.get(LocationInternal.NAMED_SPEC_NAME.getName());
         
@@ -52,16 +52,16 @@ public class SingleMachineLocationResolver extends AbstractLocationResolver {
         }
         String target = config.getStringKey("target").toString();
         config.remove("target");
-        Maybe<Location> testResolve = managementContext.getLocationRegistry().resolve(target, false, null);
+        Maybe<LocationSpec<?>> testResolve = managementContext.getLocationRegistry().getLocationSpec(target);
         if (!testResolve.isPresent()) {
             throw new IllegalArgumentException("Invalid target location '" + target + "' for location '"+SINGLE+"': "+
                 Exceptions.collapseText( ((Absent<?>)testResolve).getException() ));
         }
         
-        return managementContext.getLocationManager().createLocation(LocationSpec.create(SingleMachineProvisioningLocation.class)
+        return LocationSpec.create(SingleMachineProvisioningLocation.class)
                 .configure("location", target)
                 .configure("locationFlags", config.getAllConfig())
-                .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation)));
+                .configure(LocationConfigUtils.finalAndOriginalSpecs(spec, locationFlags, globalProperties, namedLocation));
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocation.java
@@ -68,7 +68,7 @@ public class SingleMachineProvisioningLocation<T extends MachineLocation> extend
     public synchronized T obtain() throws NoMachinesAvailableException {
         if (singleLocation == null) {
             if (provisioningLocation == null) {
-                provisioningLocation = (MachineProvisioningLocation) getManagementContext().getLocationRegistry().resolve(
+                provisioningLocation = (MachineProvisioningLocation) getManagementContext().getLocationRegistry().getLocationManaged(
                     location, locationFlags);
             }
             singleLocation = provisioningLocation.obtain(ImmutableMap.of());

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
-import org.apache.brooklyn.api.location.LocationResolver;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocationResolver;
@@ -41,9 +40,9 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
  * 
  * @author alex, aled
  */
-public class LocalhostLocationResolver extends AbstractLocationResolver implements LocationResolver.EnableableLocationResolver {
+public class LocalhostLocationResolver extends AbstractLocationResolver {
 
-    private static String BROOKLYN_LOCATION_LOCALHOST_PREFIX = "brooklyn.location.localhost";
+    private static String BROOKLYN_LOCATION_LOCALHOST_PREFIX = LocationConfigUtils.BROOKLYN_LOCATION_PREFIX + "." + "localhost";
     
     public static ConfigKey<Boolean> LOCALHOST_ENABLED = ConfigKeys.newConfigKeyWithPrefix(BROOKLYN_LOCATION_LOCALHOST_PREFIX+".", LocationConfigKeys.ENABLED);
     
@@ -56,7 +55,8 @@ public class LocalhostLocationResolver extends AbstractLocationResolver implemen
 
     @Override
     public boolean isEnabled() {
-        return LocationConfigUtils.isEnabled(managementContext, BROOKLYN_LOCATION_LOCALHOST_PREFIX);
+        // right now these two checks, but in case the generic mechanism in super changes...
+        return super.isEnabled() && LocationConfigUtils.isEnabled(managementContext, BROOKLYN_LOCATION_LOCALHOST_PREFIX);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolver.java
@@ -23,7 +23,10 @@ import java.util.Map;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
 import org.apache.brooklyn.api.location.LocationResolver;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocationResolver;
+import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.LocationConfigUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
@@ -40,6 +43,10 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
  */
 public class LocalhostLocationResolver extends AbstractLocationResolver implements LocationResolver.EnableableLocationResolver {
 
+    private static String BROOKLYN_LOCATION_LOCALHOST_PREFIX = "brooklyn.location.localhost";
+    
+    public static ConfigKey<Boolean> LOCALHOST_ENABLED = ConfigKeys.newConfigKeyWithPrefix(BROOKLYN_LOCATION_LOCALHOST_PREFIX+".", LocationConfigKeys.ENABLED);
+    
     public static final String LOCALHOST = "localhost";
 
     @Override
@@ -49,7 +56,7 @@ public class LocalhostLocationResolver extends AbstractLocationResolver implemen
 
     @Override
     public boolean isEnabled() {
-        return LocationConfigUtils.isEnabled(managementContext, "brooklyn.location.localhost");
+        return LocationConfigUtils.isEnabled(managementContext, BROOKLYN_LOCATION_LOCALHOST_PREFIX);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -300,7 +300,7 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
         // Register any pre-existing port-mappings with the PortForwardManager
         Map<Integer, String> tcpPortMappings = getConfig(TCP_PORT_MAPPINGS);
         if (tcpPortMappings != null) {
-            PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().resolve("portForwardManager(scope=global)");
+            PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
             for (Map.Entry<Integer, String> entry : tcpPortMappings.entrySet()) {
                 int targetPort = entry.getKey();
                 HostAndPort publicEndpoint = HostAndPort.fromString(entry.getValue());

--- a/core/src/test/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffectorIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffectorIntegrationTest.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -51,8 +52,8 @@ public class SshCommandEffectorIntegrationTest {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         app = TestApplication.Factory.newManagedInstanceForTests();
-        machine = app.newLocalhostProvisioningLocation().obtain();
-        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(machine));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(TestApplication.LOCALHOST_MACHINE_SPEC));
+        machine = Locations.findUniqueSshMachineLocation(entity.getLocations()).get();
         app.start(ImmutableList.<Location>of());
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
@@ -42,7 +42,7 @@ public class EntityFunctionsTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).displayName("mydisplayname"));
-        loc = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        loc = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityPredicatesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityPredicatesTest.java
@@ -47,7 +47,7 @@ public class EntityPredicatesTest extends BrooklynAppUnitTestSupport {
         super.setUp();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).displayName("mydisplayname"));
         group = app.createAndManageChild(EntitySpec.create(BasicGroup.class));
-        loc = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        loc = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySuppliersTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySuppliersTest.java
@@ -47,7 +47,7 @@ public class EntitySuppliersTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).displayName("mydisplayname"));
-        loc = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        loc = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
         machine = ((MachineProvisioningLocation<SshMachineLocation>)loc).obtain(ImmutableMap.of());
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/location/LocationManagementTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/LocationManagementTest.java
@@ -62,7 +62,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
     public void testCreateLocationUsingResolver() {
         String spec = "byon:(hosts=\"1.1.1.1\")";
         @SuppressWarnings("unchecked")
-        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve(spec);
+        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().getLocationManaged(spec);
         SshMachineLocation machine = Iterables.getOnlyElement(loc.getAllMachines());
         
         assertSame(locationManager.getLocation(loc.getId()), loc);
@@ -73,7 +73,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
     public void testChildrenOfManagedLocationAutoManaged() {
         String spec = "byon:(hosts=\"1.1.1.1\")";
         @SuppressWarnings("unchecked")
-        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve(spec);
+        FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().getLocationManaged(spec);
         SshMachineLocation machine = new SshMachineLocation(ImmutableMap.of("address", "1.2.3.4"));
 
         loc.addChild(machine);
@@ -88,7 +88,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testManagedLocationsSimpleCreateAndCleanup() {
         Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
-        Location loc = mgmt.getLocationRegistry().resolve("localhost");
+        Location loc = mgmt.getLocationRegistry().getLocationManaged("localhost");
         Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(1));
         mgmt.getLocationManager().unmanage(loc);
         Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
@@ -107,7 +107,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
         // currently such defined locations do NOT appear in catalog -- see CatalogYamlLocationTest
         Asserts.assertThat(mgmt.getCatalog().getCatalogItems(), CollectionFunctionals.sizeEquals(0));
         
-        Location loc = mgmt.getLocationRegistry().resolve("lh1");
+        Location loc = mgmt.getLocationRegistry().getLocationManaged("lh1");
         Asserts.assertThat(mgmt.getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(1));
         Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(1));
         

--- a/core/src/test/java/org/apache/brooklyn/core/location/LocationManagementTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/LocationManagementTest.java
@@ -24,11 +24,14 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.LocationManager;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -58,6 +61,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testCreateLocationUsingResolver() {
         String spec = "byon:(hosts=\"1.1.1.1\")";
+        @SuppressWarnings("unchecked")
         FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve(spec);
         SshMachineLocation machine = Iterables.getOnlyElement(loc.getAllMachines());
         
@@ -68,6 +72,7 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testChildrenOfManagedLocationAutoManaged() {
         String spec = "byon:(hosts=\"1.1.1.1\")";
+        @SuppressWarnings("unchecked")
         FixedListMachineProvisioningLocation<SshMachineLocation> loc = (FixedListMachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve(spec);
         SshMachineLocation machine = new SshMachineLocation(ImmutableMap.of("address", "1.2.3.4"));
 
@@ -79,4 +84,36 @@ public class LocationManagementTest extends BrooklynAppUnitTestSupport {
         assertNull(locationManager.getLocation(machine.getId()));
         assertFalse(machine.isManaged());
     }
+    
+    @Test
+    public void testManagedLocationsSimpleCreateAndCleanup() {
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
+        Location loc = mgmt.getLocationRegistry().resolve("localhost");
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(1));
+        mgmt.getLocationManager().unmanage(loc);
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
+    }
+
+    @Test
+    public void testManagedLocationsNamedCreateAndCleanup() {
+        Asserts.assertThat(mgmt.getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(0));
+        Asserts.assertThat(mgmt.getCatalog().getCatalogItems(), CollectionFunctionals.sizeEquals(0));
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
+        
+        mgmt.getLocationRegistry().updateDefinedLocation( new BasicLocationDefinition("lh1", "localhost", null) );
+        
+        Asserts.assertThat(mgmt.getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(1));
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
+        // currently such defined locations do NOT appear in catalog -- see CatalogYamlLocationTest
+        Asserts.assertThat(mgmt.getCatalog().getCatalogItems(), CollectionFunctionals.sizeEquals(0));
+        
+        Location loc = mgmt.getLocationRegistry().resolve("lh1");
+        Asserts.assertThat(mgmt.getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(1));
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(1));
+        
+        mgmt.getLocationManager().unmanage(loc);
+        Asserts.assertThat(mgmt.getLocationRegistry().getDefinedLocations().keySet(), CollectionFunctionals.sizeEquals(1));
+        Asserts.assertThat(locationManager.getLocations(), CollectionFunctionals.sizeEquals(0));
+    }
+
 }

--- a/core/src/test/java/org/apache/brooklyn/core/location/LocationPredicatesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/LocationPredicatesTest.java
@@ -45,7 +45,7 @@ public class LocationPredicatesTest {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         managementContext = LocalManagementContextForTests.newInstance();
-        loc = (LocalhostMachineProvisioningLocation) managementContext.getLocationRegistry().resolve("localhost:(name=mydisplayname)");
+        loc = (LocalhostMachineProvisioningLocation) managementContext.getLocationRegistry().getLocationManaged("localhost:(name=mydisplayname)");
         childLoc = loc.obtain();
         grandchildLoc = managementContext.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class).parent(childLoc));
     }

--- a/core/src/test/java/org/apache/brooklyn/core/location/MachinesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/MachinesTest.java
@@ -23,9 +23,11 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation.LocalhostMachine;
@@ -40,46 +42,56 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     protected String publicAddr = "1.2.3.4";
     protected String privateAddr = "10.1.2.3";
     
-    protected SshMachineLocation sshMachine;
-    protected SshMachineLocation sshMachineWithoutPrivate;
-    protected SshMachineLocation localMachine;
-    protected LocalhostMachineProvisioningLocation otherLoc;
+    protected LocationSpec<SshMachineLocation> sshMachineSpec;
+    protected LocationSpec<SshMachineLocation> sshMachineWithoutPrivateSpec;
+    protected LocationSpec<LocalhostMachineProvisioningLocation> otherLocSpec;
+    protected LocationSpec<LocalhostMachine> localMachineSpec;
     
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         super.setUp();
-        sshMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+        sshMachineSpec = LocationSpec.create(SshMachineLocation.class)
                 .configure("address", publicAddr)
-                .configure(SshMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of(privateAddr)));
-        sshMachineWithoutPrivate = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", publicAddr));
-        otherLoc = app.newLocalhostProvisioningLocation();
-        localMachine = otherLoc.obtain();
+                .configure(SshMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of(privateAddr));
+        sshMachineWithoutPrivateSpec = LocationSpec.create(SshMachineLocation.class)
+                .configure("address", publicAddr);
+        otherLocSpec = TestApplication.LOCALHOST_PROVISIONER_SPEC;
+        localMachineSpec = TestApplication.LOCALHOST_MACHINE_SPEC;
+    }
+    
+    private <T extends Location> T create(LocationSpec<T> spec) {
+        return mgmt.getLocationManager().createLocation(spec);
     }
     
     @Test
     public void testFindUniqueMachineLocation() throws Exception {
-        assertEquals(Machines.findUniqueMachineLocation(ImmutableList.of(sshMachine, otherLoc)).get(), sshMachine);
-        assertFalse(Machines.findUniqueMachineLocation(ImmutableList.of(otherLoc)).isPresent());
+        SshMachineLocation l1 = create(sshMachineSpec);
+        LocalhostMachineProvisioningLocation l2 = create(otherLocSpec);
+        assertEquals(Machines.findUniqueMachineLocation(ImmutableList.of(l1, l2)).get(), l1);
+        assertFalse(Machines.findUniqueMachineLocation(ImmutableList.of(l2)).isPresent());
     }
     
     @Test
     @SuppressWarnings("deprecation")
     public void testFindUniqueSshMachineLocation() throws Exception {
-        assertEquals(Machines.findUniqueSshMachineLocation(ImmutableList.of(sshMachine, otherLoc)).get(), sshMachine);
-        assertFalse(Machines.findUniqueSshMachineLocation(ImmutableList.of(otherLoc)).isPresent());
+        SshMachineLocation l1 = create(sshMachineSpec);
+        LocalhostMachineProvisioningLocation l2 = create(otherLocSpec);
+        assertEquals(Machines.findUniqueSshMachineLocation(ImmutableList.of(l1, l2)).get(), l1);
+        assertFalse(Machines.findUniqueSshMachineLocation(ImmutableList.of(l2)).isPresent());
     }
     
     @Test
     public void testFindUniqueMachineLocationOfType() throws Exception {
-        assertEquals(Machines.findUniqueMachineLocation(ImmutableList.of(sshMachine, otherLoc), SshMachineLocation.class).get(), sshMachine);
-        assertFalse(Machines.findUniqueMachineLocation(ImmutableList.of(sshMachine), LocalhostMachine.class).isPresent());
+        SshMachineLocation l1 = create(sshMachineSpec);
+        LocalhostMachineProvisioningLocation l2 = create(otherLocSpec);
+        assertEquals(Machines.findUniqueMachineLocation(ImmutableList.of(l1, l2), SshMachineLocation.class).get(), l1);
+        assertFalse(Machines.findUniqueMachineLocation(ImmutableList.of(l2), LocalhostMachine.class).isPresent());
     }
     
     @Test
     public void testFindSubnetIpFromAttribute() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         entity.sensors().set(Attributes.SUBNET_ADDRESS, "myaddr");
         
         assertEquals(Machines.findSubnetIp(entity).get(), "myaddr");
@@ -88,7 +100,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetIpFromLocation() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         
         assertEquals(Machines.findSubnetIp(entity).get(), privateAddr);
     }
@@ -96,7 +108,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetHostnameFromAttribute() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         entity.sensors().set(Attributes.SUBNET_HOSTNAME, "myval");
         assertEquals(Machines.findSubnetHostname(entity).get(), "myval");
     }
@@ -104,7 +116,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetHostnameFromLocation() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         
         assertEquals(Machines.findSubnetHostname(entity).get(), publicAddr);
     }
@@ -112,7 +124,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetOrPrivateIpWithAddressAttributePrefersLocationPrivateIp() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         entity.sensors().set(Attributes.ADDRESS, "myval");
         
         assertEquals(Machines.findSubnetOrPrivateIp(entity).get(), privateAddr);
@@ -122,7 +134,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetOrPrivateIpFromAttribute() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         entity.sensors().set(Attributes.ADDRESS, "ignored-val");
         entity.sensors().set(Attributes.SUBNET_ADDRESS, "myval");
         
@@ -133,7 +145,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetOrPrivateIpFromLocation() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachine));
+                .location(sshMachineSpec));
         entity.sensors().set(Attributes.ADDRESS, "ignored-val");
         
         assertEquals(Machines.findSubnetOrPrivateIp(entity).get(), privateAddr);
@@ -142,7 +154,7 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testFindSubnetOrPrivateIpFromLocationWithoutPrivate() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
-                .location(sshMachineWithoutPrivate));
+                .location(sshMachineWithoutPrivateSpec));
         entity.sensors().set(Attributes.ADDRESS, "ignored-val");
         
         assertEquals(Machines.findSubnetOrPrivateIp(entity).get(), publicAddr);
@@ -150,9 +162,9 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
     
     @Test
     public void testWarnIfLocalhost() throws Exception {
-        assertFalse(Machines.warnIfLocalhost(ImmutableList.of(sshMachine), "my message"));
+        assertFalse(Machines.warnIfLocalhost(ImmutableList.of(create(sshMachineSpec)), "my message"));
         
         // Visual inspection test - expect a log.warn
-        assertTrue(Machines.warnIfLocalhost(ImmutableList.of(localMachine), "my message"));
+        assertTrue(Machines.warnIfLocalhost(ImmutableList.of(create(localMachineSpec)), "my message"));
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/location/access/BrooklynAccessUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/access/BrooklynAccessUtilsTest.java
@@ -52,7 +52,7 @@ public class BrooklynAccessUtilsTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         
-        pfm = (PortForwardManager) mgmt.getLocationRegistry().resolve("portForwardManager(scope=global)");
+        pfm = (PortForwardManager) mgmt.getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerLocationResolverTest.java
@@ -61,7 +61,7 @@ public class PortForwardManagerLocationResolverTest {
     }
 
     private Location resolve(String val) {
-        Location l = managementContext.getLocationRegistry().resolve(val);
+        Location l = managementContext.getLocationRegistry().getLocationManaged(val);
         Assert.assertNotNull(l);
         return l;
     }

--- a/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerRebindTest.java
@@ -186,7 +186,7 @@ public class PortForwardManagerRebindTest extends RebindTestFixtureWithApp {
             super.init();
             
             if (getConfig(PORT_FORWARD_MANAGER) == null) {
-                PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().resolve("portForwardManager(scope=global)");
+                PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
                 sensors().set(PORT_FORWARD_MANAGER_LIVE, pfm);
                 config().set(PORT_FORWARD_MANAGER, pfm);
             }

--- a/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/access/PortForwardManagerTest.java
@@ -55,7 +55,7 @@ public class PortForwardManagerTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
 
-        pfm = (PortForwardManager) mgmt.getLocationRegistry().resolve("portForwardManager(scope=global)");
+        pfm = (PortForwardManager) mgmt.getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
 
         machine1 = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", Networking.getInetAddressWithFixedName("1.2.3.4"))
@@ -104,7 +104,7 @@ public class PortForwardManagerTest extends BrooklynAppUnitTestSupport {
         props.put(PortForwardManager.PORT_FORWARD_MANAGER_STARTING_PORT, 1234);
         LocalManagementContextForTests mgmt2 = new LocalManagementContextForTests(props);
         try {
-            PortForwardManager pfm2 = (PortForwardManager) mgmt2.getLocationRegistry().resolve("portForwardManager(scope=global)");
+            PortForwardManager pfm2 = (PortForwardManager) mgmt2.getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
             int port = pfm2.acquirePublicPort("myipid");
             assertEquals(port, 1234);
         } finally {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
@@ -64,12 +64,12 @@ public class LocalManagementContextTest {
             .globalPropertiesFile(globalPropertiesFile.getAbsolutePath());
         // no builder support in LocalManagementContextForTests (we are testing that the builder's files are reloaded so we need it here)
         context = new LocalManagementContext(propsBuilder);
-        Location location = context.getLocationRegistry().resolve("localhost");
+        Location location = context.getLocationRegistry().getLocationManaged("localhost");
         assertEquals(location.getDisplayName(), "myname");
         String newGlobalPropertiesContents = "brooklyn.location.localhost.displayName=myname2";
         Files.write(newGlobalPropertiesContents, globalPropertiesFile, Charsets.UTF_8);
         context.reloadBrooklynProperties();
-        Location location2 = context.getLocationRegistry().resolve("localhost");
+        Location location2 = context.getLocationRegistry().getLocationManaged("localhost");
         assertEquals(location.getDisplayName(), "myname");
         assertEquals(location2.getDisplayName(), "myname2");
     }
@@ -82,12 +82,12 @@ public class LocalManagementContextTest {
             .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
             .build();
         context = LocalManagementContextForTests.builder(true).useProperties(brooklynProperties).build();
-        Location location = context.getLocationRegistry().resolve("localhost");
+        Location location = context.getLocationRegistry().getLocationManaged("localhost");
         assertEquals(location.getDisplayName(), "myname");
         String newGlobalPropertiesContents = "brooklyn.location.localhost.displayName=myname2";
         Files.write(newGlobalPropertiesContents, globalPropertiesFile, Charsets.UTF_8);
         context.reloadBrooklynProperties();
-        Location location2 = context.getLocationRegistry().resolve("localhost");
+        Location location2 = context.getLocationRegistry().getLocationManaged("localhost");
         assertEquals(location.getDisplayName(), "myname");
         assertEquals(location2.getDisplayName(), "myname");
     }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterTestFixture.java
@@ -81,10 +81,9 @@ public abstract class BrooklynMementoPersisterTestFixture {
             objectStore = ((BrooklynMementoPersisterToObjectStore)persister).getObjectStore();
         }
         app = ApplicationBuilder.newManagedApp(EntitySpec.create(TestApplication.class), localManagementContext);
-        location =  localManagementContext.getLocationManager()
-            .createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", "localhost"));
-        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(location));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(
+            LocationSpec.create(SshMachineLocation.class).configure("address", "localhost")));
+        location = Iterables.getOnlyElement( entity.getLocations() );
         enricher = app.enrichers().add(Enrichers.builder().propagatingAll().from(entity).build());
         app.policies().add(policy = new TestPolicy());
     }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -187,8 +187,8 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
 
     @Test
     public void testRestoresEntityLocationAndCleansUp() throws Exception {
-        MyLocation loc = origManagementContext.getLocationManager().createLocation(LocationSpec.create(MyLocation.class));
-        origApp.createAndManageChild(EntitySpec.create(MyEntity.class).location(loc));
+        MyEntity child = origApp.createAndManageChild(EntitySpec.create(MyEntity.class).location(LocationSpec.create(MyLocation.class)));
+        Location loc = Iterables.getOnlyElement(child.getLocations());
         
         newApp = rebind();
         MyEntity newE = (MyEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(MyEntity.class));

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindPolicyTest.java
@@ -128,7 +128,7 @@ public class RebindPolicyTest extends RebindTestFixtureWithApp {
 
     @Test
     public void testExpungesOnEntityUnmanaged() throws Exception {
-        Location loc = origManagementContext.getLocationRegistry().resolve("localhost");
+        Location loc = origManagementContext.getLocationRegistry().getLocationManaged("localhost");
         TestEntity entity = origApp.createAndManageChild(EntitySpec.create(TestEntity.class));
         MyPolicy policy = entity.policies().add(PolicySpec.create(MyPolicy.class));
         MyEnricher enricher = entity.enrichers().add(EnricherSpec.create(MyEnricher.class));

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensorTest.java
@@ -18,18 +18,18 @@
  */
 package org.apache.brooklyn.core.sensor.http;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.test.http.TestHttpRequestHandler;
-import org.apache.brooklyn.test.http.TestHttpServer;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.test.http.TestHttpRequestHandler;
+import org.apache.brooklyn.test.http.TestHttpServer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.AfterMethod;
@@ -43,7 +43,7 @@ public class HttpRequestSensorTest {
     final static String TARGET_TYPE = "java.lang.String";
 
     private TestApplication app;
-    private EntityLocal entity;
+    private Entity entity;
 
     private TestHttpServer server;
     private String serverUrl;
@@ -57,7 +57,7 @@ public class HttpRequestSensorTest {
 
         app = TestApplication.Factory.newManagedInstanceForTests();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
-                .location(app.newLocalhostProvisioningLocation().obtain()));
+                .location(TestApplication.LOCALHOST_MACHINE_SPEC));
         app.start(ImmutableList.<Location>of());
     }
 
@@ -67,6 +67,7 @@ public class HttpRequestSensorTest {
         server.stop();
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testHttpSensor() throws Exception {
         HttpRequestSensor<Integer> sensor = new HttpRequestSensor<Integer>(ConfigBag.newInstance()
@@ -75,10 +76,10 @@ public class HttpRequestSensorTest {
                 .configure(HttpRequestSensor.SENSOR_TYPE, TARGET_TYPE)
                 .configure(HttpRequestSensor.JSON_PATH, "$.myKey")
                 .configure(HttpRequestSensor.SENSOR_URI, serverUrl + "/myKey/myValue"));
-        sensor.apply(entity);
+        sensor.apply((org.apache.brooklyn.api.entity.EntityLocal)entity);
         entity.sensors().set(Attributes.SERVICE_UP, true);
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_STRING, "myValue");
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_STRING, "myValue");
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensorTest.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -42,7 +43,7 @@ public class CreatePasswordSensorTest extends BrooklynAppUnitTestSupport{
         super.setUp();
 
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
-                .location(app.newLocalhostProvisioningLocation().obtain()));
+                .location(TestApplication.LOCALHOST_MACHINE_SPEC));
         app.start(ImmutableList.<Location>of());
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensorIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensorIntegrationTest.java
@@ -30,11 +30,12 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.Assert;
@@ -58,8 +59,8 @@ public class SshCommandSensorIntegrationTest {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         app = TestApplication.Factory.newManagedInstanceForTests();
-        machine = app.newLocalhostProvisioningLocation().obtain();
-        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(machine));
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class).location(TestApplication.LOCALHOST_MACHINE_SPEC));
+        machine = Locations.findUniqueSshMachineLocation(entity.getLocations()).get();
         app.start(ImmutableList.<Location>of());
         tempFile = File.createTempFile("testSshCommand", ".txt");
     }
@@ -80,7 +81,7 @@ public class SshCommandSensorIntegrationTest {
             .apply(entity);
         entity.sensors().set(Attributes.SERVICE_UP, true);
 
-        String val = EntityTestUtils.assertAttributeEventuallyNonNull(entity, SENSOR_STRING);
+        String val = EntityAsserts.assertAttributeEventuallyNonNull(entity, SENSOR_STRING);
         assertTrue(val.contains("1"), "val="+val);
         String[] counts = val.trim().split("\\s+");
         Assert.assertEquals(counts.length, 4, "val="+val);

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplication.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplication.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -40,11 +41,17 @@ import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocati
 public interface TestApplication extends StartableApplication, EntityInternal {
 
     public static final AttributeSensor<String> MY_ATTRIBUTE = Sensors.newStringSensor("test.myattribute", "Test attribute sensor");
+    
+    public static final LocationSpec<LocalhostMachineProvisioningLocation> LOCALHOST_PROVISIONER_SPEC = LocationSpec.create(LocalhostMachineProvisioningLocation.class);
+    public static final LocationSpec<LocalhostMachineProvisioningLocation.LocalhostMachine> LOCALHOST_MACHINE_SPEC = LocationSpec.create(LocalhostMachineProvisioningLocation.LocalhostMachine.class);
 
     public <T extends Entity> T createAndManageChild(EntitySpec<T> spec);
 
-    public SimulatedLocation newSimulatedLocation();
+    /** @deprecated since 0.9.0 give the location spec spec to the entity spec instead, 
+     * using {@link #LOCALHOST_PROVISIONER_SPEC} or {@link #LOCALHOST_MACHINE_SPEC} */ @Deprecated
     public LocalhostMachineProvisioningLocation newLocalhostProvisioningLocation();
+    // items below it would be nice to update; there are fewer of them but they are more involved 
+    public SimulatedLocation newSimulatedLocation();
     public LocalhostMachineProvisioningLocation newLocalhostProvisioningLocation(Map<?,?> flags);
 
     public static class Factory {

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplication.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplication.java
@@ -47,10 +47,11 @@ public interface TestApplication extends StartableApplication, EntityInternal {
 
     public <T extends Entity> T createAndManageChild(EntitySpec<T> spec);
 
-    /** @deprecated since 0.9.0 give the location spec spec to the entity spec instead, 
-     * using {@link #LOCALHOST_PROVISIONER_SPEC} or {@link #LOCALHOST_MACHINE_SPEC} */ @Deprecated
+    /** Create a managed location instance for use in tests.
+     * Note that it is typically preferred to pass a location spec to the entity spec instead,
+     * e.g. using {@link #LOCALHOST_PROVISIONER_SPEC} or {@link #LOCALHOST_MACHINE_SPEC};
+     * however in many tests this is simpler. */
     public LocalhostMachineProvisioningLocation newLocalhostProvisioningLocation();
-    // items below it would be nice to update; there are fewer of them but they are more involved 
     public SimulatedLocation newSimulatedLocation();
     public LocalhostMachineProvisioningLocation newLocalhostProvisioningLocation(Map<?,?> flags);
 

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplicationImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestApplicationImpl.java
@@ -78,7 +78,7 @@ public class TestApplicationImpl extends AbstractApplication implements TestAppl
 
     @Override
     public LocalhostMachineProvisioningLocation newLocalhostProvisioningLocation() {
-        return (LocalhostMachineProvisioningLocation) getManagementContext().getLocationRegistry().resolve("localhost");
+        return (LocalhostMachineProvisioningLocation) getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
     
     @Override

--- a/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/ByonLocationResolverTest.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.location.NoMachinesAvailableException;
@@ -54,7 +56,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
@@ -158,7 +159,7 @@ public class ByonLocationResolverTest {
     public void testRegistryCommaResolutionInListNotAllowed() throws NoMachinesAvailableException {
         // disallowed since 0.7.0
         // fails because it interprets the entire string as a single byon spec, which does not parse
-        managementContext.getLocationRegistry().resolve(ImmutableList.of("byon(hosts=\"192.168.0.1\",user=bob),byon(hosts=\"192.168.0.2\",user=bob2)"));
+        managementContext.getLocationRegistry().getListOfLocationsManaged(ImmutableList.of("byon(hosts=\"192.168.0.1\",user=bob),byon(hosts=\"192.168.0.2\",user=bob2)"));
     }
 
     @Test
@@ -248,8 +249,8 @@ public class ByonLocationResolverTest {
                 "brooklyn.location.named.foo.user", "bob"));
         ((BasicLocationRegistry)managementContext.getLocationRegistry()).updateDefinedLocations();
         
-        MachineProvisioningLocation<SshMachineLocation> ll = (MachineProvisioningLocation<SshMachineLocation>)
-                new NamedLocationResolver().newLocationFromString(MutableMap.of(), "named:foo", managementContext.getLocationRegistry());
+        LocationSpec<? extends Location> lspec = new NamedLocationResolver().newLocationSpecFromString("named:foo", MutableMap.of(), managementContext.getLocationRegistry());
+        MachineProvisioningLocation<SshMachineLocation> ll = (MachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationManager().createLocation(lspec);
         SshMachineLocation l = ll.obtain(MutableMap.of());
         Assert.assertEquals("bob", l.getUser());
     }
@@ -273,8 +274,8 @@ public class ByonLocationResolverTest {
                 "brooklyn.location.named.foo.privateKeyFile", "/tmp/x"));
         ((BasicLocationRegistry)managementContext.getLocationRegistry()).updateDefinedLocations();
         
-        MachineProvisioningLocation<SshMachineLocation> ll = (MachineProvisioningLocation<SshMachineLocation>) 
-                new NamedLocationResolver().newLocationFromString(MutableMap.of(), "named:foo", managementContext.getLocationRegistry());
+        LocationSpec<? extends Location> lspec = new NamedLocationResolver().newLocationSpecFromString("named:foo", MutableMap.of(), managementContext.getLocationRegistry());
+        MachineProvisioningLocation<SshMachineLocation> ll = (MachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationManager().createLocation(lspec);
         
         Assert.assertEquals("/tmp/x", ll.getConfig(LocationConfigKeys.PRIVATE_KEY_FILE));
         Assert.assertTrue(((LocationInternal)ll).config().getLocalRaw(LocationConfigKeys.PRIVATE_KEY_FILE).isPresent());
@@ -401,11 +402,11 @@ public class ByonLocationResolverTest {
     
     @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val) {
-        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val);
+        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val);
     }
     
     @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val, Map<?, ?> locationFlags) {
-        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val, locationFlags);
+        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val, locationFlags);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/location/byon/HostLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/HostLocationResolverTest.java
@@ -121,6 +121,6 @@ public class HostLocationResolverTest {
     
     @SuppressWarnings("unchecked")
     private MachineProvisioningLocation<SshMachineLocation> resolve(String val) {
-        return (MachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().resolve(val);
+        return (MachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/location/byon/SingleMachineLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/SingleMachineLocationResolverTest.java
@@ -126,7 +126,7 @@ public class SingleMachineLocationResolverTest {
     
     @SuppressWarnings("unchecked")
     private SingleMachineProvisioningLocation<SshMachineLocation> resolve(String val) {
-        return (SingleMachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().resolve(val);
+        return (SingleMachineProvisioningLocation<SshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val);
     }
     
 }

--- a/core/src/test/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/SingleMachineProvisioningLocationTest.java
@@ -50,7 +50,7 @@ public class SingleMachineProvisioningLocationTest {
     @Test
     public void testLocalhostSingle() throws Exception {
         SingleMachineProvisioningLocation<SshMachineLocation> l = (SingleMachineProvisioningLocation<SshMachineLocation>) 
-            managementContext.getLocationRegistry().resolve("single:(target='localhost')");
+            managementContext.getLocationRegistry().getLocationManaged("single:(target='localhost')");
         l.setManagementContext(managementContext);
         
         SshMachineLocation m1 = l.obtain();

--- a/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostLocationResolverTest.java
@@ -150,7 +150,7 @@ public class LocalhostLocationResolverTest {
 
     @Test
     public void testAcceptsList() {
-        List<Location> l = getLocationResolver().resolve(ImmutableList.of("localhost"));
+        List<Location> l = getLocationResolver().getListOfLocationsManaged(ImmutableList.of("localhost"));
         assertEquals(l.size(), 1, "l="+l);
         assertTrue(l.get(0) instanceof LocalhostMachineProvisioningLocation, "l="+l);
     }
@@ -159,14 +159,14 @@ public class LocalhostLocationResolverTest {
     @Test
     public void testRegistryCommaResolution() throws NoMachinesAvailableException {
         List<Location> l;
-        l = getLocationResolver().resolve(JavaStringEscapes.unwrapJsonishListIfPossible("localhost,localhost,localhost"));
+        l = getLocationResolver().getListOfLocationsManaged(JavaStringEscapes.unwrapJsonishListIfPossible("localhost,localhost,localhost"));
         assertEquals(l.size(), 3, "l="+l);
         assertTrue(l.get(0) instanceof LocalhostMachineProvisioningLocation, "l="+l);
         assertTrue(l.get(1) instanceof LocalhostMachineProvisioningLocation, "l="+l);
         assertTrue(l.get(2) instanceof LocalhostMachineProvisioningLocation, "l="+l);
 
         // And check works if comma in brackets
-        l = getLocationResolver().resolve(JavaStringEscapes.unwrapJsonishListIfPossible(
+        l = getLocationResolver().getListOfLocationsManaged(JavaStringEscapes.unwrapJsonishListIfPossible(
             "[ \"byon:(hosts=\\\"192.168.0.1\\\",user=bob)\", \"byon:(hosts=\\\"192.168.0.2\\\",user=bob2)\" ]"));
         assertEquals(l.size(), 2, "l="+l);
         assertTrue(l.get(0) instanceof FixedListMachineProvisioningLocation, "l="+l);
@@ -178,26 +178,26 @@ public class LocalhostLocationResolverTest {
     @Test(expectedExceptions={NoSuchElementException.class})
     public void testRegistryCommaResolutionInListNotAllowed1() throws NoMachinesAvailableException {
         // disallowed since 0.7.0
-        getLocationResolver().resolve(ImmutableList.of("localhost,localhost,localhost"));
+        getLocationResolver().getListOfLocationsManaged(ImmutableList.of("localhost,localhost,localhost"));
     }
 
     @Test(expectedExceptions={IllegalArgumentException.class})
     public void testRegistryCommaResolutionInListNotAllowed2() throws NoMachinesAvailableException {
         // disallowed since 0.7.0
         // fails because it interprets the entire string as a single spec, which does not parse
-        getLocationResolver().resolve(ImmutableList.of("localhost(),localhost()"));
+        getLocationResolver().getListOfLocationsManaged(ImmutableList.of("localhost(),localhost()"));
     }
 
     @Test(expectedExceptions={IllegalArgumentException.class})
     public void testRegistryCommaResolutionInListNotAllowed3() throws NoMachinesAvailableException {
         // disallowed since 0.7.0
         // fails because it interprets the entire string as a single spec, which does not parse
-        getLocationResolver().resolve(ImmutableList.of("localhost(name=a),localhost(name=b)"));
+        getLocationResolver().getListOfLocationsManaged(ImmutableList.of("localhost(name=a),localhost(name=b)"));
     }
 
     @Test(expectedExceptions={IllegalArgumentException.class})
     public void testDoesNotAcceptsListOLists() {
-        ((BasicLocationRegistry)managementContext.getLocationRegistry()).resolve(ImmutableList.of(ImmutableList.of("localhost")));
+        ((BasicLocationRegistry)managementContext.getLocationRegistry()).getListOfLocationsManaged(ImmutableList.of(ImmutableList.of("localhost")));
     }
 
     @Test
@@ -238,7 +238,7 @@ public class LocalhostLocationResolverTest {
     }
     
     private LocationInternal resolve(String val) {
-        Location l = managementContext.getLocationRegistry().resolve(val);
+        Location l = managementContext.getLocationRegistry().getLocationManaged(val);
         Assert.assertNotNull(l);
         return (LocationInternal) l;
     }
@@ -252,7 +252,7 @@ public class LocalhostLocationResolverTest {
         }
 
         // and check the long form returns an Absent (not throwing)
-        Assert.assertTrue(managementContext.getLocationRegistry().resolve(val, false, null).isAbsent());
+        Assert.assertTrue(managementContext.getLocationRegistry().getLocationSpec(val).isAbsent());
     }
     
     private void assertThrowsIllegalArgument(String val) {
@@ -264,6 +264,6 @@ public class LocalhostLocationResolverTest {
         }
         
         // and check the long form returns an Absent (not throwing)
-        Assert.assertTrue(managementContext.getLocationRegistry().resolve(val, false, null).isAbsent());
+        Assert.assertTrue(managementContext.getLocationRegistry().getLocationSpec(val).isAbsent());
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
@@ -204,7 +204,7 @@ public class LocalhostMachineProvisioningLocationTest {
         // bogus location so very little chance of it being what maxmind returns!
         mgmt.getBrooklynProperties().put("brooklyn.location.named.lhx.latitude", 42d);
         mgmt.getBrooklynProperties().put("brooklyn.location.named.lhx.longitude", -20d);
-        MachineProvisioningLocation<?> p = (MachineProvisioningLocation<?>) mgmt.getLocationRegistry().resolve("named:lhx");
+        MachineProvisioningLocation<?> p = (MachineProvisioningLocation<?>) mgmt.getLocationRegistry().getLocationManaged("named:lhx");
         SshMachineLocation m = (SshMachineLocation) p.obtain(MutableMap.of());
         HostGeoInfo geo = HostGeoInfo.fromLocation(m);
         log.info("Geo info for "+m+" is: "+geo);

--- a/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostProvisioningAndAccessTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostProvisioningAndAccessTest.java
@@ -49,7 +49,7 @@ public class LocalhostProvisioningAndAccessTest {
 
     @Test(groups="Integration")
     public void testProvisionAndConnect() throws Exception {
-        Location location = mgmt.getLocationRegistry().resolve("localhost");
+        Location location = mgmt.getLocationRegistry().getLocationManaged("localhost");
         assertTrue(location instanceof LocalhostMachineProvisioningLocation);
         SshMachineLocation m = ((LocalhostMachineProvisioningLocation)location).obtain();
         int result = m.execCommands("test", Arrays.asList("echo hello world"));

--- a/core/src/test/java/org/apache/brooklyn/location/multi/MultiLocationResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/multi/MultiLocationResolverTest.java
@@ -43,7 +43,6 @@ import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-import org.apache.brooklyn.location.multi.MultiLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -98,6 +97,7 @@ public class MultiLocationResolverTest {
     }
 
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testResolvesSubLocs() {
         assertMultiLocation(resolve("multi:(targets=localhost)"), 1, ImmutableList.of(Predicates.instanceOf(LocalhostMachineProvisioningLocation.class)));
@@ -107,6 +107,7 @@ public class MultiLocationResolverTest {
         assertMultiLocation(resolve("multi:(targets=byon:(hosts=\"1.1.1.1\"))"), 1, ImmutableList.of(Predicates.and(
                 Predicates.instanceOf(FixedListMachineProvisioningLocation.class),
                 new Predicate<MachineProvisioningLocation>() {
+                    @SuppressWarnings("unchecked")
                     @Override public boolean apply(MachineProvisioningLocation input) {
                         SshMachineLocation machine;
                         try {
@@ -141,10 +142,10 @@ public class MultiLocationResolverTest {
 
     @Test
     public void testResolvesFromMap() throws NoMachinesAvailableException {
-        Location l = managementContext.getLocationRegistry().resolve("multi", MutableMap.of("targets", 
+        Location l = managementContext.getLocationRegistry().getLocationManaged("multi", MutableMap.of("targets", 
             MutableList.of("localhost", MutableMap.of("byon", MutableMap.of("hosts", "127.0.0.127")))));
         MultiLocation<?> ml = (MultiLocation<?>)l;
-        Iterator<MachineProvisioningLocation<?>> ci = ml.getSubLocations().iterator();
+        Iterator<MachineProvisioningLocation<?>> ci = ml.getSubLocationsAsLocations().iterator();
         
         l = ci.next();
         Assert.assertTrue(l instanceof LocalhostMachineProvisioningLocation, "Expected localhost, got "+l);
@@ -178,10 +179,10 @@ public class MultiLocationResolverTest {
     
     @SuppressWarnings("unchecked")
     private MultiLocation<SshMachineLocation> resolve(String val) {
-        return (MultiLocation<SshMachineLocation>) managementContext.getLocationRegistry().resolve(val);
+        return (MultiLocation<SshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val);
     }
     
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void assertMultiLocation(MultiLocation<?> multiLoc, int expectedSize, List<? extends Predicate> expectedSubLocationPredicates) {
         AvailabilityZoneExtension zones = multiLoc.getExtension(AvailabilityZoneExtension.class);
         List<Location> subLocs = zones.getAllSubLocations();

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationSshToolTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationSshToolTest.java
@@ -96,7 +96,7 @@ public class SshMachineLocationSshToolTest extends BrooklynAppUnitTestSupport {
         mgmt.getBrooklynProperties().putAll(ImmutableMap.of(
                 "brooklyn.location.named.localhostWithCustomTool", "localhost",
                 "brooklyn.location.named.localhostWithCustomTool."+SshMachineLocation.SSH_TOOL_CLASS.getName(), RecordingSshTool.class.getName()));
-        MachineProvisioningLocation<SshMachineLocation> loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve("localhostWithCustomTool");
+        MachineProvisioningLocation<SshMachineLocation> loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().getLocationManaged("localhostWithCustomTool");
         SshMachineLocation machine = loc.obtain(ImmutableMap.of());
         runCustomSshToolClass(machine);
     }
@@ -108,7 +108,7 @@ public class SshMachineLocationSshToolTest extends BrooklynAppUnitTestSupport {
                 "brooklyn.location.named.localhostWithCustomTool", "byon:(hosts=127.0.0.1, user=myname)",
                 "brooklyn.location.named.localhostWithCustomTool."+SshMachineLocation.SSH_TOOL_CLASS.getName(), RecordingSshTool.class.getName(),
                 "brooklyn.location.named.localhostWithCustomTool."+SshMachineLocation.SSH_TOOL_CLASS.getName()+".myparam", "myvalue"));
-        MachineProvisioningLocation<SshMachineLocation> loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve("localhostWithCustomTool");
+        MachineProvisioningLocation<SshMachineLocation> loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().getLocationManaged("localhostWithCustomTool");
         SshMachineLocation machine = loc.obtain(ImmutableMap.of());
         runCustomSshToolClass(machine);
         

--- a/core/src/test/java/org/apache/brooklyn/util/core/text/TemplateProcessorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/text/TemplateProcessorTest.java
@@ -178,8 +178,8 @@ public class TemplateProcessorTest extends BrooklynAppUnitTestSupport {
 
     @Test
     public void testApplyTemplatedConfigWithAtributeWhenReadyInSpec() {
-        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class).configure(DynamicCluster.INITIAL_SIZE, 0).location(
-                app.getManagementContext().getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.LocalhostMachine.class))));
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class).configure(DynamicCluster.INITIAL_SIZE, 0)
+            .location(LocationSpec.create(LocalhostMachineProvisioningLocation.LocalhostMachine.class)));
         cluster.config().set(DynamicCluster.MEMBER_SPEC,
                 EntitySpec.create(TestEntity.class).configure(TestEntity.CONF_NAME,
                         DependentConfiguration.attributeWhenReady(cluster, TestEntity.NAME)));

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -470,7 +470,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
         // Create the locations. Must happen after persistence is started in case the
         // management context's catalog is loaded from persisted state. (Location
         // resolution uses the catalog's classpath to scan for resolvers.)
-        locations.addAll(managementContext.getLocationRegistry().resolve(locationSpecs));
+        locations.addAll(managementContext.getLocationRegistry().getListOfLocationsManaged(locationSpecs));
     }
 
     protected void startingUp() {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
@@ -93,7 +93,7 @@ public class JcloudsBlobStoreBasedObjectStore implements PersistenceObjectStore 
             if (location==null) {
                 Preconditions.checkNotNull(locationSpec, "locationSpec required for remote object store when location is null");
                 Preconditions.checkNotNull(mgmt, "mgmt not injected / object store not prepared");
-                location = (JcloudsLocation) mgmt.getLocationRegistry().resolve(locationSpec);
+                location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
             }
             
             String identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreCleaner.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreCleaner.java
@@ -41,7 +41,7 @@ public class BlobStoreCleaner {
     
     public static void main(String[] args) {
         LocalManagementContextForTests mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault()); 
-        JcloudsLocation location = (JcloudsLocation) mgmt.getLocationRegistry().resolve(locationSpec);
+        JcloudsLocation location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
             
         String identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");
         String credential = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_CREDENTIAL), "credential must not be null");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreExpiryTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreExpiryTest.java
@@ -95,7 +95,7 @@ public class BlobStoreExpiryTest {
             if (location==null) {
                 Preconditions.checkNotNull(locationSpec, "locationSpec required for remote object store when location is null");
                 Preconditions.checkNotNull(mgmt, "mgmt required for remote object store when location is null");
-                location = (JcloudsLocation) mgmt.getLocationRegistry().resolve(locationSpec);
+                location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
             }
             
             identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
@@ -73,7 +73,7 @@ public class BlobStoreTest {
             if (location==null) {
                 Preconditions.checkNotNull(locationSpec, "locationSpec required for remote object store when location is null");
                 Preconditions.checkNotNull(mgmt, "mgmt required for remote object store when location is null");
-                location = (JcloudsLocation) mgmt.getLocationRegistry().resolve(locationSpec);
+                location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
             }
             
             String identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsExpect100ContinueTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsExpect100ContinueTest.java
@@ -59,7 +59,7 @@ public class JcloudsExpect100ContinueTest {
         setInfoLevel("org.jclouds");
 
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
-        JcloudsLocation jcloudsLocation = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
+        JcloudsLocation jcloudsLocation = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
         context = JcloudsUtil.newBlobstoreContext(
                 jcloudsLocation.getProvider(),
                 jcloudsLocation.getEndpoint(),

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractJcloudsStubbedLiveTest extends AbstractJcloudsLive
                 return new StubbedComputeService(delegate, nodeCreator);
             }
         };
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(
                 LOCATION_SPEC, 
                 ImmutableMap.of(
                         JcloudsLocationConfig.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry,

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
@@ -70,7 +70,7 @@ public class JcloudsAddressesLiveTest extends AbstractJcloudsLiveTest {
     
     @Test(groups = {"Live"})
     protected void testAwsEc2Addresses() throws Exception {
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine(ImmutableMap.<String,Object>of());
         assertSshable(machine);
@@ -117,7 +117,7 @@ public class JcloudsAddressesLiveTest extends AbstractJcloudsLiveTest {
 
     @Test(groups = {"Live"})
     protected void testRackspaceAddresses() throws Exception {
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(RACKSPACE_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(RACKSPACE_LOCATION_SPEC);
         
         machine = createRackspaceMachine(ImmutableMap.<String,Object>of());
         assertSshable(machine);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverAwsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverAwsLiveTest.java
@@ -52,7 +52,7 @@ public class JcloudsByonLocationResolverAwsLiveTest extends AbstractJcloudsLiveT
     @BeforeClass(groups="Live")
     public void setUpClass() throws Exception {
         classManagementContext = newManagementContext();
-        classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().resolve(AWS_LOCATION_SPEC);
+        classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().getLocationManaged(AWS_LOCATION_SPEC);
         classEc2Vm = (JcloudsSshMachineLocation)classEc2Loc.obtain(MutableMap.<String,Object>builder()
                 .put("hardwareId", AWS_EC2_SMALL_HARDWARE_ID)
                 .put("inboundPorts", ImmutableList.of(22))
@@ -172,6 +172,6 @@ public class JcloudsByonLocationResolverAwsLiveTest extends AbstractJcloudsLiveT
     
     @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<JcloudsSshMachineLocation> resolve(String spec) {
-        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().resolve(spec);
+        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(spec);
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
@@ -50,7 +50,7 @@ public class JcloudsByonLocationResolverSoftlayerLiveTest extends AbstractJcloud
     @BeforeClass(groups="Live")
     public void setUpClass() throws Exception {
         classManagementContext = newManagementContext();
-        classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().resolve(SOFTLAYER_LOCATION_SPEC);
+        classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().getLocationManaged(SOFTLAYER_LOCATION_SPEC);
         classVm = (JcloudsSshMachineLocation)classEc2Loc.obtain(MutableMap.<String,Object>builder()
                 .put("inboundPorts", ImmutableList.of(22))
                 .build());
@@ -98,7 +98,7 @@ public class JcloudsByonLocationResolverSoftlayerLiveTest extends AbstractJcloud
 
     @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<JcloudsSshMachineLocation> resolve(String spec) {
-        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().resolve(spec);
+        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(spec);
     }
     
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverTest.java
@@ -57,7 +57,7 @@ public class JcloudsByonLocationResolverTest {
 
     @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<JcloudsSshMachineLocation> resolve(String spec) {
-        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().resolve(spec);
+        return (FixedListMachineProvisioningLocation<JcloudsSshMachineLocation>) managementContext.getLocationRegistry().getLocationManaged(spec);
     }
     
     private void assertThrowsNoSuchElement(String val) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonRebindLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonRebindLiveTest.java
@@ -106,13 +106,13 @@ public class JcloudsByonRebindLiveTest extends RebindTestFixtureWithApp {
                 .put("imageId", SOFTLAYER_IMAGE_ID)
                 .put("inboundPorts", ImmutableList.of(22))
                 .build();
-        JcloudsLocation provisioningLoc = (JcloudsLocation) provisioningManagementContext.getLocationRegistry().resolve(SOFTLAYER_LOCATION_SPEC);
+        JcloudsLocation provisioningLoc = (JcloudsLocation) provisioningManagementContext.getLocationRegistry().getLocationManaged(SOFTLAYER_LOCATION_SPEC);
         provisionedMachine = (JcloudsSshMachineLocation) provisioningLoc.obtain(obtainFlags);
         
         // Test with a jclouds-byon
         String locSpec = "jcloudsByon:(provider=\""+SOFTLAYER_PROVIDER+"\",region=\""+SOFTLAYER_REGION+"\",user=\""+provisionedMachine.getUser()+"\",hosts=\""+provisionedMachine.getNode().getProviderId()+"\")";
         
-        FixedListMachineProvisioningLocation<?> origByon = (FixedListMachineProvisioningLocation<?>) mgmt().getLocationRegistry().resolve(locSpec);
+        FixedListMachineProvisioningLocation<?> origByon = (FixedListMachineProvisioningLocation<?>) mgmt().getLocationRegistry().getLocationManaged(locSpec);
         
         JcloudsSshMachineLocation origMachine = (JcloudsSshMachineLocation)origByon.obtain(ImmutableMap.<String,Object>of());
         JcloudsLocation origJcloudsLocation = origMachine.getParent();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationMetadataTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationMetadataTest.java
@@ -54,7 +54,7 @@ public class JcloudsLocationMetadataTest implements JcloudsLocationConfig {
 
     @Test
     public void testGetsDefaultAwsEc2Metadata() throws Exception {
-        Location loc = managementContext.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-1");
+        Location loc = managementContext.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-west-1");
         
         assertEquals(loc.getConfig(LocationConfigKeys.LATITUDE), 40.0d);
         assertEquals(loc.getConfig(LocationConfigKeys.LONGITUDE), -120.0d);
@@ -64,7 +64,7 @@ public class JcloudsLocationMetadataTest implements JcloudsLocationConfig {
     @Test
     public void testCanOverrideDefaultAwsEc2Metadata() throws Exception {
         brooklynProperties.put("brooklyn.location.jclouds.aws-ec2@us-west-1.latitude", "41.2");
-        Location loc = managementContext.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-1");
+        Location loc = managementContext.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-west-1");
         
         assertEquals(loc.getConfig(LocationConfigKeys.LATITUDE), 41.2d);
     }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRegisterMachineLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationRegisterMachineLiveTest.java
@@ -46,7 +46,7 @@ public class JcloudsLocationRegisterMachineLiveTest extends AbstractJcloudsLiveT
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
     }
 
     @Test(groups = { "Live", "Live-sanity" })
@@ -78,7 +78,7 @@ public class JcloudsLocationRegisterMachineLiveTest extends AbstractJcloudsLiveT
         String user = checkNotNull(machine.getUser(), "user");
         
         // Create a new jclouds location, and re-bind the existing VM to that
-        JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
+        JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
         MachineLocation machineLocation = loc2.registerMachine(ImmutableMap.of("id", id, "hostname", hostname, "user", user));
         assertTrue(machineLocation instanceof SshMachineLocation);
         SshMachineLocation machine2 = (SshMachineLocation) machineLocation;
@@ -109,7 +109,7 @@ public class JcloudsLocationRegisterMachineLiveTest extends AbstractJcloudsLiveT
         String username = machine.getUser();
         
         // Create a new jclouds location, and re-bind the existing VM to that
-        JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
+        JcloudsLocation loc2 = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_PROVIDER+":"+AWS_EC2_EUWEST_REGION_NAME);
         // pass deprecated userName
         MachineLocation machineLocation = loc2.registerMachine(ImmutableMap.of("id", id, "hostname", hostname, "userName", username));
         assertTrue(machineLocation instanceof SshMachineLocation);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationReleasePortForwardingTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationReleasePortForwardingTest.java
@@ -68,8 +68,8 @@ public class JcloudsLocationReleasePortForwardingTest extends BrooklynAppLiveTes
     public void setUp() throws Exception {
         super.setUp();
         stopwatch = Stopwatch.createStarted();
-        portForwardManager = (PortForwardManager) mgmt.getLocationRegistry().resolve("portForwardManager(scope=global)");
-        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-east-1");
+        portForwardManager = (PortForwardManager) mgmt.getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
+        loc = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-east-1");
 
         node = Mockito.mock(NodeMetadata.class);
         Mockito.when(node.getId()).thenReturn("mynodeid");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationResolverTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationResolverTest.java
@@ -273,7 +273,7 @@ public class JcloudsLocationResolverTest {
         conf = resolve("named:softlayer-was2").config().getBag().getAllConfig();
         assertEquals(conf.get("region"), "was02");
         
-        conf = ((LocationInternal) managementContext.getLocationRegistry().resolve("named:softlayer-was2", MutableMap.of("region", "was03")))
+        conf = ((LocationInternal) managementContext.getLocationRegistry().getLocationManaged("named:softlayer-was2", MutableMap.of("region", "was03")))
             .config().getBag().getAllConfig();;
         assertEquals(conf.get("region"), "was03");
     }
@@ -391,6 +391,6 @@ public class JcloudsLocationResolverTest {
     }
     
     private JcloudsLocation resolve(String spec) {
-        return (JcloudsLocation) managementContext.getLocationRegistry().resolve(spec);
+        return (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(spec);
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationSuspendResumeMachineLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationSuspendResumeMachineLiveTest.java
@@ -41,7 +41,7 @@ public class JcloudsLocationSuspendResumeMachineLiveTest extends AbstractJclouds
     public void setUp() throws Exception {
         super.setUp();
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry()
-                .resolve(AWS_EC2_PROVIDER + ":" + AWS_EC2_EUWEST_REGION_NAME);
+                .getLocationManaged(AWS_EC2_PROVIDER + ":" + AWS_EC2_EUWEST_REGION_NAME);
     }
 
     @Test(groups = "Live")

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTemplateOptionsCustomisersLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTemplateOptionsCustomisersLiveTest.java
@@ -103,6 +103,6 @@ public class JcloudsLocationTemplateOptionsCustomisersLiveTest extends AbstractJ
     }
 
     private JcloudsLocation resolve(String spec) {
-        return (JcloudsLocation) managementContext.getLocationRegistry().resolve("jclouds:"+spec);
+        return (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged("jclouds:"+spec);
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLoginLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLoginLiveTest.java
@@ -87,7 +87,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     protected void testAwsEc2SpecifyingJustPrivateSshKeyInDeprecatedForm() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -105,7 +105,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.LEGACY_PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -121,7 +121,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     @Test(groups = {"Live"})
     protected void testAwsEc2SpecifyingNoKeyFiles() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -140,7 +140,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
             
             machine = createEc2Machine();
             assertSshable(machine);
@@ -162,7 +162,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             moveSshKeyFiles();
             
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
             
             machine = createEc2Machine();
             assertSshable(machine);
@@ -190,7 +190,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         if (leavePasswordSsh) {
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.DISABLE_ROOT_AND_PASSWORD_SSH.getName(), false);
         }
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -223,7 +223,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
     protected void testSpecifyingPasswordIgnoresDefaultSshKeys() throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -246,7 +246,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USE_JCLOUDS_SSH_INIT.getName(), "false");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -270,7 +270,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.DISABLE_ROOT_AND_PASSWORD_SSH.getName(), false);
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine();
         assertSshable(machine);
@@ -297,7 +297,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "root");
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PASSWORD.getName(), "mypassword");
             brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.DISABLE_ROOT_AND_PASSWORD_SSH.getName(), false);
-            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+            jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
             
             machine = createEc2Machine();
             assertSshable(machine);
@@ -317,7 +317,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "root");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine(ImmutableMap.<String,Object>of("imageId", AWS_EC2_UBUNTU_10_IMAGE_ID));
         assertSshable(machine);
@@ -334,7 +334,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine(ImmutableMap.<String,Object>of("imageId", AWS_EC2_UBUNTU_10_IMAGE_ID));
         assertSshable(machine);
@@ -353,7 +353,7 @@ public class JcloudsLoginLiveTest extends AbstractJcloudsLiveTest {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "ec2-user");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PRIVATE_KEY_FILE.getName(), "~/.ssh/id_rsa");
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.PUBLIC_KEY_FILE.getName(), "~/.ssh/id_rsa.pub");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         machine = createEc2Machine(ImmutableMap.<String,Object>of("imageId", AWS_EC2_UBUNTU_10_IMAGE_ID));
         assertSshable(machine);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindLiveTest.java
@@ -129,7 +129,7 @@ public class JcloudsRebindLiveTest extends RebindTestFixtureWithApp {
     }
     
     protected void runTest(String locSpec, Map<String, ?> obtainFlags) throws Exception {
-        JcloudsLocation location = (JcloudsLocation) mgmt().getLocationRegistry().resolve(locSpec);
+        JcloudsLocation location = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(locSpec);
         
         JcloudsMachineLocation origMachine = obtainMachine(location, obtainFlags);
         String origHostname = origMachine.getHostname();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
@@ -181,7 +181,7 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
                 "myHostname");
         
         ByonComputeServiceRegistry computeServiceRegistry = new ByonComputeServiceRegistry(node);
-        JcloudsLocation origJcloudsLoc = (JcloudsLocation) mgmt().getLocationRegistry().resolve("jclouds:softlayer", ImmutableMap.of(
+        JcloudsLocation origJcloudsLoc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged("jclouds:softlayer", ImmutableMap.of(
                 JcloudsLocation.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry,
                 JcloudsLocation.WAIT_FOR_SSHABLE, false,
                 JcloudsLocation.USE_JCLOUDS_SSH_INIT, false));

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshingLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshingLiveTest.java
@@ -49,7 +49,7 @@ public class JcloudsSshingLiveTest extends AbstractJcloudsLiveTest {
     protected void runCreatesUser(boolean useJcloudsSshInit) throws Exception {
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USE_JCLOUDS_SSH_INIT.getName(), Boolean.toString(useJcloudsSshInit));
         brooklynProperties.put(BROOKLYN_PROPERTIES_PREFIX+JcloudsLocationConfig.USER.getName(), "myname");
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(SOTLAYER_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(SOTLAYER_LOCATION_SPEC);
         
         JcloudsSshMachineLocation machine = obtainMachine(MutableMap.<String,Object>builder()
                 .putIfAbsent("inboundPorts", ImmutableList.of(22))

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSuseLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSuseLiveTest.java
@@ -48,7 +48,7 @@ public class JcloudsSuseLiveTest extends AbstractJcloudsLiveTest {
     // TODO Also requires https://github.com/jclouds/jclouds/pull/827
     @Test(groups = {"Live", "WIP"})
     protected void testSuseUsingJcloudsSshInit() throws Exception {
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         JcloudsSshMachineLocation machine = createEc2Machine(ImmutableMap.<String,Object>of(
                 JcloudsLocation.USE_JCLOUDS_SSH_INIT.getName(), true,
@@ -65,7 +65,7 @@ public class JcloudsSuseLiveTest extends AbstractJcloudsLiveTest {
     // TODO Also requires https://github.com/jclouds/jclouds/pull/??? (see BROOKLYN-188, for checking if group exists)
     @Test(groups = {"Live", "WIP"})
     protected void testSuseSkippingJcloudsSshInit() throws Exception {
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         
         JcloudsSshMachineLocation machine = createEc2Machine(ImmutableMap.<String,Object>of(
                 JcloudsLocation.USE_JCLOUDS_SSH_INIT.getName(), false,

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
@@ -62,7 +62,7 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
     public void setUp() throws Exception {
         super.setUp();
 
-        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().resolve(AWS_EC2_LOCATION_SPEC);
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(AWS_EC2_LOCATION_SPEC);
         jcloudsLocation.config().set(JcloudsLocation.HARDWARE_ID, AWS_EC2_SMALL_HARDWARE_ID);
         
         origApp = TestApplication.Factory.newManagedInstanceForTests(managementContext);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationTest.java
@@ -40,7 +40,7 @@ public class RebindJcloudsLocationTest extends RebindTestFixtureWithApp {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        origLoc = (JcloudsLocation) origManagementContext.getLocationRegistry().resolve(LOC_SPEC);
+        origLoc = (JcloudsLocation) origManagementContext.getLocationRegistry().getLocationManaged(LOC_SPEC);
     }
 
     // Previously, the rebound config contained "id" which was then passed to createTemporarySshMachineLocation, causing

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/SimpleJcloudsLocationUserLoginAndConfigLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/SimpleJcloudsLocationUserLoginAndConfigLiveTest.java
@@ -243,6 +243,6 @@ public class SimpleJcloudsLocationUserLoginAndConfigLiveTest extends AbstractJcl
     }
 
     private JcloudsLocation resolve(String spec) {
-        return (JcloudsLocation) managementContext.getLocationRegistry().resolve("jclouds:"+spec);
+        return (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged("jclouds:"+spec);
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/SingleMachineProvisioningLocationJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/SingleMachineProvisioningLocationJcloudsLiveTest.java
@@ -115,7 +115,7 @@ private static final Logger log = LoggerFactory.getLogger(SingleMachineProvision
     @SuppressWarnings("unchecked")
     private SingleMachineProvisioningLocation<JcloudsSshMachineLocation> resolve(String spec) {
         SingleMachineProvisioningLocation<JcloudsSshMachineLocation> result = (SingleMachineProvisioningLocation<JcloudsSshMachineLocation>) 
-                managementContext.getLocationRegistry().resolve(spec);
+                managementContext.getLocationRegistry().getLocationManaged(spec);
         // FIXME Do we really need to setManagementContext?!
         //result.setManagementContext(managementContext);
         return result;

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
@@ -145,7 +145,7 @@ public abstract class AbstractJcloudsLocationTest {
     	useMgmt(newMockManagementContext());
     	
         Map<String, Object> dummy = ImmutableMap.<String, Object>of("identity", "DUMMY", "credential", "DUMMY");
-        loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve(provider + (regionName == null ? "" : ":" + regionName), dummy);
+        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(provider + (regionName == null ? "" : ":" + regionName), dummy);
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder().put("imageId", imageId);
         if (imageOwner != null) builder.put("imageOwner", imageOwner);
         Map<String, Object> tagMapping = builder.build();
@@ -157,7 +157,7 @@ public abstract class AbstractJcloudsLocationTest {
 
     @Test(groups = "Live", dataProvider="fromImageId")
     public void testProvisionVmUsingImageId(String regionName, String imageId, String imageOwner) {
-        loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve(provider + (regionName == null ? "" : ":" + regionName));
+        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(provider + (regionName == null ? "" : ":" + regionName));
         SshMachineLocation machine = obtainMachine(MutableMap.of("imageId", imageId, "imageOwner", imageOwner, JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 2));
 
         LOG.info("Provisioned {} vm {}; checking if ssh'able", provider, machine);
@@ -166,7 +166,7 @@ public abstract class AbstractJcloudsLocationTest {
     
     @Test(groups = "Live", dataProvider="fromImageNamePattern")
     public void testProvisionVmUsingImageNamePattern(String regionName, String imageNamePattern, String imageOwner) {
-        loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve(provider + (regionName == null ? "" : ":" + regionName));
+        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(provider + (regionName == null ? "" : ":" + regionName));
         SshMachineLocation machine = obtainMachine(MutableMap.of("imageNameRegex", imageNamePattern, "imageOwner", imageOwner, JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 2));
         
         LOG.info("Provisioned {} vm {}; checking if ssh'able", provider, machine);
@@ -175,7 +175,7 @@ public abstract class AbstractJcloudsLocationTest {
     
     @Test(groups = "Live", dataProvider="fromImageDescriptionPattern")
     public void testProvisionVmUsingImageDescriptionPattern(String regionName, String imageDescriptionPattern, String imageOwner) {
-        loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve(provider + (regionName == null ? "" : ":" + regionName));
+        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(provider + (regionName == null ? "" : ":" + regionName));
         SshMachineLocation machine = obtainMachine(MutableMap.of("imageDescriptionRegex", imageDescriptionPattern, "imageOwner", imageOwner, JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 2));
         
         LOG.info("Provisioned {} vm {}; checking if ssh'able", provider, machine);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AwsEc2LocationWindowsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AwsEc2LocationWindowsLiveTest.java
@@ -55,7 +55,7 @@ public class AwsEc2LocationWindowsLiveTest {
     public void setUp() {
         ctx = Entities.newManagementContext(ImmutableMap.of("provider", PROVIDER));
 
-        loc = (JcloudsLocation) ctx.getLocationRegistry().resolve(LOCATION_ID);
+        loc = (JcloudsLocation) ctx.getLocationRegistry().getLocationManaged(LOCATION_ID);
     }
 
     @AfterMethod(groups = "Live")

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/CarrenzaLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/CarrenzaLocationLiveTest.java
@@ -90,7 +90,7 @@ class CarrenzaLocationLiveTest {
         brooklynProperties.put("brooklyn.jclouds."+PROVIDER+".natMapping", ImmutableMap.of("192.168.0.100", "195.3.186.200", "192.168.0.101", "195.3.186.42"));
 
         managementContext = new LocalManagementContext(brooklynProperties);
-        loc = (JcloudsLocation) managementContext.getLocationRegistry().resolve(LOCATION_ID);
+        loc = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(LOCATION_ID);
     }
     
     @AfterMethod(groups = "Live")

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/RackspaceLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/RackspaceLocationLiveTest.java
@@ -70,7 +70,7 @@ public class RackspaceLocationLiveTest extends AbstractJcloudsLocationTest {
 
     @Test(groups = "Live")
     public void testVmMetadata() {
-        loc = (JcloudsLocation) mgmt().getLocationRegistry().resolve(PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME));
+        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME));
         SshMachineLocation machine = obtainMachine(MutableMap.of("imageId", IMAGE_ID, "userMetadata", MutableMap.of("mykey", "myval"), JcloudsLocation.MACHINE_CREATE_ATTEMPTS, 2));
 
         LOG.info("Provisioned {} vm {}; checking metadata and if ssh'able", PROVIDER, machine);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
@@ -56,7 +56,7 @@ public class AwsAvailabilityZoneExtensionTest {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         mgmt = new LocalManagementContext();
-        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
+        loc = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
         zoneExtension = new AwsAvailabilityZoneExtension(mgmt, loc);
     }
     

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyLiveTest.java
@@ -29,17 +29,16 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.policy.jclouds.os.CreateUserPolicy;
-import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-import org.apache.brooklyn.location.ssh.SshMachineLocation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -61,7 +60,7 @@ public class CreateUserPolicyLiveTest extends BrooklynAppLiveTestSupport {
     public void testLiveCreatesUserOnCentos() throws Exception {
         String locSpec = "jclouds:softlayer:ams01";
         ImmutableMap<String, String> locArgs = ImmutableMap.of("imageId", "CENTOS_6_64");
-        Location loc = mgmt.getLocationRegistry().resolve(locSpec, locArgs);
+        Location loc = mgmt.getLocationRegistry().getLocationManaged(locSpec, locArgs);
         runTestCreatesUser((MachineProvisioningLocation<SshMachineLocation>) loc);
     }
     
@@ -71,7 +70,7 @@ public class CreateUserPolicyLiveTest extends BrooklynAppLiveTestSupport {
         // No SUSE images on Softlayer, so test on AWS
         String locSpec = "jclouds:aws-ec2:us-east-1";
         ImmutableMap<String, String> locArgs = ImmutableMap.of("imageId", "us-east-1/ami-8dd105e6", "loginUser", "ec2-user");
-        Location loc = mgmt.getLocationRegistry().resolve(locSpec, locArgs);
+        Location loc = mgmt.getLocationRegistry().getLocationManaged(locSpec, locArgs);
         runTestCreatesUser((MachineProvisioningLocation<SshMachineLocation>) loc);
     }
     
@@ -88,7 +87,7 @@ public class CreateUserPolicyLiveTest extends BrooklynAppLiveTestSupport {
 
             app.start(ImmutableList.of(machine));
             
-            String creds = EntityTestUtils.assertAttributeEventuallyNonNull(entity, CreateUserPolicy.VM_USER_CREDENTIALS);
+            String creds = EntityAsserts.assertAttributeEventuallyNonNull(entity, CreateUserPolicy.VM_USER_CREDENTIALS);
             Pattern pattern = Pattern.compile("(.*) : (.*) @ (.*):(.*)");
             Matcher matcher = pattern.matcher(creds);
             assertTrue(matcher.matches());

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSummary.java
@@ -30,6 +30,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 
+@SuppressWarnings("deprecation") 
+// parent will be removed but this will be kept, just for reporting Location instances
+// CatalogLocationSummary should be used for items in the catalog
 public class LocationSummary extends LocationSpec implements HasName, HasId {
 
     private static final long serialVersionUID = -4559153719273573670L;
@@ -39,6 +42,8 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
     /** only intended for instantiated Locations, not definitions */
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     private final String type;
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    private final CatalogLocationSummary catalog;
     private final Map<String, URI> links;
 
     public LocationSummary(
@@ -47,10 +52,12 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
             @JsonProperty("spec") String spec,
             @JsonProperty("type") String type,
             @JsonProperty("config") @Nullable Map<String, ?> config,
+            @JsonProperty("catalog") @Nullable CatalogLocationSummary catalog,
             @JsonProperty("links") Map<String, URI> links) {
         super(name, spec, config);
         this.id = checkNotNull(id);
         this.type = type;
+        this.catalog = catalog;
         this.links = (links == null) ? ImmutableMap.<String, URI> of() : ImmutableMap.copyOf(links);
     }
 
@@ -63,6 +70,10 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
         return type;
     }
 
+    public CatalogLocationSummary getCatalog() {
+        return catalog;
+    }
+    
     public Map<String, URI> getLinks() {
         return links;
     }
@@ -75,12 +86,13 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
         LocationSummary that = (LocationSummary) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(type, that.type) &&
+                Objects.equals(catalog, that.catalog) &&
                 Objects.equals(links, that.links);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), id, type, links);
+        return Objects.hash(super.hashCode(), id, type, catalog, links);
     }
 
     @Override
@@ -88,6 +100,7 @@ public class LocationSummary extends LocationSpec implements HasName, HasId {
         return "LocationSummary{" +
                 "id='" + id + '\'' +
                 ", type='" + type + '\'' +
+                ", catalog='" + catalog + '\'' +
                 ", links=" + links +
                 '}';
     }

--- a/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
+++ b/rest/rest-api/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
@@ -35,7 +35,7 @@ public class LocationSummaryTest extends AbstractDomainTest {
         Map<String, URI> links = Maps.newLinkedHashMap();
         links.put("self", URI.create("/locations/123"));
 
-        return new LocationSummary("123", "localhost", "localhost", null, null, links);
+        return new LocationSummary("123", "localhost", "localhost", null, null, null, links);
     }
 
 }

--- a/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
+++ b/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/ApplicationResourceIntegrationTest.java
@@ -75,7 +75,7 @@ public class ApplicationResourceIntegrationTest {
         if (manager == null) {
             manager = new LocalManagementContext();
             BrooklynRestApiLauncherTest.forceUseOfDefaultCatalogWithJavaClassPath(manager);
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             BrooklynRestApiLauncherTest.enableAnyoneLogin(manager);
         }
         return manager;

--- a/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
+++ b/rest/rest-client/src/test/java/org/apache/brooklyn/rest/client/BrooklynApiRestClientTest.java
@@ -65,7 +65,7 @@ public class BrooklynApiRestClientTest {
         if (manager == null) {
             manager = new LocalManagementContext();
             BrooklynRestApiLauncherTest.forceUseOfDefaultCatalogWithJavaClassPath(manager);
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             BrooklynRestApiLauncherTest.enableAnyoneLogin(manager);
         }
         return manager;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -443,7 +443,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
     private void checkLocationsAreValid(ApplicationSpec applicationSpec) {
         for (String locationId : applicationSpec.getLocations()) {
             locationId = BrooklynRestResourceUtils.fixLocation(locationId);
-            if (!brooklyn().getLocationRegistry().canMaybeResolve(locationId) && brooklyn().getLocationRegistry().getDefinedLocationById(locationId)==null) {
+            if (brooklyn().getLocationRegistry().getLocationSpec(locationId).isAbsent() && brooklyn().getLocationRegistry().getDefinedLocationById(locationId)==null) {
                 throw WebResourceUtils.notFound("Undefined location '%s'", locationId);
             }
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -228,8 +228,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
 
         checkApplicationTypesAreValid(applicationSpec);
         checkLocationsAreValid(applicationSpec);
-        // TODO duplicate prevention
-        List<Location> locations = brooklyn().getLocations(applicationSpec);
+        List<Location> locations = brooklyn().getLocationsManaged(applicationSpec);
         Application app = brooklyn().create(applicationSpec);
         Task<?> t = brooklyn().start(app, locations);
         waitForStart(app, Duration.millis(100));

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
@@ -18,33 +18,35 @@
  */
 package org.apache.brooklyn.rest.transform;
 
+import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceUriBuilder;
+
 import java.net.URI;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.ws.rs.core.UriBuilder;
+
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationDefinition;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.BasicLocationDefinition;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
+import org.apache.brooklyn.rest.api.LocationApi;
 import org.apache.brooklyn.rest.domain.LocationSummary;
 import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
-import javax.ws.rs.core.UriBuilder;
-import org.apache.brooklyn.rest.api.LocationApi;
-import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceUriBuilder;
 
 public class LocationTransformer {
 
-    @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(LocationTransformer.LocationDetailLevel.class);
     
     public static enum LocationDetailLevel { NONE, LOCAL_EXCLUDING_SECRET, FULL_EXCLUDING_SECRET, FULL_INCLUDING_SECRET }
@@ -54,38 +56,70 @@ public class LocationTransformer {
     public static LocationSummary newInstance(String id, org.apache.brooklyn.rest.domain.LocationSpec locationSpec, UriBuilder ub) {
         return newInstance(null, id, locationSpec, LocationDetailLevel.LOCAL_EXCLUDING_SECRET, ub);
     }
-    @SuppressWarnings("deprecation")
-    public static LocationSummary newInstance(ManagementContext mgmt, String id, org.apache.brooklyn.rest.domain.LocationSpec locationSpec, LocationDetailLevel level, UriBuilder ub) {
-        // TODO: Remove null checks on mgmt when newInstance(String, LocationSpec) is deleted
-        Map<String, ?> config = locationSpec.getConfig();
-        if (mgmt != null && (level==LocationDetailLevel.FULL_EXCLUDING_SECRET || level==LocationDetailLevel.FULL_INCLUDING_SECRET)) {
-            LocationDefinition ld = new BasicLocationDefinition(id, locationSpec.getName(), locationSpec.getSpec(), locationSpec.getConfig());
-            Location ll = mgmt.getLocationRegistry().resolve(ld, false, null).orNull();
-            if (ll!=null) config = ((LocationInternal)ll).config().getBag().getAllConfig();
+    
+    private static LocationSummary newInstance(ManagementContext mgmt, 
+            LocationSpec<? extends Location> spec, ConfigBag explicitConfig, 
+            String optionalExplicitId, String name, String specString, 
+            LocationDetailLevel level, UriBuilder ub) {
+        // mgmt not actually needed
+        Map<String, Object> config = MutableMap.copyOf(explicitConfig==null ? null : explicitConfig.getAllConfig());
+        if (spec!=null && (level==LocationDetailLevel.FULL_EXCLUDING_SECRET || level==LocationDetailLevel.FULL_INCLUDING_SECRET)) {
+            // full takes from any resolved spec AND from explicit config
+            config = ConfigBag.newInstance(spec.getConfig()).putAll(config).getAllConfig();
         } else if (level==LocationDetailLevel.LOCAL_EXCLUDING_SECRET) {
-            // get displayName
-            if (!config.containsKey(LocationConfigKeys.DISPLAY_NAME.getName()) && mgmt!=null) {
-                LocationDefinition ld = new BasicLocationDefinition(id, locationSpec.getName(), locationSpec.getSpec(), locationSpec.getConfig());
-                Location ll = mgmt.getLocationRegistry().resolve(ld, false, null).orNull();
-                if (ll!=null) {
-                    Map<String, Object> configExtra = ((LocationInternal)ll).config().getBag().getAllConfig();
-                    if (configExtra.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
-                        ConfigBag configNew = ConfigBag.newInstance(config);
-                        configNew.configure(LocationConfigKeys.DISPLAY_NAME, (String)configExtra.get(LocationConfigKeys.DISPLAY_NAME.getName()));
-                        config = configNew.getAllConfig();
-                    }
-                }
+            // in local mode, just make sure display name is set
+            if (spec!=null && !explicitConfig.containsKey(LocationConfigKeys.DISPLAY_NAME) && Strings.isNonBlank(spec.getDisplayName())) {
+                config.put(LocationConfigKeys.DISPLAY_NAME.getName(), spec.getDisplayName());
             }
         }
 
+        String id = Strings.isNonBlank(optionalExplicitId) ? optionalExplicitId : spec!=null && Strings.isNonBlank(spec.getCatalogItemId()) ? spec.getCatalogItemId() : null;
         URI selfUri = serviceUriBuilder(ub, LocationApi.class, "get").build(id);
         return new LocationSummary(
                 id,
-                locationSpec.getName(),
-                locationSpec.getSpec(),
+                Strings.isNonBlank(name) ? name : spec!=null ? spec.getDisplayName() : null,
+                Strings.isNonBlank(specString) ? specString : spec!=null ? spec.getCatalogItemId() : null,
                 null,
                 copyConfig(config, level),
                 ImmutableMap.of("self", selfUri));
+    }
+    
+    // XXX big commented out swathes should be removed when this is confirmed working
+    
+    @SuppressWarnings("deprecation") 
+    public static LocationSummary newInstance(ManagementContext mgmt, String id, org.apache.brooklyn.rest.domain.LocationSpec locationSpec, LocationDetailLevel level, UriBuilder ub) {
+        LocationDefinition ld = new BasicLocationDefinition(id, locationSpec.getName(), locationSpec.getSpec(), locationSpec.getConfig());
+        return newInstance(mgmt, ld, level, ub);
+//        
+//        Map<String, ?> config = locationSpec.getConfig();
+//        if (mgmt != null && (level==LocationDetailLevel.FULL_EXCLUDING_SECRET || level==LocationDetailLevel.FULL_INCLUDING_SECRET)) {
+//            
+//            Location ll = mgmt.getLocationRegistry().resolve(ld, false, null).orNull();
+//            if (ll!=null) config = ((LocationInternal)ll).config().getBag().getAllConfig();
+//        } else if (level==LocationDetailLevel.LOCAL_EXCLUDING_SECRET) {
+//            // get displayName
+//            if (!config.containsKey(LocationConfigKeys.DISPLAY_NAME.getName()) && mgmt!=null) {
+//                LocationDefinition ld = new BasicLocationDefinition(id, locationSpec.getName(), locationSpec.getSpec(), locationSpec.getConfig());
+//                Location ll = mgmt.getLocationRegistry().resolve(ld, false, null).orNull();
+//                if (ll!=null) {
+//                    Map<String, Object> configExtra = ((LocationInternal)ll).config().getBag().getAllConfig();
+//                    if (configExtra.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
+//                        ConfigBag configNew = ConfigBag.newInstance(config);
+//                        configNew.configure(LocationConfigKeys.DISPLAY_NAME, (String)configExtra.get(LocationConfigKeys.DISPLAY_NAME.getName()));
+//                        config = configNew.getAllConfig();
+//                    }
+//                }
+//            }
+//        }
+//
+//        URI selfUri = serviceUriBuilder(ub, LocationApi.class, "get").build(id);
+//        return new LocationSummary(
+//                id,
+//                locationSpec.getName(),
+//                locationSpec.getSpec(),
+//                null,
+//                copyConfig(config, level),
+//                ImmutableMap.of("self", selfUri));
     }
 
     /** @deprecated since 0.7.0 use method taking management context and detail specifier */
@@ -94,35 +128,36 @@ public class LocationTransformer {
         return newInstance(null, l, LocationDetailLevel.LOCAL_EXCLUDING_SECRET, ub);
     }
 
-    public static LocationSummary newInstance(ManagementContext mgmt, LocationDefinition l, LocationDetailLevel level, UriBuilder ub) {
-        // TODO: Can remove null checks on mgmt when newInstance(LocationDefinition) is deleted
-        Map<String, Object> config = l.getConfig();
-        if (mgmt != null && (level==LocationDetailLevel.FULL_EXCLUDING_SECRET || level==LocationDetailLevel.FULL_INCLUDING_SECRET)) {
-            Location ll = mgmt.getLocationRegistry().resolve(l, false, null).orNull();
-            if (ll!=null) config = ((LocationInternal)ll).config().getBag().getAllConfig();
-        } else if (level==LocationDetailLevel.LOCAL_EXCLUDING_SECRET) {
-            // get displayName
-            if (mgmt != null && !config.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
-                Location ll = mgmt.getLocationRegistry().resolve(l, false, null).orNull();
-                if (ll!=null) {
-                    Map<String, Object> configExtra = ((LocationInternal)ll).config().getBag().getAllConfig();
-                    if (configExtra.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
-                        ConfigBag configNew = ConfigBag.newInstance(config);
-                        configNew.configure(LocationConfigKeys.DISPLAY_NAME, (String)configExtra.get(LocationConfigKeys.DISPLAY_NAME.getName()));
-                        config = configNew.getAllConfig();
-                    }
-                }
-            }
-        }
-
-        URI selfUri = serviceUriBuilder(ub, LocationApi.class, "get").build(l.getId());
-        return new LocationSummary(
-                l.getId(),
-                l.getName(),
-                l.getSpec(),
-                null,
-                copyConfig(config, level),
-                ImmutableMap.of("self", selfUri));
+    public static LocationSummary newInstance(ManagementContext mgmt, LocationDefinition ld, LocationDetailLevel level, UriBuilder ub) {
+        return newInstance(mgmt, mgmt.getLocationRegistry().getLocationSpec(ld).orNull(), ConfigBag.newInstance(ld.getConfig()),
+            ld.getId(), ld.getName(), ld.getSpec(), level, ub);
+//        Map<String, Object> config = ld.getConfig();
+//        
+//        if (mgmt != null && (level==LocationDetailLevel.FULL_EXCLUDING_SECRET || level==LocationDetailLevel.FULL_INCLUDING_SECRET)) {
+//            if (ll.isPresent()) config = ConfigBag.newInstance(ll.get().getConfig()).getAllConfig();
+//        } else if (level==LocationDetailLevel.LOCAL_EXCLUDING_SECRET) {
+//            // get any displayName
+//            if (mgmt != null && !config.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
+//                Maybe<LocationSpec<?>> ll = mgmt.getLocationRegistry().getLocationSpec(ld);
+//                if (ll.isPresent()) {
+//                    ConfigBag configNew = ConfigBag.newInstance(ll.get().getConfig());
+//                    // XXX useless? 
+//                    if (configNew.containsKey(LocationConfigKeys.DISPLAY_NAME.getName())) {
+//                        configNew.configure(LocationConfigKeys.DISPLAY_NAME, (String)configNew.get(LocationConfigKeys.DISPLAY_NAME));
+//                        config = configNew.getAllConfig();
+//                    }
+//                }
+//            }
+//        }
+//
+//        URI selfUri = serviceUriBuilder(ub, LocationApi.class, "get").build(ld.getId());
+//        return new LocationSummary(
+//                ld.getId(),
+//                ld.getName(),
+//                ld.getSpec(),
+//                null,
+//                copyConfig(config, level),
+//                ImmutableMap.of("self", selfUri));
     }
 
     private static Map<String, ?> copyConfig(Map<String,?> entries, LocationDetailLevel level) {
@@ -137,6 +172,7 @@ public class LocationTransformer {
         return builder.build();
     }
 
+    private static boolean LEGACY_SPEC_WARNING = false;
     public static LocationSummary newInstance(ManagementContext mgmt, Location l, LocationDetailLevel level, UriBuilder ub) {
         String spec = null;
         String specId = null;
@@ -165,6 +201,11 @@ public class LocationTransformer {
         }
         if (specId==null && spec!=null) {
             // fall back to attempting to lookup it
+            // TODO remove this block unless we get this warning
+            if (LEGACY_SPEC_WARNING==false) {
+                log.warn("Legacy spec lookup required for rest summary of "+l);
+                LEGACY_SPEC_WARNING = true;
+            }
             Location ll = mgmt.getLocationRegistry().resolve(spec, false, null).orNull();
             if (ll!=null) specId = ll.getId();
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
@@ -403,7 +403,8 @@ public class BrooklynRestResourceUtils {
             @Override
             public Location apply(String id) {
                 id = fixLocation(id);
-                return getLocationRegistry().resolve(id);
+                // XXX
+                return getLocationRegistry().getLocationManaged(id);
             }
         };
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
@@ -259,7 +259,7 @@ public class BrooklynRestResourceUtils {
         private RegisteredType getCatalogItemForType(String typeName) {
             final RegisteredType resultI;
             if (CatalogUtils.looksLikeVersionedId(typeName)) {
-                //All catalog identifiers of the form xxxx:yyyy are composed of symbolicName+version.
+                //All catalog identifiers of the form aaaa:bbbb are composed of symbolicName+version.
                 //No javaType is allowed as part of the identifier.
                 resultI = mgmt.getTypeRegistry().get(typeName);
             } else {
@@ -389,7 +389,7 @@ public class BrooklynRestResourceUtils {
     }
     
     public Task<?> start(Application app, ApplicationSpec spec) {
-        return start(app, getLocations(spec));
+        return start(app, getLocationsManaged(spec));
     }
 
     public Task<?> start(Application app, List<? extends Location> locations) {
@@ -397,13 +397,12 @@ public class BrooklynRestResourceUtils {
                 MutableMap.of("locations", locations));
     }
 
-    public List<Location> getLocations(ApplicationSpec spec) {
+    public List<Location> getLocationsManaged(ApplicationSpec spec) {
         // Start all the managed entities by asking the app instance to start in background
         Function<String, Location> buildLocationFromId = new Function<String, Location>() {
             @Override
             public Location apply(String id) {
                 id = fixLocation(id);
-                // XXX
                 return getLocationRegistry().getLocationManaged(id);
             }
         };

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
@@ -79,7 +79,7 @@ public class LocationResourceTest extends BrooklynRestResourceTest {
         assertEquals(location.getSpec(), "brooklyn.catalog:"+legacyLocationName+":"+legacyLocationVersion);
         assertTrue(addedLegacyLocationUri.getPath().startsWith("/locations/"));
 
-        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().resolve(legacyLocationName);
+        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().getLocationManaged(legacyLocationName);
         Assert.assertEquals(l.getProvider(), "aws-ec2");
         Assert.assertEquals(l.getRegion(), "us-east-1");
         Assert.assertEquals(l.getIdentity(), "bob");
@@ -119,7 +119,7 @@ public class LocationResourceTest extends BrooklynRestResourceTest {
         Assert.assertEquals(locationSummary.getSpec(), "brooklyn.catalog:"+locationName+":"+locationVersion);
 
         // Ensure location is usable - can instantiate, and has right config
-        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().resolve(locationName);
+        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().getLocationManaged(locationName);
         Assert.assertEquals(l.getProvider(), "aws-ec2");
         Assert.assertEquals(l.getRegion(), "us-east-1");
         Assert.assertEquals(l.getIdentity(), "bob");

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceIntegrationTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceIntegrationTest.java
@@ -52,7 +52,7 @@ public class SensorResourceIntegrationTest extends BrooklynRestResourceTest {
         app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class).displayName("simple-app")
             .child(EntitySpec.create(Entity.class, RestMockSimpleEntity.class).displayName("simple-ent")));
         mgmt.getEntityManager().manage(app);
-        app.start(MutableList.of(mgmt.getLocationRegistry().resolve("localhost")));
+        app.start(MutableList.of(mgmt.getLocationRegistry().getLocationManaged("localhost")));
     }
 
     // marked integration because of time

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -146,7 +146,7 @@ public abstract class BrooklynRestApiTest {
                 manager = new LocalManagementContextForTests();
             }
             manager.getHighAvailabilityManager().disabled();
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             
             new BrooklynCampPlatformLauncherNoServer()
                 .useManagementContext(manager)

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/EntityLocationUtilsTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/EntityLocationUtilsTest.java
@@ -49,7 +49,7 @@ public class EntityLocationUtilsTest extends BrooklynAppUnitTestSupport {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        loc = mgmt.getLocationRegistry().resolve("localhost");
+        loc = mgmt.getLocationRegistry().getLocationManaged("localhost");
         ((AbstractLocation)loc).setHostGeoInfo(new HostGeoInfo("localhost", "localhost", 50, 0));
     }
     

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/domain/LocationSummaryTest.java
@@ -35,7 +35,7 @@ public class LocationSummaryTest extends AbstractDomainTest {
         Map<String, URI> links = Maps.newLinkedHashMap();
         links.put("self", URI.create("/v1/locations/123"));
 
-        return new LocationSummary("123", "localhost", "localhost", null, null, links);
+        return new LocationSummary("123", "localhost", "localhost", null, null, null, links);
     }
 
 }

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
@@ -32,9 +32,9 @@ import org.apache.brooklyn.api.mgmt.entitlement.EntitlementManager;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.machine.MachineEntity;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessStreamsTest;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.util.core.task.TaskPredicates;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.testng.annotations.BeforeMethod;
@@ -55,10 +55,9 @@ public class ActivityApiEntitlementsTest extends AbstractRestApiEntitlementsTest
     public void setUp() throws Exception {
         super.setUp();
         
-        LocalhostMachineProvisioningLocation loc = app.newLocalhostProvisioningLocation();
         machineEntity = app.addChild(EntitySpec.create(MachineEntity.class)
                 .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true)
-                .location(loc));
+                .location(TestApplication.LOCALHOST_PROVISIONER_SPEC));
         machineEntity.start(ImmutableList.<Location>of());
         
         machineEntity.execCommand("echo myval");

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
@@ -77,7 +77,7 @@ public class LocationResourceTest extends BrooklynRestResourceTest {
         assertEquals(location.getSpec(), "brooklyn.catalog:"+legacyLocationName+":"+legacyLocationVersion);
         assertTrue(addedLegacyLocationUri.getPath().startsWith("/v1/locations/"));
 
-        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().resolve(legacyLocationName);
+        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().getLocationManaged(legacyLocationName);
         Assert.assertEquals(l.getProvider(), "aws-ec2");
         Assert.assertEquals(l.getRegion(), "us-east-1");
         Assert.assertEquals(l.getIdentity(), "bob");
@@ -117,7 +117,7 @@ public class LocationResourceTest extends BrooklynRestResourceTest {
         Assert.assertEquals(locationSummary.getSpec(), "brooklyn.catalog:"+locationName+":"+locationVersion);
 
         // Ensure location is usable - can instantiate, and has right config
-        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().resolve(locationName);
+        JcloudsLocation l = (JcloudsLocation) getManagementContext().getLocationRegistry().getLocationManaged(locationName);
         Assert.assertEquals(l.getProvider(), "aws-ec2");
         Assert.assertEquals(l.getRegion(), "us-east-1");
         Assert.assertEquals(l.getIdentity(), "bob");

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceIntegrationTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceIntegrationTest.java
@@ -60,7 +60,7 @@ public class SensorResourceIntegrationTest extends BrooklynRestApiLauncherTestFi
         app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class).displayName("simple-app")
             .child(EntitySpec.create(Entity.class, RestMockSimpleEntity.class).displayName("simple-ent")));
         mgmt.getEntityManager().manage(app);
-        app.start(MutableList.of(mgmt.getLocationRegistry().resolve("localhost")));
+        app.start(MutableList.of(mgmt.getLocationRegistry().getLocationManaged("localhost")));
     }
     
     // marked integration because of time

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -85,7 +85,7 @@ public abstract class BrooklynRestApiTest {
                 manager = new LocalManagementContextForTests();
             }
             manager.getHighAvailabilityManager().disabled();
-            BasicLocationRegistry.setupLocationRegistryForTesting(manager);
+            BasicLocationRegistry.addNamedLocationLocalhost(manager);
             
             new BrooklynCampPlatformLauncherNoServer()
                 .useManagementContext(manager)

--- a/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/EntityLocationUtilsTest.java
+++ b/rest/rest-server-jersey/src/test/java/org/apache/brooklyn/rest/util/EntityLocationUtilsTest.java
@@ -49,7 +49,7 @@ public class EntityLocationUtilsTest extends BrooklynAppUnitTestSupport {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        loc = mgmt.getLocationRegistry().resolve("localhost");
+        loc = mgmt.getLocationRegistry().getLocationManaged("localhost");
         ((AbstractLocation)loc).setHostGeoInfo(new HostGeoInfo("localhost", "localhost", 50, 0));
     }
     

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
@@ -32,9 +32,9 @@ import org.apache.brooklyn.api.mgmt.entitlement.EntitlementManager;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.machine.MachineEntity;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessStreamsTest;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.util.core.task.TaskPredicates;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.testng.annotations.BeforeMethod;
@@ -55,10 +55,9 @@ public class ActivityApiEntitlementsTest extends AbstractRestApiEntitlementsTest
     public void setUp() throws Exception {
         super.setUp();
         
-        LocalhostMachineProvisioningLocation loc = app.newLocalhostProvisioningLocation();
         machineEntity = app.addChild(EntitySpec.create(MachineEntity.class)
                 .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true)
-                .location(loc));
+                .location(TestApplication.LOCALHOST_PROVISIONER_SPEC));
         machineEntity.start(ImmutableList.<Location>of());
         
         machineEntity.execCommand("echo myval");

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
@@ -86,13 +86,13 @@ public class CloudExplorer {
                 if (location != null && allLocations) {
                     throw new FatalConfigurationRuntimeException("Must not specify --location and --all-locations");
                 } else if (location != null) {
-                    JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(location);
+                    JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(location);
                     locs.add(loc);
                 } else if (allLocations) {
                     // Find all named locations that point at different target clouds
                     Map<String, LocationDefinition> definedLocations = mgmt.getLocationRegistry().getDefinedLocations();
                     for (LocationDefinition locationDef : definedLocations.values()) {
-                        Location loc = mgmt.getLocationRegistry().resolve(locationDef);
+                        Location loc = mgmt.getLocationManager().createLocation( mgmt.getLocationRegistry().getLocationSpec(locationDef).get() );
                         if (loc instanceof JcloudsLocation) {
                             boolean found = false;
                             for (JcloudsLocation existing : locs) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocationResolver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocationResolver.java
@@ -27,15 +27,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
+import org.apache.brooklyn.api.location.LocationResolver;
 import org.apache.brooklyn.api.location.LocationSpec;
-import org.apache.brooklyn.api.location.LocationResolver.EnableableLocationResolver;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
+import org.apache.brooklyn.core.location.LocationConfigUtils;
 import org.apache.brooklyn.core.location.LocationPropertiesFromBrooklynProperties;
 import org.apache.brooklyn.core.location.dynamic.DynamicLocation;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.text.KeyValueParser;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,11 +46,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.text.KeyValueParser;
-import org.apache.brooklyn.util.text.Strings;
-
-public class ServerPoolLocationResolver implements EnableableLocationResolver {
+public class ServerPoolLocationResolver implements LocationResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerPoolLocationResolver.class);
     private static final String PREFIX = "pool";
@@ -62,7 +61,7 @@ public class ServerPoolLocationResolver implements EnableableLocationResolver {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return LocationConfigUtils.isResolverPrefixEnabled(managementContext, getPrefix());
     }
 
     @Override
@@ -82,7 +81,7 @@ public class ServerPoolLocationResolver implements EnableableLocationResolver {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public Location newLocationFromString(Map locationFlags, String spec, LocationRegistry registry) {
+    public LocationSpec newLocationSpecFromString(String spec, Map locationFlags, LocationRegistry registry) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Resolving location '" + spec + "' with flags " + Joiner.on(",").withKeyValueSeparator("=").join(locationFlags));
         }
@@ -127,12 +126,11 @@ public class ServerPoolLocationResolver implements EnableableLocationResolver {
         final String locationName = namePart != null ? namePart : "serverpool-" + poolId;
 
         Entity pool = managementContext.getEntityManager().getEntity(poolId);
-        LocationSpec<ServerPoolLocation> locationSpec = LocationSpec.create(ServerPoolLocation.class)
+        return LocationSpec.create(ServerPoolLocation.class)
                 .configure(flags)
                 .configure(DynamicLocation.OWNER, pool)
                 .configure(LocationInternal.NAMED_SPEC_NAME, locationName)
                 .displayName(displayName);
-        return managementContext.getLocationManager().createLocation(locationSpec);
     }
 
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -184,7 +184,7 @@ public abstract class MachineLifecycleEffectorTasks {
                 Collection<? extends Location> locations  = null;
 
                 Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
-                locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+                locations = Locations.coerceToCollectionOfLocationsManaged(entity().getManagementContext(), locationsRaw);
 
                 if (locations==null) {
                     // null/empty will mean to inherit from parent
@@ -204,7 +204,7 @@ public abstract class MachineLifecycleEffectorTasks {
             Collection<? extends Location> locations = null;
 
             Object locationsRaw = parameters.getStringKey(LOCATIONS.getName());
-            locations = Locations.coerceToCollection(entity().getManagementContext(), locationsRaw);
+            locations = Locations.coerceToCollectionOfLocationsManaged(entity().getManagementContext(), locationsRaw);
 
             if (locations == null) {
                 // null/empty will mean to inherit from parent

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
                 .put("tags", ImmutableList.of(getClass().getName()))
                 .putAll(flags)
                 .build();
-        jcloudsLocation = mgmt.getLocationRegistry().resolve(LOCATION_SPEC, allFlags);
+        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC, allFlags);
 
         doTest(jcloudsLocation);
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractGoogleComputeLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractGoogleComputeLiveTest.java
@@ -128,7 +128,7 @@ public abstract class AbstractGoogleComputeLiveTest {
                 .put("tags", ImmutableList.of(tag))
                 .putAll(flags)
                 .build();
-        jcloudsLocation = ctx.getLocationRegistry().resolve(LOCATION_SPEC, allFlags);
+        jcloudsLocation = ctx.getLocationRegistry().getLocationManaged(LOCATION_SPEC, allFlags);
 
         doTest(jcloudsLocation);
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractSoftlayerLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractSoftlayerLiveTest.java
@@ -106,7 +106,7 @@ public abstract class AbstractSoftlayerLiveTest {
                 .put("vmNameMaxLength", MAX_VM_NAME_LENGTH)
                 .putAll(flags)
                 .build();
-        jcloudsLocation = ctx.getLocationRegistry().resolve(PROVIDER, allFlags);
+        jcloudsLocation = ctx.getLocationRegistry().getLocationManaged(PROVIDER, allFlags);
 
         doTest(jcloudsLocation);
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
@@ -38,6 +38,7 @@ import org.apache.brooklyn.core.feed.AttributePollHandler;
 import org.apache.brooklyn.core.feed.DelegatingPollHandler;
 import org.apache.brooklyn.core.feed.Poller;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.brooklynnode.BrooklynCluster;
 import org.apache.brooklyn.entity.brooklynnode.BrooklynClusterImpl;
 import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
@@ -90,7 +91,7 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
         super.setUpApp();
         http = new HttpCallback();
         cluster = app.createAndManageChild(EntitySpec.create(BrooklynCluster.class)
-            .location(app.newLocalhostProvisioningLocation())
+            .location(TestApplication.LOCALHOST_PROVISIONER_SPEC)
             .configure(BrooklynCluster.MEMBER_SPEC, EntitySpec.create(BrooklynNode.class)
                 .impl(MockBrooklynNode.class)
                 .configure(MockBrooklynNode.HTTP_CLIENT_CALLBACK, http)));

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
@@ -34,7 +34,7 @@ public class MachineEntityRebindTest extends RebindTestFixtureWithApp {
     @Test(groups = "Integration")
     public void testRebindToMachineEntity() throws Exception {
         EmptySoftwareProcess machine = origApp.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class));
-        origApp.start(ImmutableList.of(origManagementContext.getLocationRegistry().resolve("localhost")));
+        origApp.start(ImmutableList.of(origManagementContext.getLocationRegistry().getLocationManaged("localhost")));
         EntityTestUtils.assertAttributeEqualsEventually(machine, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         rebind(false);
         Entity machine2 = newManagementContext.getEntityManager().getEntity(machine.getId());

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/SetHostnameCustomizerLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/SetHostnameCustomizerLiveTest.java
@@ -80,7 +80,7 @@ public class SetHostnameCustomizerLiveTest extends BrooklynAppLiveTestSupport {
         
         super.setUp();
         
-        loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
+        loc = (MachineProvisioningLocation<SshMachineLocation>) mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
     }
 
     @Test(groups = {"Live"})

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLiveTest.java
@@ -50,7 +50,7 @@ public class ServerPoolLiveTest extends AbstractServerPoolTest {
                 .put("vmNameMaxLength", 30)
                 .put("imageId", "CENTOS_6_64")
                 .build();
-        return mgmt.getLocationRegistry().resolve(PROVIDER, allFlags);
+        return mgmt.getLocationRegistry().getLocationManaged(PROVIDER, allFlags);
     }
 
     @Override

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocationResolverTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/pool/ServerPoolLocationResolverTest.java
@@ -82,7 +82,7 @@ public class ServerPoolLocationResolverTest {
 
     private ServerPoolLocation resolve(String val) {
         Map<String, Object> flags = MutableMap.<String, Object>of(DynamicLocation.OWNER.getName(), locationOwner);
-        Location l = managementContext.getLocationRegistry().resolve(val, flags);
+        Location l = managementContext.getLocationRegistry().getLocationManaged(val, flags);
         Assert.assertNotNull(l);
         return (ServerPoolLocation) l;
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractDockerLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractDockerLiveTest.java
@@ -91,7 +91,7 @@ public abstract class AbstractDockerLiveTest {
                 .put("tags", ImmutableList.of(tag))
                 .putAll(flags)
                 .build();
-        jcloudsLocation = ctx.getLocationRegistry().resolve(PROVIDER, allFlags);
+        jcloudsLocation = ctx.getLocationRegistry().getLocationManaged(PROVIDER, allFlags);
         doTest(jcloudsLocation);
     }
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessOpenIptablesStreamsLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessOpenIptablesStreamsLiveTest.java
@@ -58,7 +58,7 @@ public class SoftwareProcessOpenIptablesStreamsLiveTest extends BrooklynAppLiveT
 
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
 
-        jcloudsLocation = mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-1", ImmutableMap.<String, Object>builder()
+        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-west-1", ImmutableMap.<String, Object>builder()
                 .put("osFamily", "centos")
                 .put("osVersionRegex", "6\\..*")
                 .put("inboundPorts", ImmutableList.of(22, 31880, 31001, 8080, 8443, 1099))

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessSubclassTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessSubclassTest.java
@@ -103,7 +103,7 @@ public class SoftwareProcessSubclassTest extends BrooklynAppUnitTestSupport {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        loc = mgmt.getLocationRegistry().resolve("localhost");
+        loc = mgmt.getLocationRegistry().getLocationManaged("localhost");
         locs = ImmutableList.of(loc);
         entity = app.createAndManageChild(EntitySpec.create(SubSoftwareProcess.class));
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
@@ -69,7 +69,7 @@ public class VanillaSoftwareProcessAndChildrenIntegrationTest {
     @BeforeMethod(alwaysRun=true)
     public void setup() {
         app = TestApplication.Factory.newManagedInstanceForTests();
-        localhost = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        localhost = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
 
     @AfterMethod(alwaysRun=true)

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessIntegrationTest.java
@@ -44,7 +44,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        localhost = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        localhost = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
         
         runRecord = Files.createTempFile("testVanillaSoftwareProcess-runRecord", ".txt");
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
@@ -34,7 +34,7 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends AbstractSoftwa
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        localhost = app.getManagementContext().getLocationRegistry().resolve("localhost");
+        localhost = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
 
     @Test(groups = "Integration")

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/autoscaling/AutoScalerPolicyNoMoreMachinesTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/autoscaling/AutoScalerPolicyNoMoreMachinesTest.java
@@ -70,7 +70,7 @@ public class AutoScalerPolicyNoMoreMachinesTest extends BrooklynAppUnitTestSuppo
                 .configure(TestCluster.INITIAL_SIZE, 0)
                 .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(EmptySoftwareProcess.class)
                         .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true)));
-        loc = mgmt.getLocationRegistry().resolve("byon(hosts='1.1.1.1,1.1.1.2')");
+        loc = mgmt.getLocationRegistry().getLocationManaged("byon(hosts='1.1.1.1,1.1.1.2')");
         app.start(ImmutableList.of(loc));
         
         entitiesAdded = Sets.newLinkedHashSet();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WindowsTestFixture.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/WindowsTestFixture.java
@@ -51,7 +51,7 @@ public class WindowsTestFixture {
         mgmt.getBrooklynProperties().remove("brooklyn.location.jclouds.userMetadata");
         mgmt.getBrooklynProperties().remove("brooklyn.location.userMetadata");
         
-        return (JcloudsLocation) mgmt.getLocationRegistry().resolve("jclouds:aws-ec2:us-west-2", MutableMap.<String, Object>builder()
+        return (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged("jclouds:aws-ec2:us-west-2", MutableMap.<String, Object>builder()
                 .put("inboundPorts", ImmutableList.of(5985, 3389))
                 .put("displayName", "AWS Oregon (Windows)")
                 .put("imageOwner", "801119661308")
@@ -73,6 +73,6 @@ public class WindowsTestFixture {
         config.put("useJcloudsSshInit", "false");
         config.put("byonIdentity", "123");
         config.putAll(props);
-        return (MachineProvisioningLocation<?>) mgmt.getLocationRegistry().resolve("byon", config);
+        return (MachineProvisioningLocation<?>) mgmt.getLocationRegistry().getLocationManaged("byon", config);
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/sensor/core/PortAttributeSensorAndConfigKeyTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/sensor/core/PortAttributeSensorAndConfigKeyTest.java
@@ -53,14 +53,14 @@ public class PortAttributeSensorAndConfigKeyTest extends BrooklynAppUnitTestSupp
      */
     @Test(enabled=false, groups="Integration") // test is slow (for some reason - why?)
     public void testStoppingEntityReleasesPortFromMachineForReuse() throws Exception {
-        LocalhostMachineProvisioningLocation loc = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().resolve("localhost");
+        LocalhostMachineProvisioningLocation loc = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().getLocationManaged("localhost");
         SshMachineLocation machine = loc.obtain();
         runStoppingEntityReleasesPortFromLocalhostForReuse(machine);
     }
 
     @Test(groups="Integration") // test is slow (for some reason - why?)
     public void testStoppingEntityReleasesPortFromLocalhostProvisioningLocationForReuse() throws Exception {
-        LocalhostMachineProvisioningLocation loc = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().resolve("localhost");
+        LocalhostMachineProvisioningLocation loc = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().getLocationManaged("localhost");
         runStoppingEntityReleasesPortFromLocalhostForReuse(loc);
     }
     

--- a/software/base/src/test/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricherTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricherTest.java
@@ -53,7 +53,7 @@ public class SystemServiceEnricherTest extends BrooklynAppLiveTestSupport {
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         super.setUp();
-        location = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
+        location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
     }
 
     @Test(groups = "Live")

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -172,7 +172,7 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         // Register any pre-existing port-mappings with the PortForwardManager
         Map<Integer, String> tcpPortMappings = getConfig(TCP_PORT_MAPPINGS);
         if (tcpPortMappings != null) {
-            PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().resolve("portForwardManager(scope=global)");
+            PortForwardManager pfm = (PortForwardManager) getManagementContext().getLocationRegistry().getLocationManaged("portForwardManager(scope=global)");
             for (Map.Entry<Integer, String> entry : tcpPortMappings.entrySet()) {
                 int targetPort = entry.getKey();
                 HostAndPort publicEndpoint = HostAndPort.fromString(entry.getValue());

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedLiveTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedLiveTest.java
@@ -75,7 +75,7 @@ public class WindowsPerformanceCounterFeedLiveTest extends BrooklynAppLiveTestSu
                 .put("tags", ImmutableList.of(getClass().getName()))
                 .build();
         MachineProvisioningLocation<?> provisioningLocation = (MachineProvisioningLocation<?>) 
-                mgmt.getLocationRegistry().resolve(LOCATION_SPEC, allFlags);
+                mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC, allFlags);
         loc = provisioningLocation.obtain(ImmutableMap.of());
 
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));

--- a/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/ByonLocationResolverTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/ByonLocationResolverTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.location.winrm;
 
 import static org.testng.Assert.assertEquals;
+
 import java.util.Map;
 
 import org.apache.brooklyn.api.location.MachineLocation;
@@ -27,32 +28,24 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import org.apache.brooklyn.util.text.StringPredicates;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 
 public class ByonLocationResolverTest {
 
-    private static final Logger log = LoggerFactory.getLogger(ByonLocationResolverTest.class);
-    
     private BrooklynProperties brooklynProperties;
     private LocalManagementContext managementContext;
-    private Predicate<CharSequence> defaultNamePredicate;
     
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         managementContext = LocalManagementContextForTests.newInstance();
         brooklynProperties = managementContext.getBrooklynProperties();
-        defaultNamePredicate = StringPredicates.startsWith(FixedListMachineProvisioningLocation.class.getSimpleName());
     }
     
     @AfterMethod(alwaysRun=true)
@@ -83,13 +76,8 @@ public class ByonLocationResolverTest {
     }
 
     @SuppressWarnings("unchecked")
-    private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val) {
-        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val);
-    }
-
-    @SuppressWarnings("unchecked")
     private FixedListMachineProvisioningLocation<MachineLocation> resolve(String val, Map<?, ?> locationFlags) {
-        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().resolve(val, locationFlags);
+        return (FixedListMachineProvisioningLocation<MachineLocation>) managementContext.getLocationRegistry().getLocationManaged(val, locationFlags);
     }
 
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableMap.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableMap.java
@@ -207,7 +207,7 @@ public class MutableMap<K,V> extends LinkedHashMap<K,V> {
             return this;
         }
         
-        public Builder<K, V> removeAll(K... keys) {
+        public Builder<K, V> removeAll(@SuppressWarnings("unchecked") K... keys) {
             for (K key : keys) {
                 result.remove(key);
             }


### PR DESCRIPTION
This improves how locations are handled internally, switching the resolvers to return `LocationSpec` rather than `Location` instances which may or may not be managed.

This allows us to fix a leak if catalog items include a location block (and includes a test for that, /cc @bostko ).  It also simplifies a number of things internally.  There is quite a bit more we'd like to do at some point (/cc @aledsage):

* have locations come entirely from the `TypeRegistry` (ie the catalog), doing away with `LocationDefinition` and `LocationRegistry`
* treat `Location` instances *as* `Entity` instances

However those are bigger changes, and this PR addresses the immediate pain points and makes the code quite a bit tidier.

There are a huge number of tests changed so to facilitate review the main important commits are:

* https://github.com/apache/brooklyn-server/commit/2876a9e5884332c38cdd2f631d0d221de2de35c9 pass location *specs* to entity spec (preferred over location instances)
* https://github.com/apache/brooklyn-server/commit/f755c25d2e66fa93a4a5f9f29ab8edc8d1c5be48 resolvers create location *specs* instead of location instances -- this breaks Resolver compatibility, mostly pretty easy to fix
* https://github.com/apache/brooklyn-server/commit/a3d74701fc37ae9b3daae15865510dfb1b94e327 special flag where a spec needs to do something special to create the instance
  (beta, used only for PortForwardManager)
* https://github.com/apache/brooklyn-server/commit/a75e8f7d1b02a8e094f631a82e1cc6ddc4340fec add catalog info to the object returned via the legacy `/v1/locations` endpoint to facilitate switching to `/v1/catalog/locations` in future, and notes

Builds on #62.

Note also that this breaks backwards compatibility if someone *implements* `LocationResolver`.  A note should be added in the release notes when this is merged.

/cc @grkvlt does clocker provide a `LocationResolver`?  if so it will need changed to return a `LocationSpec` not a `Location` instance.  if it is not a straightforward change ping me and I can help; this PR adds a "special constructor" facility which might apply if a `LocationSpec` doesn't work there