### PR TITLE
Resolve AddSensor and AddEffector config

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
@@ -47,14 +47,23 @@ import com.google.common.base.Preconditions;
 @Beta
 public class AddSensor<T> implements EntityInitializer {
 
-    public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey("name", "The name of the sensor to create");
-    public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newConfigKey(Duration.class, "period", "Period, including units e.g. 1m or 5s or 200ms; default 5 minutes", Duration.FIVE_MINUTES);
-    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newStringConfigKey("targetType", "Target type for the value; default String", "java.lang.String");
+    public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey(
+            "name", "The name of the sensor to create");
+
+    public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newDurationConfigKey(
+            "period",
+            "Period in which the sensor should be updated, including units e.g. 1m, 5s or 200ms; default 5 minutes",
+            Duration.FIVE_MINUTES);
+
+    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newStringConfigKey(
+            "targetType", "Target type for the value; default String",
+            "java.lang.String");
 
     protected final String name;
     protected final Duration period;
     protected final String type;
     protected final AttributeSensor<T> sensor;
+    protected final ConfigBag params;
 
     public AddSensor(Map<String, String> params) {
         this(ConfigBag.newInstance(params));
@@ -65,6 +74,7 @@ public class AddSensor<T> implements EntityInitializer {
         this.period = params.get(SENSOR_PERIOD);
         this.type = params.get(SENSOR_TYPE);
         this.sensor = newSensor();
+        this.params = params;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
-import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.AddSensor;
@@ -30,7 +29,6 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.enricher.stock.Propagator;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.Tasks;
-import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -47,7 +45,8 @@ import com.google.common.base.Supplier;
  * This supports a {@link StaticSensor#SENSOR_PERIOD} 
  * which can be useful if the supplied value is such a function.
  * However when the source is another sensor,
- * consider using {@link Propagator} which listens for changes instead. */
+ * consider using {@link Propagator} which listens for changes instead.
+ */
 public class StaticSensor<T> extends AddSensor<T> {
 
     private static final Logger log = LoggerFactory.getLogger(StaticSensor.class);
@@ -65,18 +64,24 @@ public class StaticSensor<T> extends AddSensor<T> {
         timeout = params.get(TIMEOUT);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void apply(final EntityLocal entity) {
         super.apply(entity);
 
         class ResolveValue implements Callable<Maybe<T>> {
+            @SuppressWarnings("unchecked")
             @Override
             public Maybe<T> call() throws Exception {
-                return Tasks.resolving(value).as((Class<T>)sensor.getType()).timeout(timeout).getMaybe();
+                return Tasks.resolving(value)
+                        .as((Class<T>)sensor.getType())
+                        .timeout(timeout)
+                        .getMaybe();
             }
         }
-        final Task<Maybe<T>> resolveValue = Tasks.<Maybe<T>>builder().displayName("resolving " + value).body(new ResolveValue()).build();
+        final Task<Maybe<T>> resolveValue = Tasks.<Maybe<T>>builder()
+                .displayName("resolving " + value)
+                .body(new ResolveValue())
+                .build();
 
         class SetValue implements Callable<T> {
             @Override

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensor.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.entity.EntityInitializers;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Identifiers;
 
@@ -33,22 +34,20 @@ public class CreatePasswordSensor extends AddSensor<String> {
 
     public static final ConfigKey<String> ACCEPTABLE_CHARS = ConfigKeys.newStringConfigKey("password.chars", "The characters allowed in password");
 
-    private Integer passwordLength;
-    private String acceptableChars;
-
     public CreatePasswordSensor(Map<String, String> params) {
         this(ConfigBag.newInstance(params));
     }
 
     public CreatePasswordSensor(ConfigBag params) {
         super(params);
-        passwordLength = params.get(PASSWORD_LENGTH);
-        acceptableChars = params.get(ACCEPTABLE_CHARS);
     }
 
     @Override
     public void apply(EntityLocal entity) {
         super.apply(entity);
+
+        Integer passwordLength = EntityInitializers.resolve(params, PASSWORD_LENGTH);
+        String acceptableChars = EntityInitializers.resolve(params, ACCEPTABLE_CHARS);
 
         String password = acceptableChars == null
                 ? Identifiers.makeRandomPassword(passwordLength)

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/DeferredSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/DeferredSupplier.java
@@ -24,12 +24,12 @@ import com.google.common.base.Supplier;
  * A class that supplies objects of a single type. When used as a ConfigKey value,
  * the evaluation is deferred until getConfig() is called. The returned value will then
  * be coerced to the correct type. 
- * 
+ * <p>
  * Subsequent calls to getConfig will result in further calls to deferredProvider.get(), 
  * rather than reusing the result. If you want to reuse the result, consider instead 
  * using a Future.
- * 
- * Note that this functionality replaces the ues of Closure in brooklyn 0.4.0, which 
+ * <p>
+ * Note that this functionality replaces the ues of Closure in brooklyn 0.4.0, which
  * served the same purpose.
  */
 public interface DeferredSupplier<T> extends Supplier<T> {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
@@ -50,7 +50,7 @@ import com.google.common.reflect.TypeToken;
 
 /** 
  * Resolves a given object, as follows:
- * <li> If it is a {@link Tasks} or a {@link DeferredSupplier} then get its contents
+ * <li> If it is a {@link Task} or a {@link DeferredSupplier} then get its contents
  * <li> If it's a map and {@link #deep(boolean)} is requested, it applies resolution to contents
  * <li> It applies coercion
  * <p>


### PR DESCRIPTION
Resolves useful parameters of implementations of the `AddEffector` and `AddSensor` entity initializers, meaning that their values can be sourced from DslComponents.

Affects:
* SshCommandEffector's command and executionDir
* SshCommandSensor's command and executionDir
* CreatePasswordSensor's passwordLength and acceptableChars
* JmxAttributeSensor's objectName, attribute and defaultValue