### PR TITLE
Updating deprecated EntityTestUtils to EntityAsserts

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/entity/DependentConfigurationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/DependentConfigurationTest.java
@@ -39,7 +39,6 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.BasicTask;
@@ -325,7 +324,7 @@ public class DependentConfigurationTest extends BrooklynAppUnitTestSupport {
                 .build());
 
         ServiceStateLogic.setExpectedState(entity, Lifecycle.ON_FIRE);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         
         try {
             assertDoneEventually(t);
@@ -349,7 +348,7 @@ public class DependentConfigurationTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testAttributeWhenReadyAbortsWhenAlreadyOnFireByDefault() throws Exception {
         ServiceStateLogic.setExpectedState(entity, Lifecycle.ON_FIRE);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         
         final Task<String> t = submit(DependentConfiguration.builder()
                 .attributeWhenReady(entity, TestEntity.NAME)

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.location.SimulatedLocation;
@@ -46,7 +47,6 @@ import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.text.Identifiers;
@@ -93,7 +93,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         TestEntity newEntity = (TestEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(TestEntity.class));
 
         newEntity.sensors().set(METRIC1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, METRIC1, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(newApp, METRIC1, "myval");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         TestEntity newEntity = (TestEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(TestEntity.class));
 
         newEntity.sensors().set(METRIC1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, METRIC1, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(newApp, METRIC1, "myval");
     }
 
     @Test
@@ -121,7 +121,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         TestEntity newEntity = (TestEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(TestEntity.class));
 
         newEntity.sensors().set(METRIC1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, METRIC2, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(newApp, METRIC2, "myval");
     }
 
     @SuppressWarnings("unchecked")
@@ -139,7 +139,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
 
         newEntity.sensors().set(METRIC1, "myval");
         newEntity.sensors().set(METRIC2, "myval2");
-        EntityTestUtils.assertAttributeEventually(newApp, METRIC2, Predicates.or(Predicates.equalTo("myval,myval2"), Predicates.equalTo("myval2,myval")));
+        EntityAsserts.assertAttributeEventually(newApp, METRIC2, Predicates.or(Predicates.equalTo("myval,myval2"), Predicates.equalTo("myval2,myval")));
     }
 
     @Test
@@ -162,7 +162,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         for (Entity member : newCluster.getMembers()) {
             ((EntityInternal)member).sensors().set(METRIC1, "myval"+(i++));
         }
-        EntityTestUtils.assertAttributeEventually(newApp, METRIC2, Predicates.or(Predicates.equalTo("myval1,myval2"), Predicates.equalTo("myval2,myval1")));
+        EntityAsserts.assertAttributeEventually(newApp, METRIC2, Predicates.or(Predicates.equalTo("myval1,myval2"), Predicates.equalTo("myval2,myval1")));
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.brooklyn.core.mgmt.rebind;
 
-import static org.apache.brooklyn.test.EntityTestUtils.assertAttributeEquals;
-import static org.apache.brooklyn.test.EntityTestUtils.assertConfigEquals;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -56,6 +54,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.entity.trait.Resizable;
 import org.apache.brooklyn.core.entity.trait.Startable;
@@ -261,9 +260,9 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         newApp = rebind();
         MyEntityReffingOthers newE = (MyEntityReffingOthers) Iterables.find(newApp.getChildren(), Predicates.instanceOf(MyEntityReffingOthers.class));
         MyEntity newOtherE = (MyEntity) Iterables.find(newApp.getChildren(), Predicates.instanceOf(MyEntity.class));
-        
-        assertAttributeEquals(newE, MyEntityReffingOthers.ENTITY_REF_SENSOR, newOtherE);
-        assertConfigEquals(newE, MyEntityReffingOthers.ENTITY_REF_CONFIG, newOtherE);
+
+        EntityAsserts.assertAttributeEquals(newE, MyEntityReffingOthers.ENTITY_REF_SENSOR, newOtherE);
+        EntityAsserts.assertConfigEquals(newE, MyEntityReffingOthers.ENTITY_REF_CONFIG, newOtherE);
     }
     
     @Test
@@ -348,9 +347,9 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         newApp = rebind();
         MyEntityReffingOthers newE = (MyEntityReffingOthers) Iterables.find(newApp.getChildren(), Predicates.instanceOf(MyEntityReffingOthers.class));
         MyLocation newLoc = (MyLocation) Iterables.getOnlyElement(newApp.getLocations());
-        
-        assertAttributeEquals(newE, MyEntityReffingOthers.LOCATION_REF_SENSOR, newLoc);
-        assertConfigEquals(newE, MyEntityReffingOthers.LOCATION_REF_CONFIG, newLoc);
+
+        EntityAsserts.assertAttributeEquals(newE, MyEntityReffingOthers.LOCATION_REF_SENSOR, newLoc);
+        EntityAsserts.assertConfigEquals(newE, MyEntityReffingOthers.LOCATION_REF_CONFIG, newLoc);
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedTest.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.internal.BrooklynGarbageCollector;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -44,7 +45,6 @@ import org.apache.brooklyn.feed.ssh.SshFeed;
 import org.apache.brooklyn.feed.ssh.SshPollConfig;
 import org.apache.brooklyn.feed.ssh.SshValueFunctions;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
@@ -105,8 +105,8 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
     public void testHttpFeedRegisteredInInitIsPersistedAndFeedsStop() throws Exception {
         TestEntity origEntity = origApp.createAndManageChild(EntitySpec.create(TestEntity.class).impl(MyEntityWithHttpFeedImpl.class)
                 .configure(MyEntityWithHttpFeedImpl.BASE_URL, baseUrl));
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)200);
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)200);
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
         assertEquals(origEntity.feeds().getFeeds().size(), 1);
 
         final long taskCountBefore = ((BasicExecutionManager)origManagementContext.getExecutionManager()).getNumIncompleteTasks();
@@ -124,8 +124,8 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
         // Expect the feed to still be polling
         newEntity.sensors().set(SENSOR_INT, null);
         newEntity.sensors().set(SENSOR_STRING, null);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)200);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)200);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
         
         // Now test that everything in the origApp stops, including feeds
         Entities.unmanage(origApp);
@@ -143,7 +143,7 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
     @Test
     public void testFunctionFeedRegisteredInInitIsPersisted() throws Exception {
         TestEntity origEntity = origApp.createAndManageChild(EntitySpec.create(TestEntity.class).impl(MyEntityWithFunctionFeedImpl.class));
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)1);
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer) 1);
         assertEquals(origEntity.feeds().getFeeds().size(), 2);
 
         newApp = rebind();
@@ -154,7 +154,7 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
         
         // Expect the feed to still be polling
         newEntity.sensors().set(SENSOR_INT, null);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)1);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)1);
     }
     
     @Test(groups="Integration")
@@ -167,7 +167,7 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
         
         origApp.start(ImmutableList.<Location>of());
 
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)0);
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)0);
         assertEquals(origEntity.feeds().getFeeds().size(), 1);
 
         newApp = rebind();
@@ -178,7 +178,7 @@ public class RebindFeedTest extends RebindTestFixtureWithApp {
         
         // Expect the feed to still be polling
         newEntity.sensors().set(SENSOR_INT, null);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)0);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)0);
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
@@ -30,10 +30,10 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Feed;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
 import org.apache.brooklyn.util.repeat.Repeater;
@@ -87,8 +87,8 @@ public class RebindFeedWithHaTest extends RebindTestFixtureWithApp {
     public void testHttpFeedCleansUpAfterHaDisabledAndRunsAtFailover() throws Exception {
         TestEntity origEntity = origApp.createAndManageChild(EntitySpec.create(TestEntity.class).impl(RebindFeedTest.MyEntityWithHttpFeedImpl.class)
                 .configure(RebindFeedTest.MyEntityWithHttpFeedImpl.BASE_URL, baseUrl));
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer)200);
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_INT, (Integer) 200);
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
         assertEquals(origEntity.feeds().getFeeds().size(), 1);
         origManagementContext.getRebindManager().forcePersistNow();
 
@@ -119,8 +119,8 @@ public class RebindFeedWithHaTest extends RebindTestFixtureWithApp {
         // Expect the feed to still be polling
         newEntity.sensors().set(SENSOR_INT, null);
         newEntity.sensors().set(SENSOR_STRING, null);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)200);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_INT, (Integer)200);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
     }
 
     @Test(groups="Integration", invocationCount=50)

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/CustomAggregatingEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/CustomAggregatingEnricherTest.java
@@ -25,13 +25,12 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.group.BasicGroup;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +75,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .computingSum()
                 .fromChildren()
                 .build());
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
     }
 
     @Test
@@ -89,7 +88,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .defaultValueForUnreportedSensors(11)
                 .valueToReportIfNoSensors(40)
                 .build());
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 40);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 40);
     }
 
     @Test
@@ -102,7 +101,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .defaultValueForUnreportedSensors(11)
                 .valueToReportIfNoSensors(40)
                 .build());
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 11);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 11);
     }
 
     @Test
@@ -113,7 +112,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .computingSum()
                 .fromHardcodedProducers(ImmutableList.of(entity))
                 .build());
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
     }
 
     @Test
