### PR TITLE
[OSGi] Load jclouds bundles in Karaf

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -96,7 +96,7 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-rest-api/${project.version}</bundle>
 
         <bundle dependency="true">mvn:com.sun.jersey.contribs/jersey-multipart/${jersey.version}</bundle>
-        <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/1.9.3</bundle>
+        <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/${mimepull.version}</bundle>
         <bundle dependency="true">mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
 
         <!-- TODO: version 1.1.0.Final has OSGi manifest; check if upgrade doesn't get rid of wrap -->
@@ -240,8 +240,8 @@
             https://github.com/square/okhttp/issues/2243
             https://github.com/square/okhttp/pull/2246
         -->
-        <bundle dependency="true">wrap:mvn:com.squareup.okhttp/okhttp/2.2.0</bundle>
-        <bundle dependency="true">wrap:mvn:com.squareup.okio/okio/1.2.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp/okhttp/${okhttp.version}</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okio/okio/${okio.version}</bundle>
         <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-okhttp/${jclouds.version}</bundle>
 
         <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-sshj/${jclouds.version}</bundle>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -16,12 +16,17 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="org.apache.brooklyn-${project.version}">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
+          name="org.apache.brooklyn-${project.version}"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">
 
     <repository>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</repository>
     <repository>mvn:org.apache.karaf.features/enterprise/${karaf.version}/xml/features</repository>
     <repository>mvn:org.apache.karaf.features/spring/${karaf.version}/xml/features</repository>
 
+    <!-- TODO how to add central.maven.org repo? -->
+    <repository>http://central.maven.org/maven2/org/apache/jclouds/karaf/jclouds-karaf/1.9.2/jclouds-karaf-1.9.2-features.xml</repository>
     <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</repository>
 
     <!-- temporary feature until we migrate to swagger-1.5.4, which is properly bundled -->
@@ -228,14 +233,57 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-jmxrmi-agent/${project.version}</bundle>
     </feature>
 
-    <!-- WARNING: feature brooklyn-locations-jclouds cannot really be installed, due to guava 17 issues -->
     <feature name="brooklyn-locations-jclouds" version="${project.version}" description="Brooklyn Jclouds Location Targets">
