### PR TITLE
[WIP] Add support for JSR-223 scripting of effectors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,11 +150,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.python</groupId>
-            <artifactId>jython</artifactId>
-            <version>2.7.0</version>
-        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
@@ -198,6 +193,12 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.python</groupId>
+            <artifactId>jython</artifactId>
+            <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,6 +150,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.python</groupId>
+            <artifactId>jython</artifactId>
+            <version>2.7.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/core/src/main/java/org/apache/brooklyn/core/effector/script/ScriptClassLoader.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/script/ScriptClassLoader.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.script;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * Blocks access to any {@code org.apache.brooklyn} classes
+ * with an entitlements check.
+ */
+public class ScriptClassLoader extends ClassLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ScriptClassLoader.class);
+
+    private List<Pattern> blacklist = ImmutableList.of();
+
+    public ScriptClassLoader(ClassLoader parent, String...blacklist) {
+        super(parent);
+        this.blacklist = compileBlacklist(blacklist);
+    }
+
+    private List<Pattern> compileBlacklist(String...blacklist) {
+        List<Pattern> patterns = Lists.newArrayList();
+        for (String entry : blacklist) {
+            patterns.add(Pattern.compile(entry));
+        }
+        return ImmutableList.copyOf(patterns);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        LOG.info("Script class loader: {}", name);
+        for (Pattern pattern : blacklist) {
+            if (pattern.matcher(name).matches()) {
+                throw new ClassNotFoundException(String.format("Class %s is blacklisted: %s", name, pattern.pattern()));
+            }
+        }
+        return super.loadClass(name, resolve);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ScriptClassLoader %s", Iterables.toString(blacklist));
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/script/ScriptEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/script/ScriptEffector.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.script;
+
+import java.util.Map;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
+
+import org.python.core.Options;
+
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.effector.ParameterType;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+
+import sun.org.mozilla.javascript.internal.NativeJavaObject;
+
+public final class ScriptEffector<T> extends AddEffector {
+
+    static {
+        Options.importSite = false; // Workaround for Jython
+    }
+
+    @SetFromFlag("lang")
+    public static final ConfigKey<String> EFFECTOR_SCRIPT_LANGUAGE = ConfigKeys.newStringConfigKey(
+            "script.language", "The scripting language the effector is written in", "JavaScript");
+
+    @SetFromFlag("content")
+    public static final ConfigKey<String> EFFECTOR_SCRIPT_CONTENT = ConfigKeys.newStringConfigKey(
+            "script.content", "The script code to evaluate for the effector");
+
+    @SetFromFlag("script")
+    public static final ConfigKey<String> EFFECTOR_SCRIPT_URL = ConfigKeys.newStringConfigKey(
+            "script.url", "A URL for the script to evaluate for the effector");
+
+    @SetFromFlag("return")
+    public static final ConfigKey<String> EFFECTOR_SCRIPT_RETURN_VAR = ConfigKeys.newStringConfigKey(
+            "script.return.var", "An optional script variable to return from the effector");
+
+    @SetFromFlag("type")
+    public static final ConfigKey<Class<?>> EFFECTOR_SCRIPT_RETURN_TYPE = ConfigKeys.newConfigKey(
+            new TypeToken<Class<?>>() { },
+            "script.return.type", "The type of the return value from the effector", Object.class);
+
+    public ScriptEffector(ConfigBag params) {
+        super(newEffectorBuilder(params).build());
+    }
+
+    public ScriptEffector(Map<String,?> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    public static EffectorBuilder<Object> newEffectorBuilder(ConfigBag params) {
+        EffectorBuilder<Object> eff = AddEffector.newEffectorBuilder(Object.class, params);
+        eff.impl(new Body(eff.buildAbstract(), params));
+        return eff;
+    }
+
+    protected static class Body extends EffectorBody<Object> {
+        private final Effector<?> effector;
+        private final String script;
+        private final String language;
+        private final String returnVar;
+        private final Class<?> returnType;
+        private final ScriptEngineManager factory = new ScriptEngineManager();
+        private final ScriptEngine engine;
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            this.effector = eff;
+            String content = params.get(EFFECTOR_SCRIPT_CONTENT);
+            String url = params.get(EFFECTOR_SCRIPT_URL);
+            if (Strings.isNonBlank(content)) {
+                this.script = content;
+            } else {
+                this.script = ResourceUtils.create().getResourceAsString(Preconditions.checkNotNull(url, "Script URL or content must be specified"));
+            }
+            this.language = params.get(EFFECTOR_SCRIPT_LANGUAGE);
+            this.returnVar = params.get(EFFECTOR_SCRIPT_RETURN_VAR);
+            this.returnType = params.get(EFFECTOR_SCRIPT_RETURN_TYPE);
+            this.engine = Preconditions.checkNotNull(factory.getEngineByName(language), "Engine for requested language does not exist");
+        }
+
+        @Override
+        public Object call(ConfigBag params) {
+            ScriptContext context = new SimpleScriptContext();
+
+            // Store effector arguments as engine scope bindings
+            for (ParameterType<?> param: effector.getParameters()) {
+                context.setAttribute(param.getName(), params.get(Effectors.asConfigKey(param)), ScriptContext.ENGINE_SCOPE);
+            }
+
+            // Add global scope object bindings
+            context.setAttribute("entity", entity(), ScriptContext.ENGINE_SCOPE);
+            context.setAttribute("managementContext", entity().getManagementContext(), ScriptContext.ENGINE_SCOPE);
+            context.setAttribute("task", Tasks.current(), ScriptContext.ENGINE_SCOPE);
+            context.setAttribute("config", params.getAllConfig(), ScriptContext.ENGINE_SCOPE);
+
+            try {
+                // Execute the script and return result
+                Object result = engine.eval(script, context);
+                if (Strings.isNonBlank(returnVar)) {
+                    result = context.getAttribute(returnVar, ScriptContext.ENGINE_SCOPE);
+                }
+                if (result instanceof NativeJavaObject) { // Unwarap JavaScript return values
+                    result = ((NativeJavaObject) result).unwrap();
+                }
+                return TypeCoercions.coerce(result, returnType);
+            } catch (ScriptException e) {
+                throw Exceptions.propagate(e);
+            }
+        }
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/effector/script/ScriptEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/script/ScriptEffectorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.script;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.guava.Maybe;
+
+public class ScriptEffectorTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testAddJavaScriptEffector() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new ScriptEffector(ConfigBag.newInstance(ImmutableMap.of(
+                        AddEffector.EFFECTOR_NAME, "javaScriptEffector",
+                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "js",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_VAR, "o",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_TYPE, String.class,
+                        ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "var o; o = \"jsval\";")))));
+        Maybe<Effector<?>> javaScriptEffector = entity.getEntityType().getEffectorByName("javaScriptEffector");
+        Assert.assertTrue(javaScriptEffector.isPresentAndNonNull(), "The JavaScript effector does not exist");
+        Object result = Entities.invokeEffector(entity, entity, javaScriptEffector.get()).getUnchecked();
+        Assert.assertTrue(result instanceof String, "Returned value is of type String");
+        Assert.assertEquals(result, "jsval", "Returned value is not correct");
+    }
+
+    @Test
+    public void testAddPythonEffector() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new ScriptEffector(ConfigBag.newInstance(ImmutableMap.of(
+                        AddEffector.EFFECTOR_NAME, "pythonEffector",
+                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "python",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_VAR, "o",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_TYPE, String.class,
+                        ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "o = \"pyval\"")))));
+        Maybe<Effector<?>> pythonEffector = entity.getEntityType().getEffectorByName("pythonEffector");
+        Assert.assertTrue(pythonEffector.isPresentAndNonNull(), "The Python effector does not exist");
+        Object result = Entities.invokeEffector(entity, entity, pythonEffector.get()).getUnchecked();
+        Assert.assertTrue(result instanceof String, "Returned value is of type String");
+        Assert.assertEquals(result, "pyval", "Returned value is not correct");
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/effector/script/ScriptEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/script/ScriptEffectorTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.effector.AddEffector;
 import org.apache.brooklyn.core.entity.Entities;
