### PR TITLE
Test and fix locations not being unmanaged

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -72,6 +72,8 @@ import org.apache.brooklyn.core.internal.storage.BrooklynStorage;
 import org.apache.brooklyn.core.internal.storage.Reference;
 import org.apache.brooklyn.core.internal.storage.impl.BasicReference;
 import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
 import org.apache.brooklyn.core.mgmt.internal.EffectorUtils;
 import org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -877,6 +879,21 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         if (newLocations==null || newLocations.isEmpty()) {
             return;
         }
+
+        for (Location loc : newLocations) {
+            NamedStringTag ownerEntityTag = BrooklynTags.findFirst(BrooklynTags.OWNER_ENTITY_ID, loc.tags().getTags());
+            if (ownerEntityTag != null) {
+                if (!getId().equals(ownerEntityTag.getContents())) {
+                    // A location is "owned" if it was created as part of the EntitySpec of an entity (by Brooklyn).
+                    // To share a location between entities create it yourself and pass it to any entities that needs it.
+                    LOG.warn("Adding location {} to entity {} which is already owner by another entity {}. " +
+                            "Locations which are owned by a specific entity should not be shared with other entities as they " +
+                            "will be unmanaged together with their owner, regardless of other references to them.",
+                            new Object[] {loc, this, ownerEntityTag.getContents()});
+                }
+            }
+        }
+
         synchronized (locations) {
             List<Location> oldLocations = locations.get();
             Set<Location> trulyNewLocations = Sets.newLinkedHashSet(newLocations);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.util.collections.MutableList;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -37,6 +38,7 @@ public class BrooklynTags {
 
     public static final String YAML_SPEC_KIND = "yaml_spec";
     public static final String NOTES_KIND = "notes";
+    public static final String OWNER_ENTITY_ID = "owner_entity_id";
     
     public static class NamedStringTag implements Serializable {
         private static final long serialVersionUID = 7932098757009051348L;
@@ -113,6 +115,10 @@ public class BrooklynTags {
 
     public static NamedStringTag newNotesTag(String contents) {
         return new NamedStringTag(NOTES_KIND, contents);
+    }
+    
+    public static NamedStringTag newOwnerEntityTag(String ownerId) {
+        return new NamedStringTag(OWNER_ENTITY_ID, ownerId);
     }
 
     public static TraitsTag newTraitsTag(List<Class<?>> interfaces) {

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -46,6 +46,7 @@ import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityDynamicType;
 import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
@@ -327,8 +328,14 @@ public class InternalEntityFactory extends InternalFactory {
                 ((AbstractEntity)entity).init();
 
                 for (LocationSpec<?> locationSpec : spec.getLocationSpecs()) {
+                    // Would prefer to tag with the Proxy object (((AbstractEntity)entity).getProxy())
+                    // but it's not clear how is the tag being serialized. Better make sure that
+                    // anything in tags can be serialized and deserialized. For example catalog tags
+                    // are already accessible through the REST API.
+                    LocationSpec<?> taggedSpec = LocationSpec.create(locationSpec)
+                            .tag(BrooklynTags.newOwnerEntityTag(entity.getId()));
                     ((AbstractEntity)entity).addLocations(MutableList.of(
-                        managementContext.getLocationManager().createLocation(locationSpec)));
+                        managementContext.getLocationManager().createLocation(taggedSpec)));
                 }
                 ((AbstractEntity)entity).addLocations(spec.getLocations());
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -478,6 +478,7 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
                 .configure("nodeId", "myNodeId")
                 .configure("imageId", "myImageId")
                 .configure("privateAddresses", ImmutableSet.of("10.0.0.1"))
+                .configure("privateHostname", "10.0.0.1")
                 .configure("publicAddresses", ImmutableSet.of("56.0.0.1"))
                 );
             registerJcloudsMachineLocation("bogus", result);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/SoftwareProcessLocationUnmanageTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/location/SoftwareProcessLocationUnmanageTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.software.base.test.location;
+
+import java.util.Set;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationTest.FakeLocalhostWithParentJcloudsLocation;
+import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+public class SoftwareProcessLocationUnmanageTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testLocalhostLocationUnmanagedOnStop() {
+        LocationSpec<LocalhostMachineProvisioningLocation> locationSpec = LocationSpec.create(TestApplication.LOCALHOST_PROVISIONER_SPEC);
+        testLocationUnmanagedOnStop(locationSpec);
+    }
+
+    @Test(groups="Live")
+    public void testDockerLocationUnmanagedOnStop() {
+        LocationSpec<? extends Location> locationSpec = LocationSpec.create(JcloudsLocation.class)
+                .configure(JcloudsLocation.CLOUD_PROVIDER, "docker")
+                .configure(JcloudsLocation.CLOUD_ENDPOINT, "http://<docker-ip>:2375")
+                // Either the certificates for a tls enabled endpoint or any valid keys for non-tls endpoints (still required by jclouds)
+                .configure(JcloudsLocation.ACCESS_IDENTITY, "<path to>/cert.pem")
+                .configure(JcloudsLocation.ACCESS_CREDENTIAL, "<path to>/key.pem")
+                // needs "docker pull ubuntu:14.04" beforehand
+                .configure(JcloudsLocation.IMAGE_DESCRIPTION_REGEX, "ubuntu:14.04")
+                .configure(JcloudsLocation.WAIT_FOR_SSHABLE, "false");
+        testLocationUnmanagedOnStop(locationSpec);
+    }
+
+    @Test
+    public void testJcloudsLocationUnmanagedOnStop() {
+        LocationSpec<? extends Location> locationSpec = LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class)
+                .configure(JcloudsLocation.CLOUD_PROVIDER, "aws-ec2")
+                .configure(JcloudsLocation.ACCESS_IDENTITY, "dummy")
+                .configure(JcloudsLocation.ACCESS_CREDENTIAL, "xxx")
+                .configure(JcloudsLocation.WAIT_FOR_SSHABLE, "false");
+        testLocationUnmanagedOnStop(locationSpec);
+    }
+
+    private void testLocationUnmanagedOnStop(LocationSpec<? extends Location> locationSpec) {
+        EntitySpec<BasicApplication> appSpec = EntitySpec.create(BasicApplication.class)
+            .location(locationSpec)
+            .child(EntitySpec.create(EmptySoftwareProcess.class)
+                    .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, Boolean.TRUE)
+                    .configure(EmptySoftwareProcess.USE_SSH_MONITORING, Boolean.FALSE));
+
+        BasicApplication app = mgmt.getEntityManager().createEntity(appSpec);
+        Entity child = Iterables.getOnlyElement(app.getChildren());
+
+        Assert.assertEquals(child.getLocations(), ImmutableList.of());
+
+        app.start(ImmutableList.<Location>of());
+        Location appLocation = Iterables.getOnlyElement(app.getLocations());
+        assertOwned(app, appLocation);
+        Location entityLocation = Iterables.getOnlyElement(child.getLocations());
+        // No owner tag because it's created by SoftwareProcess, not by Brooklyn internals
+        assertNotOwned(entityLocation);
+        app.stop();
+
+        Assert.assertEquals(child.getLocations(), ImmutableList.of());
+
+        Assert.assertFalse(mgmt.getEntityManager().isManaged(child));
+        Assert.assertFalse(mgmt.getEntityManager().isManaged(app));
+        Set<Location> locs = ImmutableSet.copyOf(mgmt.getLocationManager().getLocations());
+        Assert.assertFalse(locs.contains(entityLocation), locs + " should not contain " + entityLocation);
+        Assert.assertFalse(locs.contains(appLocation), locs + " should not contain " + appLocation);
+    }
+
+    private void assertOwned(BasicApplication app, Location loc) {
+        NamedStringTag ownerEntityTag = BrooklynTags.findFirst(BrooklynTags.OWNER_ENTITY_ID, loc.tags().getTags());
+        Assert.assertNotNull(ownerEntityTag);
+        Assert.assertEquals(ownerEntityTag.getContents(), app.getId());
+    }
+
+    private void assertNotOwned(Location loc) {
+        NamedStringTag ownerEntityTag = BrooklynTags.findFirst(BrooklynTags.OWNER_ENTITY_ID, loc.tags().getTags());
+        Assert.assertNull(ownerEntityTag);
+    }
+
+}


### PR DESCRIPTION
Only `MachineLocation` locations created by `SoftwareProcess` are unmanaged. Currently there's no owner for `LocationResolver` locations so there's no one to unmanage them.

The changes will mark locations created as part of bringing up a spec as owner by the entity where they are attached. When the entity is unmanaged the locations will be unmanaged as well.
