### PR TITLE
Fix persistence for entities containing Java 8 lambdas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <guava.version>16.0.1</guava.version>
         <!-- This can be different, OSGi will pick it up -->
         <guava-swagger.version>18.0</guava-swagger.version>
-        <xstream.version>1.4.7</xstream.version>
+        <xstream.version>1.4.8</xstream.version>
         <!-- double-check downstream projects before changing jackson and resteasy versions -->
         <fasterxml.jackson.version>2.4.5</fasterxml.jackson.version>
         <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
 - XStream version bumped to 1.4.8 to avoid known bug.
   See http://x-stream.github.io/jira/767/

Custom entities that hold serializable lambda expressions fail to rebind with XStream 1.4.7