### PR TITLE
Fix clocker pattern: reload-properties listener

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/ClockerDynamicLocationPatternTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/ClockerDynamicLocationPatternTest.java
@@ -20,17 +20,23 @@ package org.apache.brooklyn.core.location.dynamic.clocker;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.BasicLocationRegistry;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -42,6 +48,8 @@ import com.google.common.collect.Iterables;
  * See explanation of what we're testing in {@link StubInfrastructure}.
  */
 public class ClockerDynamicLocationPatternTest extends BrooklynAppUnitTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClockerDynamicLocationPatternTest.class);
 
     private LocalhostMachineProvisioningLocation loc;
 
@@ -85,18 +93,21 @@ public class ClockerDynamicLocationPatternTest extends BrooklynAppUnitTestSuppor
         
         String infraLocSpec = infra.sensors().get(StubInfrastructure.LOCATION_SPEC);
         String infraLocName = infra.sensors().get(StubInfrastructure.LOCATION_NAME);
-        StubInfrastructureLocation infraLoc = (StubInfrastructureLocation) mgmt.getLocationRegistry().resolve(infraLocSpec);
-        StubInfrastructureLocation infraLoc2 = (StubInfrastructureLocation) mgmt.getLocationRegistry().resolve(infraLocName);
+        StubInfrastructureLocation infraLoc = (StubInfrastructureLocation) mgmt.getLocationRegistry().getLocationManaged(infraLocSpec);
+        StubInfrastructureLocation infraLoc2 = (StubInfrastructureLocation) mgmt.getLocationRegistry().getLocationManaged(infraLocName);
         assertSame(infraLoc, infraLoc2);
-        
+        assertHasLocation(mgmt.getLocationRegistry().getDefinedLocations().values(), infraLocName);
+
+
         MachineLocation machine = infraLoc.obtain(ImmutableMap.of());
         
         StubHost host = (StubHost) Iterables.getOnlyElement(infra.getStubHostCluster().getMembers());
         String hostLocSpec = host.sensors().get(StubHost.LOCATION_SPEC);
         String hostLocName = host.sensors().get(StubHost.LOCATION_NAME);
-        StubHostLocation hostLoc = (StubHostLocation) mgmt.getLocationRegistry().resolve(hostLocSpec);
-        StubHostLocation hostLoc2 = (StubHostLocation) mgmt.getLocationRegistry().resolve(hostLocName);
+        StubHostLocation hostLoc = (StubHostLocation) mgmt.getLocationRegistry().getLocationManaged(hostLocSpec);
+        StubHostLocation hostLoc2 = (StubHostLocation) mgmt.getLocationRegistry().getLocationManaged(hostLocName);
         assertSame(hostLoc, hostLoc2);
+        assertHasLocation(mgmt.getLocationRegistry().getDefinedLocations().values(), hostLocName);
 
         StubContainer container = (StubContainer) Iterables.getOnlyElement(host.getDockerContainerCluster().getMembers());
         StubContainerLocation containerLoc = container.getDynamicLocation();
@@ -106,5 +117,64 @@ public class ClockerDynamicLocationPatternTest extends BrooklynAppUnitTestSuppor
         infraLoc.release(machine);
         assertFalse(Entities.isManaged(container));
         assertFalse(Locations.isManaged(containerLoc));
