### PR TITLE
XML SpecResolver: use context instead of thread-local storage

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -235,6 +235,8 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
         if (!Objects.equal(getCatalogItemId(), other.getCatalogItemId())) return false;
         if (!Objects.equal(getType(), other.getType())) return false;
         if (!Objects.equal(getTags(), other.getTags())) return false;
+        if (!Objects.equal(getConfig(), other.getConfig())) return false;
+        if (!Objects.equal(getFlags(), other.getFlags())) return false;
         if (!Objects.equal(getParameters(), other.getParameters())) return false;
         return true;
     }


### PR DESCRIPTION
As per @neykov 's comments in PR #59 