@@ -31,6 +32,7 @@ import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
 
 public class ScriptEffectorTest extends BrooklynAppUnitTestSupport {
 
@@ -44,25 +46,53 @@ public class ScriptEffectorTest extends BrooklynAppUnitTestSupport {
                         ScriptEffector.EFFECTOR_SCRIPT_RETURN_TYPE, String.class,
                         ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "var o; o = \"jsval\";")))));
         Maybe<Effector<?>> javaScriptEffector = entity.getEntityType().getEffectorByName("javaScriptEffector");
-        Assert.assertTrue(javaScriptEffector.isPresentAndNonNull(), "The JavaScript effector does not exist");
+        Assert.assertTrue(javaScriptEffector.isPresentAndNonNull(), "The effector does not exist");
         Object result = Entities.invokeEffector(entity, entity, javaScriptEffector.get()).getUnchecked();
-        Assert.assertTrue(result instanceof String, "Returned value is of type String");
+        Assert.assertTrue(result instanceof String, "Returned value is not of type String");
         Assert.assertEquals(result, "jsval", "Returned value is not correct");
     }
 
     @Test
+    public void testJavaScriptEffectorEntityAccess() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new ScriptEffector(ConfigBag.newInstance(ImmutableMap.of(
+                        AddEffector.EFFECTOR_NAME, "entityEffector",
+                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "js",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_VAR, "a",
+                        ScriptEffector.EFFECTOR_SCRIPT_RETURN_TYPE, Entity.class,
+                        ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "var a; a = entity.getApplication();")))));
+        Maybe<Effector<?>> entityEffector = entity.getEntityType().getEffectorByName("entityEffector");
+        Assert.assertTrue(entityEffector.isPresentAndNonNull(), "The effector does not exist");
+        Object result = Entities.invokeEffector(entity, entity, entityEffector.get()).getUnchecked();
+        Assert.assertTrue(result instanceof Entity, "Returned value is not of type Entity");
+        Assert.assertEquals(result, app, "Returned value is not correct");
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "Script language not supported: ruby")
+    public void testAddRubyEffector() {
+        app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new ScriptEffector(ConfigBag.newInstance(ImmutableMap.of(
+                        AddEffector.EFFECTOR_NAME, "rubyEffector",
+                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "ruby",
+                        ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "print \"Ruby\\n\"")))));
+    }
+
+    // TODO requires python.path to be set as JVM property
+    @Test(enabled = false)
     public void testAddPythonEffector() {
+        // System.setProperty("python.path", "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/");
         BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
                 .addInitializer(new ScriptEffector(ConfigBag.newInstance(ImmutableMap.of(
                         AddEffector.EFFECTOR_NAME, "pythonEffector",
-                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "python",
+                        ScriptEffector.EFFECTOR_SCRIPT_LANGUAGE, "jython",
                         ScriptEffector.EFFECTOR_SCRIPT_RETURN_VAR, "o",
                         ScriptEffector.EFFECTOR_SCRIPT_RETURN_TYPE, String.class,
                         ScriptEffector.EFFECTOR_SCRIPT_CONTENT, "o = \"pyval\"")))));
         Maybe<Effector<?>> pythonEffector = entity.getEntityType().getEffectorByName("pythonEffector");
