### PR TITLE
Support removal of catalog entries from bundle BOM when the bundle is stopped.

### DIFF
--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,62 +25,62 @@ limitations under the License.
 
     <!-- Makes sure core bundle is already started -->
     <reference id="brooklynVersion"
-               interface="org.apache.brooklyn.core.BrooklynVersionService"/>
+               interface="org.apache.brooklyn.core.BrooklynVersionService" />
 
     <reference id="systemService"
                interface="org.apache.karaf.system.SystemService" />
 
     <cm:property-placeholder persistent-id="org.apache.brooklyn.osgilauncher" update-strategy="reload">
         <cm:default-properties>
-            <cm:property name="ignoreCatalogErrors" value="true"/>
-            <cm:property name="ignorePersistenceErrors" value="true"/>
-            <cm:property name="highAvailabilityMode" value="DISABLED"/>
-            <cm:property name="persistMode" value="DISABLED"/>
-            <cm:property name="persistenceDir" value=""/>
-            <cm:property name="persistenceLocation" value=""/>
-            <cm:property name="persistPeriod" value="1s"/>
-            <cm:property name="globalBrooklynPropertiesFile" value="~/.brooklyn/brooklyn.properties"/>
-            <cm:property name="localBrooklynPropertiesFile" value=""/> <!-- used to be settable through cli params -->
+            <cm:property name="ignoreCatalogErrors" value="true" />
+            <cm:property name="ignorePersistenceErrors" value="true" />
+            <cm:property name="highAvailabilityMode" value="DISABLED" />
+            <cm:property name="persistMode" value="DISABLED" />
+            <cm:property name="persistenceDir" value="" />
+            <cm:property name="persistenceLocation" value="" />
+            <cm:property name="persistPeriod" value="1s" />
+            <cm:property name="globalBrooklynPropertiesFile" value="~/.brooklyn/brooklyn.properties" />
+            <cm:property name="localBrooklynPropertiesFile" value="" /> <!-- used to be settable through cli params -->
         </cm:default-properties>
     </cm:property-placeholder>
 
     <bean id="propertiesBuilderFactory"
           class="org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelper">
-        <argument value="${globalBrooklynPropertiesFile}"/>
-        <argument value="${localBrooklynPropertiesFile}"/>
+        <argument value="${globalBrooklynPropertiesFile}" />
+        <argument value="${localBrooklynPropertiesFile}" />
     </bean>
 
     <bean id="propertiesBuilder"
           class="org.apache.brooklyn.core.internal.BrooklynProperties.Factory.Builder"
           factory-ref="propertiesBuilderFactory"
-          factory-method="createPropertiesBuilder"/>
+          factory-method="createPropertiesBuilder" />
 
     <bean id="launcher"
           class="org.apache.brooklyn.launcher.osgi.OsgiLauncher"
           init-method="init"
           destroy-method="destroy">
 
-        <property name="brooklynVersion" ref="brooklynVersion"/>
-        <property name="brooklynPropertiesBuilder" ref="propertiesBuilder"/>
+        <property name="brooklynVersion" ref="brooklynVersion" />
+        <property name="brooklynPropertiesBuilder" ref="propertiesBuilder" />
 
-        <property name="ignoreCatalogErrors" value="${ignoreCatalogErrors}"/>
-        <property name="ignorePersistenceErrors" value="${ignorePersistenceErrors}"/>
-        <property name="highAvailabilityMode" value="${highAvailabilityMode}"/>
-        <property name="persistMode" value="${persistMode}"/>
-        <property name="persistenceDir" value="${persistenceDir}"/>
-        <property name="persistenceLocation" value="${persistenceLocation}"/>
-        <property name="persistPeriod" value="${persistPeriod}"/>
+        <property name="ignoreCatalogErrors" value="${ignoreCatalogErrors}" />
+        <property name="ignorePersistenceErrors" value="${ignorePersistenceErrors}" />
+        <property name="highAvailabilityMode" value="${highAvailabilityMode}" />
+        <property name="persistMode" value="${persistMode}" />
+        <property name="persistenceDir" value="${persistenceDir}" />
+        <property name="persistenceLocation" value="${persistenceLocation}" />
+        <property name="persistPeriod" value="${persistPeriod}" />
     </bean>
 
     <bean id="localManagementContextService"
           class="org.apache.brooklyn.core.mgmt.internal.LocalManagementContext"
           factory-ref="launcher"
-          factory-method="getManagementContext"/>
+          factory-method="getManagementContext" />
 
     <bean id="campPlatform"
           class="org.apache.brooklyn.camp.CampPlatform"
           factory-ref="launcher"
-          factory-method="getCampPlatform"/>
+          factory-method="getCampPlatform" />
 
     <service interface="org.apache.brooklyn.core.mgmt.ShutdownHandler">
         <bean class="org.apache.brooklyn.launcher.osgi.OsgiShutdownHandler" />
@@ -98,7 +98,7 @@ limitations under the License.
                     availability="optional">
 
         <reference-listener bind-method="bind" unbind-method="unbind">
-            <bean class="org.apache.brooklyn.core.catalog.internal.CatalogBomScanner"/>
+            <bean class="org.apache.brooklyn.core.catalog.internal.CatalogBomScanner" />
         </reference-listener>
     </reference-list>
 


### PR DESCRIPTION

This change follows on from https://github.com/apache/brooklyn-server/pull/80.

With this change any catalog members that were added by scanning the bundle's
catalog.bom when the bundle started will be removed upon stopping the bundle.