### PR TITLE
Transformer enricher: support triggerSensors

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -186,6 +186,10 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         private static final String DEFAULT_TYPE = "string";
         private static final Map<String, Class<?>> BUILT_IN_TYPES = ImmutableMap.<String, Class<?>>builder()
                 .put(DEFAULT_TYPE, String.class)
+                .put("boolean", Boolean.class)
+                .put("byte", Byte.class)
+                .put("char", Character.class)
+                .put("short", Short.class)
                 .put("integer", Integer.class)
                 .put("long", Long.class)
                 .put("float", Float.class)

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -40,9 +40,9 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
     private static final Logger LOG = LoggerFactory.getLogger(Transformer.class);
 
     // exactly one of these should be supplied to set a value
-    public static ConfigKey<?> TARGET_VALUE = ConfigKeys.newConfigKey(Object.class, "enricher.targetValue");
-    public static ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation");
-    public static ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation.fromevent");
+    public static final ConfigKey<Object> TARGET_VALUE = ConfigKeys.newConfigKey(Object.class, "enricher.targetValue");
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation");
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation.fromevent");
 
     public Transformer() { }
     

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricher.java
@@ -20,7 +20,9 @@ package org.apache.brooklyn.enricher.stock;
 
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
+import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.config.ConfigKey;
@@ -79,6 +81,14 @@ public class YamlRollingTimeWindowMeanEnricher<T extends Number> extends Abstrac
     private final LinkedList<T> values = new LinkedList<T>();
     private final LinkedList<Long> timestamps = new LinkedList<Long>();
     volatile ConfidenceQualifiedNumber lastAverage = new ConfidenceQualifiedNumber(0d,0d);
+    
+    @Override
+    public void setEntity(EntityLocal entity) {
+        super.setEntity(entity);
+        
+        // Check that sourceSensor has been set (rather than triggerSensors)
+        getRequiredConfig(SOURCE_SENSOR);
+    }
     
     @Override
     protected Function<SensorEvent<T>, Double> getTransformation() {

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlTimeWeightedDeltaEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlTimeWeightedDeltaEnricher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.enricher.stock;
 
+import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -44,8 +45,16 @@ public class YamlTimeWeightedDeltaEnricher<T extends Number> extends AbstractTra
     Number lastValue;
     long lastTime = -1;
     
-    public static ConfigKey<Duration> DELTA_PERIOD = ConfigKeys.newConfigKey(Duration.class, "enricher.delta.period",
+    public static final ConfigKey<Duration> DELTA_PERIOD = ConfigKeys.newConfigKey(Duration.class, "enricher.delta.period",
         "Duration that this delta should compute for, default per second", Duration.ONE_SECOND);
+    
+    @Override
+    public void setEntity(EntityLocal entity) {
+        super.setEntity(entity);
+        
+        // Check that sourceSensor has been set (rather than triggerSensors)
+        getRequiredConfig(SOURCE_SENSOR);
+    }
     
     @Override
     protected Function<SensorEvent<T>, Double> getTransformation() {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
@@ -24,7 +24,7 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
- * Entity that makes a HTTP Request and tests the respose
+ * Entity that makes a HTTP Request and tests the response
  *
  * @author johnmccabe
  */


### PR DESCRIPTION
Some uses of the transformer want to be triggered by multiple sensor
events (e.g. when they will combine two sensor values). This change
allows us to subscribe to multiple sensors, and to trigger the
evaulation when any of those change.

The sourceSensor is now optional. You can use it in the same way as
previously, or you can use just triggerSensors, or you can combine the
two. If combined, then the triggerSensors will cause us to look up the
latest value of the sourceSensor and synthesise an event as though
the source sensor had just published.
