### PR TITLE
pass brooklynConfig when making call to getLocationSpec

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampInternalUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampInternalUtils.java
@@ -228,7 +228,7 @@ class CampInternalUtils {
             }
             return spec;
         } else {
-            Maybe<LocationSpec<? extends Location>> loc = loader.getManagementContext().getLocationRegistry().getLocationSpec(type);
+            Maybe<LocationSpec<? extends Location>> loc = loader.getManagementContext().getLocationRegistry().getLocationSpec(type, brooklynConfig);
             if (loc.isPresent()) {
                 return loc.get().configure(brooklynConfig);
             } else {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -314,4 +314,50 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
         assertLocationManagerInstancesCount(0);
     }
 
+    @Test
+    public void testByonLocationHostsInConfig() {
+        String symbolicName = "my.catalog.app.id.byon.config";
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: " + symbolicName,
+                "    itemType: location",
+                "    item:",
+                "      type: byon",
+                "      brooklyn.config:",
+                "        displayName: testingdisplayName",
+                "        user: testinguser",
+                "        password: testingpassword",
+                "        hosts:",
+                "        - 10.10.10.102"
+        );
+
+        assertLocationRegistryCount(1);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(0);
+    }
+
+    @Test
+    public void testByonLocationHostsInType() {
+        String symbolicName = "my.catalog.app.id.byon.config.inline";
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: " + symbolicName,
+                "    itemType: location",
+                "    item:",
+                "      type: byon:(hosts=\"10.10.10.102\")",
+                "      brooklyn.config:",
+                "        displayName: testingdisplayName",
+                "        user: testinguser",
+                "        password: testingpassword"
+        );
+
+        assertLocationRegistryCount(1);
+        assertCatalogCount(1);
+        assertLocationManagerInstancesCount(0);
+    }
+
 }


### PR DESCRIPTION
Fixes [BROOKLYN-246](https://issues.apache.org/jira/browse/BROOKLYN-246)

Was failing for byon locations where the host wasn't specified in the type.

For example the byon catalog location as shown in `testByonLocationHostsInConfig` had been failing due to `extractConfig` in the `ByonLocationResolver` throwing an `IllegalArgumentException` as no hosts were found.