-        <bundle>mvn:org.apache.brooklyn/brooklyn-locations-jclouds/${project.version}</bundle>
+        <!--
+            OkHttp had OSGi support shortly in 3.0.0, but was immediately reverted in 3.0.1
+            https://github.com/square/okhttp/pull/2192
+            https://github.com/square/okhttp/issues/2243
+            https://github.com/square/okhttp/pull/2246
+        -->
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp/okhttp/2.2.0</bundle>
+        <bundle dependency="true">wrap:mvn:com.squareup.okio/okio/1.2.0</bundle>
+        <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-okhttp/${jclouds.version}</bundle>
+
+        <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-sshj/${jclouds.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.jclouds.labs/abiquo/${jclouds.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.jclouds.labs/docker/${jclouds.version}</bundle>
+
+        <!-- Not bundle-ized, fixed in 2.0.0-SNAPSHOT -->
+        <!-- bundle dependency="true">mvn:org.apache.jclouds.labs/google-compute-engine/${jclouds.version}</bundle -->
+
+        <feature>jclouds-services</feature>
+
+        <!-- Same as allcompute -->
+        <feature>jclouds-aws-ec2</feature>
+        <feature>jclouds-api-openstack-nova</feature>
+        <feature>jclouds-api-byon</feature>
+        <feature>jclouds-api-ec2</feature>
+        <feature>jclouds-gogrid</feature>
+        <feature>jclouds-elastichosts-lon-b</feature>
+        <feature>jclouds-elastichosts-lon-p</feature>
+        <feature>jclouds-elastichosts-sat-p</feature>
+        <feature>jclouds-openhosting-east1</feature>
+        <feature>jclouds-serverlove-z1-man</feature>
+        <feature>jclouds-skalicloud-sdg-my</feature>
+        <feature>jclouds-go2cloud-jhb1</feature>
+        <feature>jclouds-softlayer</feature>
+        <feature>jclouds-api-cloudstack</feature>
+        <!-- feature>hpcloud</feature-->
+        <feature>jclouds-rackspace-cloudservers-us</feature>
+        <feature>jclouds-rackspace-cloudservers-uk</feature>
+
+        <!-- Same as allblobstore -->
+        <feature>jclouds-aws-s3</feature>
+        <feature>jclouds-azureblob</feature>
+        <feature>jclouds-api-atmos</feature>
+        <feature>jclouds-api-openstack-swift</feature>
+        <feature>jclouds-rackspace-cloudfiles-uk</feature>
+        <feature>jclouds-rackspace-cloudfiles-us</feature>
+        <!-- feature>hpcloud</feature -->
+        <feature>jclouds-api-filesystem</feature>
+
+        <bundle start-level="85">mvn:org.apache.brooklyn/brooklyn-locations-jclouds/${project.version}</bundle>
         <feature>brooklyn-software-winrm</feature>
-        <bundle dependency="true">mvn:com.google.inject/guice/${guice.version}</bundle>
-        <bundle dependency="true">mvn:${jclouds.groupId}.driver/jclouds-bouncycastle/${jclouds.version}</bundle>
-        <bundle dependency="true">mvn:${jclouds.groupId}/jclouds-core/${jclouds.version}</bundle>
-        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
     </feature>
 
     <feature name="brooklyn-software-network" version="${project.version}" description="Brooklyn Network Software Entities">
@@ -289,8 +337,9 @@
     <feature name="brooklyn-osgi-launcher" version="${project.version}" description="Brooklyn init">
         <feature>brooklyn-core</feature>
         <feature>brooklyn-software-base</feature>
+        <feature>brooklyn-locations-jclouds</feature>
         <bundle>mvn:org.apache.brooklyn/brooklyn-launcher-common/${project.version}</bundle>
-        <bundle>mvn:org.apache.brooklyn/brooklyn-karaf-init/${project.version}</bundle>
+        <bundle start-level="90">mvn:org.apache.brooklyn/brooklyn-karaf-init/${project.version}</bundle>
     </feature>
 
 </features>

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -147,7 +147,6 @@ import org.jclouds.domain.Credentials;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.ec2.compute.options.EC2TemplateOptions;
-import org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions;
 import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.scriptbuilder.domain.LiteralStatement;
@@ -1197,9 +1196,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                         } else if (t instanceof SoftLayerTemplateOptions) {
                             String[] securityGroups = toStringArray(v);
                             ((SoftLayerTemplateOptions)t).securityGroups(securityGroups);
-                        } else if (t instanceof GoogleComputeEngineTemplateOptions) {
+                        } else if (isGoogleComputeTemplateOptions(t)) {
                             String[] securityGroups = toStringArray(v);
-                            ((GoogleComputeEngineTemplateOptions)t).securityGroups(securityGroups);
+                            t.securityGroups(securityGroups);
                         } else {
                             LOG.info("ignoring securityGroups({}) in VM creation because not supported for cloud/type ({})", v, t.getClass());
                         }
@@ -1279,7 +1278,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     }})
             .put(EXTRA_PUBLIC_KEY_DATA_TO_AUTH, new CustomizeTemplateOptions() {
                     public void apply(TemplateOptions t, ConfigBag props, Object v) {
-                        if (t instanceof GoogleComputeEngineTemplateOptions) {
+                        if (isGoogleComputeTemplateOptions(t)) {
                             // see email to jclouds list, 29 Aug 2015; 
                             // GCE takes this to be the only login public key, 
                             // and setting this only works if you also overrideLoginPrivateKey
@@ -1371,7 +1370,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                             ((AWSEC2TemplateOptions)t).subnetId((String)v);
                             
                         } else {
-                            if (t instanceof GoogleComputeEngineTemplateOptions) {
+                            if (isGoogleComputeTemplateOptions(t)) {
                                 // no warning needed
                                 // we think this is the only jclouds endpoint which supports this option
                                 
@@ -1412,6 +1411,14 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     }
                 }})
             .build();
+
+    /**
+     * Avoid having a dependency on googlecompute because it doesn't have an OSGi bundle yet.
+     * Fixed in jclouds 2.0.0-SNAPSHOT
+     */
+    private static boolean isGoogleComputeTemplateOptions(TemplateOptions t) {
+        return t.getClass().getName().equals("org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions");
+    }
 
     /** hook whereby template customizations can be made for various clouds */
     protected void customizeTemplate(ConfigBag setup, ComputeService computeService, Template template) {

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,13 @@
         <includedTestGroups />
         <excludedTestGroups>Integration,Acceptance,Live,WIP,Broken</excludedTestGroups>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
-        <coverage.target>${working.dir}</coverage.target>
 
         <!-- Dependency Versions -->
         <jclouds.version>1.9.2</jclouds.version> <!-- JCLOUDS_VERSION -->
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
-        <guava.version>17.0</guava.version>
+        <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->
+        <guava.version>16.0.1</guava.version>
         <xstream.version>1.4.7</xstream.version>
         <!-- double-check downstream projects before changing jackson and resteasy versions -->
         <fasterxml.jackson.version>2.4.5</fasterxml.jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,9 @@
         <minidev.asm.version>1.0.2</minidev.asm.version>
         <commons-beanutils.version>1.9.1</commons-beanutils.version>
         <commons-collections.version>3.2.1</commons-collections.version>
+        <okhttp.version>2.2.0</okhttp.version>
+        <okio.version>1.2.0</okio.version>
+        <mimepull.version>1.9.3</mimepull.version>
 
         <!-- Testing Dependency Versions -->
         <testng.version>6.8.8</testng.version>


### PR DESCRIPTION
Needed to break the `locations-jclouds` dependency on `googlecompute` as it doesn't have an osgi bundle in `1.9.2`.

With the change I am able to deploy `MachineEntity` to Amazon, Softlayer, Bluebox.

Depends on (but not based on):
  * #55
  * #65 
  * #66
