### PR TITLE
Merge Map values in Location config

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -459,7 +459,7 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
 
         @Override
         public void addToLocalBag(Map<String, ?> vals) {
-            configBag.putAll(vals);
+            configBag = ConfigBag.newInstanceExtending(configBag, vals);
         }
 
         @Override

--- a/core/src/main/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocation.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -279,7 +280,7 @@ implements MachineProvisioningLocation<T>, Closeable {
     public T obtain(Map<?,?> flags) throws NoMachinesAvailableException {
         T machine;
         T desiredMachine = (T) flags.get("desiredMachine");
-        ConfigBag allflags = ConfigBag.newInstanceExtending(config().getBag()).putAll(flags);
+        ConfigBag allflags = ConfigBag.newInstanceExtending(config().getBag(), flags);
         Function<Iterable<? extends MachineLocation>, MachineLocation> chooser = allflags.get(MACHINE_CHOOSER);
         
         synchronized (lock) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -29,8 +29,8 @@ import javax.annotation.Nonnull;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.collections.CollectionHelpers;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
@@ -123,10 +123,17 @@ public class ConfigBag {
         }
     }
     
-    /** As {@link #newInstanceExtending(ConfigBag)} but also putting the supplied values. */
+    /** As {@link #newInstanceExtending(ConfigBag)} but also putting the supplied values.
+     * In Apache Brooklyn the method is used only for Location configuration.
+     * The method will do a shallow merge only for templateOptions key, other keys will override with <code>optionalAdditionalValues</code>.
+     */
     @Beta
     public static ConfigBag newInstanceExtending(final ConfigBag configBag, Map<?,?> optionalAdditionalValues) {
-        return newInstanceExtending(configBag).putAll(optionalAdditionalValues);
+        if (optionalAdditionalValues != null) {
+            return newInstance(CollectionHelpers.mergeMapsAndTheirInnerMapValues(configBag.getAllConfig(), (Map<String, Object>) optionalAdditionalValues, "templateOptions"));
+        } else {
+            return newInstanceExtending(configBag);
+        }
     }
 
     /** @deprecated since 0.7.0, not used; kept only for rebind compatibility where the inner class is used 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/collections/CollectionHelpers.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/collections/CollectionHelpers.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.collections;
+
+import java.util.Map;
+
+public class CollectionHelpers {
+    public static Map<String, Object> mergeMapsAndTheirInnerMapValues(Map<String, Object> defaultEntries, Map<String, Object> overrideWith) {
+        return mergeMapsAndTheirInnerMapValues(defaultEntries, overrideWith, null);
+    }
+
+    /**
+     * Does a shallow merge of two maps.
+     */
+    public static Map<String, Object> mergeMapsAndTheirInnerMapValues(Map<String, Object> defaultEntries, Map<String, Object> overrideWith, String keyToWhichShallowMergeIsRestricted) {
+        Map<String, Object> result = MutableMap.of();
+        result.putAll(defaultEntries);
+        for (Map.Entry<String, Object> newEntry: overrideWith.entrySet()) {
+            if (!defaultEntries.containsKey(newEntry.getKey())) {
+                result.put(newEntry.getKey(), newEntry.getValue());
+            } else if (newEntry.getValue() instanceof Map) {
+                Map<Object, Object> mergedValue = MutableMap.of();
+                if (defaultEntries.get(newEntry.getKey()) instanceof Map) {
+                    if (keyToWhichShallowMergeIsRestricted == null || keyToWhichShallowMergeIsRestricted.equals(newEntry.getKey())) {
+                        mergedValue.putAll((Map) defaultEntries.get(newEntry.getKey()));
+                    }
+                }
+                mergedValue.putAll((Map<Object,Object>) newEntry.getValue());
+                result.put(newEntry.getKey(), mergedValue);
+            } else {
+                result.put(newEntry.getKey(), newEntry.getValue());
+            }
+        }
+        return result;
+    }
+}

