### PR TITLE
Fix StopAfterDurationPolicyTest

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/sensor/DurationSinceSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/DurationSinceSensorTest.java
@@ -58,16 +58,16 @@ public class DurationSinceSensorTest extends BrooklynAppUnitTestSupport {
                         DurationSinceSensor.EPOCH_SUPPLIER, Suppliers.ofInstance(0L),
                         DurationSinceSensor.TIME_SUPPLIER, timeSupplier)))));
 
-        final Map<?, ?> timeout = ImmutableMap.of("timeout", Duration.millis(10));
+        final Map<?, ?> continuallyTimeout = ImmutableMap.of("timeout", Duration.millis(10));
         final AttributeSensor<Duration> duration = Sensors.newSensor(Duration.class, "sensor");
         assertAttributeEqualsEventually(entity, duration, Duration.millis(0));
-        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(0));
+        assertAttributeEqualsContinually(continuallyTimeout, entity, duration, Duration.millis(0));
         ticker.incrementAndGet();
         assertAttributeEqualsEventually(entity, duration, Duration.millis(1));
-        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(1));
+        assertAttributeEqualsContinually(continuallyTimeout, entity, duration, Duration.millis(1));
         ticker.incrementAndGet();
         assertAttributeEqualsEventually(entity, duration, Duration.millis(2));
-        assertAttributeEqualsContinually(timeout, entity, duration, Duration.millis(2));
+        assertAttributeEqualsContinually(continuallyTimeout, entity, duration, Duration.millis(2));
     }
 
 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicyTest.java
@@ -19,28 +19,74 @@
 
 package org.apache.brooklyn.policy.action;
 