@@ -124,7 +123,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .computingSum()
                 .fromHardcodedProducers(ImmutableList.of(entity))
                 .build());
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
     }
     
     @Test
@@ -137,7 +136,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
         entity.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
     }
     
     @Test
@@ -150,7 +149,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
         entity.sensors().set(intSensor, null);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, null);
     }
     
     @Test
@@ -164,16 +163,16 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(5)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 3);
         
         entity.sensors().set(intSensor, null);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, 3);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, target, 3);
         
         entity.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
         
         entity.sensors().set(intSensor, 7);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 7);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 7);
     }
     
     @Test
@@ -190,13 +189,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
         producer3.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
 
         producer1.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 3);
 
         producer2.sensors().set(intSensor, 4);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 7);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 7);
     }
     
     @Test
@@ -210,10 +209,10 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .fromHardcodedProducers(ImmutableList.of(producer1))
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
         
         producer1.sensors().set(intSensor, null);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
     }
 
     @Test
@@ -229,13 +228,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(5)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
         
         producer1.sensors().set(intSensor, null);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, 3d);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, 3d);
         
         producer1.sensors().set(intSensor, 4);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 4d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 4d);
     }
 
     @Test
@@ -249,7 +248,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(5)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 5d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 5d);
     }
 
     @Test
@@ -261,7 +260,7 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .fromChildren()
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
     }
 
     @Test
@@ -277,19 +276,19 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .fromHardcodedProducers(ImmutableList.of(producer1, producer2, producer3))
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 50), entity, doubleSensor, null);
 
         producer1.sensors().set(intSensor, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
         
         producer2.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 2d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 2d);
 
         producer3.sensors().set(intSensor, 5);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
 
         producer2.sensors().set(intSensor, 4);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 4d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 4d);
     }
     
     @Test
@@ -307,16 +306,16 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(0)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 0d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 0d);
 
         producer1.sensors().set(intSensor, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 1d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 1d);
 
         producer2.sensors().set(intSensor, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 2d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 2d);
 
         producer3.sensors().set(intSensor, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(entity, doubleSensor, 3d);
     }
     
     @Test
@@ -335,18 +334,18 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(0)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 0);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 0);
 
         group.addMember(p1);
         p1.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 1);
 
         group.addMember(p2);
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 3);
 
         group.removeMember(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 1);
     }
     
     @Test(groups = "Integration", invocationCount=50)
@@ -371,13 +370,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
 
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 1);
 
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 3);
         
         group.removeMember(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 1);
     }
     
     @Test
@@ -398,13 +397,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
 
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 1);
 
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 3);
         
         group.removeMember(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 1);
     }
     
     @Test
@@ -427,10 +426,10 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .entityFilter(Predicates.equalTo((Entity)p1))
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(group, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, target, 1);
         
         group.addMember(p3);
-        EntityTestUtils.assertAttributeEqualsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), group, target, 1);
+        EntityAsserts.assertAttributeEqualsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), group, target, 1);
     }
     
     @Test
@@ -444,18 +443,18 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .valueToReportIfNoSensors(0)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 0);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 0);
 
         TestEntity p1 = entity.createAndManageChild(EntitySpec.create(TestEntity.class));
         p1.sensors().set(intSensor, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
 
         TestEntity p2 = entity.createAndManageChild(EntitySpec.create(TestEntity.class));
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 3);
 
         Entities.unmanage(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
     }
     
     @Test
@@ -472,13 +471,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
 
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 3);
         
         Entities.unmanage(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
     }
     
     @Test
@@ -495,14 +494,13 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .fromChildren()
                 .build());
 
-
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 1);
 
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 3);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 3);
         
         Entities.unmanage(p2);
-        EntityTestUtils.assertAttributeEqualsEventually(app, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(app, target, 1);
     }
     
     @Test
@@ -518,11 +516,11 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .entityFilter(Predicates.equalTo((Entity)p1))
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
         
         TestEntity p2 = entity.createAndManageChild(EntitySpec.create(TestEntity.class));
         p2.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), entity, target, 1);
+        EntityAsserts.assertAttributeEqualsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), entity, target, 1);
     }
     
     @Test
@@ -544,10 +542,10 @@ public class CustomAggregatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .defaultValueForUnreportedSensors(0)
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 1);
         
         // Event by producer
         producer1.sensors().set(intSensor, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, target, 5);
+        EntityAsserts.assertAttributeEqualsEventually(entity, target, 5);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/EnricherWithDeferredSupplierTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/EnricherWithDeferredSupplierTest.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.EffectorTasks;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.location.SimulatedLocation;
@@ -38,7 +39,6 @@ import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -76,7 +76,7 @@ public class EnricherWithDeferredSupplierTest extends BrooklynAppUnitTestSupport
                 .from(new EntityDeferredSupplier("myproducer").newTask())
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(target, sensor, 3);
+        EntityAsserts.assertAttributeEqualsEventually(target, sensor, 3);
     }
     
     // TODO This is a cut-down version of DslComponent, from the camp project

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
@@ -28,14 +28,13 @@ import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAdjuncts;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -94,7 +93,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         
         entity.sensors().set(NUM1, 2);
         entity.sensors().set(NUM2, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, NUM3, 5);
+        EntityAsserts.assertAttributeEqualsEventually(entity, NUM3, 5);
     }
     
     @Test
@@ -107,7 +106,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         
         entity.sensors().set(NUM1, 2);
         entity.sensors().set(NUM2, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, NUM3, 1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, NUM3, 1);
     }
     
     @Test(groups="Integration") // because takes a second
@@ -127,10 +126,10 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         
         entity.sensors().set(NUM1, 123);
         entity.sensors().set(NUM2, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, NUM3, 126);
+        EntityAsserts.assertAttributeEqualsEventually(entity, NUM3, 126);
         
         entity.sensors().set(NUM1, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(entity, NUM3, 126);
+        EntityAsserts.assertAttributeEqualsContinually(entity, NUM3, 126);
     }
     
     @Test
@@ -143,7 +142,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity2.sensors().set(NUM1, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, NUM1, 2);
+        EntityAsserts.assertAttributeEqualsEventually(entity, NUM1, 2);
     }
     
     @Test
@@ -155,7 +154,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity.sensors().set(STR1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR2, "myvalmysuffix");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR2, "myvalmysuffix");
     }
 
     @Test
@@ -167,7 +166,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity.sensors().set(NUM1, 123);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, LONG1, Long.valueOf(1));
+        EntityAsserts.assertAttributeEqualsEventually(entity, LONG1, Long.valueOf(1));
     }
 
     @Test
@@ -182,7 +181,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity.sensors().set(STR1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR2, "myvalmysuffix");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR2, "myvalmysuffix");
     }
 
     @Test(groups="Integration") // because takes a second
@@ -202,14 +201,14 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
 
         entity.sensors().set(STR1, "myval");
         Asserts.eventually(Suppliers.ofInstance(record), CollectionFunctionals.sizeEquals(1));
-        EntityTestUtils.assertAttributeEquals(entity, STR2, "myval");
+        EntityAsserts.assertAttributeEquals(entity, STR2, "myval");
 
         entity.sensors().set(STR1, "ignoredval");
-        EntityTestUtils.assertAttributeEqualsContinually(entity, STR2, "myval");
+        EntityAsserts.assertAttributeEqualsContinually(entity, STR2, "myval");
 
         entity.sensors().set(STR1, "myval2");
         Asserts.eventually(Suppliers.ofInstance(record), CollectionFunctionals.sizeEquals(2));
-        EntityTestUtils.assertAttributeEquals(entity, STR2, "myval2");
+        EntityAsserts.assertAttributeEquals(entity, STR2, "myval2");
 
         entity.sensors().set(STR1, "myval2");
         entity.sensors().set(STR1, "myval2");
@@ -230,12 +229,12 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
 
         entity.sensors().set(STR1, "myval");
         Asserts.eventually(Suppliers.ofInstance(record), CollectionFunctionals.sizeEquals(1));
-        EntityTestUtils.assertAttributeEquals(entity, STR2, "myval");
+        EntityAsserts.assertAttributeEquals(entity, STR2, "myval");
 
         entity.sensors().set(STR1, "myval2");
         entity.sensors().set(STR1, "myval2");
         entity.sensors().set(STR1, "myval3");
-        EntityTestUtils.assertAttributeEqualsContinually(entity, STR2, "myval3");
+        EntityAsserts.assertAttributeEqualsContinually(entity, STR2, "myval3");
         Asserts.assertThat(record.getEvents(), CollectionFunctionals.sizeEquals(3));
     }
 
@@ -247,10 +246,10 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity2.sensors().set(STR1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR1, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR1, "myval");
         
         entity2.sensors().set(STR1, null);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR1, null);
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR1, null);
     }
     
     @Test
@@ -261,7 +260,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity2.sensors().set(STR1, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR2, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR2, "myval");
     }
     
     // FIXME What is default? members? children? fail?
@@ -280,7 +279,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         child1.sensors().set(NUM1, 1);
         entity.sensors().set(NUM1, 2);
         entity2.sensors().set(NUM1, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(group, NUM2, 5);
+        EntityAsserts.assertAttributeEqualsEventually(group, NUM2, 5);
     }
     
     @Test
