### PR TITLE
BROOKLYN-257: allow nulling imageId in jcloudsLocation.obtain()

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1146,11 +1146,15 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     }})
             .put(HARDWARE_ID, new CustomizeTemplateBuilder() {
                     public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
-                        tb.hardwareId(((CharSequence)v).toString());
+                        if (v != null) {
+                            tb.hardwareId(((CharSequence)v).toString());
+                        }
                     }})
             .put(IMAGE_ID, new CustomizeTemplateBuilder() {
                     public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
-                        tb.imageId(((CharSequence)v).toString());
+                        if (v != null) {
+                            tb.imageId(((CharSequence)v).toString());
+                        }
                     }})
             .put(IMAGE_DESCRIPTION_REGEX, new CustomizeTemplateBuilder() {
                     public void apply(TemplateBuilder tb, ConfigBag props, Object v) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.location.jclouds;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -115,9 +116,16 @@ public abstract class AbstractJcloudsStubbedLiveTest extends AbstractJcloudsLive
         };
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(
                 LOCATION_SPEC, 
-                ImmutableMap.of(
+                jcloudsLocationConfig(ImmutableMap.<Object, Object>of(
                         JcloudsLocationConfig.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry,
-                        JcloudsLocationConfig.WAIT_FOR_SSHABLE, "false"));
+                        JcloudsLocationConfig.WAIT_FOR_SSHABLE, "false")));
+    }
+    
+    /**
+     * For overriding.
+     */
+    protected Map<Object, Object> jcloudsLocationConfig(Map<Object, Object> defaults) {
+        return defaults;
     }
     
     protected abstract NodeCreator newNodeCreator();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsImageChoiceStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsImageChoiceStubbedLiveTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.NodeMetadata.Status;
+import org.jclouds.compute.domain.NodeMetadataBuilder;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.domain.LoginCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class JcloudsImageChoiceStubbedLiveTest extends AbstractJcloudsStubbedLiveTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(JcloudsImageChoiceStubbedLiveTest.class);
+    
+    private Template template;
+    
+    @Override
+    protected NodeCreator newNodeCreator() {
+        return new NodeCreator() {
+            @Override protected NodeMetadata newNode(String group, Template template) {
+                JcloudsImageChoiceStubbedLiveTest.this.template = template;
+                
+                NodeMetadata result = new NodeMetadataBuilder()
+                        .id("myid")
+                        .credentials(LoginCredentials.builder().identity("myuser").credential("mypassword").build())
+                        .loginPort(22)
+                        .status(Status.RUNNING)
+                        .publicAddresses(ImmutableList.of("173.194.32.123"))
+                        .privateAddresses(ImmutableList.of("172.168.10.11"))
+                        .build();
+                return result;
+            }
+        };
+    }
+
+    protected Map<Object, Object> jcloudsLocationConfig(Map<Object, Object> defaults) {
+        return ImmutableMap.<Object, Object>builder()
+                .putAll(defaults)
+                .put(JcloudsLocationConfig.IMAGE_ID, "CENTOS_5_64")
+                .build();
+    }
+
+    @Test(groups={"Live", "Live-sanity"})
+    public void testJcloudsCreateWithImageId() throws Exception {
+        obtainMachine(ImmutableMap.of(JcloudsLocationConfig.IMAGE_ID, "DEBIAN_8_64"));
+        assertEquals(template.getImage().getId(), "DEBIAN_8_64", "template="+template);
+    }
+    
+    @Test(groups={"Live", "Live-sanity"})
+    public void testJcloudsCreateWithImageDescriptionRegex() throws Exception {
+        // overrides the imageId specified in jcloudsLocationConfig
+        obtainMachine(MutableMap.of(JcloudsLocationConfig.IMAGE_DESCRIPTION_REGEX, ".*DEBIAN_8_64.*", JcloudsLocationConfig.IMAGE_ID, null));
+        assertEquals(template.getImage().getId(), "DEBIAN_8_64", "template="+template);
+    }
+}


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BROOKLYN-257.

To fix this, I was tempted to instead change `JcloudsLocation.buildTemplate` so that it ignored all null values, changing the code below:

```
        for (Map.Entry<ConfigKey<?>, CustomizeTemplateBuilder> entry : SUPPORTED_TEMPLATE_BUILDER_PROPERTIES.entrySet()) {
            ConfigKey<?> name = entry.getKey();
            CustomizeTemplateBuilder code = entry.getValue();
            if (config.containsKey(name))
                code.apply(templateBuilder, config, config.get(name));
        }
```

to:

```
        for (Map.Entry<ConfigKey<?>, CustomizeTemplateBuilder> entry : SUPPORTED_TEMPLATE_BUILDER_PROPERTIES.entrySet()) {
            ConfigKey<?> name = entry.getKey();
            CustomizeTemplateBuilder code = entry.getValue();
            if (config.containsKey(name) && config.get(name) != null)
                code.apply(templateBuilder, config, config.get(name));
        }
```

But is that risky? Do we rely for any config keys on `null` meaning something other than "use the jclouds default"?