### PR TITLE
Add dontRequireTtyForSudo option to locations

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/SshTasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/SshTasks.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.util.core.task.ssh;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -71,12 +73,20 @@ import com.google.common.collect.Maps;
 public class SshTasks {
 
     private static final Logger log = LoggerFactory.getLogger(SshTasks.class);
-        
+
     public static ProcessTaskFactory<Integer> newSshExecTaskFactory(SshMachineLocation machine, String ...commands) {
+        return newSshExecTaskFactory(machine,  Arrays.asList(commands));
+    }
+
+    public static ProcessTaskFactory<Integer> newSshExecTaskFactory(SshMachineLocation machine, final boolean useMachineConfig, String ...commands) {
+        return newSshExecTaskFactory(machine, useMachineConfig, Arrays.asList(commands));
+    }
+
+    public static ProcessTaskFactory<Integer> newSshExecTaskFactory(SshMachineLocation machine, List<String> commands) {
         return newSshExecTaskFactory(machine, true, commands);
     }
-    
-    public static ProcessTaskFactory<Integer> newSshExecTaskFactory(SshMachineLocation machine, final boolean useMachineConfig, String ...commands) {
+
+    public static ProcessTaskFactory<Integer> newSshExecTaskFactory(SshMachineLocation machine, final boolean useMachineConfig, List<String> commands) {
         return new PlainSshExecTaskFactory<Integer>(machine, commands) {
             {
                 if (useMachineConfig)
@@ -167,7 +177,7 @@ public class SshTasks {
                 BashCommands.dontRequireTtyForSudo(),
                 // strange quotes are to ensure we don't match against echoed stdin
                 BashCommands.sudo("echo \"sudo\"-is-working-"+id))
-            .summary("setting up sudo")
+            .summary("patch /etc/sudoers to disable requiretty")
             .configure(SshTool.PROP_ALLOCATE_PTY, true)
             .allowingNonZeroExitCode()
             .returning(new Function<ProcessTaskWrapper<?>,Boolean>() { public Boolean apply(ProcessTaskWrapper<?> task) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -879,6 +879,22 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                         }
                     }
                 }
+                
+                Boolean dontRequireTtyForSudo = setup.get(JcloudsLocationConfig.DONT_REQUIRE_TTY_FOR_SUDO);
+                if (Boolean.TRUE.equals(dontRequireTtyForSudo) ||
+                        dontRequireTtyForSudo == null && setup.get(DONT_CREATE_USER)) {
+                    if (windows) {
+                        LOG.warn("Ignoring flag DONT_REQUIRE_TTY_FOR_SUDO on Windows location {}", machineLocation);
+                    } else {
+                        customisationForLogging.add("patch /etc/sudoers to disable requiretty");
+
+                        executeCommandThrowingOnError(
+                                ImmutableMap.<String, Object>of(SshTool.PROP_ALLOCATE_PTY.getName(), true),
+                                (SshMachineLocation)machineLocation,
+                                "patch /etc/sudoers to disable requiretty",
+                                ImmutableList.of(BashCommands.dontRequireTtyForSudo()));
+                    }
+                }
 
                 if (setup.get(JcloudsLocationConfig.MAP_DEV_RANDOM_TO_DEV_URANDOM)) {
                     if (windows) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -79,8 +79,11 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
     public static final ConfigKey<Boolean> AUTO_ASSIGN_FLOATING_IP = ConfigKeys.newBooleanConfigKey("autoAssignFloatingIp",
             "Whether to generate floating ips (in Nova paralance), or elastic IPs (in CloudStack parlance)");
 
-    public static final ConfigKey<Boolean> DONT_CREATE_USER = ConfigKeys.newBooleanConfigKey("dontCreateUser", 
-            "Whether to skip creation of 'user' when provisioning machines (default false)", false);
+    public static final ConfigKey<Boolean> DONT_CREATE_USER = ConfigKeys.newBooleanConfigKey("dontCreateUser",
+            "Whether to skip creation of 'user' when provisioning machines (default false). " +
+            "Note that setting this will prevent jclouds from overwriting /etc/sudoers which might be " +
+            "configured incorrectly by default. See 'dontRequireTtyForSudo' for details.",
+            false);
     public static final ConfigKey<Boolean> GRANT_USER_SUDO = ConfigKeys.newBooleanConfigKey("grantUserSudo",
             "Whether to grant the created user sudo privileges. Irrelevant if dontCreateUser is true. Default: true.", true);
     public static final ConfigKey<Boolean> DISABLE_ROOT_AND_PASSWORD_SSH = ConfigKeys.newBooleanConfigKey("disableRootAndPasswordSsh",
@@ -172,6 +175,17 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
 
     public static final ConfigKey<Boolean> INCLUDE_BROOKLYN_USER_METADATA = ConfigKeys.newBooleanConfigKey("includeBrooklynUserMetadata", 
         "Whether to set metadata about the context of a machine, e.g. brooklyn-entity-id, brooklyn-app-name (default true)", true);
+
+    // See also SoftwareProcess.DONT_REQUIRE_TTY_FOR_SUDO
+    public static final ConfigKey<Boolean> DONT_REQUIRE_TTY_FOR_SUDO = ConfigKeys.newBooleanConfigKey("dontRequireTtyForSudo",
+            "Whether to explicitly set /etc/sudoers, so don't need tty (will leave unchanged if 'false'); " +
+            "some machines require a tty for sudo; brooklyn by default does not use a tty " +
+            "(so that it can get separate error+stdout streams); you can enable a tty as an " +
+            "option to every ssh command, or you can do it once and " +
+            "modify the machine so that a tty is not subsequently required. " +
+            "Usually used in conjunction with 'dontCreateUser' since it will prevent " +
+            "jclouds from overwriting /etc/sudoers and overriding the system default. " +
+            "When not explicitly set will be applied if 'dontCreateUser' is set.");
 
     public static final ConfigKey<Boolean> MAP_DEV_RANDOM_TO_DEV_URANDOM = ConfigKeys.newBooleanConfigKey(
             "installDevUrandom", "Map /dev/random to /dev/urandom to prevent halting on insufficient entropy", true);


### PR DESCRIPTION
When using the `dontCreateUser` option on locations jclouds initialization won't run which means it won't overwrite `/etc/sudoers` leaving in the defaults. For CentOS that means having `requiretty` enabled. This will lead to all `sudo` calls from Brooklyn failing because we are running without a session.
It becomes even bigger problem because the `installDevUrandom` will fail (silently) and the machine will be unresponsive for no apparent reason.

The changes 
  * run the `/etc/sudoers` fix if explicitly requested or if `dontCreateUser` is set.
  * convert commands executed during location obtain to tasks so they are visible in the acitivty tab
  * fails location obtaining on a non-0 exit code