-        Assert.assertTrue(pythonEffector.isPresentAndNonNull(), "The Python effector does not exist");
+        Assert.assertTrue(pythonEffector.isPresentAndNonNull(), "The effector does not exist");
         Object result = Entities.invokeEffector(entity, entity, pythonEffector.get()).getUnchecked();
-        Assert.assertTrue(result instanceof String, "Returned value is of type String");
+        Assert.assertTrue(result instanceof String, "Returned value is not of type String");
         Assert.assertEquals(result, "pyval", "Returned value is not correct");
     }
 }

--- a/core/src/test/resources/org/apache/brooklyn/core/effector/script/script-effector-example.yaml
+++ b/core/src/test/resources/org/apache/brooklyn/core/effector/script/script-effector-example.yaml
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+location:
+  localhost
+
+services:
+- type: org.apache.brooklyn.entity.stock.BasicStartable
+  brooklyn.initializers:
+
+  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+    brooklyn.config:
+      name: javascript
+      description: |
+        An effector implemented in JavaScript
+      parameters:
+        one:
+          type: java.lang.String
+          description: "A string argument"
+          defaultValue: "one"
+        two:
+          type: java.lang.Integer
+          description: "An integer argument"
+          defaultValue: 2
+      script.language: "JavaScript"
+      script.return.type: java.lang.String
+      script.content: |
+        var n = 0;
+        var out = "";
+        while (n < two) {
+          out += one;
+          n++;
+        }
+        out;
+  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+    brooklyn.config:
+      name: python
+      description: |
+        An effector implemented in Python
+      parameters:
+        n:
+          type: java.lang.Integer
+          defaultValue: 3
+      script.language: "python"
+      script.return.var: "s"
+      script.return.type: java.lang.Integer
+      script.content: |
+        class Square:
+          def square(self, x):
+            return int(x) * int(x)
+
+        s = Square().square(n)
+  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+    brooklyn.config:
+      name: renameEntity
+      description: |
+        A JavaScript effector manipulating entity data
+      parameters:
+        name:
+          type: java.lang.String
+          description: "The new entity name"
+      script.language: "JavaScript"
+      script.content: |
+        entity.setDisplayName(name);
+  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+    brooklyn.config:
+      name: getId
+      description: |
+        A Python effector returning entity data
+      script.language: "python"
+      script.return.var: "id"
+      script.return.type: java.lang.String
+      script.content: |
+        id = entity.getId()

