### PR TITLE
Don't skip tests jar generation during tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1408,17 +1408,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-jar-creation</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -1443,17 +1432,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-jar-creation</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -1463,21 +1441,6 @@
                 <includedTestGroups>Live</includedTestGroups>
                 <excludedTestGroups>Acceptance,WIP,Broken</excludedTestGroups>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-jar-creation</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>
@@ -1486,21 +1449,6 @@
                 <includedTestGroups>Live-sanity</includedTestGroups>
                 <excludedTestGroups>Acceptance,WIP,Broken</excludedTestGroups>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>test-jar-creation</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
When passed `-PIntegration` tests jars are not getting built on purpose. This causes build failures down the road where the missing tests-jar is a dependency in another module.

Initially introduced in https://github.com/apache/incubator-brooklyn/commit/dbda0be45531ba20085c1d082430b44aaca55231?w=1 without any details on why it's needed.