### PR TITLE
FOR REVIEW: easier access for entity config by name (not ConfigKey)

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -112,6 +112,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 
 /**
  * Default {@link Entity} implementation, which should be extended whenever implementing an entity.
@@ -1174,6 +1175,14 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     @Beta
     // TODO revert to private when config() is reverted to return ConfigurationSupportInternal
     public class BasicConfigurationSupport extends AbstractConfigurationSupportInternal {
+
+        public <T> T get(String key, Class<T> targetType) {
+            return getBag().get(key, targetType);
+        }
+
+        public <T> T get(String key, TypeToken<T> targetType) {
+            return getBag().get(key, targetType);
+        }
 
         @Override
         public <T> T get(ConfigKey<T> key) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
 import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
 
 /**
  * Stores config in such a way that usage can be tracked.
@@ -336,6 +337,16 @@ public class ConfigBag {
 
     public synchronized boolean containsKey(String key) {
         return config.containsKey(key);
+    }
+
+    public <T> T get(String key, Class<T> targetType) {
+        return get(key, TypeToken.of(targetType));
+    }
+
+    public <T> T get(String key, TypeToken<T> targetType) {
+        markUsed(key);
+        Object rawValue = config.get(key);
+        return TypeCoercions.coerce(rawValue, targetType);
     }
 
     /** returns the value of this config key, falling back to its default (use containsKey to see whether it was contained);

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -56,6 +56,7 @@ import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -138,6 +139,9 @@ public class TypeCoercions {
     @SuppressWarnings({ "unchecked" })
     public static <T> T coerce(Object value, TypeToken<T> targetTypeToken) {
         if (value==null) return null;
+        if (value instanceof DeferredSupplier<?>) {
+            value = ((DeferredSupplier<?>) value).get();
+        }
         Class<? super T> targetType = targetTypeToken.getRawType();
 
         //recursive coercion of parameterized collections and map entries


### PR DESCRIPTION
* Inspired by several sightings of client code downcasting `Entity` to `EntityInternal` just for the purpose of accessing the raw config map with simple string keys.
* Ensures that appropriate type coersions are performed on the returned result, including resolution of `DeferredSupplier` values.
* IMO, "ad-hod" config (i.e. named entries in the `brooklyn.config` clause that do not correspond to explicit `ConfigKey` declarations) is extremely useful, especially for customising the behaviour of stock entities without subclassing.

Comments welcome!