### PR TITLE
Windows helper script for using Invoke-Command -Auth CredSSP

### DIFF
--- a/launcher/src/test/resources/mssql-test.yaml
+++ b/launcher/src/test/resources/mssql-test.yaml
@@ -35,6 +35,8 @@ services:
 - type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
   brooklyn.config:
     templates.install:
+      classpath://org/apache/brooklyn/software/winrm/utils/enable-credssp.ps1: "C:\\enable-credssp.ps1"
+      classpath://org/apache/brooklyn/software/winrm/utils/invoke-command-credssp.ps1: "C:\\invoke-command-credssp.ps1"
       classpath://org/apache/brooklyn/entity/database/mssql/ConfigurationFile.ini: "C:\\ConfigurationFile.ini"
       classpath://org/apache/brooklyn/entity/database/mssql/installmssql.ps1: "C:\\installmssql.ps1"
       classpath://org/apache/brooklyn/entity/database/mssql/configuremssql.ps1: "C:\\configuremssql.ps1"
@@ -44,7 +46,9 @@ services:
     customize.command: powershell -command "C:\\configuremssql.ps1"
     launch.command: "C:\\launchmssql.bat"
     stop.command: "C:\\stopmssql.bat"
-    checkRunning.command: echo true
+    checkRunning.powershell.command: |
+      $service = Get-Service -Name MSSQLSERVER
+      If ( (-not $service) -or ($service.Status -ne 'Running') ) { exit 1 }
 
     ## NOTE: Values must be supplied for the following
     mssql.download.url: ${mssql.download.url}

--- a/software/base/src/main/resources/org/apache/brooklyn/software/winrm/utils/enable-credssp.ps1
+++ b/software/base/src/main/resources/org/apache/brooklyn/software/winrm/utils/enable-credssp.ps1
@@ -21,11 +21,8 @@
 #  https://github.com/mwrock/boxstarter/blob/master/LICENSE.txt
 #  https://github.com/mwrock/boxstarter/blob/master/Boxstarter.Chocolatey/Enable-BoxstarterCredSSP.ps1
 
-function Custom-Enable-CredSSP {
+function Enable-CredSSP {
 <#
-.DEPRECATED
-Please use classpath://org/apache/brooklyn/software/winrm/utils/enable-credssp.ps1
-
 .SYNOPSIS
 Enables and configures CredSSP Authentication to be used in PowerShell remoting sessions
 
@@ -45,7 +42,7 @@ A list of ComputerNames to add to the CredSSP Trusted hosts list.
 A list of the original trusted hosts on the local machine.
 
 .EXAMPLE
-Custom-Enable-CredSSP box1,box2
+Enable-CredSSP box1,box2
 
 
 #>
@@ -53,6 +50,7 @@ Custom-Enable-CredSSP box1,box2
     [string[]] $RemoteHostsToTrust
     )
 
+    Write-Host "Configuring CredSSP settings..."
     # Required to be running for using CredSSP
     winrm quickconfig -transport:http -quiet
 
@@ -68,7 +66,6 @@ Custom-Enable-CredSSP box1,box2
         PreviousFreshCredDelegationHostCount=0
     }
 
-    Write-Host "Configuring CredSSP settings..."
     $credssp = Get-WSManCredSSP
 
     $ComputersToAdd = @()
@@ -128,7 +125,10 @@ function Set-CredentialDelegation($key, $subKey, $allowed){
     return $currentLength
 }
 
-$result = Custom-Enable-CredSSP $env:COMPUTERNAME,localhost
+$result = Enable-CredSSP $env:COMPUTERNAME,localhost
 if (-not $result.Success) {
+  Write-Error "Enabling CredSSP didn't succeed."
   exit 1
+} else {
+  Write-Host "CredSSP enabled."
 }

