### PR TITLE
jclouds.ImageChooser configurable

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -61,7 +61,6 @@ import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.Sanitizer;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.BasicMachineMetadata;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
@@ -1467,7 +1466,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         if (templateBuilder instanceof PortableTemplateBuilder<?>) {
             if (((PortableTemplateBuilder<?>)templateBuilder).imageChooser()==null) {
                 Function<Iterable<? extends Image>, Image> chooser = config.get(JcloudsLocationConfig.IMAGE_CHOOSER);
-                chooser = BrooklynImageChooser.cloneFor(chooser, computeService);
+                chooser = BrooklynImageChooser.cloneFor(chooser, computeService, config);
                 templateBuilder.imageChooser(chooser);
             } else {
                 // an image chooser is already set, so do nothing

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedLiveTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractJcloudsStubbedLiveTest extends AbstractJcloudsLive
             }
         };
         jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(
-                LOCATION_SPEC, 
+                getLocationSpec(), 
                 jcloudsLocationConfig(ImmutableMap.<Object, Object>of(
                         JcloudsLocationConfig.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry,
                         JcloudsLocationConfig.WAIT_FOR_SSHABLE, "false")));
@@ -126,6 +126,11 @@ public abstract class AbstractJcloudsStubbedLiveTest extends AbstractJcloudsLive
      */
     protected Map<Object, Object> jcloudsLocationConfig(Map<Object, Object> defaults) {
         return defaults;
+    }
+
+    // For overriding
+    protected String getLocationSpec() {
+        return LOCATION_SPEC;
     }
     
     protected abstract NodeCreator newNodeCreator();


### PR DESCRIPTION
This makes a custom-supplied `JcloudsLocationConfig.IMAGE_CHOOSER` customizable: if it implements `ConfigAwareChooser` then `cloneFor(ConfigBag)` will be called. This follows the same pattern as `ComputeServiceAwareChooser` (both inside `BrooklynImageChooser`).

This also adds `BrooklynImageChooser.imageChooserFromOrderings(Iterable<? extends Ordering<? super Image>>)`, so that a downstream image chooser can supply multiple orderings (the first taking priority, and subsequent ones to break any ties).

Strictly speaking, this is a break to semantic versioning to put this in the 0.9.x branch. However, the ImageChooser is quite niche. (Frankly, we should have marked `BrooklynImageChooser` as `@Beta` until it had been used in anger in more places.) The change is backwards compatible. It's just that if someone used this in a 0.9.1 and then switched back to 0.9.0 then they `ConfigAwareChooser` wouldn't be there so it wouldn't compile. On balance, I'm fine with us making that sacrifice.

The use case is...

On VMware vCloudDirector there is a customer preference for VM images that are local to the vDC (virtual datacenter) over those in other vDCs and public images. They are using imageNameRegex so jclouds can return us the corresponding image in multiple vDCs and in the public catalog. To choose the local image in a Brooklyn image chooser, we need to know where the VM is going to be provisioned. We therefore need to know the config being supplied to the `jcloudsLocation.obtain()` method *inside* an image chooser.