--- a/core/src/test/resources/org/apache/brooklyn/core/effector/script/script-effector-example.yaml
+++ b/core/src/test/resources/org/apache/brooklyn/core/effector/script/script-effector-example.yaml
@@ -15,74 +15,81 @@
 # specific language governing permissions and limitations
 # under the License.
 
-location:
-  localhost
+brooklyn.catalog:
+  version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
 
-services:
-- type: org.apache.brooklyn.entity.stock.BasicStartable
-  brooklyn.initializers:
+  brooklyn.libraries:
+  - https://oss.sonatype.org/service/local/repositories/releases/content/org/python/jython/2.7.0/jython-2.7.0.jar
 
-  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
-    brooklyn.config:
-      name: javascript
-      description: |
-        An effector implemented in JavaScript
-      parameters:
-        one:
-          type: java.lang.String
-          description: "A string argument"
-          defaultValue: "one"
-        two:
-          type: java.lang.Integer
-          description: "An integer argument"
-          defaultValue: 2
-      script.language: "JavaScript"
-      script.return.type: java.lang.String
-      script.content: |
-        var n = 0;
-        var out = "";
-        while (n < two) {
-          out += one;
-          n++;
-        }
-        out;
-  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
-    brooklyn.config:
-      name: python
-      description: |
-        An effector implemented in Python
-      parameters:
-        n:
-          type: java.lang.Integer
-          defaultValue: 3
-      script.language: "python"
-      script.return.var: "s"
-      script.return.type: java.lang.Integer
-      script.content: |
-        class Square:
-          def square(self, x):
-            return int(x) * int(x)
-
-        s = Square().square(n)
-  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
-    brooklyn.config:
-      name: renameEntity
-      description: |
-        A JavaScript effector manipulating entity data
-      parameters:
-        name:
-          type: java.lang.String
-          description: "The new entity name"
-      script.language: "JavaScript"
-      script.content: |
-        entity.setDisplayName(name);
-  - type: org.apache.brooklyn.core.effector.script.ScriptEffector
-    brooklyn.config:
-      name: getId
-      description: |
-        A Python effector returning entity data
-      script.language: "python"
-      script.return.var: "id"
-      script.return.type: java.lang.String
-      script.content: |
-        id = entity.getId()
+  items:
+  - id: script-effector-example
+    name: "Script Effector Example"
+    description: |
+      An example entity with multiple effectors implemented using JSR-223
+      scripting. Includes Jython library for Python effectors.
+    itemType: entity
+    item:
+      services:
+      - type: org.apache.brooklyn.entity.stock.BasicStartable
+        brooklyn.initializers:
+        - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+          brooklyn.config:
+            name: javascript
+            description: |
+              An effector implemented in JavaScript
+            parameters:
+              one:
+                type: java.lang.String
+                description: "A string argument"
+                defaultValue: "one"
+              two:
+                type: java.lang.Integer
+                description: "An integer argument"
+                defaultValue: 2
+            script.language: "JavaScript"
+            script.return.type: java.lang.String
+            script.content: |
+              var n = 0;
+              var out = "";
+              while (n < two) {
+                out += one;
+                n++;
+              }
+              out;
+        - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+          brooklyn.config:
+            name: python
+            description: |
+              An effector implemented in Python
+            parameters:
+              n:
+                type: java.lang.Integer
+                defaultValue: 3
+            script.language: "python"
+            script.return.var: "s"
+            script.return.type: java.lang.Integer
+            script.content: |
+              class Square:
+                def square(self, x):
+                  return int(x) * int(x)
+              s = Square().square(n)
+        - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+          brooklyn.config:
+            name: renameEntity
+            description: |
+              A JavaScript effector manipulating entity data
+            parameters:
+              name:
+                type: java.lang.String
+                description: "The new entity name"
+            script.language: "JavaScript"
+            script.content: |
+              entity.setDisplayName(name);
+        - type: org.apache.brooklyn.core.effector.script.ScriptEffector
+          brooklyn.config:
+            name: getId
+            description: |
+              A Python effector returning entity data
+            script.language: "python"
+            script.return.var: "id"
+            script.return.type: java.lang.String


### PR DESCRIPTION
This is an attempt to add scripting language support to Brooklyn blueprints, so that effectors can be added in various languages directly. JSR-223 supports JavaScript and I have also added the Python 2.7.0 plugin, but many other languages are available.

See the `script-effector-example.yaml` file for an example of how these scripting languages can be used to implement effectors.
