### PR TITLE
Fix conversion of unsigned bytes to IP addresses

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -332,7 +332,7 @@ public class Networking {
             StringBuilder name = new StringBuilder();
             for (byte part : ip) {
                 if (name.length() > 0) name.append(".");
-                name.append(part);
+                name.append(UnsignedBytes.toString(part));
             }
             return InetAddress.getByAddress(name.toString(), ip);
         } catch (UnknownHostException e) {
@@ -375,7 +375,7 @@ public class Networking {
                 String[] parts = hostnameOrIp.split("\\.");
                 assert parts.length == 4 : "val="+hostnameOrIp+"; split="+Arrays.toString(parts)+"; length="+parts.length;
                 for (int i = 0; i < parts.length; i++) {
-                    ip[i] = (byte)Integer.parseInt(parts[i]);
+                    ip[i] = UnsignedBytes.parseUnsignedByte(parts[i]);
                 }
                 return InetAddress.getByAddress(hostnameOrIp, ip);
             } else {

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
@@ -61,28 +61,32 @@ public class NetworkingUtilsTest {
         assertFalse(Networking.isValidIp4("127.0.0."));
         assertFalse(Networking.isValidIp4("127.0.0.9f"));
         assertFalse(Networking.isValidIp4("127.0.0.1."));
+        assertFalse(Networking.isValidIp4("255.255.255.255."));
     }
-        
+
     @Test
     public void testGetInetAddressWithFixedNameByIpBytes() throws Exception {
-        InetAddress addr = Networking.getInetAddressWithFixedName(new byte[] {1,2,3,4});
-        assertEquals(addr.getAddress(), new byte[] {1,2,3,4});
+        InetAddress addr = Networking.getInetAddressWithFixedName(new byte[] { 1, 2, 3, 4 });
+        assertEquals(addr.getAddress(), new byte[] { 1, 2, 3, 4 });
         assertEquals(addr.getHostName(), "1.2.3.4");
+
+        InetAddress addr2 = Networking.getInetAddressWithFixedName(new byte[] { (byte) 255, (byte) 255, (byte) 255, (byte) 255 });
+        assertEquals(addr2.getAddress(), new byte[] { (byte) 255, (byte) 255, (byte) 255, (byte) 255 });
+        assertEquals(addr2.getHostName(), "255.255.255.255");
     }
     
     @Test
     public void testGetInetAddressWithFixedNameByIp() throws Exception {
         InetAddress addr = Networking.getInetAddressWithFixedName("1.2.3.4");
-        assertEquals(addr.getAddress(), new byte[] {1,2,3,4});
+        assertEquals(addr.getAddress(), new byte[] { 1, 2, 3, 4 });
         assertEquals(addr.getHostName(), "1.2.3.4");
-        
+
         InetAddress addr2 = Networking.getInetAddressWithFixedName("255.255.255.255");
-        assertEquals(addr2.getAddress(), new byte[] {(byte)(int)255,(byte)(int)255,(byte)(int)255,(byte)(int)255});
+        assertEquals(addr2.getAddress(), new byte[] { (byte) 255, (byte) 255, (byte) 255, (byte) 255 });
         assertEquals(addr2.getHostName(), "255.255.255.255");
-        
+
         InetAddress addr3 = Networking.getInetAddressWithFixedName("localhost");
         assertEquals(addr3.getHostName(), "localhost");
-        
     }
     
     @Test(groups="Integration")


### PR DESCRIPTION
IP addresses with octets greater than 127 should be parsed as unsigned bytes, to prevent them being displayed with negative numbers.