### PR TITLE
Use minimal management context in AbstractYamlTest

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatformLauncherAbstract.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatformLauncherAbstract.java
@@ -46,7 +46,7 @@ public abstract class BrooklynCampPlatformLauncherAbstract {
 
         if (getBrooklynMgmt()==null)
             useManagementContext(newMgmtContext());
-        
+
         platform = new BrooklynCampPlatform(
                 PlatformRootSummary.builder().name("Brooklyn CAMP Platform").build(),
                 getBrooklynMgmt())

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -81,8 +81,12 @@ public abstract class AbstractYamlTest {
     }
 
     protected LocalManagementContext newTestManagementContext() {
-        // TODO they don't all need osgi, just a few do, so could speed it up by specifying when they do
-        return LocalManagementContextForTests.newInstanceWithOsgi();
+        return LocalManagementContextForTests.builder(true).disableOsgi(disableOsgi()).build();
+    }
+
+    /** Override to enable OSGi in the management context for all tests in the class. */
+    protected boolean disableOsgi() {
+        return true;
     }
     
     @AfterMethod(alwaysRun = true)

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencedYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencedYamlTest.java
@@ -31,7 +31,12 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Iterables;
 
 public class ReferencedYamlTest extends AbstractYamlTest {
-    
+
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @Test
     public void testReferenceEntityYamlAsPlatformComponent() throws Exception {
         String entityName = "Reference child name";

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
@@ -48,7 +48,12 @@ import com.google.common.collect.Iterables;
 public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest {
     
     private static final Logger log = LoggerFactory.getLogger(CatalogOsgiVersionMoreEntityTest.class);
-    
+
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     private static String getLocalResource(String filename) {
         return ResourceUtils.create(CatalogOsgiVersionMoreEntityTest.class).getResourceAsString(
             "classpath:/"+CatalogOsgiVersionMoreEntityTest.class.getPackage().getName().replace('.', '/')+"/"+filename);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlAppTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlAppTest.java
@@ -22,20 +22,12 @@ import org.testng.annotations.Test;
 
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.camp.brooklyn.ApplicationsYamlTest;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 
 /**
  * Also see related tests in {@link ApplicationsYamlTest}.
  * TODO Not clear what the difference is between these two test classes!
  */
 public class CatalogYamlAppTest extends AbstractYamlTest {
-
-    @Override
-    protected LocalManagementContext newTestManagementContext() {
-        // Don't need osgi
-        return LocalManagementContextForTests.newInstance();
-    }
 
     /**
      * "Contrived" example was encountered by a customer in a real use-case!

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -54,6 +54,11 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
     
     private static final String SIMPLE_ENTITY_TYPE = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY;
 
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @Test
     public void testAddCatalogItemVerySimple() throws Exception {
         String symbolicName = "my.catalog.app.id.load";

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -60,6 +60,11 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
     private static final String LOCALHOST_LOCATION_TYPE = LocalhostMachineProvisioningLocation.class.getName();
     private static final String SIMPLE_LOCATION_TYPE = "org.apache.brooklyn.test.osgi.entities.SimpleLocation";
 
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @AfterMethod
     public void tearDown() {
         for (RegisteredType ci : mgmt().getTypeRegistry().getMatching(RegisteredTypePredicates.IS_LOCATION)) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlPolicyTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlPolicyTest.java
@@ -36,6 +36,11 @@ public class CatalogYamlPolicyTest extends AbstractYamlTest {
     private static final String SIMPLE_POLICY_TYPE = "org.apache.brooklyn.test.osgi.entities.SimplePolicy";
     private static final String SIMPLE_ENTITY_TYPE = "org.apache.brooklyn.test.osgi.entities.SimpleEntity";
 
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @Test
     public void testAddCatalogItem() throws Exception {
         assertEquals(countCatalogPolicies(), 0);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
@@ -54,6 +54,11 @@ public class CatalogYamlTemplateTest extends AbstractYamlTest {
     
     private static final String SIMPLE_ENTITY_TYPE = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY;
 
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @Test
     public void testAddCatalogItem() throws Exception {
         RegisteredType item = makeItem();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
@@ -42,7 +42,12 @@ import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 
 public class SpecParameterParsingTest  extends AbstractYamlTest {
-    
+
+    @Override
+    protected boolean disableOsgi() {
+        return false;
+    }
+
     @Test
     public void testYamlInputsParsed() {
         String itemId = add(


### PR DESCRIPTION
Speeds tests up a lot. Subclasses can enable OSGi by overriding `disableOsgi`.

Build of `camp-brooklyn` took 2:38 before and 1:40 afterwards on my relatively snappy laptop. The improvement should be more noticeable in Jenkins builds.

