### PR TITLE
WinRM Parametrize number of retries of network failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <jax-rs-api.version>2.0.1</jax-rs-api.version>
         <maxmind.version>0.8.1</maxmind.version>
         <jna.version>4.0.0</jna.version>
-        <winrm4j.version>0.3.4</winrm4j.version>
+        <winrm4j.version>0.3.5</winrm4j.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>
         <zookeeper.version>3.3.4</zookeeper.version>

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -78,6 +78,7 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
 
     public static final ConfigKey<Integer> WINRM_CONFIG_PORT = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.PROP_PORT);
     public static final ConfigKey<String> OPERATION_TIMEOUT = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.OPERATION_TIMEOUT);
+    public static final ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.RETRIES_OF_NETWORK_FAILURES);
     public static final ConfigKey<Boolean> USE_HTTPS_WINRM = WinRmTool.USE_HTTPS_WINRM;
 
 

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -45,8 +45,8 @@ public interface WinRmTool {
     
     ConfigKey<String> PROP_HOST = newStringConfigKey("host", "Host to connect to (required)", null);
     ConfigKey<Integer> PROP_PORT = ConfigKeys.newIntegerConfigKey("port", "WinRM port to use when connecting to the remote machine");
-    ConfigKey<Boolean> USE_HTTPS_WINRM = ConfigKeys.newBooleanConfigKey("winrm.useHttps", "The parameter configures tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", false);
-
+    ConfigKey<Boolean> USE_HTTPS_WINRM = ConfigKeys.newBooleanConfigKey("winrm.useHttps", "The parameter tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", false);
+    ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = ConfigKeys.newIntegerConfigKey("retriesOfNetworkFailures", "The parameter sets the number of retries for connection failures. If you use high value, consider taking care for the machine's network.");
     /**
      * Flag which tells winrm whether to use Basic Authentication
      * or Negotiate plus NTLM.

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -71,6 +71,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
     private final Boolean useSecureWinrm;
     private final String authenticationScheme;
     private final String operationTimeout;
+    private final Integer retriesOfNetworkFailures;
     
     public Winrm4jTool(Map<String,?> config) {
         this(ConfigBag.newInstance(config));
@@ -88,6 +89,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
         execRetryDelay = getRequiredConfig(config, PROP_EXEC_RETRY_DELAY);
         logCredentials = getRequiredConfig(config, LOG_CREDENTIALS);
         operationTimeout = config.get(OPERATION_TIMEOUT);
+        retriesOfNetworkFailures = config.get(RETRIES_OF_NETWORK_FAILURES);
     }
     
     @Override
@@ -151,6 +153,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
             Duration execTimestamp = null;
             try {
                 WinRmTool tool = connect();
+                tool.setRetriesForConnectionFailures(retriesOfNetworkFailures);
                 tool.setOperationTimeout(Duration.of(operationTimeout).toMilliseconds());
                 connectTimestamp = Duration.of(stopwatch);
                 WinRmToolResponse result = task.apply(tool);


### PR DESCRIPTION
For some networks retries could be useful if user is able to configure high number of tries for connection failures.
Requires publishing new version of winrm4j.
