### PR TITLE
Change org.apache.cxf log level to ERROR

### DIFF
--- a/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
+++ b/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
@@ -66,7 +66,7 @@
          and warns and errors which we catch and handle;
          it might be nice to keep the latter, but they show up in info log (no way to say debug file only?),
          so simplest is to disable all but severe -->
-    <logger name="org.apache.cxf" level="SEVERE"/>
+    <logger name="org.apache.cxf" level="ERROR"/>
     
     <logger name="io.cloudsoft.winrm4j.winrm.WinRmTool" level="DEBUG"/>
 </included>


### PR DESCRIPTION
The previous change to “SEVERE” doesn’t work, because that is not a
logbook logging level.

 In the stdout of Brooklyn, we were still getting:

    10:55:48,833 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.apache.cxf] to DEBUG

With this change, we get:

    10:58:19,047 |-INFO in ch.qos.logback.classic.joran.action.LoggerAction - Setting level of logger [org.apache.cxf] to ERROR
