### PR TITLE
Fixed command for installing python via apt-get and yum by using sudo

### DIFF
--- a/server-cli/src/main/resources/brooklyn/default.catalog.bom
+++ b/server-cli/src/main/resources/brooklyn/default.catalog.bom
@@ -97,8 +97,8 @@ brooklyn.catalog:
           install.command: |
             # install python if not present
             which python || \
-              { apt-get update && apt-get install python ; } || \
-              { yum update && yum install python ; } || \
+              { sudo apt-get update && sudo apt-get install python ; } || \
+              { sudo yum update && sudo yum install python ; } || \
               { echo WARNING: cannot install python && exit 1 ; }
 
           customize.command: |

--- a/server-cli/src/main/resources/catalog.bom
+++ b/server-cli/src/main/resources/catalog.bom
@@ -97,8 +97,8 @@ brooklyn.catalog:
           install.command: |
             # install python if not present
             which python || \
-              { apt-get update && apt-get install python ; } || \
-              { yum update && yum install python ; } || \
+              { sudo apt-get update && sudo apt-get install python ; } || \
+              { sudo yum update && sudo yum install python ; } || \
               { echo WARNING: cannot install python && exit 1 ; }
 
           customize.command: |


### PR DESCRIPTION
When I use a "Template 2: Bash Web Server" with non-root user and password-less sudo, I've got a error because I don't have any python installed. We should use sudo command for installing python.