@@ -298,7 +297,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         entity.sensors().set(NUM1, 1);
         child1.sensors().set(NUM1, 2);
         child2.sensors().set(NUM1, 3);
-        EntityTestUtils.assertAttributeEqualsEventually(group, NUM2, 5);
+        EntityAsserts.assertAttributeEqualsEventually(group, NUM2, 5);
     }
 
     @Test
@@ -319,15 +318,15 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
         
         entity.sensors().set(STR1, "1");
         entity2.sensors().set(STR1, "2");
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("1", "2"));
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("1", "2"));
         
         entity.sensors().set(STR1, "3");
         entity2.sensors().set(STR1, null);
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("3"));
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("3"));
         
         entity.sensors().set(STR1, "");
         entity2.sensors().set(STR1, "4");
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("4"));
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of("4"));
     }
 
     @Test
@@ -345,16 +344,16 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                     }})
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of());
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of());
 
         entity.sensors().set(NUM1, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of(1));
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of(1));
         
         entity.sensors().set(NUM1, null);
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of());
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of());
         
         entity.sensors().set(NUM1, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of(2));
+        EntityAsserts.assertAttributeEqualsEventually(group, SET1, ImmutableSet.<Object>of(2));
     }
 
     @Test
@@ -368,7 +367,7 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity.sensors().set(NUM1, 123);
-        EntityTestUtils.assertAttributeEqualsEventually(group, LONG1, Long.valueOf(1));
+        EntityAsserts.assertAttributeEqualsEventually(group, LONG1, Long.valueOf(1));
     }
     
     @Test(groups="Integration") // because takes a second
@@ -389,10 +388,10 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         
         entity.sensors().set(NUM1, 123);
-        EntityTestUtils.assertAttributeEqualsEventually(group, LONG1, Long.valueOf(123));
+        EntityAsserts.assertAttributeEqualsEventually(group, LONG1, Long.valueOf(123));
         
         entity.sensors().set(NUM1, 987654);
-        EntityTestUtils.assertAttributeEqualsContinually(group, LONG1, Long.valueOf(123));
+        EntityAsserts.assertAttributeEqualsContinually(group, LONG1, Long.valueOf(123));
     }
     @Test
     public void testUpdatingMap1() {
@@ -419,14 +418,14 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
     
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected void doUpdatingMapChecks(AttributeSensor mapSensor) {
-        EntityTestUtils.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of());
+        EntityAsserts.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of());
         
         entity.sensors().set(LONG1, -1L);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of(
+        EntityAsserts.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of(
             LONG1.getName(), "-1 is not allowed"));
         
         entity.sensors().set(LONG1, 1L);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of());
+        EntityAsserts.assertAttributeEqualsEventually(entity, mapSensor, MutableMap.<String,String>of());
     }
 
     private static AttributeSensor<Object> LIST_SENSOR = Sensors.newSensor(Object.class, "sensor.list");
@@ -439,15 +438,15 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         // null values ignored, and it quotes
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of("a", "\"b").append(null));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, "\"a\",\"\\\"b\"");
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, "\"a\",\"\\\"b\"");
         
         // empty list causes ""
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of().append(null));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, "");
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, "");
         
         // null causes null
         entity.sensors().set(LIST_SENSOR, null);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
     }
 
     @Test
@@ -462,11 +461,11 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
             .quote(false)
             .build());
         // in this case, it should be immediately available upon adding the enricher
-        EntityTestUtils.assertAttributeEquals(entity, TestEntity.NAME, "a:\"b");
+        EntityAsserts.assertAttributeEquals(entity, TestEntity.NAME, "a:\"b");
         
         // empty list causes null here, because below the minimum
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of().append(null));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
     }
 
     @Test
@@ -480,15 +479,15 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
                 .build());
         // null values ignored, and it quotes
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of("a", "b"));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, "a,b");
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, "a,b");
         
         // empty list causes ""
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of("x"));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, null);
         
         // null causes null
         entity.sensors().set(LIST_SENSOR, MutableList.<String>of("a", "b", "c", "d", "e"));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, TestEntity.NAME, "a,b,c,d");
+        EntityAsserts.assertAttributeEqualsEventually(entity, TestEntity.NAME, "a,b,c,d");
     }
 
 

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/SensorPropagatingEnricherDeprecatedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/SensorPropagatingEnricherDeprecatedTest.java
@@ -24,12 +24,11 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.enricher.stock.SensorPropagatingEnricher;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.AtomicReferences;
 import org.testng.annotations.BeforeMethod;
@@ -55,11 +54,11 @@ public class SensorPropagatingEnricherDeprecatedTest extends BrooklynAppUnitTest
 
         // name propagated
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
         
         // sequence not propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
     }
     
     @Test
@@ -70,8 +69,8 @@ public class SensorPropagatingEnricherDeprecatedTest extends BrooklynAppUnitTest
         entity.sensors().set(TestEntity.NAME, "foo");
         entity.sensors().set(TestEntity.SEQUENCE, 2);
         
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
         
         // notification-sensor propagated
         final AtomicReference<Integer> notif = new AtomicReference<Integer>();
@@ -89,11 +88,11 @@ public class SensorPropagatingEnricherDeprecatedTest extends BrooklynAppUnitTest
 
         // name propagated
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
         
         // sequence not propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
     }
     
     @Test
@@ -103,6 +102,6 @@ public class SensorPropagatingEnricherDeprecatedTest extends BrooklynAppUnitTest
 
         // name propagated as different attribute
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/SensorPropagatingEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/SensorPropagatingEnricherTest.java
@@ -25,12 +25,12 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.javalang.AtomicReferences;
@@ -61,11 +61,11 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         // name propagated
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
         
         // sequence not propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
     }
     
     @Test
@@ -78,7 +78,7 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .build());
 
         // name propagated
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
     }
     
     @Test
@@ -92,8 +92,8 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
         entity.sensors().set(TestEntity.NAME, "foo");
         entity.sensors().set(TestEntity.SEQUENCE, 2);
         
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
         
         // notification-sensor propagated
         final AtomicReference<Integer> notif = new AtomicReference<Integer>();
@@ -117,7 +117,7 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         entity.sensors().set(dynamicAttribute, "foo");
         
-        EntityTestUtils.assertAttributeEqualsEventually(app, dynamicAttribute, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, dynamicAttribute, "foo");
         
         // notification-sensor propagated
         final AtomicReference<String> notif = new AtomicReference<String>();
@@ -138,11 +138,11 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         // name propagated
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
         
         // sequence not propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
     }
     
     @Test
@@ -156,7 +156,7 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         // name propagated as different attribute
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
     }
     
     @Test
@@ -169,11 +169,11 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         // name propagated
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.NAME, "foo");
         
         // sequence not propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.SEQUENCE, null);
     }
     
     @Test
@@ -189,14 +189,14 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
 
         // name propagated as alternative sensor
         entity.sensors().set(TestEntity.NAME, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
+        EntityAsserts.assertAttributeEqualsEventually(app, ANOTHER_ATTRIBUTE, "foo");
         
         // sequence also propagated
         entity.sensors().set(TestEntity.SEQUENCE, 2);
-        EntityTestUtils.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(app, TestEntity.SEQUENCE, 2);
 
         // name not propagated as original sensor
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.NAME, null);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", 100), app, TestEntity.NAME, null);
     }
     
     @Test
@@ -224,7 +224,7 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .from(entity)
                 .build());
         entity.sensors().set(origSensor, "myval");
-        EntityTestUtils.assertAttributeEqualsEventually(app, targetSensor, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(app, targetSensor, "myval");
     }
     
     @Test
@@ -261,8 +261,8 @@ public class SensorPropagatingEnricherTest extends BrooklynAppUnitTestSupport {
                 .propagating(ImmutableMap.of(sourceSensorFromYaml, targetSensor))
                 .from(app)
                 .build());
-        EntityTestUtils.assertAttributeEqualsEventually(app, targetSensor, entity.sensors().get(TestEntity.NAME));
+        EntityAsserts.assertAttributeEqualsEventually(app, targetSensor, entity.sensors().get(TestEntity.NAME));
         entity.sensors().set(TestEntity.NAME, "newName");
-        EntityTestUtils.assertAttributeEqualsEventually(app, targetSensor, "newName");
+        EntityAsserts.assertAttributeEqualsEventually(app, targetSensor, "newName");
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/TransformingEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/TransformingEnricherTest.java
@@ -20,12 +20,11 @@ package org.apache.brooklyn.enricher.stock;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.enricher.stock.Enrichers;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.math.MathFunctions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +65,6 @@ public class TransformingEnricherTest extends BrooklynAppUnitTestSupport {
                 .computing((Function)MathFunctions.times(2)) // TODO doesn't match strongly typed int->long
                 .build());
 
-        EntityTestUtils.assertAttributeEqualsEventually(producer, target, 6L);
+        EntityAsserts.assertAttributeEqualsEventually(producer, target, 6L);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/reducer/ReducerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/reducer/ReducerTest.java
@@ -25,16 +25,14 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.text.StringFunctions;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -69,13 +67,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
             )
         );
 
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsContinually(entity, STR3, null);
+        EntityAsserts.assertAttributeEqualsContinually(entity, STR3, null);
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foobar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foobar");
     }
 
     @Test
