### PR TITLE
Skip to next bundle on predicate failure.

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
@@ -184,9 +184,7 @@ public class Osgis {
             for (Bundle b: framework.getBundleContext().getBundles()) {
                 if (symbolicName!=null && !symbolicName.equals(b.getSymbolicName())) continue;
                 if (version!=null && !Version.parseVersion(version).equals(b.getVersion())) continue;
-                for (Predicate<? super Bundle> predicate: predicates) {
-                    if (!predicate.apply(b)) continue;
-                }
+                if (!Predicates.and(predicates).apply(b)) continue;
 
                 // check url last, because if it isn't mandatory we should only clear if we find a url
                 // for which the other items also match


### PR DESCRIPTION
Without this change, if the predicate fails, the code flow just picks the next predicate to check,
when really we want to skip to checking the next bundle.