### PR TITLE
Fix persisting localhost

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
@@ -315,7 +315,10 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
             if (source == null) return;
             if (((Task<?>)source).isDone() && !((Task<?>)source).isError()) {
                 try {
-                    context.convertAnother(((Task<?>)source).get());
+                    Object nextItem = ((Task<?>)source).get();
+                    if (nextItem != null) {
+                        context.convertAnother(nextItem);
+                    }
                 } catch (InterruptedException e) {
                     throw Exceptions.propagate(e);
                 } catch (ExecutionException e) {

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -176,7 +176,6 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
             Map<Object,Object> flags2 = MutableMap.<Object,Object>builder()
                     .putAll(flags)
                     .put("address", elvis(address, Networking.getLocalHost()))
-                    .put("mutexSupport", LocalhostMachine.mutexSupport)
                     .build();
             
             // copy inherited keys for ssh; 


### PR DESCRIPTION
When running `org.apache.brooklyn.qa.load.LoadTest`, I hit exceptions about serializing localhost machine location. I didn't try rebinding, but I presume the localhost machine's location object would not have been deserialised correctly (or not been available at all).

This PR fixes the two exceptions I hit.