@@ -88,13 +86,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
                 .build()
         );
 
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsContinually(entity, STR3, null);
+        EntityAsserts.assertAttributeEqualsContinually(entity, STR3, null);
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foobar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foobar");
     }
     
     @Test
@@ -107,13 +105,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
                 .build()
         );
 
-        EntityTestUtils.assertAttributeEquals(entity, INT1, null);
+        EntityAsserts.assertAttributeEquals(entity, INT1, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, INT1, 3);
+        EntityAsserts.assertAttributeEqualsEventually(entity, INT1, 3);
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, INT1, 6);
+        EntityAsserts.assertAttributeEqualsEventually(entity, INT1, 6);
     }
     
     @Test
@@ -126,13 +124,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
                 .build()
         );
 
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo-null");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo-null");
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo-bar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo-bar");
     }
     
     @Test
@@ -144,13 +142,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
             .publishing(STR3)
             .build()
         );
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo, null");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo, null");
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo, bar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo, bar");
     }
     
     @Test
@@ -163,13 +161,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
             .publishing(STR3)
             .build()
         );
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo, null");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo, null");
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "foo, bar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "foo, bar");
     }
     
     @Test
@@ -182,13 +180,13 @@ public class ReducerTest extends BrooklynAppUnitTestSupport {
             .build()
         );
         
-        EntityTestUtils.assertAttributeEquals(entity, STR3, null);
+        EntityAsserts.assertAttributeEquals(entity, STR3, null);
         
         entity.sensors().set(STR1, "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "hello, foo and null");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "hello, foo and null");
 
         entity.sensors().set(STR2, "bar");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, STR3, "hello, foo and bar");
+        EntityAsserts.assertAttributeEqualsEventually(entity, STR3, "hello, foo and bar");
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -49,6 +49,7 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.entity.factory.EntityFactory;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -63,7 +64,6 @@ import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
@@ -169,7 +169,7 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
                 .configure(DynamicCluster.INITIAL_SIZE, 0));
         cluster.start(ImmutableList.of(loc));
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertTrue(cluster.getAttribute(Attributes.SERVICE_UP));
     }
 
@@ -279,7 +279,7 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
         app.subscriptions().subscribe(cluster, Attributes.SERVICE_STATE_ACTUAL, r);
 
         cluster.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         for (SensorEvent<Lifecycle> evt: r.getEvents()) {
             if (evt.getValue()==Lifecycle.ON_FIRE)
                 Assert.fail("Should not have published " + Lifecycle.ON_FIRE + " during normal start up: " + r.getEvents());
@@ -1020,7 +1020,7 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
                 .configure(DynamicCluster.INITIAL_SIZE, 2));
         cluster.start(ImmutableList.of(loc));
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertTrue(cluster.getAttribute(Attributes.SERVICE_UP));
     }
 
@@ -1045,7 +1045,7 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
             .configure(DynamicCluster.INITIAL_SIZE, 3));
         cluster.start(ImmutableList.of(loc));
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertTrue(cluster.getAttribute(Attributes.SERVICE_UP));
         
         assertEquals(cluster.getMembers().size(), 3);

--- a/core/src/test/java/org/apache/brooklyn/entity/group/GroupPickUpEntitiesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/GroupPickUpEntitiesTest.java
@@ -26,14 +26,13 @@ import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.javalang.Boxing;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -61,31 +60,31 @@ public class GroupPickUpEntitiesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testGroupFindsElement() {
         Assert.assertEquals(group.getMembers().size(), 0);
-        EntityTestUtils.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 0);
+        EntityAsserts.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 0);
         
         final TestEntity e1 = app.createAndManageChild(EntitySpec.create(TestEntity.class));
 
-        EntityTestUtils.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 0);
+        EntityAsserts.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 0);
 
         e1.sensors().set(Startable.SERVICE_UP, true);
         e1.sensors().set(TestEntity.NAME, "bob");
 
-        EntityTestUtils.assertAttributeEqualsEventually(group, BasicGroup.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEqualsEventually(group, BasicGroup.GROUP_SIZE, 1);
         Asserts.assertEqualsIgnoringOrder(group.getAttribute(BasicGroup.GROUP_MEMBERS), ImmutableList.of(e1));
         
         final TestEntity e2 = app.createAndManageChild(EntitySpec.create(TestEntity.class));
 
-        EntityTestUtils.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 1);
         Assert.assertEquals(group.getMembers().size(), 1);
         Assert.assertTrue(group.getMembers().contains(e1));
 
         e2.sensors().set(Startable.SERVICE_UP, true);
         e2.sensors().set(TestEntity.NAME, "fred");
 
-        EntityTestUtils.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEquals(group, BasicGroup.GROUP_SIZE, 1);
 
         e2.sensors().set(TestEntity.NAME, "BOB");
-        EntityTestUtils.assertAttributeEqualsEventually(group, BasicGroup.GROUP_SIZE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(group, BasicGroup.GROUP_SIZE, 2);
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
                 // must use "succeedsEventually" because size + members attributes are set sequentially in another thread; 

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/DataEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/DataEntityTest.java
@@ -28,14 +28,13 @@ import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.stock.DataEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -87,7 +86,7 @@ public class DataEntityTest {
 
         reference.set("new");
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, stringSensor, "new");
+        EntityAsserts.assertAttributeEqualsEventually(entity, stringSensor, "new");
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/feed/function/FunctionFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/function/FunctionFeedTest.java
@@ -36,16 +36,13 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityInternal.FeedSupport;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.feed.function.FunctionFeed;
-import org.apache.brooklyn.feed.function.FunctionFeedTest;
-import org.apache.brooklyn.feed.function.FunctionPollConfig;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -150,7 +147,7 @@ public class FunctionFeedTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(new AddOneFunction()))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 124);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 124);
     }
     
     @Test
@@ -186,7 +183,7 @@ public class FunctionFeedTest extends BrooklynAppUnitTestSupport {
                         .onFailure(Functions.constant(-1)))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, -1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, -1);
     }
 
     @Test
@@ -201,7 +198,7 @@ public class FunctionFeedTest extends BrooklynAppUnitTestSupport {
                         .onException(Functions.constant(-1)))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, -1);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, -1);
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedIntegrationTest.java
@@ -27,16 +27,13 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.HttpService;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.feed.http.HttpFeed;
-import org.apache.brooklyn.feed.http.HttpPollConfig;
-import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -91,7 +88,7 @@ public class HttpFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(HttpValueFunctions.stringContentsFunction()))
                 .build();
         
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
                 String val = entity.getAttribute(SENSOR_STRING);
@@ -121,7 +118,7 @@ public class HttpFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onSuccess(HttpValueFunctions.stringContentsFunction()))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
                 String val = entity.getAttribute(SENSOR_STRING);
@@ -149,7 +146,7 @@ public class HttpFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onException(Functions.constant("Failed!")))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 401);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 401);
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
                 String val = entity.getAttribute(SENSOR_STRING);

--- a/core/src/test/java/org/apache/brooklyn/feed/shell/ShellFeedIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/shell/ShellFeedIntegrationTest.java
@@ -26,19 +26,16 @@ import java.util.concurrent.TimeUnit;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityInternal.FeedSupport;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.feed.function.FunctionFeedTest;
-import org.apache.brooklyn.feed.shell.ShellFeed;
-import org.apache.brooklyn.feed.shell.ShellFeedIntegrationTest;
-import org.apache.brooklyn.feed.shell.ShellPollConfig;
 import org.apache.brooklyn.feed.ssh.SshPollValue;
 import org.apache.brooklyn.feed.ssh.SshValueFunctions;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.stream.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +87,7 @@ public class ShellFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                         .onFailure(SshValueFunctions.exitStatus()))
                 .build();
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SENSOR_INT, 123);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 123);
     }
     
     @Test(groups="Integration")

--- a/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorIntegrationTest.java
@@ -21,8 +21,8 @@ package org.apache.brooklyn.entity.brooklynnode;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
@@ -35,15 +35,12 @@ import org.testng.annotations.Test;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynEntityMirror;
 import org.apache.brooklyn.launcher.BrooklynWebServer;
