### PR TITLE
Disable tests on Windows

### DIFF
--- a/launcher-common/src/test/java/org/apache/brooklyn/launcher/common/BrooklynPropertiesFactoryHelperTest.java
+++ b/launcher-common/src/test/java/org/apache/brooklyn/launcher/common/BrooklynPropertiesFactoryHelperTest.java
@@ -43,7 +43,7 @@ import com.google.common.io.Files;
 
 public class BrooklynPropertiesFactoryHelperTest {
 
-    @Test
+    @Test(groups="UNIX")
     public void testChecksGlobalBrooklynPropertiesPermissionsX00() throws Exception {
         File propsFile = File.createTempFile("testChecksGlobalBrooklynPropertiesPermissionsX00", ".properties");
         propsFile.setReadable(true, false);
@@ -59,7 +59,7 @@ public class BrooklynPropertiesFactoryHelperTest {
         }
     }
 
-    @Test
+    @Test(groups="UNIX")
     public void testChecksLocalBrooklynPropertiesPermissionsX00() throws Exception {
         File propsFile = File.createTempFile("testChecksLocalBrooklynPropertiesPermissionsX00", ".properties");
         propsFile.setReadable(true, false);


### PR DESCRIPTION
Windows doesn't support the expected file attributes, disable tests.

because of https://builds.apache.org/view/Brooklyn/job/brooklyn-master-windows/10