### PR TITLE
Let downstream projects pass custom brooklyn properties to Brooklyn

### DIFF
--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -760,6 +760,10 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
     public void setBrooklynPropertiesBuilder(BrooklynProperties.Factory.Builder brooklynPropertiesBuilder) {
         this.brooklynPropertiesBuilder = brooklynPropertiesBuilder;
     }
+    
+    public BrooklynProperties.Factory.Builder getBrooklynPropertiesBuilder() {
+        return brooklynPropertiesBuilder;
+    }
 
     public BrooklynProperties getBrooklynProperties() {
         return brooklynProperties;


### PR DESCRIPTION
The properties passed in `getBrooklynPropertiesSupplier` have less precedence than global and local  properties.