-import org.apache.brooklyn.rest.filter.BrooklynPropertiesSecurityFilter;
 
 /**
  * Test for EntityMirror, launching an in-memory server and ensuring we can mirror.
@@ -122,15 +119,15 @@ public class BrooklynEntityMirrorIntegrationTest {
                 getBaseUri()+"/v1/applications/"+serviceId+"/entities/"+serviceId)
         );
 
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "austria");
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, BrooklynEntityMirror.MIRROR_CATALOG_ITEM_ID, catalogItemId);
+        EntityAsserts.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "austria");
+        EntityAsserts.assertAttributeEqualsEventually(mirror, BrooklynEntityMirror.MIRROR_CATALOG_ITEM_ID, catalogItemId);
         assertTrue(mirror.getAttribute(BrooklynEntityMirror.MIRROR_SUMMARY) != null, "entity summary is null");
         log.info("Sensors mirrored are: "+((EntityInternal)mirror).getAllAttributes());
         
         serverApp.sensors().set(TestApplication.MY_ATTRIBUTE, "bermuda");
         serverApp.setCatalogItemId(catalogItemIdGA);
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "bermuda");
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, BrooklynEntityMirror.MIRROR_CATALOG_ITEM_ID, catalogItemIdGA);
+        EntityAsserts.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "bermuda");
+        EntityAsserts.assertAttributeEqualsEventually(mirror, BrooklynEntityMirror.MIRROR_CATALOG_ITEM_ID, catalogItemIdGA);
 
         serverApp.stop();
         assertUnmanagedEventually(mirror);
@@ -160,11 +157,11 @@ public class BrooklynEntityMirrorIntegrationTest {
                 getBaseUri()+"/v1/applications/"+serviceId+"/entities/"+serviceId)
         );
 
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "austria");
+        EntityAsserts.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "austria");
         log.info("Sensors mirrored are: "+((EntityInternal)mirror).getAllAttributes());
         
         serverApp.sensors().set(TestApplication.MY_ATTRIBUTE, "bermuda");
-        EntityTestUtils.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "bermuda");
+        EntityAsserts.assertAttributeEqualsEventually(mirror, TestApplication.MY_ATTRIBUTE, "bermuda");
 
         serverApp.stop();
         assertUnmanagedEventually(mirror);

--- a/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeRestTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeRestTest.java
@@ -21,7 +21,7 @@ package org.apache.brooklyn.entity.brooklynnode;
 import java.net.URI;
 import java.util.concurrent.Callable;
 
-import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.util.collections.Jsonya;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -74,7 +74,7 @@ public class BrooklynNodeRestTest {
             
             URI uri = bn.getAttribute(BrooklynNode.WEB_CONSOLE_URI);
             Assert.assertNotNull(uri);
-            EntityTestUtils.assertAttributeEqualsEventually(bn, Attributes.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(bn, Attributes.SERVICE_UP, true);
             log.info("Created BrooklynNode: "+bn);
 
             // deploy
@@ -103,10 +103,10 @@ public class BrooklynNodeRestTest {
             
             Entities.dumpInfo(mirror);
             
-            EntityTestUtils.assertAttributeEqualsEventually(mirror, Attributes.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(mirror, Attributes.SERVICE_UP, true);
             
             ((EntityInternal)newApp).sensors().set(TestEntity.NAME, "foo");
-            EntityTestUtils.assertAttributeEqualsEventually(mirror, TestEntity.NAME, "foo");
+            EntityAsserts.assertAttributeEqualsEventually(mirror, TestEntity.NAME, "foo");
             log.info("Mirror successfully validated");
             
             // also try deploying by invoking deploy through json
@@ -134,7 +134,7 @@ public class BrooklynNodeRestTest {
             Application newApp2 = Iterables.getOnlyElement(apps);
             Entities.dumpInfo(newApp2);
             
-            EntityTestUtils.assertAttributeEqualsEventually(newApp2, Attributes.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(newApp2, Attributes.SERVICE_UP, true);
             Assert.assertEquals(newApp2.getConfig(TestEntity.CONF_NAME), "foo");
             
         } finally {

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherAbstract;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
@@ -43,7 +44,6 @@ import org.apache.brooklyn.launcher.BrooklynLauncher;
 import org.apache.brooklyn.launcher.SimpleYamlLauncherForTests;
 import org.apache.brooklyn.launcher.camp.BrooklynCampPlatformLauncher;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.stream.Streams;
@@ -158,8 +158,8 @@ public abstract class AbstractBlueprintTest {
     }
     
     protected void assertNoFires(final Entity app) {
-        EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(app, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
@@ -168,8 +168,8 @@ public abstract class AbstractBlueprintTest {
                     assertNotEquals(entity.getAttribute(Attributes.SERVICE_UP), false);
                     
                     if (entity instanceof SoftwareProcess) {
-                        EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
-                        EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_UP, Boolean.TRUE);
+                        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+                        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_UP, Boolean.TRUE);
                     }
                 }
             }});

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicyTest.java
@@ -29,10 +29,9 @@ import java.util.regex.Pattern;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.policy.jclouds.os.CreateUserPolicy;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +109,7 @@ public class CreateUserPolicyTest extends BrooklynAppUnitTestSupport {
         TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
         app.start(ImmutableList.of(machine));
         
-        String creds = EntityTestUtils.assertAttributeEventuallyNonNull(entity, CreateUserPolicy.VM_USER_CREDENTIALS);
+        String creds = EntityAsserts.assertAttributeEventuallyNonNull(entity, CreateUserPolicy.VM_USER_CREDENTIALS);
         Pattern pattern = Pattern.compile("(.*) : (.*) @ (.*):(.*)");
         Matcher matcher = pattern.matcher(creds);
         assertTrue(matcher.matches());

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
@@ -34,7 +35,6 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.group.DynamicCluster;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -126,9 +126,9 @@ public class AutoScalerPolicyRebindTest extends RebindTestFixtureWithApp {
         assertEquals(newCluster.getCurrentSize(), (Integer)1);
         
         ((EntityInternal)newCluster).sensors().set(METRIC_SENSOR, 1000);
-        EntityTestUtils.assertGroupSizeEqualsEventually(newCluster, 3);
+        EntityAsserts.assertGroupSizeEqualsEventually(newCluster, 3);
         
         ((EntityInternal)newCluster).sensors().set(METRIC_SENSOR, 1);
-        EntityTestUtils.assertGroupSizeEqualsEventually(newCluster, 1);
+        EntityAsserts.assertGroupSizeEqualsEventually(newCluster, 1);
     }
 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/enricher/HttpLatencyDetectorTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/enricher/HttpLatencyDetectorTest.java
@@ -25,11 +25,10 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.policy.enricher.HttpLatencyDetector;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
 import org.slf4j.Logger;
@@ -97,7 +96,7 @@ public class HttpLatencyDetectorTest {
                 .build());
         
         // nothing until url is set
-        EntityTestUtils.assertAttributeEqualsContinually(
+        EntityAsserts.assertAttributeEqualsContinually(
                 MutableMap.of("timeout", 200), 
                 entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT, null);
         
@@ -130,7 +129,7 @@ public class HttpLatencyDetectorTest {
                 .build());
         
         // nothing until url is set
-        EntityTestUtils.assertAttributeEqualsContinually(
+        EntityAsserts.assertAttributeEqualsContinually(
                 MutableMap.of("timeout", 200), 
                 entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT, null);
         
@@ -140,8 +139,8 @@ public class HttpLatencyDetectorTest {
     }
     
     protected void assertLatencyAttributesNonNull(Entity entity) {
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT); 
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW); 
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT); 
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW);
 
         log.info("Latency to "+entity.getAttribute(TEST_URL)+" is "+entity.getAttribute(HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT));
         log.info("Mean latency to "+entity.getAttribute(TEST_URL)+" is "+entity.getAttribute(HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW));

--- a/policy/src/test/java/org/apache/brooklyn/policy/enricher/RebindEnricherTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/enricher/RebindEnricherTest.java
@@ -25,17 +25,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.policy.enricher.DeltaEnricher;
-import org.apache.brooklyn.policy.enricher.HttpLatencyDetector;
-import org.apache.brooklyn.policy.enricher.RollingMeanEnricher;
-import org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher;
-import org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher;
-import org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -69,7 +63,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
 
         newApp.sensors().set(INT_METRIC, 1);
         newApp.sensors().set(INT_METRIC, 10);
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, INT_METRIC2, 9);
+        EntityAsserts.assertAttributeEqualsEventually(newApp, INT_METRIC2, 9);
     }
 
     @Test
@@ -93,8 +87,8 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         newApp.sensors().set(HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT, null);
         newApp.sensors().set(HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW, null);
 
-        EntityTestUtils.assertAttributeEventuallyNonNull(newApp, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT);
-        EntityTestUtils.assertAttributeEventuallyNonNull(newApp, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW);
+        EntityAsserts.assertAttributeEventuallyNonNull(newApp, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT);
+        EntityAsserts.assertAttributeEventuallyNonNull(newApp, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW);
     }
 
     @Test
@@ -104,7 +98,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         TestApplication newApp = rebind();
 
         newApp.sensors().set(INT_METRIC, 10);
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, DOUBLE_METRIC, 10d);
+        EntityAsserts.assertAttributeEqualsEventually(newApp, DOUBLE_METRIC, 10d);
     }
 
     @Test
@@ -116,7 +110,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         newApp.sensors().set(INT_METRIC, 10);
         Time.sleep(Duration.millis(10));
         newApp.sensors().set(INT_METRIC, 10);
-        EntityTestUtils.assertAttributeEqualsEventually(newApp, DOUBLE_METRIC, 10d);
+        EntityAsserts.assertAttributeEqualsEventually(newApp, DOUBLE_METRIC, 10d);
     }
     
     @Test

--- a/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceFailureDetectorTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceFailureDetectorTest.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
@@ -41,7 +42,6 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -116,7 +116,7 @@ public class ServiceFailureDetectorTest {
 
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
         assertEquals(events.size(), 1, "events="+events);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
     }
     
     @Test
@@ -132,7 +132,7 @@ public class ServiceFailureDetectorTest {
 
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
         assertEquals(events.size(), 1, "events="+events);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
     }
     
     @Test
@@ -143,7 +143,7 @@ public class ServiceFailureDetectorTest {
 
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
         assertEquals(events.size(), 1, "events="+events);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
     }
     
     @Test
@@ -156,13 +156,13 @@ public class ServiceFailureDetectorTest {
         e1.sensors().set(TestEntity.SERVICE_UP, false);
 
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         // And make the entity recover
         e1.sensors().set(TestEntity.SERVICE_UP, true);
         assertHasEventEventually(HASensors.ENTITY_RECOVERED, Predicates.<Object>equalTo(e1), null);
         assertEquals(events.size(), 2, "events="+events);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     }
     
     @Test
@@ -175,13 +175,13 @@ public class ServiceFailureDetectorTest {
         ServiceProblemsLogic.updateProblemsIndicator(e1, "test", "foo");
 
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         // And make the entity recover
         ServiceProblemsLogic.clearProblemsIndicator(e1, "test");
         assertHasEventEventually(HASensors.ENTITY_RECOVERED, Predicates.<Object>equalTo(e1), null);
         assertEquals(events.size(), 2, "events="+events);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     }
     
     
@@ -193,7 +193,7 @@ public class ServiceFailureDetectorTest {
         e1.sensors().set(TestEntity.SERVICE_UP, false);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
 
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         assertNoEventsContinually();
     }
     
@@ -205,7 +205,7 @@ public class ServiceFailureDetectorTest {
         e1.sensors().set(TestEntity.SERVICE_UP, false);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
 
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
     }
     
@@ -217,7 +217,7 @@ public class ServiceFailureDetectorTest {
         // Make the entity fail
         e1.sensors().set(TestEntity.SERVICE_UP, true);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         e1.sensors().set(TestEntity.SERVICE_UP, false);
 
         assertEquals(e1.getAttribute(TestEntity.SERVICE_STATE_ACTUAL), Lifecycle.RUNNING);
@@ -231,14 +231,14 @@ public class ServiceFailureDetectorTest {
         // Make the entity fail
         e1.sensors().set(TestEntity.SERVICE_UP, true);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         e1.sensors().set(TestEntity.SERVICE_UP, false);
 
         assertEquals(e1.getAttribute(TestEntity.SERVICE_STATE_ACTUAL), Lifecycle.RUNNING);
         Time.sleep(Duration.millis(100));
         assertEquals(e1.getAttribute(TestEntity.SERVICE_STATE_ACTUAL), Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
     }
     
     @Test(groups="Integration") // Has a 1 second wait
@@ -250,19 +250,19 @@ public class ServiceFailureDetectorTest {
         // Set the entity to healthy
         e1.sensors().set(TestEntity.SERVICE_UP, true);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         // Make the entity fail; won't set on-fire for 1s but will publish FAILED immediately.
         ServiceStateLogic.ServiceProblemsLogic.updateProblemsIndicator(e1, "test", "foo");
-        EntityTestUtils.assertAttributeEqualsContinually(ImmutableMap.of("timeout", 100), e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsContinually(ImmutableMap.of("timeout", 100), e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
         assertEquals(e1.getAttribute(TestEntity.SERVICE_STATE_ACTUAL), Lifecycle.RUNNING);
         
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         
         // Now recover: will publish RUNNING immediately, but has 1s stabilisation for RECOVERED
         ServiceStateLogic.ServiceProblemsLogic.clearProblemsIndicator(e1, "test");
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         assertEquals(events.size(), 1, "events="+events);
         
@@ -324,11 +324,11 @@ public class ServiceFailureDetectorTest {
         // Set the entity to healthy
         e1.sensors().set(TestEntity.SERVICE_UP, true);
         ServiceStateLogic.setExpectedState(e1, Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         // Make the entity fail;
         ServiceStateLogic.ServiceProblemsLogic.updateProblemsIndicator(e1, "test", "foo");
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
         assertHasEventEventually(HASensors.ENTITY_FAILED, Predicates.<Object>equalTo(e1), null);
 
         //wait for at least 10 republish events (~1 sec)
@@ -336,7 +336,7 @@ public class ServiceFailureDetectorTest {
 
         // Now recover
         ServiceStateLogic.ServiceProblemsLogic.clearProblemsIndicator(e1, "test");
-        EntityTestUtils.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(e1, TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertHasEventEventually(HASensors.ENTITY_RECOVERED, Predicates.<Object>equalTo(e1), null);
 
         //once recovered check no more failed events emitted periodically

--- a/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceReplacerTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceReplacerTest.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -48,7 +49,6 @@ import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
@@ -146,7 +146,7 @@ public class ServiceReplacerTest {
         // should not be on fire
         Assert.assertNotEquals(cluster.getAttribute(Attributes.SERVICE_STATE_ACTUAL), Lifecycle.ON_FIRE);
         // and should eventually be running
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         log.info("started "+app+" for "+JavaClassNames.niceClassAndMethod());
         
@@ -161,7 +161,7 @@ public class ServiceReplacerTest {
         // Expect cluster to go on-fire when fails to start replacement
         // Note that we've set up-quorum and running-quorum to be "alwaysTrue" so that we don't get a transient onFire
         // when the failed node fails to start (but before it has been removed from the group to be put in quarantine).
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         // Expect to have the second failed entity still kicking around as proof (in quarantine)
         // The cluster should NOT go on fire until after the 2nd failure

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynClusterIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynClusterIntegrationTest.java
@@ -23,11 +23,9 @@ import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynCluster;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
 import org.apache.brooklyn.entity.brooklynnode.BrooklynNode.ExistingFileBehaviour;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
@@ -88,10 +86,10 @@ public class BrooklynClusterIntegrationTest extends BrooklynAppUnitTestSupport {
         Entity brooklynNode = Iterables.find(cluster.getMembers(), Predicates.instanceOf(BrooklynNode.class));
         LOG.info("started "+app+" containing "+cluster+" for "+JavaClassNames.niceClassAndMethod());
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, BrooklynNode.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, BrooklynNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
 
         cluster.stop();
-        EntityTestUtils.assertAttributeEquals(cluster, BrooklynNode.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEquals(cluster, BrooklynNode.SERVICE_UP, false);
     }    
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.location.Locations;
@@ -53,7 +54,6 @@ import org.apache.brooklyn.feed.http.JsonFunctions;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
@@ -178,10 +178,10 @@ services:
         app.start(locs);
         log.info("started "+app+" containing "+brooklynNode+" for "+JavaClassNames.niceClassAndMethod());
 
-        EntityTestUtils.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
 
         brooklynNode.stop();
-        EntityTestUtils.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
     }
 
     @Test(groups="Integration")
@@ -691,7 +691,7 @@ services:
         brooklynNode.invoke(eff, Collections.<String, Object>emptyMap()).getUnchecked();
 
         // Note can't use driver.isRunning to check shutdown; can't invoke scripts on an unmanaged entity
-        EntityTestUtils.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEquals(brooklynNode, BrooklynNode.SERVICE_UP, false);
         
         // unmanaged if the machine is destroyed - ie false on localhost (this test by default), but true in the cloud 
 //        assertFalse(Entities.isManaged(brooklynNode));
@@ -729,7 +729,7 @@ services:
         app.start(locs);
         log.info("started "+app+" containing "+brooklynNode+" for "+JavaClassNames.niceClassAndMethod());
 
-        EntityTestUtils.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(brooklynNode, BrooklynNode.SERVICE_UP, true);
 
         String baseUrl = brooklynNode.getAttribute(BrooklynNode.WEB_CONSOLE_URI).toString();
         waitForApps(baseUrl);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
@@ -34,18 +34,15 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.feed.AttributePollHandler;
 import org.apache.brooklyn.core.feed.DelegatingPollHandler;
 import org.apache.brooklyn.core.feed.Poller;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynCluster;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynClusterImpl;
-import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
 import org.apache.brooklyn.entity.brooklynnode.BrooklynCluster.SelectMasterEffector;
 import org.apache.brooklyn.entity.brooklynnode.CallbackEntityHttpClient.Request;
 import org.apache.brooklyn.entity.group.DynamicCluster;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.http.client.methods.HttpPost;
@@ -116,7 +113,7 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
     @Test(groups="Integration") // because slow, due to sensor feeds
     public void testSelectMasterAfterChange() {
         List<Entity> nodes = makeTwoNodes();
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode)nodes.get(0));
+        EntityAsserts.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode) nodes.get(0));
 
         selectMaster(cluster, nodes.get(1).getId());
         checkMaster(cluster, nodes.get(1));
@@ -134,7 +131,7 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
 
         List<Entity> nodes = makeTwoNodes();
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode)nodes.get(0));
+        EntityAsserts.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode)nodes.get(0));
 
         try {
             selectMaster(cluster, nodes.get(1).getId());
@@ -180,8 +177,8 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
 
                 checkRequest(input, HttpPost.METHOD_NAME, "/v1/server/ha/state", "mode", "HOT_STANDBY");
                 Entity entity = input.getEntity();
-                EntityTestUtils.assertAttributeEquals(entity, BrooklynNode.MANAGEMENT_NODE_STATE, ManagementNodeState.MASTER);
-                EntityTestUtils.assertAttributeEquals(entity, MockBrooklynNode.HA_PRIORITY, 0);
+                EntityAsserts.assertAttributeEquals(entity, BrooklynNode.MANAGEMENT_NODE_STATE, ManagementNodeState.MASTER);
+                EntityAsserts.assertAttributeEquals(entity, MockBrooklynNode.HA_PRIORITY, 0);
 
                 setManagementState(entity, ManagementNodeState.HOT_STANDBY);
 
@@ -241,7 +238,7 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
     private void masterFailover(Entity member) {
         LOG.debug("Master failover to " + member);
         setManagementState(member, ManagementNodeState.MASTER);
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode)member);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, BrooklynCluster.MASTER_NODE, (BrooklynNode)member);
         return;
     }
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/EntityPollingTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/EntityPollingTest.java
@@ -24,17 +24,14 @@ import javax.management.ObjectName;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.java.UsesJmx;
-import org.apache.brooklyn.entity.java.VanillaJavaAppImpl;
-import org.apache.brooklyn.entity.java.VanillaJavaAppSshDriver;
 import org.apache.brooklyn.entity.java.UsesJmx.JmxAgentModes;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.test.jmx.JmxService;
 import org.apache.brooklyn.feed.jmx.JmxAttributePollConfig;
 import org.apache.brooklyn.feed.jmx.JmxFeed;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
@@ -151,7 +148,7 @@ public class EntityPollingTest {
         app.start(ImmutableList.of(new SshMachineLocation(MutableMap.of("address", "localhost"))));
         
         // Starts with value defined when registering...
-        EntityTestUtils.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
     }
 
     // Test that connect will keep retrying (e.g. start script returns before the JMX server is up)
@@ -174,7 +171,7 @@ public class EntityPollingTest {
             t.start();
             app.start(ImmutableList.of(new SshMachineLocation(MutableMap.of("address", "localhost"))));
 
-            EntityTestUtils.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
+            EntityAsserts.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
             
         } finally {
             t.interrupt();
@@ -188,7 +185,7 @@ public class EntityPollingTest {
 
         app.start(ImmutableList.of(new SshMachineLocation(MutableMap.of("address", "localhost"))));
         
-        EntityTestUtils.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(entity, stringAttribute, "myval");
         
         // Shutdown the MBeanServer - simulates network failure so can't connect
         jmxService.shutdown();
@@ -201,6 +198,6 @@ public class EntityPollingTest {
         jmxService = new JmxService("localhost", 40123);
         jmxService.registerMBean(ImmutableMap.of(attributeName, "myval2"), objectName);
         
-        EntityTestUtils.assertAttributeEqualsEventually(entity, stringAttribute, "myval2");
+        EntityAsserts.assertAttributeEqualsEventually(entity, stringAttribute, "myval2");
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/VanillaJavaAppRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/VanillaJavaAppRebindTest.java
@@ -25,15 +25,13 @@ import java.io.File;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.java.VanillaJavaApp;
-import org.apache.brooklyn.entity.java.VanillaJavaAppImpl;
 import org.apache.brooklyn.entity.java.JavaOptsTest.TestingJavaOptsVanillaJavaAppImpl;
 import org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.time.Duration;
@@ -100,7 +98,7 @@ public class VanillaJavaAppRebindTest {
         rebind();
         VanillaJavaApp javaProcess2 = (VanillaJavaApp) Iterables.find(app.getChildren(), Predicates.instanceOf(VanillaJavaApp.class));
         
-        EntityTestUtils.assertAttributeEqualsEventually(javaProcess2, VanillaJavaApp.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(javaProcess2, VanillaJavaApp.SERVICE_UP, true);
     }
 
     @Test(groups="Integration")
@@ -116,7 +114,7 @@ public class VanillaJavaAppRebindTest {
         long rebindTime = System.currentTimeMillis() - starttime;
         
         VanillaJavaApp javaProcess2 = (VanillaJavaApp) Iterables.find(app.getChildren(), Predicates.instanceOf(VanillaJavaApp.class));
-        EntityTestUtils.assertAttributeEqualsEventually(javaProcess2, VanillaJavaApp.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(javaProcess2, VanillaJavaApp.SERVICE_UP, false);
         
         // check that it was quick (previously it hung)
         assertTrue(rebindTime < 30*1000, "rebindTime="+rebindTime);
@@ -130,20 +128,20 @@ public class VanillaJavaAppRebindTest {
 
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEventuallyNonNull(javaProcess, EnrichedVanillaJavaAppImpl.AVG1);
-        EntityTestUtils.assertAttributeEventuallyNonNull(javaProcess, EnrichedVanillaJavaAppImpl.AVG2);
+        EntityAsserts.assertAttributeEventuallyNonNull(javaProcess, EnrichedVanillaJavaAppImpl.AVG1);
+        EntityAsserts.assertAttributeEventuallyNonNull(javaProcess, EnrichedVanillaJavaAppImpl.AVG2);
         LOG.info("Got avg "+javaProcess.getAttribute(EnrichedVanillaJavaAppImpl.AVG1));
 
         rebind();
         VanillaJavaApp javaProcess2 = (VanillaJavaApp) Iterables.find(app.getChildren(), Predicates.instanceOf(VanillaJavaApp.class));
 
         // check sensors working
-        EntityTestUtils.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.PROCESS_CPU_TIME); 
+        EntityAsserts.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.PROCESS_CPU_TIME); 
         LOG.info("Avg now "+javaProcess2.getAttribute(EnrichedVanillaJavaAppImpl.AVG1));
         
         // check enrichers are functioning
-        EntityTestUtils.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.AVG1); 
-        EntityTestUtils.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.AVG2);
+        EntityAsserts.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.AVG1);
+        EntityAsserts.assertAttributeChangesEventually(javaProcess2, EnrichedVanillaJavaAppImpl.AVG2);
         LOG.info("Avg now "+javaProcess2.getAttribute(EnrichedVanillaJavaAppImpl.AVG1));
         
         // and check we don't have too many

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
@@ -21,10 +21,10 @@ package org.apache.brooklyn.entity.machine;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -35,10 +35,10 @@ public class MachineEntityRebindTest extends RebindTestFixtureWithApp {
     public void testRebindToMachineEntity() throws Exception {
         EmptySoftwareProcess machine = origApp.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class));
         origApp.start(ImmutableList.of(origManagementContext.getLocationRegistry().getLocationManaged("localhost")));
-        EntityTestUtils.assertAttributeEqualsEventually(machine, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(machine, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         rebind(false);
         Entity machine2 = newManagementContext.getEntityManager().getEntity(machine.getId());
-        EntityTestUtils.assertAttributeEqualsEventually(machine2, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(machine2, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     }
 
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessRestartIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessRestartIntegrationTest.java
@@ -23,13 +23,12 @@ import java.util.Map;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
-import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.RestartSoftwareParameters;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,26 +70,26 @@ public abstract class AbstractSoftwareProcessRestartIntegrationTest extends Broo
         
         // Start the app
         app.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_UP, true);
 
         // Stop the process
         Entities.invokeEffector(app, entity, SoftwareProcess.STOP, ImmutableMap.of(
                 StopSoftwareParameters.STOP_MACHINE_MODE.getName(), StopSoftwareParameters.StopMode.NEVER))
                 .get();
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, false);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
-        EntityTestUtils.assertAttributeEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, CollectionFunctionals.<String>mapSizeEquals(1));
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
+        EntityAsserts.assertAttributeEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, CollectionFunctionals.<String>mapSizeEquals(1));
         
         // Restart the process
         Entities.invokeEffector(app, entity, restartEffector, args).get();
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, ImmutableMap.<String, Object>of());
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, ImmutableMap.<String, Object>of());
 
-        EntityTestUtils.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(app, SoftwareProcess.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.api.location.NoMachinesAvailableException;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceProblemsLogic;
@@ -44,7 +45,6 @@ import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.MyService;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -107,10 +107,10 @@ public class SoftwareProcessEntityRebindTest extends BrooklynAppUnitTestSupport 
                 .displayName("mylocname"));
         app.start(ImmutableList.of(origLoc));
         assertEquals(origE.getAttribute(Attributes.SERVICE_STATE_EXPECTED).getState(), Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
 
         ServiceProblemsLogic.updateProblemsIndicator((EntityLocal)origE, "test", "fire");
-        EntityTestUtils.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         newApp = (TestApplication) rebind();
         MyService newE = (MyService) Iterables.getOnlyElement(newApp.getChildren());
@@ -127,10 +127,10 @@ public class SoftwareProcessEntityRebindTest extends BrooklynAppUnitTestSupport 
                 .displayName("mylocname"));
         app.start(ImmutableList.of(origLoc));
         assertEquals(origE.getAttribute(Attributes.SERVICE_STATE_EXPECTED).getState(), Lifecycle.RUNNING);
-        EntityTestUtils.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
 
         ServiceStateLogic.setExpectedState(origE, Lifecycle.ON_FIRE);
-        EntityTestUtils.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+        EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         newApp = (TestApplication) rebind();
         MyService newE = (MyService) Iterables.getOnlyElement(newApp.getChildren());

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
@@ -46,6 +46,7 @@ import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.drivers.BasicEntityDriverManager;
 import org.apache.brooklyn.core.entity.drivers.ReflectiveEntityDriverFactory;
@@ -53,25 +54,16 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.Locations;
-import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
-import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
-import org.apache.brooklyn.entity.software.base.EmptySoftwareProcessDriver;
-import org.apache.brooklyn.entity.software.base.EmptySoftwareProcessImpl;
-import org.apache.brooklyn.entity.software.base.SoftwareProcess;
-import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
-import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.RestartSoftwareParameters;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.RestartSoftwareParameters.RestartMachineMode;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters.StopMode;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasksTest;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -474,7 +466,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         final ReleaseLatchLocation loc = mgmt.getLocationManager().createLocation(LocationSpec.create(ReleaseLatchLocation.class));
         try {
             app.start(ImmutableSet.of(loc));
-            EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     
             final Task<Void> firstStop = entity.invoke(Startable.STOP, ImmutableMap.<String, Object>of());
             // Wait until first task tries to release the location, at this point the entity's reference 
@@ -497,7 +489,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
             });
     
             // Entity state is STOPPED even though first location is still releasing
-            EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+            EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
             Asserts.succeedsContinually(new Runnable() {
                 @Override
                 public void run() {
@@ -508,7 +500,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
             loc.unblock();
 
             // After the location is released, first task ends as well.
-            EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+            EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
             Asserts.succeedsEventually(new Runnable() {
                 @Override
                 public void run() {
@@ -539,7 +531,7 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
         final ReleaseLatchLocation loc = mgmt.getLocationManager().createLocation(LocationSpec.create(ReleaseLatchLocation.class));
         try {
             app.start(ImmutableSet.of(loc));
-            EntityTestUtils.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     
             final Task<Void> firstStop = app.invoke(Startable.STOP, ImmutableMap.<String, Object>of());
             // Wait until first task tries to release the location, at this point the entity's reference 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessAndChildrenIntegrationTest.java
@@ -25,9 +25,9 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.ChildStartableMode;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.os.Os;
@@ -156,7 +156,7 @@ public class VanillaSoftwareProcessAndChildrenIntegrationTest {
 
     private void checkChildComesUpSoon() {
         Stopwatch stopwatch = Stopwatch.createStarted();
-        EntityTestUtils.assertAttributeEqualsEventually(p2, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(p2, Attributes.SERVICE_UP, true);
         log.info("Took "+Time.makeTimeStringRounded(stopwatch)+" for child-process to be service-up");
     }
 

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
@@ -33,7 +34,6 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,13 +114,13 @@ public class VanillaWindowsProcessWinrmExitStatusLiveTest {
         
         app.start(ImmutableList.of(machine));
         LOG.info("app started; asserting up");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         entity.stop();
         LOG.info("stopping entity");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
     }
 
     @Test(groups = "Live")
@@ -138,13 +138,13 @@ public class VanillaWindowsProcessWinrmExitStatusLiveTest {
         
         app.start(ImmutableList.of(machine));
         LOG.info("app started; asserting up");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         
         entity.stop();
         LOG.info("stopping entity");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
     }
 
     @Test(groups = "Live")

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelperTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelperTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
@@ -33,7 +34,6 @@ import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.MyServ
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.MyServiceImpl;
 import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.feed.function.FunctionPollConfig;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,17 +75,17 @@ public class ScriptHelperTest extends BrooklynAppUnitTestSupport {
         SimulatedInessentialIsRunningDriver driver = (SimulatedInessentialIsRunningDriver) entity.getDriver();
         Assert.assertTrue(driver.isRunning());
         
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
         
         log.debug("up, now cause failure");
         
         driver.setFailExecution(true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, false);
         
         log.debug("caught failure, now clear");
         driver.setFailExecution(false);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, true);
     }
     
     public static class MyServiceInessentialDriverImpl extends MyServiceImpl {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/MachineDetailsEc2LiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/MachineDetailsEc2LiveTest.java
@@ -26,13 +26,13 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineDetails;
 import org.apache.brooklyn.api.location.OsDetails;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.BasicMachineDetails;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ public class MachineDetailsEc2LiveTest extends AbstractEc2LiveTest {
     protected void doTest(Location loc) throws Exception {
         Entity testEntity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class));
         app.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS),
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS),
                 testEntity, Startable.SERVICE_UP, true);
 
         SshMachineLocation sshLoc = Locations.findUniqueSshMachineLocation(testEntity.getLocations()).get();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/MachineDetailsGoogleComputeLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/MachineDetailsGoogleComputeLiveTest.java
@@ -26,13 +26,13 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineDetails;
 import org.apache.brooklyn.api.location.OsDetails;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.BasicMachineDetails;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.AbstractGoogleComputeLiveTest;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class MachineDetailsGoogleComputeLiveTest extends AbstractGoogleComputeLi
     protected void doTest(Location loc) throws Exception {
         Entity testEntity = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class));
         app.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(testEntity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(testEntity, Startable.SERVICE_UP, true);
 
         SshMachineLocation sshLoc = Locations.findUniqueSshMachineLocation(testEntity.getLocations()).get();
         MachineDetails machine = app.getExecutionContext()

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/AbstractToyMySqlEntityTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/AbstractToyMySqlEntityTest.java
@@ -24,9 +24,9 @@ import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
@@ -78,12 +78,12 @@ public abstract class AbstractToyMySqlEntityTest extends BrooklynAppLiveTestSupp
 
     protected void checkStartsRunning(Entity mysql) {
         // should be starting within a few seconds (and almost certainly won't complete in that time)
-        EntityTestUtils.assertAttributeEventually(
-                mysql, 
+        EntityAsserts.assertAttributeEventually(
+                mysql,
                 Attributes.SERVICE_STATE_ACTUAL,
                 Predicates.or(Predicates.equalTo(Lifecycle.STARTING), Predicates.equalTo(Lifecycle.RUNNING)));
         // should be up and running within 5m 
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", Duration.FIVE_MINUTES),
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", Duration.FIVE_MINUTES),
                 mysql, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
     }
 

--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
@@ -39,10 +40,6 @@ import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.entity.java.UsesJmx.JmxAgentModes;
 import org.apache.brooklyn.entity.software.base.test.jmx.GeneralisedDynamicMBean;
 import org.apache.brooklyn.entity.software.base.test.jmx.JmxService;
-import org.apache.brooklyn.feed.jmx.JmxAttributePollConfig;
-import org.apache.brooklyn.feed.jmx.JmxFeed;
-import org.apache.brooklyn.feed.jmx.JmxHelper;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +99,7 @@ public class RebindJmxFeedTest extends RebindTestFixtureWithApp {
         jmxService = new JmxService(origEntity);
         GeneralisedDynamicMBean mbean = jmxService.registerMBean(MutableMap.of(JMX_ATTRIBUTE_NAME, "myval"), OBJECT_NAME);
         
-        EntityTestUtils.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(origEntity, SENSOR_STRING, "myval");
         assertEquals(origEntity.feeds().getFeeds().size(), 1);
 
         newApp = rebind();
@@ -113,7 +110,7 @@ public class RebindJmxFeedTest extends RebindTestFixtureWithApp {
         
         // Expect the feed to still be polling
         newEntity.sensors().set(SENSOR_STRING, null);
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "myval");
     }
 
     public static class MyEntityWithJmxFeedImpl extends TestEntityImpl {

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeedTest.java
@@ -30,10 +30,10 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
@@ -114,9 +114,9 @@ public class WindowsPerformanceCounterFeedTest extends BrooklynAppUnitTestSuppor
 
         sendPerfCountersToSensors.onSuccess(new WinRmToolResponse(responseBuilder.toString(), "", 0));
 
-        EntityTestUtils.assertAttributeEquals(entity, stringSensor, "99.9");
-        EntityTestUtils.assertAttributeEquals(entity, integerSensor, 15);
-        EntityTestUtils.assertAttributeEquals(entity, doubleSensor, 3.1415926);
+        EntityAsserts.assertAttributeEquals(entity, stringSensor, "99.9");
+        EntityAsserts.assertAttributeEquals(entity, integerSensor, 15);
+        EntityAsserts.assertAttributeEquals(entity, doubleSensor, 3.1415926);
     }
 
     private void addMockResponse(StringBuilder responseBuilder, String path, String value) {

--- a/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/AdvertiseWinrmLoginPolicyTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/AdvertiseWinrmLoginPolicyTest.java
@@ -21,9 +21,9 @@ package org.apache.brooklyn.location.winrm;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -44,6 +44,6 @@ public class AdvertiseWinrmLoginPolicyTest extends BrooklynAppUnitTestSupport {
         
         String expected = "myuser : mypassword @ 1.2.3.4:5678";
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, AdvertiseWinrmLoginPolicy.VM_USER_CREDENTIALS, expected);
+        EntityAsserts.assertAttributeEqualsEventually(entity, AdvertiseWinrmLoginPolicy.VM_USER_CREDENTIALS, expected);
     }
 }


### PR DESCRIPTION
Updating deprecated `EntityTestUtils` methods to `EntityAsserts`.