### PR TITLE
[BROOKLYN-343] A test to illustrate a failing case where cross-referencing catalog items fails

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -38,6 +38,7 @@ import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -802,6 +803,28 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
                 "services:",
                 "- type: cluster",
                 "- type: vanilla");
+    }
+    
+    @Test(groups = "Broken")
+    public void testSameCatalogReferences() {
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  items:",
+            "  - id: referenced-entity",
+            "    item:",
+            "      services:",
+            "      - type: " + BasicEntity.class.getName(),
+            "  - id: referrer-entity",
+            "    item:",
+            "      services:",
+            "      - type: " + BasicApplication.class.getName(),
+            "        brooklyn.children:",
+            "        - type: referenced-entity",
+            "        brooklyn.config:",
+            "          spec: ",
+            "            $brooklyn:entitySpec:",
+            "              type: referenced-entity");
+
     }
 
     private void registerAndLaunchAndAssertSimpleEntity(String symbolicName, String serviceType) throws Exception {


### PR DESCRIPTION
On the other hand removing `services` works just fine.

The problem is that the camp parser doesn't see items which are in the same catalog and already parsed. Only already added items are visible. The catalog parsers does a poor-man's validation on the top level items only, we need to replace that with the normal CAMP parser workflow, but able to see items in the current catalog preceding the current item.