-import static org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsEventually;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
+import java.util.List;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class StopAfterDurationPolicyTest extends BrooklynAppUnitTestSupport {
 
     @Test
     public void testAppStoppedWhenDurationExpires() {
+        // Using a second app for the subscriber. Otherwise when app is stopped+unmanaged, we might not
+        // receive the last event because all its subscriptions will be closed!
+        final RecordingSensorEventListener<Lifecycle> listener = new RecordingSensorEventListener<>();
+        Application app2 = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+        app2.subscriptions().subscribe(app, Attributes.SERVICE_STATE_ACTUAL, listener);
+        
         PolicySpec<StopAfterDurationPolicy> policy = PolicySpec.create(StopAfterDurationPolicy.class)
                 .configure(StopAfterDurationPolicy.LIFETIME, Duration.ONE_MILLISECOND)
                 .configure(StopAfterDurationPolicy.POLL_PERIOD, Duration.ONE_MILLISECOND);
         app.policies().add(policy);
         app.start(ImmutableList.of(app.newSimulatedLocation()));
-        assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
-        assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        
+        Asserts.succeedsEventually(new Runnable() {
+            @Override public void run() {
+                // TODO In tests, have seen duplicate "starting"; and always begins with "stopped"; and have
+                // seen "on-fire" between stopping and stopped! Therefore not using 
+                // assertEqualsOrderIgnoringDuplicates.
+                List<Lifecycle> states = ImmutableList.copyOf(listener.getEventValues());
+                assertContainsOrdered(states, ImmutableList.of(Lifecycle.RUNNING, Lifecycle.STOPPING, Lifecycle.STOPPED));
+            }});
     }
-
+    
+    @SuppressWarnings("unused")
+    private void assertEqualsOrderIgnoringDuplicates(Iterable<?> actual, Iterable<?> expected) {
+        List<?> actualNoDups = Lists.newArrayList(Sets.newLinkedHashSet(actual));
+        List<?> expectedNoDups = Lists.newArrayList(Sets.newLinkedHashSet(expected));
+        assertEquals(actualNoDups, expectedNoDups, "actual="+actual);
+    }
+    
+    /**
+     * Asserts the actual contains the expected in the same order (but potentially with 
+     * other values interleaved).
+     */
+    private static void assertContainsOrdered(Iterable<?> actual, Iterable<?> expected) {
+        List<?> actualList = Lists.newArrayList(actual);
+        int index = 0;
+        for (Object exp : expected) {
+            int foundIndex = actualList.subList(index, actualList.size()).indexOf(exp);
+            if (foundIndex >= 0) {
+                index = foundIndex + 1;
+            } else {
+                fail("Failed to find "+exp+" after index "+index+" in "+actual);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Previously test failed in jenkins when asserting state was RUNNING, 
then STOPPED. Unclear if this re-write will fix that (!), but at least
we’ll get more info about what states it was in.

There was another race, which this fixes: the policy might shutdown the entity before we manage to assert it is RUNNING (if we were extremely unlucky with the main thread context switching!).

The failure was in https://builds.apache.org/job/brooklyn-server-pull-requests/org.apache.brooklyn$brooklyn-policy/460/testReport/junit/org.apache.brooklyn.policy.action/StopAfterDurationPolicyTest/testAppStoppedWhenDurationExpires/:

```
2016-05-27 20:39:41,707 INFO  TESTNG INVOKING CONFIGURATION: "Surefire test" - @BeforeMethod org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport.setUp()
2016-05-27 20:39:41,734 INFO  TESTNG PASSED CONFIGURATION: "Surefire test" - @BeforeMethod org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport.setUp() finished in 28 ms
2016-05-27 20:39:41,734 INFO  TESTNG INVOKING: "Surefire test" - org.apache.brooklyn.policy.action.StopAfterDurationPolicyTest.testAppStoppedWhenDurationExpires()
2016-05-27 20:39:41,754 INFO  No Camp-YAML parser registered for parsing catalog item DSL; skipping DSL-parsing
2016-05-27 20:40:11,771 INFO  succeedsEventually exceeded max attempts or timeout - 69 attempts lasting 30001 ms, for RunnableAdapter(org.apache.brooklyn.core.entity.EntityAsserts$1@6879b52d)
2016-05-27 20:40:11,772 INFO  failed succeeds-eventually, 69 attempts, 30002ms elapsed (rethrowing): java.lang.AssertionError: entity=Application[REyzoEtY]; attribute=Sensor: service.state (org.apache.brooklyn.core.entity.lifecycle.Lifecycle) expected [stopped] but found [stopping]
2016-05-27 20:40:11,775 INFO  TESTNG FAILED: "Surefire test" - org.apache.brooklyn.policy.action.StopAfterDurationPolicyTest.testAppStoppedWhenDurationExpires() finished in 30039 ms
org.apache.brooklyn.util.exceptions.PropagatedRuntimeException: failed succeeds-eventually, 69 attempts, 30002ms elapsed: AssertionError: entity=Application[REyzoEtY]; attribute=Sensor: service.state (org.apache.brooklyn.core.entity.lifecycle.Lifecycle) expected [stopped] but found [stopping]
	at org.apache.brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:164)
	at org.apache.brooklyn.util.exceptions.Exceptions.propagateAnnotated(Exceptions.java:144)
	at org.apache.brooklyn.test.Asserts.succeedsEventually(Asserts.java:963)
	at org.apache.brooklyn.test.Asserts.succeedsEventually(Asserts.java:854)
	at org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsEventually(EntityAsserts.java:67)
	at org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEqualsEventually(EntityAsserts.java:62)
	at org.apache.brooklyn.policy.action.StopAfterDurationPolicyTest.testAppStoppedWhenDurationExpires(StopAfterDurationPolicyTest.java:43)
Caused by: java.lang.AssertionError: entity=Application[REyzoEtY]; attribute=Sensor: service.state (org.apache.brooklyn.core.entity.lifecycle.Lifecycle) expected [stopped] but found [stopping]
	at org.apache.brooklyn.test.Asserts.fail(Asserts.java:721)
	at org.apache.brooklyn.test.Asserts.failNotEquals(Asserts.java:114)
	at org.apache.brooklyn.test.Asserts.assertEquals(Asserts.java:436)
	at org.apache.brooklyn.core.entity.EntityAsserts.assertAttributeEquals(EntityAsserts.java:54)
	at org.apache.brooklyn.core.entity.EntityAsserts$1.run(EntityAsserts.java:70)
	at org.apache.brooklyn.test.Asserts$RunnableAdapter.call(Asserts.java:1277)
	at org.apache.brooklyn.test.Asserts.succeedsEventually(Asserts.java:930)
	... 32 more
```