### PR TITLE
pr173: Refactor stubbing of jclouds for tests

### DIFF
--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
@@ -37,6 +37,8 @@ import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.time.Duration;
@@ -112,7 +114,7 @@ public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloud
     protected NodeCreator newNodeCreator() {
         return new NodeCreatorForRebinding();
     }
-    public static class NodeCreatorForRebinding extends NodeCreator {
+    public static class NodeCreatorForRebinding extends AbstractNodeCreator {
         @Override
         public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
             NodeMetadata result = new NodeMetadataBuilder()

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedTest.java
@@ -31,6 +31,8 @@ import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
 import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
@@ -68,7 +70,7 @@ public class JcloudsByonLocationResolverStubbedTest extends AbstractJcloudsStubb
 
     @Override
     protected NodeCreator newNodeCreator() {
-        return new NodeCreator() {
+        return new AbstractNodeCreator() {
             @Override
             public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
                 NodeMetadata result = new NodeMetadataBuilder()

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsHardwareProfilesStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsHardwareProfilesStubbedLiveTest.java
@@ -21,6 +21,8 @@ package org.apache.brooklyn.location.jclouds;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
@@ -42,7 +44,7 @@ public class JcloudsHardwareProfilesStubbedLiveTest extends AbstractJcloudsStubb
     
     @Override
     protected NodeCreator newNodeCreator() {
-        return new NodeCreator() {
+        return new AbstractNodeCreator() {
             @Override protected NodeMetadata newNode(String group, Template template) {
                 JcloudsHardwareProfilesStubbedLiveTest.this.template = template;
                 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsImageChoiceStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsImageChoiceStubbedLiveTest.java
@@ -22,6 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
 
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
@@ -44,7 +46,7 @@ public class JcloudsImageChoiceStubbedLiveTest extends AbstractJcloudsStubbedLiv
     
     @Override
     protected NodeCreator newNodeCreator() {
-        return new NodeCreator() {
+        return new AbstractNodeCreator() {
             @Override protected NodeMetadata newNode(String group, Template template) {
                 JcloudsImageChoiceStubbedLiveTest.this.template = template;
                 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
@@ -31,7 +31,6 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.RunNodesException;
@@ -189,7 +188,7 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
                 LoginCredentials.builder().identity("myidentity").password("mypassword").build(), 
                 "myHostname");
         
-        ByonComputeServiceRegistry computeServiceRegistry = new ByonComputeServiceRegistry(node);
+        StubbedComputeServiceRegistry computeServiceRegistry = new StubbedComputeServiceRegistry(node);
 
         JcloudsLocation origJcloudsLoc = newJcloudsLocation(computeServiceRegistry);
     
@@ -223,48 +222,5 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
                 JcloudsLocation.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry, 
                 JcloudsLocation.WAIT_FOR_SSHABLE, false,
                 JcloudsLocation.USE_JCLOUDS_SSH_INIT, false));
-    }
-    
-    protected static class ByonComputeServiceRegistry extends ComputeServiceRegistryImpl implements ComputeServiceRegistry {
-        private final NodeMetadata node;
-
-        ByonComputeServiceRegistry(NodeMetadata node) throws Exception {
-            this.node = node;
-        }
-
-        @Override
-        public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) {
-            ComputeService delegate = super.findComputeService(conf, allowReuse);
-            return new StubComputeService(delegate, node);
-        }
-    }
-
-    static class StubComputeService extends DelegatingComputeService {
-        private final NodeMetadata node;
-        
-        public StubComputeService(ComputeService delegate, NodeMetadata node) {
-            super(delegate);
-            this.node = checkNotNull(node, "node");
-        }
-        
-        @Override
-        public void destroyNode(String id) {
-            // no-op
-        }
-        
-        @Override
-        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count) throws RunNodesException {
-            return ImmutableSet.of(node);
-        }
-        
-        @Override
-        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException {
-            return ImmutableSet.of(node);
-        }
-        
-        @Override
-        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, TemplateOptions templateOptions) throws RunNodesException {
-            return ImmutableSet.of(node);
-        }
     }
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/StubbedComputeServiceRegistry.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/StubbedComputeServiceRegistry.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.RunNodesException;
+import org.jclouds.compute.domain.ComputeMetadata;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.options.TemplateOptions;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+public class StubbedComputeServiceRegistry implements ComputeServiceRegistry {
+
+    public static interface NodeCreator {
+        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException;
+        public void destroyNode(String id);
+        public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter);
+    }
+
+    public static abstract class AbstractNodeCreator implements NodeCreator {
+        public final List<NodeMetadata> created = Lists.newCopyOnWriteArrayList();
+        public final List<String> destroyed = Lists.newCopyOnWriteArrayList();
+        
+        @Override
+        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException {
+            Set<NodeMetadata> result = Sets.newLinkedHashSet();
+            for (int i = 0; i < count; i++) {
+                NodeMetadata node = newNode(group, template);
+                created.add(node);
+                result.add(node);
+            }
+            return result;
+        }
+        @Override
+        public void destroyNode(String id) {
+            destroyed.add(id);
+        }
+        @Override
+        public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
+            return ImmutableSet.of();
+        }
+        protected abstract NodeMetadata newNode(String group, Template template);
+    }
+
+    public static class SingleNodeCreator extends AbstractNodeCreator {
+        private final NodeMetadata node;
+
+        public SingleNodeCreator(NodeMetadata node) {
+            this.node = node;
+        }
+        protected NodeMetadata newNode(String group, Template template) {
+            return node;
+        }
+    }
+
+    static class StubbedComputeService extends DelegatingComputeService {
+        private final NodeCreator nodeCreator;
+        
+        public StubbedComputeService(ComputeService delegate, NodeCreator nodeCreator) {
+            super(delegate);
+            this.nodeCreator = nodeCreator;
+        }
+        @Override
+        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException {
+            return nodeCreator.createNodesInGroup(group, count, template);
+        }
+        @Override
+        public void destroyNode(String id) {
+            nodeCreator.destroyNode(id);
+        }
+        @Override
+        public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
+            return nodeCreator.listNodesDetailsMatching(filter);
+        }
+        @Override
+        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count) {
+            throw new UnsupportedOperationException();
+        }
+        @Override
+        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, TemplateOptions templateOptions) {
+            throw new UnsupportedOperationException();
+        }
+        @Override
+        public Set<? extends NodeMetadata> destroyNodesMatching(Predicate<NodeMetadata> filter) {
+            throw new UnsupportedOperationException();
+        }
+    }
+    
+    private final NodeCreator nodeCreator;
+
+    public StubbedComputeServiceRegistry(NodeMetadata node) throws Exception {
+        this(new SingleNodeCreator(node));
+    }
+
+    public StubbedComputeServiceRegistry(NodeCreator nodeCreator) throws Exception {
+        this.nodeCreator = nodeCreator;
+    }
+
+    @Override
+    public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) {
+        ComputeService delegate = ComputeServiceRegistryImpl.INSTANCE.findComputeService(conf, allowReuse);
+        return new StubbedComputeService(delegate, nodeCreator);
+    }
+}


### PR DESCRIPTION
Part of #173 - please review + merge here, to decrease the size of PR #173 !

Reason for refactoring is:
1. share the one impl of the stubbed ComputeServiceRegistry (previously we had two)
2. allow that to be re-used by other tests in PR #173, that location's templateOptions config values are correctly merged.