### PR TITLE
Ability to perform installation on a Windows Blueprint which changes Computer Name and requires reboot

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.entity.software.base;
 
 import java.util.Collection;
 
+import com.google.common.annotations.Beta;
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.ImplementedBy;
@@ -96,9 +97,12 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
 
     ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",
             "indicates that a reboot should be performed after the pre-install command is run", false);
-    
+
+    @Beta
     ConfigKey<Boolean> INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("install.reboot.required",
-            "indicates that a reboot should be performed after the install command is run", false);
+            "indicates that a reboot should be performed after the install command is run." +
+            "When running the install command and the reboot command this parameter adds computername when authenticating.",
+            false);
     
     ConfigKey<Boolean> CUSTOMIZE_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("customize.reboot.required",
             "indicates that a reboot should be performed after the customize command is run", false);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskQueueingContext;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.core.task.Tasks;
@@ -54,6 +55,7 @@ public class WinRmExecuteHelper {
     protected final NativeWindowsScriptRunner runner;
     public final String summary;
 
+    private String domain;
     private String command;
     private String psCommand;
 
@@ -65,6 +67,11 @@ public class WinRmExecuteHelper {
     public WinRmExecuteHelper(NativeWindowsScriptRunner runner, String summary) {
         this.runner = runner;
         this.summary = summary;
+    }
+
+    public WinRmExecuteHelper setNtDomain(String domain) {
+        this.domain = domain;
+        return this;
     }
 
     public WinRmExecuteHelper setCommand(String command) {
@@ -142,6 +149,7 @@ public class WinRmExecuteHelper {
             flags.put("out", stdout);
             flags.put("err", stderr);
         }
+        flags.put(WinRmTool.COMPUTER_NAME, domain);
         result = runner.executeNativeOrPsCommand(flags, command, psCommand, summary, false);
         if (!resultCodeCheck.apply(result)) {
             throw logWithDetailsAndThrow(format("Execution failed, invalid result %s for %s", result, summary), null);

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -46,7 +46,7 @@ public interface WinRmTool {
     ConfigKey<String> PROP_HOST = newStringConfigKey("host", "Host to connect to (required)", null);
     ConfigKey<Integer> PROP_PORT = ConfigKeys.newIntegerConfigKey("port", "WinRM port to use when connecting to the remote machine");
     ConfigKey<Boolean> USE_HTTPS_WINRM = ConfigKeys.newBooleanConfigKey("winrm.useHttps", "The parameter tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", false);
-    ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = ConfigKeys.newIntegerConfigKey("retriesOfNetworkFailures", "The parameter sets the number of retries for connection failures. If you use high value, consider taking care for the machine's network.");
+    ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = ConfigKeys.newIntegerConfigKey("retriesOfNetworkFailures", "The parameter sets the number of retries for connection failures. If you use high value, consider taking care for the machine's network.", 4);
     /**
      * Flag which tells winrm whether to use Basic Authentication
      * or Negotiate plus NTLM.
@@ -55,6 +55,9 @@ public interface WinRmTool {
      */
     @Beta
     ConfigKey<Boolean> USE_NTLM = ConfigKeys.newBooleanConfigKey("winrm.useNtlm", "The parameter configures tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", true);
+
+    @Beta
+    ConfigKey<String> COMPUTER_NAME = ConfigKeys.newStringConfigKey("winrm.computerName", "Windows Computer Name to use for authentication.");
     ConfigKey<String> PROP_USER = newStringConfigKey("user", "User to connect as", null);
     ConfigKey<String> PROP_PASSWORD = newStringConfigKey("password", "Password to use to connect", null);
     ConfigKey<String> OPERATION_TIMEOUT = newStringConfigKey("winrm.operationTimeout", "WinRM OperationTimeout. If no output is available before the wsman:OperationTimeout expires, " +

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmException;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 import org.apache.commons.codec.binary.Base64;
@@ -63,6 +64,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
     private final ConfigBag bag;
     private final String host;
     private final Integer port;
+    private final String computerName;
     private final String user;
     private final String password;
     private final int execTries;
@@ -83,6 +85,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
         port = config.get(PROP_PORT);
         useSecureWinrm = config.get(USE_HTTPS_WINRM);
         authenticationScheme = config.get(USE_NTLM) ? AuthSchemes.NTLM : null;
+        computerName = Strings.isNonBlank(config.get(COMPUTER_NAME)) ? config.get(COMPUTER_NAME) : null;
         user = getRequiredConfig(config, PROP_USER);
         password = getRequiredConfig(config, PROP_PASSWORD);
         execTries = getRequiredConfig(config, PROP_EXEC_TRIES);
@@ -195,7 +198,7 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
     }
 
     private io.cloudsoft.winrm4j.winrm.WinRmTool connect() {
-        WinRmTool.Builder builder = WinRmTool.Builder.builder(host, user, password);
+        WinRmTool.Builder builder = WinRmTool.Builder.builder(host, computerName, user, password);
         builder.setAuthenticationScheme(authenticationScheme);
         builder.useHttps(useSecureWinrm);
         builder.port(port);


### PR DESCRIPTION
- update the `install.reboot.required` action to use computername when running the install command and the reboot command
- set small and reasonable default value for connection retries of winrm4j client
