### PR TITLE
Add method HttpFeed.Builder#credentials(Credentials)

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
@@ -197,6 +197,10 @@ public class HttpFeed extends AbstractFeed {
             this.credentials = new UsernamePasswordCredentials(username, password);
             return this;
         }
+        public Builder credentials(Credentials credentials) {
+            this.credentials = credentials;
+            return this;
+        }
         public Builder credentialsIfNotNull(String username, String password) {
             if (username != null && password != null) {
                 this.credentials = new UsernamePasswordCredentials(username, password);


### PR DESCRIPTION
Useful when we want to use a custom implementations of Credentials like a UsernamePasswordCredentials like implementation with updatable password.
