### PR TITLE
Rest API location transformers use mutable map

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSpec.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/LocationSpec.java
@@ -25,9 +25,10 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.util.collections.MutableMap;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.ImmutableMap;
 
 // FIXME change name, due to confusion with LocationSpec <- no need, as we can kill the class instead soon!
 /** @deprecated since 0.7.0 location spec objects will not be used from the client, instead pass yaml location spec strings */
@@ -53,7 +54,7 @@ public class LocationSpec implements HasName, HasConfig, Serializable {
             @JsonProperty("config") @Nullable Map<String, ?> config) {
         this.name = name;
         this.spec = spec;
-        this.config = (config == null) ? Collections.<String, String> emptyMap() : ImmutableMap.copyOf(config);
+        this.config = (config == null) ? Collections.<String, String> emptyMap() : MutableMap.copyOf(config);
     }
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
@@ -121,7 +121,7 @@ public class LocationTransformer {
     }
 
     private static Map<String, ?> copyConfig(Map<String,?> entries, LocationDetailLevel level) {
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        MutableMap.Builder<String, Object> builder = MutableMap.builder();
         if (level!=LocationDetailLevel.NONE) {
             for (Map.Entry<String,?> entry : entries.entrySet()) {
                 if (level==LocationDetailLevel.FULL_INCLUDING_SECRET || !Sanitizer.IS_SECRET_PREDICATE.apply(entry.getKey())) {


### PR DESCRIPTION
LocationConfig contains null values which Guava's ImmutableMap rejects with a NullPointerException.

This fixes an error observed when deploying the "Template 1: Server" sample to localhost then running `br application <id>` with the CLI. The output from the CLI was "500 Server Error". The server logs contained:

```
java.lang.NullPointerException: null value in entry: byon.machineSpecs=null
	at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:33) ~[com.google.guava-guava-16.0.1.jar:na]
	at com.google.common.collect.ImmutableMap.entryOf(ImmutableMap.java:135) ~[com.google.guava-guava-16.0.1.jar:na]
	at com.google.common.collect.ImmutableMap$Builder.put(ImmutableMap.java:206) ~[com.google.guava-guava-16.0.1.jar:na]
	at org.apache.brooklyn.rest.transform.LocationTransformer.copyConfig(LocationTransformer.java:128) ~[org.apache.brooklyn-brooklyn-rest-resources-0.10.0-SNAPSHOT.jar:0.10.0-SNAPSHOT]
	at org.apache.brooklyn.rest.transform.LocationTransformer.newInstance(LocationTransformer.java:189) ~[org.apache.brooklyn-brooklyn-rest-resources-0.10.0-SNAPSHOT.jar:0.10.0-SNAPSHOT]
	at org.apache.brooklyn.rest.resources.LocationResource.get(LocationResource.java:139) ~[org.apache.brooklyn-brooklyn-rest-resources-0.10.0-SNAPSHOT.jar:0.10.0-SNAPSHOT]
	at org.apache.brooklyn.rest.resources.LocationResource.get(LocationResource.java:132) ~[org.apache.brooklyn-brooklyn-rest-resources-0.10.0-SNAPSHOT.jar:0.10.0-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_05]

```