### PR TITLE
Driver copyResources walks the filesystem 

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerPaths.java
+++ b/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerPaths.java
@@ -266,7 +266,7 @@ public class BrooklynServerPaths {
     public static File getOsgiCacheDirCleanedIfNeeded(ManagementContext mgmt) {
         File cacheDirF = getOsgiCacheDir(mgmt);
         boolean clean = isOsgiCacheForCleaning(mgmt, cacheDirF);
-        log.debug("OSGi cache dir computed as "+cacheDirF.getName()+" ("+
+        log.debug("OSGi cache dir computed as "+cacheDirF.getAbsolutePath()+" ("+
             (cacheDirF.exists() ? "already exists" : "does not exist")+", "+
             (clean ? "cleaning now (and on exit)" : "cleaning not requested"));
 

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -384,7 +384,7 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
         if (getPersistMode() != PersistMode.DISABLED) {
             try {
                 Stopwatch stopwatch = Stopwatch.createStarted();
-                if (managementContext.getHighAvailabilityManager().getPersister() != null) {
+                if (managementContext.getHighAvailabilityManager() != null && managementContext.getHighAvailabilityManager().getPersister() != null) {
                     managementContext.getHighAvailabilityManager().getPersister().waitForWritesCompleted(Duration.TEN_SECONDS);
                 }
                 managementContext.getRebindManager().waitForPendingComplete(Duration.TEN_SECONDS, true);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
@@ -497,11 +497,11 @@ public class Os {
      * @return whether the path is absolute under the above constraints.
      */
     public static boolean isAbsolutish(String path) {
-        return
-            path.codePointAt(0) == SEPARATOR_UNIX ||
-            path.equals("~") || path.startsWith("~" + SEPARATOR_UNIX) ||
-            path.length()>=3 && path.codePointAt(1) == ':' &&
-                                isSeparator(path.codePointAt(2));
+        return Strings.isNonBlank(path) &&
+                (path.codePointAt(0) == SEPARATOR_UNIX ||
+                        path.equals("~") ||
+                        path.startsWith("~" + SEPARATOR_UNIX) ||
+                        (path.length() >= 3 && path.codePointAt(1) == ':' && isSeparator(path.codePointAt(2))));
     }
 
     /** @deprecated since 0.7.0, use {@link #isAbsolutish(String)} */

--- a/utils/common/src/test/java/org/apache/brooklyn/util/os/OsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/os/OsTest.java
@@ -43,7 +43,16 @@ import com.google.common.io.Files;
 public class OsTest {
 
     private static final Logger log = LoggerFactory.getLogger(OsTest.class);
-    
+
+    public void testIsAbsolutish() {
+        assertFalse(Os.isAbsolutish(""));
+        assertFalse(Os.isAbsolutish("foo/bar"));
+        assertTrue(Os.isAbsolutish("/"));
+        assertTrue(Os.isAbsolutish("~/"));
+        assertTrue(Os.isAbsolutish("~"));
+        assertTrue(Os.isAbsolutish("/foo/bar"));
+    }
+
     public void testTmp() {
         log.info("tmp dir is: "+Os.tmp());
         Assert.assertNotNull(Os.tmp());


### PR DESCRIPTION
So blueprint writers can replace
```yaml
  brooklyn.config:
    runtimeTemplates:
      /path/to/source1: dest1
      /path/to/source2: dest2
      ...
      /path/to/sourceN: destN
```
With
```yaml
  brooklyn.config:
    runtimeTemplates:
      /path/to: dest
```
One minor difference: in the first example the two files end up in `runDir/` but in the second in `runDir/dest/`. If using the latter syntax I think this would be expected.

Each file is copied in a task so there's better visibility of what is in progress at any given point.