### PR TITLE
New PerUserEntitlementManager keyword: user

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/EntitlementManagerAdapter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/EntitlementManagerAdapter.java
@@ -53,10 +53,12 @@ public abstract class EntitlementManagerAdapter implements EntitlementManager {
         public Boolean handleSeeCatalogItem(String catalogItemId) {
             return isEntitledToSeeCatalogItem(context, catalogItemId);
         }
+
         @Override
         public Boolean handleAddCatalogItem(Object catalogItemBeingAdded) {
             return isEntitledToAddCatalogItem(context, catalogItemBeingAdded);
         }
+
         @Override
         public Boolean handleModifyCatalogItem(StringAndArgument catalogItemIdAndModification) {
             return isEntitledToModifyCatalogItem(context, catalogItemIdAndModification==null ? null : catalogItemIdAndModification.getString(),
@@ -67,6 +69,7 @@ public abstract class EntitlementManagerAdapter implements EntitlementManager {
         public Boolean handleSeeEntity(Entity entity) {
             return isEntitledToSeeEntity(context, entity);
         }
+
         @Override
         public Boolean handleSeeSensor(EntityAndItem<String> sensorInfo) {
             return isEntitledToSeeSensor(context, sensorInfo.getEntity(), sensorInfo.getItem());
@@ -76,6 +79,7 @@ public abstract class EntitlementManagerAdapter implements EntitlementManager {
             StringAndArgument item = effectorInfo.getItem();
             return isEntitledToInvokeEffector(context, effectorInfo.getEntity(), item==null ? null : item.getString(), item==null ? null : item.getArgument());
         }
+
         @Override
         public Boolean handleModifyEntity(Entity entity) {
             return isEntitledToModifyEntity(context, entity);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
@@ -329,6 +329,7 @@ public class Entitlements {
         return FineGrainedEntitlements.anyOf(
             FineGrainedEntitlements.allowing(SEE_ENTITY),
             FineGrainedEntitlements.allowing(SEE_ACTIVITY_STREAMS),
+            FineGrainedEntitlements.allowing(SEE_CATALOG_ITEM),
             FineGrainedEntitlements.seeNonSecretSensors(),
             FineGrainedEntitlements.seeNonSecretConfig()
         );

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.mgmt.entitlement;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -72,23 +73,32 @@ public class Entitlements {
     public static EntitlementClass<EntityAndItem<StringAndArgument>> INVOKE_EFFECTOR = new BasicEntitlementClassDefinition<EntityAndItem<StringAndArgument>>("effector.invoke", EntityAndItem.typeToken(StringAndArgument.class));
     public static EntitlementClass<Entity> MODIFY_ENTITY = new BasicEntitlementClassDefinition<Entity>("entity.modify", Entity.class);
     
-    /** the permission to deploy an application, where parameter is some representation of the app to be deployed (spec instance or yaml plan) */
+    /**
+     * Permission to deploy an application, where parameter is some representation
+     * of the app to be deployed (spec instance or yaml plan)
+     */
     public static EntitlementClass<Object> DEPLOY_APPLICATION = new BasicEntitlementClassDefinition<Object>("app.deploy", Object.class);
 
-    /** catch-all for catalog, locations, scripting, usage, etc - exporting persistence, shutting down, etc;
+    /**
+     * Catch-all for catalog, locations, scripting, usage, etc - exporting persistence, shutting down, etc;
      * this is significantly more powerful than {@link #SERVER_STATUS}.
-     * NB: this may be refactored and deprecated in future */
+     * NB: this may be refactored and deprecated in future
+     */
     public static EntitlementClass<Void> SEE_ALL_SERVER_INFO = new BasicEntitlementClassDefinition<Void>("server.info.all.see", Void.class);
 
-    /** permission to see general server status info: basically HA status; not nearly as much as {@link #SEE_ALL_SERVER_INFO} */
+    /**
+     * Permission to see general server status info: basically HA status; not nearly as much as {@link #SEE_ALL_SERVER_INFO}
+     */
     public static EntitlementClass<Void> SERVER_STATUS = new BasicEntitlementClassDefinition<Void>("server.status", Void.class);
     
-    /** permission to run untrusted code or embedded scripts at the server; 
-     * secondary check required for any operation which could potentially grant root-level access */ 
+    /**
+     * Permission to run untrusted code or embedded scripts at the server.
+     * A secondary check is required for any operation which could potentially grant root-level access.
+     */
     public static EntitlementClass<Void> ROOT = new BasicEntitlementClassDefinition<Void>("root", Void.class);
 
     @SuppressWarnings("unchecked")
-    public static enum EntitlementClassesEnum {
+    public enum EntitlementClassesEnum {
         ENTITLEMENT_SEE_CATALOG_ITEM(SEE_CATALOG_ITEM) { public <T> T handle(EntitlementClassesHandler<T> handler, Object argument) { return handler.handleSeeCatalogItem((String)argument); } },
         ENTITLEMENT_ADD_CATALOG_ITEM(ADD_CATALOG_ITEM) { public <T> T handle(EntitlementClassesHandler<T> handler, Object argument) { return handler.handleAddCatalogItem(argument); } },
         ENTITLEMENT_MODIFY_CATALOG_ITEM(MODIFY_CATALOG_ITEM) { public <T> T handle(EntitlementClassesHandler<T> handler, Object argument) { return handler.handleModifyCatalogItem((StringAndArgument)argument); } },
@@ -107,7 +117,7 @@ public class Entitlements {
         
         private EntitlementClass<?> entitlementClass;
 
-        private EntitlementClassesEnum(EntitlementClass<?> specificClass) {
+        EntitlementClassesEnum(EntitlementClass<?> specificClass) {
             this.entitlementClass = specificClass;
         }
         public EntitlementClass<?> getEntitlementClass() {
@@ -194,7 +204,9 @@ public class Entitlements {
     
     // ------------- permission sets -------------
     
-    /** always ALLOW access to everything */
+    /**
+     * @return An entitlement manager allowing access to everything.
+     */
     public static EntitlementManager root() {
         return new EntitlementManager() {
             @Override
@@ -208,7 +220,25 @@ public class Entitlements {
         };
     }
 
-    /** always DENY access to anything which requires entitlements */
+    /**
+     * @return An entitlement manager allowing everything but {@link #ROOT} and {@link #SEE_ALL_SERVER_INFO}.
+     */
+    public static EntitlementManager user() {
+        return new EntitlementManager() {
+            @Override
+            public <T> boolean isEntitled(EntitlementContext context, EntitlementClass<T> permission, T entitlementClassArgument) {
+                return !SEE_ALL_SERVER_INFO.equals(permission) && !ROOT.equals(permission);
+            }
+            @Override
+            public String toString() {
+                return "Entitlements.user";
+            }
+        };
+    }
+
+    /**
+     * @return An entitlement manager denying access to anything that requires entitlements.
+     */
     public static EntitlementManager minimal() {
         return new EntitlementManager() {
             @Override
@@ -286,41 +316,32 @@ public class Entitlements {
             @SuppressWarnings("unchecked")
             @Override
             public <T> boolean isEntitled(EntitlementContext context, EntitlementClass<T> permission, T typeArgument) {
-                if (!Objects.equal(this.permission, permission)) return false;
-                return test.apply((U)typeArgument);
+                return Objects.equal(this.permission, permission) && test.apply((U) typeArgument);
             }
             @Override
             public String toString() {
                 return "Entitlements.allowing(" + permission + " -> " + test + ")";
             }
         }
-        
+
+        private static class NonSecretPredicate implements Predicate<EntityAndItem<String>> {
+            @Override
+            public boolean apply(EntityAndItem<String> input) {
+                return input != null && !Sanitizer.IS_SECRET_PREDICATE.apply(input.getItem());
+            }
+
+            @Override
+            public String toString() {
+                return "Predicates.nonSecret";
+            }
+        }
+
         public static EntitlementManager seeNonSecretSensors() {
-            return allowing(SEE_SENSOR, new Predicate<EntityAndItem<String>>() {
-                @Override
-                public boolean apply(EntityAndItem<String> input) {
-                    if (input == null) return false;
-                    return !Sanitizer.IS_SECRET_PREDICATE.apply(input.getItem());
-                }
-                @Override
-                public String toString() {
-                    return "Predicates.nonSecret";
-                }
-            });
+            return allowing(SEE_SENSOR, new NonSecretPredicate());
         }
         
         public static EntitlementManager seeNonSecretConfig() {
-            return allowing(SEE_CONFIG, new Predicate<EntityAndItem<String>>() {
-                @Override
-                public boolean apply(EntityAndItem<String> input) {
-                    if (input == null) return false;
-                    return !Sanitizer.IS_SECRET_PREDICATE.apply(input.getItem());
-                }
-                @Override
-                public String toString() {
-                    return "Predicates.nonSecret";
-                }
-            });
+            return allowing(SEE_CONFIG, new NonSecretPredicate());
         }
     }
     
@@ -399,6 +420,8 @@ public class Entitlements {
      * @since 0.7.0
      * @deprecated since 0.7.0, use {@link #checkEntitled(EntitlementManager, EntitlementClass, Object)};
      * kept briefly because there is some downstream usage*/
+    // Note: @Deprecated annotation only added from v0.10.0.
+    @Deprecated
     public static <T> void requireEntitled(EntitlementManager checker, EntitlementClass<T> permission, T typeArgument) {
         checkEntitled(checker, permission, typeArgument);
     }
@@ -406,10 +429,10 @@ public class Entitlements {
     // ----------------- initialization ----------------
 
     public final static String ENTITLEMENTS_CONFIG_PREFIX = "brooklyn.entitlements";
-    
-    public static ConfigKey<String> GLOBAL_ENTITLEMENT_MANAGER = ConfigKeys.newStringConfigKey(ENTITLEMENTS_CONFIG_PREFIX+".global", 
+
+    public static final ConfigKey<String> GLOBAL_ENTITLEMENT_MANAGER = ConfigKeys.newStringConfigKey(ENTITLEMENTS_CONFIG_PREFIX + ".global",
         "Class for entitlements in effect globally; "
-        + "short names 'minimal', 'readonly', or 'root' are permitted here, with the default 'root' giving full access to all declared users; "
+        + "short names 'minimal', 'readonly', 'user' or 'root' are permitted here, with the default 'root' giving full access to all declared users; "
         + "or supply the name of an "+EntitlementManager.class+" class to instantiate, taking a 1-arg BrooklynProperties constructor or a 0-arg constructor",
         "root");
     
@@ -421,13 +444,20 @@ public class Entitlements {
     }
     
     public static EntitlementManager load(@Nullable ManagementContext mgmt, BrooklynProperties brooklynProperties, String type) {
-        if ("root".equalsIgnoreCase(type)) return root();
-        if ("readonly".equalsIgnoreCase(type) || "read_only".equalsIgnoreCase(type)) return readOnly();
-        if ("minimal".equalsIgnoreCase(type)) return minimal();
+        if ("root".equalsIgnoreCase(type)) {
+            return root();
+        } else if ("readonly".equalsIgnoreCase(type) || "read_only".equalsIgnoreCase(type)) {
+            return readOnly();
+        } else if ("minimal".equalsIgnoreCase(type)) {
+            return minimal();
+        } else if ("user".equalsIgnoreCase(type)) {
+            return user();
+        }
         if (Strings.isNonBlank(type)) {
             try {
-                ClassLoader cl = mgmt==null ? null : ((ManagementContextInternal)mgmt).getCatalogClassLoader();
-                if (cl==null) cl = Entitlements.class.getClassLoader();
+                ClassLoader cl = mgmt != null
+                        ? mgmt.getCatalogClassLoader()
+                        : Entitlements.class.getClassLoader();
                 Class<?> clazz = cl.loadClass(DeserializingClassRenamesProvider.findMappedName(type));
                 return (EntitlementManager) instantiate(clazz, ImmutableList.of(
                         new Object[] {mgmt, brooklynProperties},

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/PerUserEntitlementManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/PerUserEntitlementManager.java
@@ -64,7 +64,7 @@ public class PerUserEntitlementManager implements EntitlementManager {
     public PerUserEntitlementManager(BrooklynProperties properties) {
         this(load(properties, properties.getConfig(DEFAULT_MANAGER)));
         
-        BrooklynProperties users = properties.submap(ConfigPredicates.startingWith(PER_USER_ENTITLEMENTS_CONFIG_PREFIX+"."));
+        BrooklynProperties users = properties.submap(ConfigPredicates.nameStartsWith(PER_USER_ENTITLEMENTS_CONFIG_PREFIX+"."));
         for (Map.Entry<ConfigKey<?>,?> key: users.getAllConfig().entrySet()) {
             if (key.getKey().getName().equals(DEFAULT_MANAGER.getName())) continue;
             String user = Strings.removeFromStart(key.getKey().getName(), PER_USER_ENTITLEMENTS_CONFIG_PREFIX+".");
@@ -85,12 +85,12 @@ public class PerUserEntitlementManager implements EntitlementManager {
 
     @Override
     public <T> boolean isEntitled(EntitlementContext context, EntitlementClass<T> entitlementClass, T entitlementClassArgument) {
-        EntitlementManager entitlementInEffect = null;
+        EntitlementManager entitlementInEffect;
         if (context==null || context.user()==null) {
             // no user means it is running as an internal process, always has root
             entitlementInEffect = Entitlements.root(); 
         } else {
-            if (context!=null) entitlementInEffect = perUserManagers.get(context.user());
+            entitlementInEffect = perUserManagers.get(context.user());
             if (entitlementInEffect==null) entitlementInEffect = defaultManager;
         }
         return entitlementInEffect.isEntitled(context, entitlementClass, entitlementClassArgument);

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ScriptApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ScriptApi.java
@@ -36,10 +36,14 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ScriptApi {
-    
+
+    /** @deprecated since 0.10.0. Use constant in ScriptResource instead. */
+    @Deprecated
     public static final String USER_DATA_MAP_SESSION_ATTRIBUTE = "brooklyn.script.groovy.user.data";
+    /** @deprecated since 0.10.0. Use constant in ScriptResource instead. */
+    @Deprecated
     public static final String USER_LAST_VALUE_SESSION_ATTRIBUTE = "brooklyn.script.groovy.user.last";
-    
+
     @POST
     @Path("/groovy")
     @Consumes("application/text")

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ScriptResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ScriptResource.java
@@ -18,8 +18,10 @@
  */
 package org.apache.brooklyn.rest.resources;
 
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.rest.api.ScriptApi;
 import org.apache.brooklyn.rest.domain.ScriptExecutionSummary;
+import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.apache.brooklyn.util.stream.ThreadLocalPrintStream;
 import org.apache.brooklyn.util.stream.ThreadLocalPrintStream.OutputCapturingContext;
 
@@ -45,6 +47,10 @@ public class ScriptResource extends AbstractBrooklynRestResource implements Scri
     @SuppressWarnings("rawtypes")
     @Override
     public ScriptExecutionSummary groovy(HttpServletRequest request, String script) {
+        if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_ALL_SERVER_INFO, null)) {
+            throw WebResourceUtils.forbidden("User '%s' is not authorized for this operation", Entitlements.getEntitlementContext().user());
+        }
+
         log.info("Web REST executing user-supplied script");
         if (log.isDebugEnabled()) {
             log.debug("Web REST user-supplied script contents:\n"+script);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -96,7 +96,11 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
 
     @Override
     public void reloadBrooklynProperties() {
-        brooklyn().reloadBrooklynProperties();
+        if (Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_ALL_SERVER_INFO, null)) {
+            brooklyn().reloadBrooklynProperties();
+        } else {
+            throw WebResourceUtils.forbidden("User '%s' is not authorized for this operation", Entitlements.getEntitlementContext().user());
+        }
     }
 
     private boolean isMaster() {

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ActivityApiEntitlementsTest.java
@@ -76,6 +76,7 @@ public class ActivityApiEntitlementsTest extends AbstractRestApiEntitlementsTest
     public void testGetTask() throws Exception {
         String path = "/v1/activities/"+subTask.getId();
         assertPermitted("myRoot", path);
+        assertPermitted("myUser", path);
         assertPermitted("myReadonly", path);
         assertForbidden("myMinimal", path);
         assertForbidden("unrecognisedUser", path);
@@ -89,6 +90,7 @@ public class ActivityApiEntitlementsTest extends AbstractRestApiEntitlementsTest
             String expectedStream = entry.getValue();
 
             assertEquals(httpGet("myRoot", pathPrefix+streamId), expectedStream);
+            assertEquals(httpGet("myUser", pathPrefix+streamId), expectedStream);
             assertEquals(httpGet("myReadonly", pathPrefix+streamId), expectedStream);
             assertForbidden("myMinimal", pathPrefix+streamId);
             assertForbidden("unrecognisedUser", pathPrefix+streamId);

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/EntityConfigApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/EntityConfigApiEntitlementsTest.java
@@ -50,6 +50,7 @@ public class EntityConfigApiEntitlementsTest extends AbstractRestApiEntitlements
         String val = "\"myname\"";
         
         assertEquals(httpGet("myRoot", path), val);
+        assertEquals(httpGet("myUser", path), val);
         assertEquals(httpGet("myReadonly", path), val);
         assert404("myMinimal", path); // can't see app, to retrieve entity
         assert404("unrecognisedUser", path);
@@ -68,6 +69,7 @@ public class EntityConfigApiEntitlementsTest extends AbstractRestApiEntitlements
         String regex = ".*"+confName+".*myname.*";
         
         Asserts.assertStringMatchesRegex(httpGet("myRoot", path), regex);
+        Asserts.assertStringMatchesRegex(httpGet("myUser", path), regex);
         Asserts.assertStringMatchesRegex(httpGet("myReadonly", path), regex);
         assert404("myMinimal", path); // can't see app, to retrieve entity
         assert404("unrecognisedUser", path);

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ScriptApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ScriptApiEntitlementsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.rest.entitlement;
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.brooklyn.util.http.HttpTool;
+import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+
+public class ScriptApiEntitlementsTest extends AbstractRestApiEntitlementsTest {
+
+    @Test(groups = "Integration")
+    public void testGroovy() throws Exception {
+        String script = "1 + 1";
+        HttpToolResponse rootRepsonse = httpPost("myRoot", "/v1/script/groovy", script.getBytes());
+        assertHealthyStatusCode(rootRepsonse);
+        Map groovyOutput = new Gson().fromJson(rootRepsonse.getContentAsString(), Map.class);
+        assertEquals(groovyOutput.get("result"), "2");
+        assertForbiddenPost("myUser", "/v1/script/groovy", script.getBytes());
+        assertForbiddenPost("myReadonly", "/v1/script/groovy", script.getBytes());
+        assertForbiddenPost("myMinimal", "/v1/script/groovy", script.getBytes());
+        assertForbiddenPost("unrecognisedUser", "/v1/script/groovy", script.getBytes());
+    }
+
+    @Override
+    protected HttpToolResponse httpPost(String user, String path, byte[] body) throws Exception {
+        final ImmutableMap<String, String> headers = ImmutableMap.of(
+                "Content-Type", "application/text");
+        final URI uri = URI.create(getBaseUriRest()).resolve(path);
+        return HttpTool.httpPost(newClient(user), uri, headers, body);
+    }
+}

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/SensorApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/SensorApiEntitlementsTest.java
@@ -53,6 +53,7 @@ public class SensorApiEntitlementsTest extends AbstractRestApiEntitlementsTest {
         String val = "\"myval\"";
         
         assertEquals(httpGet("myRoot", path), val);
+        assertEquals(httpGet("myUser", path), val);
         assertEquals(httpGet("myReadonly", path), val);
         assert404("myMinimal", path); // can't see app, to retrieve entity
         assert404("unrecognisedUser", path);
@@ -73,6 +74,7 @@ public class SensorApiEntitlementsTest extends AbstractRestApiEntitlementsTest {
         String regex = ".*"+sensorName+".*myval.*";
         
         Asserts.assertStringMatchesRegex(httpGet("myRoot", path), regex);
+        Asserts.assertStringMatchesRegex(httpGet("myUser", path), regex);
         Asserts.assertStringMatchesRegex(httpGet("myReadonly", path), regex);
         assert404("myMinimal", path); // can't see app, to retrieve entity
         assert404("unrecognisedUser", path);

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ServerApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/ServerApiEntitlementsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.rest.entitlement;
 
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.testng.annotations.Test;
 
 @Test(singleThreaded = true)
@@ -27,8 +28,31 @@ public class ServerApiEntitlementsTest extends AbstractRestApiEntitlementsTest {
     public void testGetHealthy() throws Exception {
         String path = "/v1/server/up";
         assertPermitted("myRoot", path);
+        assertPermitted("myUser", path);
         assertForbidden("myReadonly", path);
         assertForbidden("myMinimal", path);
         assertForbidden("unrecognisedUser", path);
     }
+
+    @Test(groups = "Integration")
+    public void testReloadProperties() throws Exception {
+        String resource = "/v1/server/properties/reload";
+        assertPermittedPost("myRoot", resource, null);
+        assertForbiddenPost("myUser", resource, null);
+        assertForbiddenPost("myReadonly", resource, null);
+        assertForbiddenPost("myMinimal", resource, null);
+        assertForbiddenPost("unrecognisedUser", resource, null);
+    }
+
+    @Test(groups = "Integration")
+    public void testGetConfig() throws Exception {
+        // Property set in test setup.
+        String path = "/v1/server/config/" + Entitlements.GLOBAL_ENTITLEMENT_MANAGER.getName();
+        assertPermitted("myRoot", path);
+        assertForbidden("myUser", path);
+        assertForbidden("myReadonly", path);
+        assertForbidden("myMinimal", path);
+        assertForbidden("unrecognisedUser", path);
+    }
+
 }


### PR DESCRIPTION
`PerUserEntitlementManager` transforms the "user" keyword into an entitlement to everything but the most privileged actions (everything but `ROOT` and `SEE_ALL_SERVER_INFO`). Practically this means a user can do everything but: use `ScriptApi` to run any Groovy, stop the server, access management context configuration via `ServerApi`, reload Brooklyn properties and export persistence data.

I wasn't sure about the choice of "user" for the keyword. I wanted to indicate that it was a step down from "root". Other ideas people gave me include "manager" and "administrator", neither of which are hugely satisfactory to me. Suggestions welcome.