### PR TITLE
Wait to start windows parameter.

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvis;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 import static org.apache.brooklyn.util.ssh.BashCommands.sbinPath;
+import static org.jclouds.util.Throwables2.getFirstThrowableOfType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -46,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
+import javax.xml.ws.WebServiceException;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.LocationSpec;
@@ -61,7 +63,6 @@ import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.Sanitizer;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.BasicMachineMetadata;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
@@ -157,6 +158,7 @@ import org.jclouds.scriptbuilder.statements.login.AdminAccess;
 import org.jclouds.scriptbuilder.statements.login.ReplaceShadowPasswordEntry;
 import org.jclouds.scriptbuilder.statements.ssh.AuthorizeRSAPublicKeys;
 import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.jclouds.util.Predicates2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2746,14 +2748,52 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             Callable<Boolean> checker = new Callable<Boolean>() {
                 public Boolean call() {
                     for (Map.Entry<WinRmMachineLocation, LoginCredentials> entry : machinesToTry.entrySet()) {
-                        WinRmMachineLocation machine = entry.getKey();
+                        final WinRmMachineLocation machine = entry.getKey();
                         WinRmToolResponse response = machine.executeCommand(
                                 ImmutableMap.of(WinRmTool.PROP_EXEC_TRIES.getName(), 1),
                                 ImmutableList.of("echo testing"));
                         boolean success = (response.getStatusCode() == 0);
                         if (success) {
                             credsSuccessful.set(entry.getValue());
-                            return true;
+
+                            String verifyWindowsUp = getConfig(WinRmMachineLocation.WAIT_WINDOWS_TO_START);
+                            if (Strings.isBlank(verifyWindowsUp) || verifyWindowsUp.equals("false")) {
+                                return true;
+                            }
+
+                            Predicate<WinRmMachineLocation> machineReachable = new Predicate<WinRmMachineLocation>() {
+                                @Override
+                                public boolean apply(@Nullable WinRmMachineLocation machine) {
+                                    try {
+                                        WinRmToolResponse response = machine.executeCommand("echo testing");
+                                        int statusCode = response.getStatusCode();
+                                        return statusCode == 0;
+                                    } catch (RuntimeException e) {
+                                        if (getFirstThrowableOfType(e, IOException.class) != null || getFirstThrowableOfType(e, WebServiceException.class) != null) {
+                                            LOG.debug("WinRM Connectivity lost", e);
+                                            return false;
+                                        } else {
+                                            throw e;
+                                        }
+                                    }
+                                }
+                            };
+                            Duration verifyWindowsUpTime = Duration.of(verifyWindowsUp);
+                            boolean restartHappened = Predicates2.retry(Predicates.not(machineReachable),
+                                    verifyWindowsUpTime.toMilliseconds(),
+                                    Duration.FIVE_SECONDS.toMilliseconds(),
+                                    Duration.THIRTY_SECONDS.toMilliseconds(),
+                                    TimeUnit.MILLISECONDS).apply(machine);
+                            if (restartHappened) {
+                                LOG.info("Connectivity to the machine was lost. Probably Windows have restarted {} as part of the provisioning process.\nRetrying to connect...", machine);
+                                return Predicates2.retry(machineReachable,
+                                        verifyWindowsUpTime.toMilliseconds(),
+                                        Duration.of(5, TimeUnit.SECONDS).toMilliseconds(),
+                                        Duration.of(30, TimeUnit.SECONDS).toMilliseconds(),
+                                        TimeUnit.MILLISECONDS).apply(machine);
+                            } else {
+                                return true;
+                            }
                         }
                     }
                     return false;
@@ -2905,7 +2945,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         Stopwatch stopwatch = Stopwatch.createStarted();
 
-        ReferenceWithError<Boolean> reachable = new Repeater()
+        ReferenceWithError<Boolean> reachable = new Repeater("reachable repeater ")
                 .backoff(Duration.ONE_SECOND, 2, Duration.TEN_SECONDS) // exponential backoff, to 10 seconds
                 .until(checker)
                 .limitTimeTo(timeout)

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -66,6 +66,7 @@ import com.google.common.net.HostAndPort;
 import com.google.common.reflect.TypeToken;
 
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
+import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
 
 public class WinRmMachineLocation extends AbstractLocation implements MachineLocation {
 
@@ -80,6 +81,9 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
     public static final ConfigKey<String> OPERATION_TIMEOUT = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.OPERATION_TIMEOUT);
     public static final ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = newConfigKeyWithPrefix(BrooklynConfigKeys.BROOKLYN_WINRM_CONFIG_KEY_PREFIX, WinRmTool.RETRIES_OF_NETWORK_FAILURES);
     public static final ConfigKey<Boolean> USE_HTTPS_WINRM = WinRmTool.USE_HTTPS_WINRM;
+    public static final ConfigKey<String> WAIT_WINDOWS_TO_START = newStringConfigKey("waitWindowsToStart",
+            "By default Brooklyn will return the machine immediately after Brooklyn is able to WinRM. Sometimes restart could happen after a Windows VM is provisioned. This could be because of System Upgrade or other." +
+            " By setting this config key to 60s, 5m or other X Duration of time Brooklyn will wait X amount of time for disconnect to occur. If connection failure occurs it will wait X amount of time for the machine to come up.", null);
 
 
     /**


### PR DESCRIPTION
The problem this PR tries to solve is that In some clouds a restart could happen on a Windows Host 2 minutes after it is provisioned. This could be because of System Upgrade or other.

What particularly I experience is that this Blueprint fail:
```yaml
services:
  type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
  brooklyn.config:
    pre.install.command: echo preInstallCommand
    install.command: echo installCommand > C:\\install.txt
    post.install.command: echo postInstallCommand
    customize.command: echo customizeCommand
    pre.launch.command: echo preLaunchCommand
    launch.powershell.command: |
      Start-Sleep -s 400
      Write-Host Test Completed
    post.launch.command: echo postLaunchCommand
    checkRunning.command: echo checkRunningCommand
    stop.command: echo stopCommand
```

When I login on the host and search for System event of type 1074 in Windows Event Viewer, there is
```none
The process C:\Windows\system32\winlogon.exe (W2K12-STD) has initiated the restart of computer WIN-JV0CGR5J6GN on behalf of user NT AUTHORITY\SYSTEM for the following reason: Operating System: Upgrade (Planned) Reason Code: 0x80020003 Shutdown Type: restart Comment:
```
 
-----
With this config key Brooklyn will wait 5 minutes for a restart to happen before returning the machine as accessible. With this config Brooklyn waits before giving the machine to the entity and the blueprint succeeds.

I tried adding Get-PendingReboot script from  [gallery.technet.microsoft.com](https://gallery.technet.microsoft.com/scriptcenter/Get-PendingReboot-Query-bdb79542) but every time it executes it tells that no restarts are pending and again it restarts.
I left out commented code so you can test Get-PendingReboot yourself.

Do you think adding this option is enough or I should investigate further why it restarts?