### PR TITLE
NotUpDiagnostics: don’t collect if starting && !up

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -172,7 +172,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             Lifecycle state = entity.getAttribute(SERVICE_STATE_ACTUAL);
             if (up == null || up) {
                 entity.sensors().set(ServiceStateLogic.SERVICE_NOT_UP_DIAGNOSTICS, ImmutableMap.<String, Object>of());
-            } else if (state == null || state == Lifecycle.CREATED) {
+            } else if (state == null || state == Lifecycle.CREATED || state == Lifecycle.STARTING) {
                 // not yet started; do nothing
             } else if (state == Lifecycle.STOPPING || state == Lifecycle.STOPPED || state == Lifecycle.DESTROYED) {
                 // stopping/stopped, so expect not to be up; get rid of the diagnostics.


### PR DESCRIPTION
Previously we'd collect the not-up-diagnostics when starting, even though we didn't expect the Entity to be up yet. Now we only call it when there is a genuine problem that would result in the entity being "on-fire".