--- a/software/base/src/main/resources/org/apache/brooklyn/software/winrm/utils/invoke-command-credssp.ps1
+++ b/software/base/src/main/resources/org/apache/brooklyn/software/winrm/utils/invoke-command-credssp.ps1
@@ -1,0 +1,112 @@
+[#ftl]
+#!ps1
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+Param([Parameter(Mandatory=$True)][String]$Command, [String[]] $ArgumentList, [switch] $LogOutputInFile, $ScriptBlockInCredSSP)
+<#
+.SYNOPSIS
+Helper Script which executes commands through Invoke-Command -Authentication CredSSP
+
+.DESCRIPTION
+By default, PowerShell sessions do not
+use credSSP and therefore cannot bake a "second hop" to use other remote resources that
+require their authentication token.
+Microsoft: "CAUTION: Credential Security Support Provider (CredSSP) authentication, in which the user's credentials are passed to a remote computer to be authenticated, is designed for commands that require authentication on more than one resource, such as accessing a remote network share. This mechanism increases the security risk of the remote operation."
+Passing parameters in powershell: https://technet.microsoft.com/en-us/magazine/jj554301.aspx
+
+.NOTES
+The script may not work properly on a machine which has installed Active Directory.
+
+.PARAMETER Command
+The command which you want to invoke through CredSSP
+
+.PARAMETER ArgumentList
+A list of arguments you want to pass to $Command which will be executed.
+
+.PARAMETER LogOutputInFile
+Redirect output to a file in $env:TEMP folder
+
+.OUTPUTS
+The output of the command.
+
+.EXAMPLE
+
+If you are inside command prompt and you want to run a native command or a batch script with CredSSP:
+
+powershell -command C:\invoke-command-credssp.ps1 -Command C:\setup.exe "/q","/param2"
+
+.EXAMPLE
+
+If you are inside powershell and you want to run a native command or batch script with CredSSP:
+
+C:\Invoke-Command-Credssp.ps1 -Com C:\test.bat -ArgumentList ("/q",/"f")
+
+.EXAMPLE
+
+If you are in command prompt and want to run another powershell script with CredSSP:
+
+powershell -command "C:\Invoke-Command-Credssp -Command powershell -ArgumentList (\"-command\",\"c:\hi_params.ps1\")"
+
+.EXAMPLE
+
+If you are inside powershell and want to execute a powershell block through CredSSP.
+Then you can use the special -ScriptBlock parameter.
+Since -Command is threated as the most common case and it is made mandatory parameter,
+Just pass an empty command and a Script-Block which you want to be executed through CredSSP
+
+C:\Invoke-Command-Credssp -Command "empty" -ScriptBlock {Write-Host "A script block which is using CredSSP..."; 0}
+
+#>
+
+$exitCode = 1
+Try {
+  $pass = '${attribute['windows.password']}'
+  $secpasswd = ConvertTo-SecureString $pass -AsPlainText -Force
+  $mycreds = New-Object System.Management.Automation.PSCredential ($($env:COMPUTERNAME + "\${location.user}"), $secpasswd)
+
+  $exitCode = Invoke-Command -Credential $mycreds -ComputerName $env:COMPUTERNAME -ScriptBlock {
+    param($Command,$ArgumentList,$LogOutputInFile,$ScriptBlockInCredSSP)
+    $startProcArgs = If ($ArgumentList.Length -gt 0) { @{ArgumentList = $ArgumentList} } Else { @{} }
+    If ($ScriptBlockInCredSSP) {
+      $ScriptBlockInCredSSP = ([scriptblock]::Create($ScriptBlockInCredSSP))
+      $r = & $ScriptBlockInCredSSP
+      if ($r -is [int]) {
+        Write-Host "ScriptBlock reported that its status is ($r)"
+        $r
+      } else {
+        Write-Host "ScriptBlock didn't report its status"
+        0
+      }
+    } ElseIf ($LogOutputInFile) {
+      $stdFilePathNoExt = "$($Env:TEMP)\$(Split-Path $Command -Leaf)_$((Get-Date).Ticks / 1000)"
+      $stdOutFile = "$($stdFilePathNoExt).stdout.log"
+      $stdErrFile = "$($stdFilePathNoExt).stderr.log"
+      $process = Start-Process $Command @startProcArgs -RedirectStandardOutput $stdOutFile -RedirectStandardError $stdErrFile -Wait -PassThru -NoNewWindow
+      $process.ExitCode
+    } Else {
+      $process = Start-Process $Command @startProcArgs -Wait -PassThru -NoNewWindow
+      $process.ExitCode
+    }
+  } -Authentication CredSSP -ArgumentList $Command,$ArgumentList,$LogOutputInFile.IsPresent,$ScriptBlockInCredSSP
+} Catch {
+  Write-Error $_.Exception
+  Write-Host 'Exception logged'
+  exit 1
+}
+exit $exitCode


### PR DESCRIPTION
(please do not merge immediately, doing live tests)
Using Invoke-Command in windows scripts is not very obvious and requires Windows blueprint.
Developer include all these lines in their ps scripts, windows username and password and then passing parameters.
With this change using CredSSP should be just one line in the install script and one line in the YAML to add the script on the Windows machine.
Here it is important the name of the script since for future users it will be included in their new Blueprint YAMLs as well as in their `.ps1` or `.cmd` scripts.
We should files like this and https://github.com/apache/brooklyn-server/blob/master/software/base/src/main/resources/org/apache/brooklyn/software/base/custom-enable-credssp.ps1  into some convention.
Can you please share thoughts about this change and the name of the script?
