### PR TITLE
Fix BROOKLYN-271: Avoiding object hashcode in entities' toString.

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
@@ -432,5 +432,10 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
     private void checkMutable() {
         if (immutable) throw new IllegalStateException("Cannot modify immutable entity spec "+this);
     }
-    
+
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }

--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntitySpec.java
@@ -433,9 +433,4 @@ public class EntitySpec<T extends Entity> extends AbstractBrooklynObjectSpec<T,E
         if (immutable) throw new IllegalStateException("Cannot modify immutable entity spec "+this);
     }
 
-    @Override
-    public String toString(){
-        return getClass().getName();
-    }
-
 }

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -83,7 +83,10 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("type", getType()).toString()+"@"+Integer.toHexString(System.identityHashCode(this));
+        return Objects.toStringHelper(this).omitNullValues()
+                .add("type", type)
+                .add("displayName", displayName)
+                .toString();
     }
 
     protected abstract void checkValidType(Class<? extends T> type);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/BalancingNodePlacementStrategy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/BalancingNodePlacementStrategy.java
@@ -128,4 +128,10 @@ public class BalancingNodePlacementStrategy implements NodePlacementStrategy {
         });
         return stoppables.subList(0, Math.min(numToPick, stoppables.size()));
     }
+
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.entity.group.zoneaware;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.util.time.Duration;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Ticker;
 
 public class ProportionalZoneFailureDetector extends AbstractZoneFailureDetector {
@@ -59,7 +60,11 @@ public class ProportionalZoneFailureDetector extends AbstractZoneFailureDetector
 
     @Override
     public String toString(){
-        return getClass().getName();
+        return Objects.toStringHelper(this)
+                .add("minDatapoints", minDatapoints)
+                .add("timeToConsider",  timeToConsider)
+                .add("maxProportionFailures", maxProportionFailures)
+                .toString();
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
@@ -56,4 +56,10 @@ public class ProportionalZoneFailureDetector extends AbstractZoneFailureDetector
             return numDatapoints >= minDatapoints && proportionFailure >= maxProportionFailures;
         }
     }
+
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
@@ -461,5 +461,10 @@ public class BrooklynImageChooser implements Cloneable {
     public Function<Iterable<? extends Image>,Image> chooser() {
         return imageChooserFromOrdering(ordering());
     }
-    
+
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
@@ -371,7 +371,12 @@ public class BrooklynImageChooser implements Cloneable {
             } else {
                 return this;
             }
-        }        
+        }
+
+        @Override
+        public String toString(){
+            return getClass().getName();
+        }
     }
 
     public static Function<Iterable<? extends Image>, Image> imageChooserFromOrdering(final Ordering<Image> ordering) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -179,4 +179,10 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
             return null;
         }
     }
+
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -261,5 +261,10 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
         entity().postStop();
     }
 
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }
 


### PR DESCRIPTION
Fixing [BROOKLYN-271](https://issues.apache.org/jira/browse/BROOKLYN-271)
Avoiding object references in catalog ConfigKey cards, for example:

<img width="1036" alt="captura de pantalla 2016-05-19 a la s 17 46 04" src="https://cloud.githubusercontent.com/assets/3704424/15399867/992624fa-1de9-11e6-9e21-b9efe659ab1e.png">

Last picture shows that default value of `softwareProcess.lifecycleTasks` config key does not contain the object hashcode `@XXXXX`. Then, objects `toString` methods are modified to avoid the hashcode.