### PR TITLE
[OSGi] Load properties from config admin

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
@@ -79,12 +79,7 @@ public interface BrooklynProperties extends Map, StringConfigMap {
             private String globalPropertiesFile = null;
             private String localPropertiesFile = null;
             private BrooklynProperties originalProperties = null;
-            
-            /** @deprecated since 0.7.0 use static methods in {@link Factory} to create */
-            public Builder() {
-                this(true);
-            }
-            
+
             private Builder(boolean setGlobalFileDefaults) {
                 resetDefaultLocationMetadataUrl();
                 if (setGlobalFileDefaults) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -394,7 +394,7 @@ public class LocalManagementContext extends AbstractManagementContext {
         
         BrooklynProperties properties = builder.build();
         configMap = new DeferredBrooklynProperties(properties, this);
-        if (brooklynAdditionalProperties != null) {
+        if (brooklynAdditionalProperties != null && !brooklynAdditionalProperties.isEmpty()) {
             log.info("Reloading additional brooklyn properties from " + brooklynAdditionalProperties);
             configMap.addFromMap(brooklynAdditionalProperties);
         }

--- a/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesBuilderTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesBuilderTest.java
@@ -54,7 +54,7 @@ public class BrooklynPropertiesBuilderTest {
         String globalPropertiesContents = "brooklyn.mykey=myval";
         Files.write(globalPropertiesContents, globalPropertiesFile, Charsets.UTF_8);
         
-        BrooklynProperties props = new BrooklynProperties.Factory.Builder()
+        BrooklynProperties props = BrooklynProperties.Factory.builderDefault()
                 .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
                 .build();
         
@@ -71,7 +71,7 @@ public class BrooklynPropertiesBuilderTest {
                 "brooklyn.mykeyLocal=myvallocal2"+"\n";
         Files.write(localPropertiesContents, localPropertiesFile, Charsets.UTF_8);
         
-        BrooklynProperties props = new BrooklynProperties.Factory.Builder()
+        BrooklynProperties props = BrooklynProperties.Factory.builderDefault()
                 .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
                 .localPropertiesFile(localPropertiesFile.getAbsolutePath())
                 .build();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
@@ -60,7 +60,7 @@ public class LocalManagementContextTest {
     public void testReloadPropertiesFromBuilder() throws IOException {
         String globalPropertiesContents = "brooklyn.location.localhost.displayName=myname";
         Files.write(globalPropertiesContents, globalPropertiesFile, Charsets.UTF_8);
-        Builder propsBuilder = new BrooklynProperties.Factory.Builder()
+        Builder propsBuilder = BrooklynProperties.Factory.builderDefault()
             .globalPropertiesFile(globalPropertiesFile.getAbsolutePath());
         // no builder support in LocalManagementContextForTests (we are testing that the builder's files are reloaded so we need it here)
         context = new LocalManagementContext(propsBuilder);
@@ -78,7 +78,7 @@ public class LocalManagementContextTest {
     public void testReloadPropertiesFromProperties() throws IOException {
         String globalPropertiesContents = "brooklyn.location.localhost.displayName=myname";
         Files.write(globalPropertiesContents, globalPropertiesFile, Charsets.UTF_8);
-        BrooklynProperties brooklynProperties = new BrooklynProperties.Factory.Builder()
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.builderDefault()
             .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
             .build();
         context = LocalManagementContextForTests.builder(true).useProperties(brooklynProperties).build();

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>org.apache.karaf.system.core</artifactId>
             <version>${karaf.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.compendium</artifactId>
+            <version>${felix-osgi-compendium.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/ConfigSupplier.java
+++ b/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/ConfigSupplier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.launcher.osgi;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.osgi.service.cm.Configuration;
+
+import com.google.common.base.Supplier;
+
+public class ConfigSupplier implements Supplier<Map<?, ?>> {
+    private Map<?, ?> props;
+
+    public ConfigSupplier(@Nullable Configuration config) {
+        if (config != null) {
+            this.props = dictToMap(config.getProperties());
+        } else {
+            this.props = MutableMap.of();
+        }
+    }
+
+    @Override
+    public Map<?, ?> get() {
+        return props;
+    }
+
+    public void update(Map<?, ?> props) {
+        this.props = props;
+    }
+
+    private static Map<?, ?> dictToMap(Dictionary<?, ?> props) {
+        Map<Object, Object> mapProps = MutableMap.of();
+        Enumeration<?> keyEnum = props.keys();
+        while (keyEnum.hasMoreElements()) {
+            Object key = keyEnum.nextElement();
+            mapProps.put(key, props.get(key));
+        }
+        return mapProps;
+    }
+
+}

--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,6 +30,9 @@ limitations under the License.
     <reference id="systemService"
                interface="org.apache.karaf.system.SystemService" />
 
+    <reference id="configAdmin"
+               interface="org.osgi.service.cm.ConfigurationAdmin" />
+
     <cm:property-placeholder persistent-id="org.apache.brooklyn.osgilauncher" update-strategy="reload">
         <cm:default-properties>
             <cm:property name="ignoreCatalogErrors" value="true"/>
@@ -44,24 +47,12 @@ limitations under the License.
         </cm:default-properties>
     </cm:property-placeholder>
 
-    <bean id="propertiesBuilderFactory"
-          class="org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelper">
-        <argument value="${globalBrooklynPropertiesFile}"/>
-        <argument value="${localBrooklynPropertiesFile}"/>
-    </bean>
-
-    <bean id="propertiesBuilder"
-          class="org.apache.brooklyn.core.internal.BrooklynProperties.Factory.Builder"
-          factory-ref="propertiesBuilderFactory"
-          factory-method="createPropertiesBuilder"/>
-
     <bean id="launcher"
           class="org.apache.brooklyn.launcher.osgi.OsgiLauncher"
           init-method="init"
           destroy-method="destroy">
 
         <property name="brooklynVersion" ref="brooklynVersion"/>
-        <property name="brooklynPropertiesBuilder" ref="propertiesBuilder"/>
 
         <property name="ignoreCatalogErrors" value="${ignoreCatalogErrors}"/>
         <property name="ignorePersistenceErrors" value="${ignorePersistenceErrors}"/>
@@ -70,6 +61,13 @@ limitations under the License.
         <property name="persistenceDir" value="${persistenceDir}"/>
         <property name="persistenceLocation" value="${persistenceLocation}"/>
         <property name="persistPeriod" value="${persistPeriod}"/>
+        <property name="globalBrooklynProperties" value="${globalBrooklynPropertiesFile}"/>
+        <property name="localBrooklynProperties" value="${localBrooklynPropertiesFile}"/>
+        <property name="configAdmin" ref="configAdmin"/>
+
+        <cm:managed-properties persistent-id="brooklyn"
+                               update-method="updateProperties"
+                               update-strategy="component-managed" />
     </bean>
 
     <bean id="localManagementContextService"

--- a/karaf/itest/src/test/java/org/apache/brooklyn/launcher/osgi/OsgiLauncherTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/launcher/osgi/OsgiLauncherTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.launcher.osgi;
+
+import static org.apache.brooklyn.KarafTestUtils.defaultOptionsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.apache.brooklyn.KarafTestUtils;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.IntegrationTest;
+import org.apache.karaf.features.BootFinished;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.util.Filter;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IntegrationTest.class)
+public class OsgiLauncherTest {
+
+    private static final String TEST_VALUE_RUNTIME = "test.value";
+    private static final String TEST_KEY_RUNTIME = "test.key";
+    private static final String TEST_VALUE_IN_CFG = "test.cfg";
+    private static final String TEST_KEY_IN_CFG = "test.key.in.cfg";
+
+    @Inject
+    protected ManagementContext mgmt;
+
+    @Inject
+    protected ConfigurationAdmin configAdmin;
+
+    /**
+     * To make sure the tests run only when the boot features are fully
+     * installed
+     */
+    @Inject
+    @Filter(timeout = 120000)
+    BootFinished bootFinished;
+
+    @Configuration
+    public static Option[] configuration() throws Exception {
+        return defaultOptionsWith(
+                editConfigurationFilePut("etc/org.apache.brooklyn.osgilauncher.cfg", "globalBrooklynPropertiesFile", ""),
+                editConfigurationFilePut("etc/org.apache.brooklyn.osgilauncher.cfg", "localBrooklynPropertiesFile", ""),
+                editConfigurationFilePut("etc/brooklyn.cfg", TEST_KEY_IN_CFG, TEST_VALUE_IN_CFG),
+                features(KarafTestUtils.brooklynFeaturesRepository(), "brooklyn-osgi-launcher")
+                // Uncomment this for remote debugging the tests on port 5005
+                // ,KarafDistributionOption.debugConfiguration()
+        );
+    }
+
+    @Test
+    public void testConfig() throws IOException {
+        assertFalse(mgmt.getConfig().getAllConfig().containsKey(TEST_KEY_RUNTIME));
+        org.osgi.service.cm.Configuration config = configAdmin.getConfiguration("brooklyn", null);
+        assertEquals(config.getProperties().get(TEST_KEY_IN_CFG), TEST_VALUE_IN_CFG);
+        config.getProperties().put(TEST_KEY_RUNTIME, TEST_VALUE_RUNTIME);
+        config.update();
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(TEST_VALUE_RUNTIME, mgmt.getConfig().getFirst(TEST_KEY_RUNTIME));
+            }
+        });
+    }
+}

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BrooklynPropertiesFactoryHelper.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BrooklynPropertiesFactoryHelper.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.launcher.common;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Map;
 
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.internal.BrooklynProperties.Factory.Builder;
@@ -32,27 +33,45 @@ import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Supplier;
+
 public class BrooklynPropertiesFactoryHelper {
     private static final Logger LOG = LoggerFactory.getLogger(BrooklynPropertiesFactoryHelper.class);
 
     private final String globalBrooklynPropertiesFile;
     private final String localBrooklynPropertiesFile;
+    private final Supplier<Map<?, ?>> propertiesSupplier;
     private final BrooklynProperties brooklynProperties;
 
     public BrooklynPropertiesFactoryHelper(String globalBrooklynPropertiesFile, String localBrooklynPropertiesFile) {
-        this(globalBrooklynPropertiesFile, localBrooklynPropertiesFile, null);
+        this(globalBrooklynPropertiesFile, localBrooklynPropertiesFile, null, null);
     }
 
     public BrooklynPropertiesFactoryHelper(BrooklynProperties brooklynProperties) {
-        this(null, null, brooklynProperties);
+        this(null, null, brooklynProperties, null);
     }
 
     public BrooklynPropertiesFactoryHelper(String globalBrooklynPropertiesFile,
             String localBrooklynPropertiesFile,
             BrooklynProperties brooklynProperties) {
+        this(globalBrooklynPropertiesFile, localBrooklynPropertiesFile, brooklynProperties, null);
+    }
+
+    public BrooklynPropertiesFactoryHelper(
+            String globalBrooklynPropertiesFile,
+            String localBrooklynPropertiesFile,
+            Supplier<Map<?, ?>> propertiesSupplier) {
+        this(globalBrooklynPropertiesFile, localBrooklynPropertiesFile, null, propertiesSupplier);
+    }
+
+    public BrooklynPropertiesFactoryHelper(String globalBrooklynPropertiesFile,
+            String localBrooklynPropertiesFile,
+            BrooklynProperties brooklynProperties,
+            Supplier<Map<?, ?>> propertiesSupplier) {
         this.globalBrooklynPropertiesFile = globalBrooklynPropertiesFile;
         this.localBrooklynPropertiesFile = localBrooklynPropertiesFile;
         this.brooklynProperties = brooklynProperties;
+        this.propertiesSupplier = propertiesSupplier;
     }
 
     public BrooklynProperties.Factory.Builder createPropertiesBuilder() {
@@ -83,6 +102,10 @@ public class BrooklynPropertiesFactoryHelper {
                 checkFileReadable(localProperties);
                 checkFilePermissionsX00(localProperties);
                 builder.localPropertiesFile(localProperties.getAbsolutePath());
+            }
+
+            if (propertiesSupplier != null) {
+                builder.propertiesSupplier(propertiesSupplier);
             }
             return builder;
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <jna.version>4.0.0</jna.version>
         <winrm4j.version>0.3.5</winrm4j.version>
         <karaf.version>4.0.4</karaf.version>
+        <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>
         <zookeeper.version>3.3.4</zookeeper.version>


### PR DESCRIPTION
Load properties from:
  * global brooklyn.properties
  * local properties
  * config admin's brooklyn PID

It's a one-way integration where changes in config admin will cause reloading the properties in brooklyn. Setting properties programmatically in brooklyn will not update config admin.

--

Since we are relying on config admin to read the configuration (which could be coming from multiple places) there's no check on the security attributes of the source.