### PR TITLE
Fix BROOKLYN-268: DynamicCluster on-fire when initially empty

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -259,6 +259,7 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
                 Preconditions.checkNotNull(getConfig(INITIAL_SIZE), "Cluster initial size overridden to be null. Must be set explicitly.")==0) {
             // if initial size is 0 then override up check to allow zero if empty
             config().set(UP_QUORUM_CHECK, QuorumChecks.atLeastOneUnlessEmpty());
+            sensors().set(ServiceStateLogic.SERVICE_NOT_UP_INDICATORS, MutableMap.<String, Object>of());
             sensors().set(SERVICE_UP, true);
         } else {
             sensors().set(SERVICE_UP, false);


### PR DESCRIPTION
Fixes `DynamicClusterTest.testServiceUpAfterStartingWithNoMembers`.

It feels like there should be a more general fix to this. But given that the DynamicCluster code is explicitly setting service.isUp to true, then it feels ok to also explicitly say that we know there are no service-not-up-indicators.