+    }
+    
+    @Test
+    public void testThroughLocationRegistryAfterReloadProperties() throws Exception {
+        StubInfrastructure infra = mgmt.getEntityManager().createEntity(EntitySpec.create(StubInfrastructure.class)
+                .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, shouldSkipOnBoxBaseDirResolution()));
+        infra.start(ImmutableList.of(loc));
+        
+        String infraLocSpec = infra.sensors().get(StubInfrastructure.LOCATION_SPEC);
+        String infraLocName = infra.sensors().get(StubInfrastructure.LOCATION_NAME);
+        
+        StubHost host = (StubHost) Iterables.getOnlyElement(infra.getStubHostCluster().getMembers());
+        String hostLocSpec = host.sensors().get(StubHost.LOCATION_SPEC);
+        String hostLocName = host.sensors().get(StubHost.LOCATION_NAME);
+
+        // Force a reload of brooklyn.properties (causes location-registry to be repopulated from scratch) 
+        mgmt.reloadBrooklynProperties();
+
+        // Should still be listed
+        assertHasLocation(mgmt.getLocationRegistry().getDefinedLocations().values(), infraLocName);
+        assertHasLocation(mgmt.getLocationRegistry().getDefinedLocations().values(), hostLocName);
+
+        // We are willing to re-register our resolver, because in real-life we'd register it through 
+        // services in META-INF.
+        ((BasicLocationRegistry)mgmt.getLocationRegistry()).registerResolver(new StubResolver());
+        LOG.info("Locations to look up: infraLocSpec="+infraLocSpec+"; infraLocName="+infraLocName+"; hostLocSpec="+hostLocSpec+"; hostLocName="+hostLocName);
+
+        // Confirm can still load infra-location
+        StubInfrastructureLocation infraLoc = (StubInfrastructureLocation) mgmt.getLocationRegistry().getLocationManaged(infraLocSpec);
+        StubInfrastructureLocation infraLoc2 = (StubInfrastructureLocation) mgmt.getLocationRegistry().getLocationManaged(infraLocName);
+        assertNotNull(infraLoc);
+        assertSame(infraLoc, infraLoc2);
+        
+        // Confirm can still load host-location
+        StubHostLocation hostLoc = (StubHostLocation) mgmt.getLocationRegistry().getLocationManaged(hostLocSpec);
+        StubHostLocation hostLoc2 = (StubHostLocation) mgmt.getLocationRegistry().getLocationManaged(hostLocName);
+        assertNotNull(hostLoc);
+        assertSame(hostLoc, hostLoc2);
+
+        // Confirm can still use infra-loc (to obtain a machine)
+        MachineLocation machine = infraLoc.obtain(ImmutableMap.of());
+        
+        StubContainer container = (StubContainer) Iterables.getOnlyElement(host.getDockerContainerCluster().getMembers());
+        StubContainerLocation containerLoc = container.getDynamicLocation();
+        assertEquals(containerLoc, machine);
+        assertEquals(Iterables.getOnlyElement(hostLoc.getChildren()), machine);
+        
+        infraLoc.release(machine);
+        assertFalse(Entities.isManaged(container));
+        assertFalse(Locations.isManaged(containerLoc));
+    }
+
+    private void assertHasLocation(Iterable<? extends LocationDefinition> locs, String expectedName) {
+        for (LocationDefinition loc : locs) {
+            if (expectedName.equals(loc.getName())) {
+                return;
+            }
+        }
+        fail("No location named '"+expectedName+"' in "+locs);
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
@@ -68,9 +68,17 @@ public class StubHostLocation extends AbstractLocation implements MachineProvisi
     @Override
     public void init() {
         super.init();
-        dockerHost = (StubHost) checkNotNull(getConfig(OWNER), "owner");
-        machine = (SshMachineLocation) checkNotNull(getConfig(MACHINE), "machine");
-        addReloadListener();
+        
+        // TODO BasicLocationRebindsupport.addCustoms currently calls init() unfortunately!
+        // Don't checkNotNull in that situation - it could be this location is orphaned!
+        if (isRebinding()) {
+            dockerHost = (StubHost) config().get(OWNER);
+            machine = config().get(MACHINE);
+        } else {
+            dockerHost = (StubHost) checkNotNull(getConfig(OWNER), "owner");
+            machine = (SshMachineLocation) checkNotNull(getConfig(MACHINE), "machine");
+            addReloadListener();
+        }
     }
     
     @Override

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.location.NoMachinesAvailableException;
+import org.apache.brooklyn.api.mgmt.ManagementContext.PropertiesReloadListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
@@ -69,6 +70,7 @@ public class StubHostLocation extends AbstractLocation implements MachineProvisi
         super.init();
         dockerHost = (StubHost) checkNotNull(getConfig(OWNER), "owner");
         machine = (SshMachineLocation) checkNotNull(getConfig(MACHINE), "machine");
+        addReloadListener();
     }
     
     @Override
@@ -81,6 +83,15 @@ public class StubHostLocation extends AbstractLocation implements MachineProvisi
         if (getConfig(LOCATION_NAME) != null) {
             register();
         }
+        addReloadListener();
+    }
+
+    @SuppressWarnings("serial")
+    private void addReloadListener() {
+        getManagementContext().addPropertiesReloadListener(new PropertiesReloadListener() {
+            @Override public void reloaded() {
+                register();
+            }});
     }
 
     @Override

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubInfrastructureLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubInfrastructureLocation.java
@@ -63,8 +63,15 @@ public class StubInfrastructureLocation extends AbstractLocation implements Mach
     @Override
     public void init() {
         super.init();
-        infrastructure = (StubInfrastructure) checkNotNull(getConfig(OWNER), "owner");
-        addReloadListener();
+        
+        // TODO BasicLocationRebindsupport.addCustoms currently calls init() unfortunately!
+        // Don't checkNotNull in that situation - it could be this location is orphaned!
+        if (isRebinding()) {
+            infrastructure = (StubInfrastructure) getConfig(OWNER);
+        } else {
+            infrastructure = (StubInfrastructure) checkNotNull(getConfig(OWNER), "owner");
+            addReloadListener();
+        }
     }
     
     @Override

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubInfrastructureLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubInfrastructureLocation.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.location.NoMachinesAvailableException;
+import org.apache.brooklyn.api.mgmt.ManagementContext.PropertiesReloadListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocation;
@@ -63,6 +64,7 @@ public class StubInfrastructureLocation extends AbstractLocation implements Mach
     public void init() {
         super.init();
         infrastructure = (StubInfrastructure) checkNotNull(getConfig(OWNER), "owner");
+        addReloadListener();
     }
     
     @Override
@@ -74,6 +76,15 @@ public class StubInfrastructureLocation extends AbstractLocation implements Mach
         if (getConfig(LOCATION_NAME) != null) {
             register();
         }
+        addReloadListener();
+    }
+
+    @SuppressWarnings("serial")
+    private void addReloadListener() {
+        getManagementContext().addPropertiesReloadListener(new PropertiesReloadListener() {
+            @Override public void reloaded() {
+                register();
+            }});
     }
 
     @Override


### PR DESCRIPTION
See https://github.com/brooklyncentral/clocker/issues/290

This PR is testing how to fix that in Brooklyn, and to ensure that we continue to support that use-case in clocker.

Note the second commit (update for checkNotNull on rebind) is just to bring this code up-to-date with how Clocker actually does it. It is the first commit that is actually interesting here.

@grkvlt please review.