### PR TITLE
pull displayName from flags in LocationTransformer if present - fixes BROOKLYN-250

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/LocationTransformer.java
@@ -74,8 +74,12 @@ public class LocationTransformer {
             config = ConfigBag.newInstance(spec.getConfig()).putAll(config).getAllConfig();
         } else if (level==LocationDetailLevel.LOCAL_EXCLUDING_SECRET) {
             // in local mode, just make sure display name is set
-            if (spec!=null && !explicitConfig.containsKey(LocationConfigKeys.DISPLAY_NAME) && Strings.isNonBlank(spec.getDisplayName())) {
-                config.put(LocationConfigKeys.DISPLAY_NAME.getName(), spec.getDisplayName());
+            if (spec!=null && !explicitConfig.containsKey(LocationConfigKeys.DISPLAY_NAME) ) {
+                if (Strings.isNonBlank((String) spec.getFlags().get(LocationConfigKeys.DISPLAY_NAME.getName()))){
+                    config.put(LocationConfigKeys.DISPLAY_NAME.getName(), spec.getFlags().get(LocationConfigKeys.DISPLAY_NAME.getName()));
+                } else if ( Strings.isNonBlank(spec.getDisplayName()) ) {
+                    config.put(LocationConfigKeys.DISPLAY_NAME.getName(), spec.getDisplayName());
+                }
             }
         }
 


### PR DESCRIPTION
Untyped config from the YAML is being pushed into flags rather than config, so rather than expose flags in the locations API (which we're moving away from to the catalog API), I'm now checking for the presence of a displayName parameter in flags and setting it in the LocationTransformer.

Tests added.