### PR TITLE
Fix JcloudsSshMachineLocation.getSubnetIp

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -374,8 +374,8 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
         if (privateAddress.isPresent()) {
             return privateAddress.get();
         }
-        if (groovyTruth(node.getPublicAddresses())) {
-            return node.getPublicAddresses().iterator().next();
+        if (groovyTruth(getPublicAddresses())) {
+            return getPublicAddresses().iterator().next();
         }
         return null;
     }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedLiveTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.NodeMetadata.Status;
+import org.jclouds.compute.domain.NodeMetadataBuilder;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.domain.LoginCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStubbedLiveTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(JcloudsImageChoiceStubbedLiveTest.class);
+    
+    private List<String> privateAddresses;
+    private List<String> publicAddresses;
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        privateAddresses = ImmutableList.of("172.168.10.11");
+        publicAddresses = ImmutableList.of("173.194.32.123");
+        super.setUp();
+    }
+    
+    @Override
+    protected NodeCreator newNodeCreator() {
+        return new AbstractNodeCreator() {
+            @Override protected NodeMetadata newNode(String group, Template template) {
+                NodeMetadata result = new NodeMetadataBuilder()
+                        .id("myid")
+                        .credentials(LoginCredentials.builder().identity("myuser").credential("mypassword").build())
+                        .loginPort(22)
+                        .status(Status.RUNNING)
+                        .publicAddresses(publicAddresses)
+                        .privateAddresses(privateAddresses)
+                        .build();
+                return result;
+            }
+        };
+    }
+
+    protected Map<Object, Object> jcloudsLocationConfig(Map<Object, Object> defaults) {
+        return ImmutableMap.<Object, Object>builder()
+                .putAll(defaults)
+                .put(JcloudsLocationConfig.IMAGE_ID, "CENTOS_5_64")
+                .build();
+    }
+
+    @Test(groups={"Live", "Live-sanity"})
+    public void testWithNoPrivateAddress() throws Exception {
+        privateAddresses = ImmutableList.of();
+        JcloudsSshMachineLocation machine = obtainMachine();
+        assertEquals(machine.getPrivateAddresses(), ImmutableSet.of());
+        assertEquals(machine.getPrivateAddress(), Optional.absent());
+        assertEquals(machine.getSubnetIp(), publicAddresses.get(0));
+        assertEquals(machine.getSubnetHostname(), publicAddresses.get(0));
+    }
+    
+    @Test(groups={"Live", "Live-sanity"})
+    public void testWithPrivateAddress() throws Exception {
+        JcloudsSshMachineLocation machine = obtainMachine();
+        assertEquals(machine.getPrivateAddresses(), privateAddresses);
+        assertEquals(machine.getPrivateAddress(), Optional.of(privateAddresses.get(0)));
+        assertEquals(machine.getSubnetIp(), privateAddresses.get(0));
+        assertEquals(machine.getSubnetHostname(), privateAddresses.get(0));
+    }
+}


### PR DESCRIPTION
Previously would throw NPE if privateAddresses was empty.