--- a/utils/common/src/test/java/org/apache/brooklyn/util/collections/CollectionHelpersTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/collections/CollectionHelpersTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.collections;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.apache.brooklyn.util.collections.CollectionHelpers.mergeMapsAndTheirInnerMapValues;
+import static org.testng.Assert.assertEquals;
+
+public class CollectionHelpersTest {
+    @Test
+    public void testMergeMapsEmpty() {
+        Map<String, Object> targetMap = MutableMap.of();
+        Map<String, Object> overrideWithNew = MutableMap.of();
+
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew), MutableMap.of());
+    }
+
+    @Test
+    public void testMergeMapsNonMapValues() {
+        Map<String, Object> targetMap = ImmutableMap.<String, Object>of("testKeyTarget", "testValTarget", "testKeyTarget1", "testVal1");
+        Map<String, Object> overrideWithNew = ImmutableMap.<String, Object>of("testKeyNew1", "testValNew1", "testKeyTarget", "testValNew2");
+
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew),
+                ImmutableMap.<String, Object>of(
+                        "testKeyTarget1", "testVal1",
+                        "testKeyNew1", "testValNew1",
+                        "testKeyTarget", "testValNew2"));
+    }
+
+    /**
+     * Always override with the new value
+     */
+    @Test
+    public void testMergeMapsOverridingMapAndNonMapValues() {
+        Map<String, Object> targetMap = ImmutableMap.<String, Object>of("testMapValue", ImmutableMap.of(), "testKeyTarget1", "testVal1");
+        Map<String, Object> overrideWithNew = ImmutableMap.<String, Object>of("testKeyNew1", "testValNew1", "testMapValue", "testValNew2");
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew),
+                ImmutableMap.<String, Object>of(
+                        "testMapValue", "testValNew2",
+                        "testKeyTarget1", "testVal1",
+                        "testKeyNew1", "testValNew1"));
+
+        targetMap = ImmutableMap.<String, Object>of("testMapValue", "testValNew2", "testKeyTarget1", "testVal1", "testKeyTarget2", "testVal2");
+        overrideWithNew = MutableMap.<String, Object>of("testKeyNew1", "testValNew1", "testMapValue", ImmutableMap.of());
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew),
+                ImmutableMap.<String, Object>of(
+                        "testMapValue", ImmutableMap.of(),
+                        "testKeyTarget1", "testVal1",
+                        "testKeyNew1", "testValNew1",
+                        "testKeyTarget2", "testVal2"));
+    }
+
+    @Test
+    public void testMergeMapsOverridingMapValues() {
+        Map<String, Object> targetMap = ImmutableMap.<String, Object>of("testTargetKey", "testTargetValue",
+                "testTargetKey1", "testTargetValue1",
+                "templateOptions", ImmutableMap.of("locKey1", "locVal1", "locKey2", "locVal2", "locKey3", "locVal3"));
+
+        Map<String, Object> overrideWithNew = ImmutableMap.<String, Object>of("testKeyNew1", "testValNew1",
+                "templateOptions", ImmutableMap.of("locKey1", "locValNew1", "locKey2", "locValNew2"),
+                "testTargetKey", "testNewValue");
+
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew),
+                ImmutableMap.<String, Object>of(
+                        "testTargetKey1", "testTargetValue1",
+                        "templateOptions", ImmutableMap.of("locKey1", "locValNew1", "locKey3", "locVal3", "locKey2", "locValNew2"),
+                        "testKeyNew1", "testValNew1",
+                        "testTargetKey", "testNewValue"));
+    }
+
+    @Test
+    public void testMergeMapsOverridingMapValuesNested() {
+        Map<String, Object> targetMap = ImmutableMap.<String, Object>of(
+                "testTargetKey", "testTargetValue",
+                "testTargetKey1", "testTargetValue1",
+                "templateOptions", ImmutableMap.of(
+                        "locKey2", ImmutableMap.of("locKeyNestedTarget", "locKey2UniqVal"),
+                        "locKey1", "locVal1",
+                        "locKey3", "locVal3"));
+
+        Map<String, Object> overrideWithNew = ImmutableMap.<String, Object>of("testKeyNew1", "testValNew1",
+                "templateOptions", ImmutableMap.of(
+                        "locKey1", "locValNew1",
+                        "locKey2", ImmutableMap.of("locKey21", "locKeyVal21")),
+                "testTargetKey", "testNewValue");
+
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew),
+                ImmutableMap.<String, Object>of(
+                        "testTargetKey1", "testTargetValue1",
+                        "templateOptions", ImmutableMap.of(
+                                "locKey1", "locValNew1",
+                                "locKey3", "locVal3",
+                                "locKey2", ImmutableMap.of("locKey21", "locKeyVal21")), // It will override Maps which are one level deeper
+                        "testKeyNew1", "testValNew1",
+                        "testTargetKey", "testNewValue"));
+    }
+
+    @Test
+    public void testMergeMapsOverridingMapValuesRestrictedToAKey() {
+        Map<String, Object> targetMap = ImmutableMap.<String, Object>of("testTargetKey", "testTargetValue",
+                "testTargetKey1", "testTargetValue1",
+                "keyToReplace", ImmutableMap.of("locKey1", "locValNew1", "locKey3", "locVal3", "locKey2", "locValNew2"),
+                "keyToMerge",   ImmutableMap.of("locKey1", "locValNew1", "locKey3", "locVal3", "locKey2", "locValNew2"));
+
+        Map<String, Object> overrideWithNew = ImmutableMap.<String, Object>of("testKeyNew1", "testValNew1",
+                "keyToReplace", ImmutableMap.of("mlocKey1", "newLocValNew1", "locKey3", "newLocVal3", "locKey2", "newLocValNew2"),
+                "keyToMerge",   ImmutableMap.of("mlocKey1", "newLocValNew1", "locKey3", "newLocVal3", "locKey2", "newLocValNew2"),
+                "testTargetKey", "testNewValue");
+
+        assertEquals(mergeMapsAndTheirInnerMapValues(targetMap, overrideWithNew, "keyToMerge"),
+                ImmutableMap.<String, Object>of(
+                        "testTargetKey1", "testTargetValue1",
+                        "keyToReplace", ImmutableMap.of("mlocKey1", "newLocValNew1", "locKey3", "newLocVal3", "locKey2", "newLocValNew2"),
+                        "keyToMerge", ImmutableMap.of("locKey1", "locValNew1",
+                                "mlocKey1", "newLocValNew1", "locKey3", "newLocVal3", "locKey2", "newLocValNew2"),
+                        "testKeyNew1", "testValNew1",
+                        "testTargetKey", "testNewValue"));
+    }
+}


### PR DESCRIPTION
Merge location configuration and application's provisioning.properties.
This PR will modify the behaviour of existing blueprints, I believe to better.
When deploying a blueprint with provisioning.properties and templateOptions configuration for example with will again prefer the provisioning.properties but it will also take any old values in templateOptions.