### PR TITLE
Fix/required open ports

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
@@ -27,13 +27,13 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
@@ -82,7 +82,7 @@ public class InboundPortsUtils {
             Set<ConfigKey<?>> configKeys = Sets.newHashSet(extraConfigKeys);
             configKeys.addAll(entity.getEntityType().getConfigKeys());
             // Also add dynamically added config keys
-            Map<ConfigKey<?>, ?> configuredConfigKeys = ImmutableMap.copyOf(((EntityInternal) entity).config().getBag().getAllConfigAsConfigKeyMap());
+            Map<ConfigKey<?>, ?> configuredConfigKeys = MutableMap.copyOf(((EntityInternal) entity).config().getBag().getAllConfigAsConfigKeyMap());
             configKeys.addAll(configuredConfigKeys.keySet());
 
             if (portRegex == null) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/InboundPortsUtils.java
@@ -91,7 +91,8 @@ public class InboundPortsUtils {
 
             Pattern portsPattern = Pattern.compile(portRegex);
             for (ConfigKey<?> k : configKeys) {
-                if (isAssignableFromPortConfigKey(configuredConfigKeys, k, portsPattern)) {
+                if (isAssignableFromPortConfigKey(configuredConfigKeys, k)
+                        || (portsPattern.matcher(k.getName()).matches())) {
                     Object value = entity.config().get(k);
                     Maybe<PortRange> maybePortRange = TypeCoercions.tryCoerce(value, new TypeToken<PortRange>() {
                     });
@@ -111,17 +112,13 @@ public class InboundPortsUtils {
     /**
      * Checks if a configkey can be managed as a config key {@link PortRange}. The method checks if
      * the config type or the entity config key value are assignable from the {@link PortRange}.
-     * Moreover the method retrieves true if the config key name matches with pattern.
      *
      * @param configuredConfigKeys the configured entity config keys
      * @param configKey            the configkey that could be assigned as a {@link org.apache.brooklyn.api.location.PortRange}
-     * @param portsPattern         pattern to recognized Config key {@link org.apache.brooklyn.api.location.PortRange} of the name   @return if the config key is recognized as a config key {@link PortRange}
      */
-    private static boolean isAssignableFromPortConfigKey(Map<ConfigKey<?>, ?> configuredConfigKeys, ConfigKey<?> configKey, Pattern portsPattern) {
-        Object a = configuredConfigKeys.get(configKey);
+    private static boolean isAssignableFromPortConfigKey(Map<ConfigKey<?>, ?> configuredConfigKeys, ConfigKey<?> configKey) {
         return PortRange.class.isAssignableFrom(configKey.getType())
-                || (portsPattern.matcher(configKey.getName()).matches())
-                || (a != null) && (a instanceof PortRange);
+                || configuredConfigKeys.get(configKey) instanceof PortRange;
     }
 
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
@@ -19,99 +19,111 @@
 package org.apache.brooklyn.entity.brooklynnode;
 
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolver;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
+import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 public class BrooklynNodeTest {
 
+    private static final Logger log = LoggerFactory.getLogger(BrooklynNodeTest.class);
+
     // TODO Need test for copying/setting classpath
-    
+
     private TestApplication app;
     private SshMachineLocation loc;
-    
+
     public static class SlowStopBrooklynNode extends BrooklynNodeImpl {
-        public SlowStopBrooklynNode() {}
-        
+        public SlowStopBrooklynNode() {
+        }
+
         @Override
         protected void postStop() {
             super.postStop();
-            
+
             //Make sure UnmanageTask will wait for the STOP effector to complete.
             Time.sleep(Duration.FIVE_SECONDS);
         }
-        
+
     }
 
-    @BeforeMethod(alwaysRun=true)
+    @BeforeMethod(alwaysRun = true)
     public void setUp() throws Exception {
         app = TestApplication.Factory.newManagedInstanceForTests();
         loc = new SshMachineLocation(MutableMap.of("address", "localhost"));
     }
 
-    @AfterMethod(alwaysRun=true)
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws Exception {
         if (app != null) Entities.destroyAll(app.getManagementContext());
     }
-    
+
     @Test
     public void testGeneratesCorrectSnapshotDownload() throws Exception {
         String version = "0.0.1-SNAPSHOT";
-        String expectedUrl = "https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&v="+version+"&a=brooklyn-dist&c=dist&e=tar.gz";
+        String expectedUrl = "https://repository.apache.org/service/local/artifact/maven/redirect?r=snapshots&g=org.apache.brooklyn&v=" + version + "&a=brooklyn-dist&c=dist&e=tar.gz";
         runTestGeneratesCorrectDownloadUrl(version, expectedUrl);
     }
-    
+
     @Test
     public void testGeneratesCorrectReleaseDownload() throws Exception {
         String version = "0.0.1";
-        String expectedUrl = "http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/brooklyn-dist/"+version+"/brooklyn-dist-"+version+"-dist.tar.gz";
+        String expectedUrl = "http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/brooklyn-dist/" + version + "/brooklyn-dist-" + version + "-dist.tar.gz";
         runTestGeneratesCorrectDownloadUrl(version, expectedUrl);
     }
-    
+
     private void runTestGeneratesCorrectDownloadUrl(String version, String expectedUrl) throws Exception {
         // TODO Using BrooklynNodeImpl directly, because want to instantiate a BroolynNodeSshDriver.
         //      Really want to make that easier to test, without going through "wrong" code path for creating entity.
         BrooklynNode entity = app.addChild(EntitySpec.create(BrooklynNode.class)
                 .configure(BrooklynNode.SUGGESTED_VERSION, version));
         BrooklynNodeImpl entityImpl = (BrooklynNodeImpl) Entities.deproxy(entity);
-        
-        ConfigToAttributes.apply((EntityLocal)entity);
+
+        ConfigToAttributes.apply((EntityLocal) entity);
         BrooklynNodeSshDriver driver = new BrooklynNodeSshDriver(entityImpl, loc);
-        
+
         DownloadResolver resolver = Entities.newDownloader(driver);
         List<String> urls = resolver.getTargets();
-        
-        System.out.println("urls="+urls);
-        assertTrue(urls.contains(expectedUrl), "urls="+urls);
+
+        System.out.println("urls=" + urls);
+        assertTrue(urls.contains(expectedUrl), "urls=" + urls);
     }
-    
+
     @Test(groups = "Integration")
     public void testUnmanageOnStop() throws Exception {
         final BrooklynNode node = app.addChild(EntitySpec.create(BrooklynNode.class).impl(SlowStopBrooklynNode.class));
         assertTrue(Entities.isManaged(node), "Entity " + node + " must be managed.");
-        node.invoke(Startable.STOP, ImmutableMap.<String,Object>of()).asTask().getUnchecked();
+        node.invoke(Startable.STOP, ImmutableMap.<String, Object>of()).asTask().getUnchecked();
         //The UnmanageTask will unblock after the STOP effector completes, so we are competing with it here.
         Asserts.succeedsEventually(new Runnable() {
             @Override
@@ -120,7 +132,7 @@ public class BrooklynNodeTest {
             }
         });
     }
-    
+
 
     @Test
     public void testCanStartSameNode() throws Exception {
@@ -128,10 +140,50 @@ public class BrooklynNodeTest {
         // but test BrooklynNodeRestTest in downstream project does
         BrooklynNode bn = app.createAndManageChild(EntitySpec.create(BrooklynNode.class, SameBrooklynNodeImpl.class));
         bn.start(MutableSet.<Location>of());
-        
-        Assert.assertEquals(bn.getAttribute(Attributes.SERVICE_UP), (Boolean)true);
+
+        Assert.assertEquals(bn.getAttribute(Attributes.SERVICE_UP), (Boolean) true);
         // no URI
         Assert.assertNull(bn.getAttribute(BrooklynNode.WEB_CONSOLE_URI));
+    }
+
+    @Test(groups = "Integration")
+    public void testOpenHttpConsoleWebPort() throws Exception {
+
+        BrooklynNodeWitOpenedPorts brooklynNode = app.createAndManageChild(
+                EntitySpec.create(BrooklynNodeWitOpenedPorts.class)
+                        .configure(BrooklynNode.ON_EXISTING_PROPERTIES_FILE, BrooklynNode.ExistingFileBehaviour.DO_NOT_USE)
+                        .configure(BrooklynNode.NO_WEB_CONSOLE_AUTHENTICATION, true)
+                        .configure(BrooklynNode.HTTP_PORT, PortRanges.fromString("8082+")));
+
+        app.start(ImmutableList.of(loc));
+        assertNotNull(app);
+
+        log.info("started " + app + " containing " + brooklynNode + " for " + JavaClassNames.niceClassAndMethod());
+
+        //EntityTestUtils.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
+        assertTrue(brooklynNode.getRequiredOpenPorts().contains(8082));
+
+        brooklynNode.stop();
+        EntityAsserts.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
+    }
+
+    @ImplementedBy(BrooklynNodeWitOpenedPortsImpl.class)
+    public interface BrooklynNodeWitOpenedPorts extends BrooklynNode {
+
+        public Collection<Integer> getRequiredOpenPorts();
+    }
+
+    public static class BrooklynNodeWitOpenedPortsImpl extends BrooklynNodeImpl
+            implements BrooklynNodeWitOpenedPorts {
+
+        public BrooklynNodeWitOpenedPortsImpl() {
+            super();
+        }
+
+        public Collection<Integer> getRequiredOpenPorts() {
+            return super.getRequiredOpenPorts();
+        }
     }
 
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
@@ -149,8 +149,8 @@ public class BrooklynNodeTest {
     @Test(groups = "Integration")
     public void testOpenHttpConsoleWebPort() throws Exception {
 
-        BrooklynNodeWitOpenedPorts brooklynNode = app.createAndManageChild(
-                EntitySpec.create(BrooklynNodeWitOpenedPorts.class)
+        BrooklynNodeWithOpenedPorts brooklynNode = app.createAndManageChild(
+                EntitySpec.create(BrooklynNodeWithOpenedPorts.class)
                         .configure(BrooklynNode.ON_EXISTING_PROPERTIES_FILE, BrooklynNode.ExistingFileBehaviour.DO_NOT_USE)
                         .configure(BrooklynNode.NO_WEB_CONSOLE_AUTHENTICATION, true)
                         .configure(BrooklynNode.HTTP_PORT, PortRanges.fromString("8082+")));
@@ -160,7 +160,6 @@ public class BrooklynNodeTest {
 
         log.info("started " + app + " containing " + brooklynNode + " for " + JavaClassNames.niceClassAndMethod());
 
-        //EntityTestUtils.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
         EntityAsserts.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
         assertTrue(brooklynNode.getRequiredOpenPorts().contains(8082));
 
@@ -168,16 +167,16 @@ public class BrooklynNodeTest {
         EntityAsserts.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
     }
 
-    @ImplementedBy(BrooklynNodeWitOpenedPortsImpl.class)
-    public interface BrooklynNodeWitOpenedPorts extends BrooklynNode {
+    @ImplementedBy(BrooklynNodeWithOpenedPortsImpl.class)
+    public interface BrooklynNodeWithOpenedPorts extends BrooklynNode {
 
         public Collection<Integer> getRequiredOpenPorts();
     }
 
-    public static class BrooklynNodeWitOpenedPortsImpl extends BrooklynNodeImpl
-            implements BrooklynNodeWitOpenedPorts {
+    public static class BrooklynNodeWithOpenedPortsImpl extends BrooklynNodeImpl
+            implements BrooklynNodeWithOpenedPorts {
 
-        public BrooklynNodeWitOpenedPortsImpl() {
+        public BrooklynNodeWithOpenedPortsImpl() {
             super();
         }
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/InboundPortsUtilsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/InboundPortsUtilsTest.java
@@ -21,18 +21,14 @@ package org.apache.brooklyn.entity.software.base;
 import java.util.Collection;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.location.PortRanges;
+import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -50,4 +46,23 @@ public class InboundPortsUtilsTest extends BrooklynAppUnitTestSupport {
         Collection<Integer> dynamicRequiredOpenPorts = InboundPortsUtils.getRequiredOpenPorts(entity, ImmutableSet.<ConfigKey<?>>of(), true, null);
         Assert.assertEquals(dynamicRequiredOpenPorts, ImmutableSet.of(9999), "Expected new port to be added");
     }
+
+    @Test
+    public void testGetRequiredOpenPortsGetsDynamicallyAddedPortBasedKeys() {
+        TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+
+        PortAttributeSensorAndConfigKey newTestConfigKeyPort = ConfigKeys.newPortSensorAndConfigKey("new.test.config.port.string.first", "port", "7777+");
+        PortAttributeSensorAndConfigKey newTestConfigKeyPort2 = ConfigKeys.newPortSensorAndConfigKey("new.test.config.port.string.second", "port");
+
+        ConfigKey<String> newTestConfigKeyString = ConfigKeys.newStringConfigKey("new.test.config.key.string");
+        entity.config().set(newTestConfigKeyPort, PortRanges.fromString("8888+"));
+        entity.config().set(newTestConfigKeyPort2, PortRanges.fromInteger(9999));
+        entity.config().set(newTestConfigKeyString, "foo.bar");
+
+        Collection<Integer> dynamicRequiredOpenPorts = InboundPortsUtils.getRequiredOpenPorts(entity, ImmutableSet.<ConfigKey<?>>of(), true, null);
+        Assert.assertTrue(dynamicRequiredOpenPorts.contains(8888));
+        Assert.assertTrue(dynamicRequiredOpenPorts.contains(9999));
+    }
+
+
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/InboundPortsUtilsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/InboundPortsUtilsTest.java
@@ -54,14 +54,17 @@ public class InboundPortsUtilsTest extends BrooklynAppUnitTestSupport {
         PortAttributeSensorAndConfigKey newTestConfigKeyPort = ConfigKeys.newPortSensorAndConfigKey("new.test.config.port.string.first", "port", "7777+");
         PortAttributeSensorAndConfigKey newTestConfigKeyPort2 = ConfigKeys.newPortSensorAndConfigKey("new.test.config.port.string.second", "port");
 
+        ConfigKey<Object> newTestConfigKeyObject = ConfigKeys.newConfigKey(Object.class, "new.test.config.object");
         ConfigKey<String> newTestConfigKeyString = ConfigKeys.newStringConfigKey("new.test.config.key.string");
         entity.config().set(newTestConfigKeyPort, PortRanges.fromString("8888+"));
         entity.config().set(newTestConfigKeyPort2, PortRanges.fromInteger(9999));
+        entity.config().set(newTestConfigKeyObject, PortRanges.fromInteger(2222));
         entity.config().set(newTestConfigKeyString, "foo.bar");
 
         Collection<Integer> dynamicRequiredOpenPorts = InboundPortsUtils.getRequiredOpenPorts(entity, ImmutableSet.<ConfigKey<?>>of(), true, null);
         Assert.assertTrue(dynamicRequiredOpenPorts.contains(8888));
         Assert.assertTrue(dynamicRequiredOpenPorts.contains(9999));
+        Assert.assertTrue(dynamicRequiredOpenPorts.contains(2222));
     }
 
 


### PR DESCRIPTION
This PR tries to fix the issue described by issue [BROOKLYN-263](  https://issues.apache.org/jira/browse/BROOKLYN-263).

`BrooklynNode` requires `brooklynnode.webconsole.httpPort` config key as a open port. However, the config was not being considered as a open port, because `InboundPortsUtils#getRequiredOpenPorts` just consideres either config keys whose name matches with `*.port` or config keys that are based on `PortRanges` and that are not configured (using default values).

This PR adds to `InboundPortsUtils#getRequiredOpenPorts` the capability to take in account explicit configured config keys that are based on `PortRanges`.