### PR TITLE
Use login port for ssh

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2896,7 +2896,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         String user = (users.size() == 1) ? Iterables.getOnlyElement(users) : "{" + Joiner.on(",").join(users) + "}";
         String vmIp = hostAndPortOverride.isPresent() ? hostAndPortOverride.get().getHostText() : getFirstReachableAddress(node, setup);
         if (vmIp==null) LOG.warn("Unable to extract IP for "+node+" ("+setup.getDescription()+"): subsequent connection attempt will likely fail");
-        int vmPort = hostAndPortOverride.isPresent() ? hostAndPortOverride.get().getPortOrDefault(22) : 22;
+        int vmPort = hostAndPortOverride.isPresent() ? hostAndPortOverride.get().getPortOrDefault(22) : getLoginPortOrDefault(node, 22);
 
         String connectionDetails = user + "@" + vmIp + ":" + vmPort;
         final HostAndPort hostAndPort = hostAndPortOverride.isPresent() ? hostAndPortOverride.get() : HostAndPort.fromParts(vmIp, vmPort);
@@ -2946,6 +2946,15 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
         
         return credsSuccessful.get();
+    }
+
+    @VisibleForTesting
+    static int getLoginPortOrDefault(NodeMetadata node, int defaultPort) {
+        int loginPort = node.getLoginPort();
+        if (loginPort > 0) {
+            return loginPort;
+        }
+        return defaultPort;
     }
 
     protected void waitForReachable(Callable<Boolean> checker, String hostAndPort, List<LoginCredentials> credentialsToLog, ConfigBag setup, Duration timeout) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -47,6 +47,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.http.HttpAsserts;
+import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.scriptbuilder.domain.OsFamily;
 import org.jclouds.scriptbuilder.domain.StatementList;
 import org.mockito.Mockito;
@@ -613,5 +614,18 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
     public void testAwsVpcFailureDocLink() {
         HttpAsserts.assertContentContainsText(JcloudsLocation.AWS_VPC_HELP_URL, "VPC", "Classic");
     }
-    
+
+    @Test
+    public void testGetLoginPortOrDefaultReturnsDefaultWhenLoginPortNve() {
+        NodeMetadata mock = Mockito.mock(NodeMetadata.class);
+        Mockito.when(mock.getLoginPort()).thenReturn(-1);
+        Assert.assertEquals(JcloudsLocation.getLoginPortOrDefault(mock,22), 22);
+    }
+
+    @Test
+    public void testGetLoginPortOrDefaultReturnsPortWhenLoginPortPve() {
+        NodeMetadata mock = Mockito.mock(NodeMetadata.class);
+        Mockito.when(mock.getLoginPort()).thenReturn(666);
+        Assert.assertEquals(JcloudsLocation.getLoginPortOrDefault(mock,22), 666);
+    }
 }


### PR DESCRIPTION
Currently we assume port 22 for ssh unless a
portforwarder has been configured.  This uses the getLoginPort
from nodemetadata to determine the ssh port.