### PR TITLE
Entity display name: fix catalog item defaults

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampResolver.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.camp.brooklyn.api.AssemblyTemplateSpecInstantiator;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
 import org.apache.brooklyn.camp.spi.instantiate.AssemblyTemplateInstantiator;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
+import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -115,17 +116,20 @@ class CampResolver {
             throw new IllegalStateException("Creating spec from "+item+", got "+spec.getType()+" which is incompatible with expected "+expectedType);                
         }
 
-        ((AbstractBrooklynObjectSpec<?, ?>)spec).catalogItemIdIfNotNull(item.getId());
+        spec.catalogItemIdIfNotNull(item.getId());
 
         if (spec instanceof EntitySpec) {
-            if (Strings.isBlank( ((AbstractBrooklynObjectSpec<?, ?>)spec).getDisplayName() )) {
-                ((AbstractBrooklynObjectSpec<?, ?>)spec).displayName(item.getDisplayName());
+            String name = spec.getDisplayName();
+            Object defaultNameConf = spec.getConfig().get(AbstractEntity.DEFAULT_DISPLAY_NAME);
+            Object defaultNameFlag = spec.getFlags().get(AbstractEntity.DEFAULT_DISPLAY_NAME.getName());
+            if (Strings.isBlank(name) && defaultNameConf == null && defaultNameFlag == null) {
+                spec.configure(AbstractEntity.DEFAULT_DISPLAY_NAME, item.getDisplayName());
             }
         } else {
             // See https://issues.apache.org/jira/browse/BROOKLYN-248, and the tests in 
             // ApplicationYamlTest and CatalogYamlLocationTest.
             if (Strings.isNonBlank(item.getDisplayName())) {
-                ((AbstractBrooklynObjectSpec<?, ?>)spec).displayName(item.getDisplayName());
+                spec.displayName(item.getDisplayName());
             }
         }
         

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
@@ -68,15 +68,6 @@ public class EntityNameYamlTest extends AbstractYamlTest {
         deployAndAssertDisplayName(yaml, "PREFIXmyvalSUFFIX");
     }
 
-    @Test
-    public void testBrooklynConfig() throws Exception {
-        String yaml = Joiner.on("\n").join(
-                "services:",
-                "- type: org.apache.brooklyn.core.test.entity.TestEntity",
-                "  name: myDisplayName");
-        deployAndAssertDisplayName(yaml, "myDisplayName");
-    }
-
     protected void deployAndAssertDisplayName(String yaml, String expectedName) throws Exception {
         Entity app = createAndStartApplication(yaml);
         Entity entity = Iterables.getOnlyElement(Entities.descendants(app, Predicates.instanceOf(TestEntity.class)));

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityNameTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityNameTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.catalog;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+
+
+public class CatalogYamlEntityNameTest extends AbstractYamlTest {
+    
+    @Test
+    public void testUsesNameInCatalogItemMetadataIfNonSupplied() throws Exception {
+        String symbolicName = "my.catalog.app.id.load";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  id: " + symbolicName,
+            "  name: nameInItemMetadata",
+            "  version: " + TEST_VERSION,
+            "  item:",
+            "    type: "+ BasicEntity.class.getName());
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName);
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "nameInItemMetadata");
+        
+        Entity app2 = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName,
+                "  name: nameInEntity");
+        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        assertEquals(entity2.getDisplayName(), "nameInEntity");
+    }
+    
+    // TODO Has never worked. See CampResolver.createSpecFromFull, for how it injects the name of the item.
+    @Test(groups={"WIP","Broken"})
+    public void testUsesNameInSubtypeItemMetadataIfNonSupplied() throws Exception {
+        String parentSymbolicName = "mySyperType";
+        String symbolicName = "mySubType";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  version: " + TEST_VERSION,
+            "  itemType: entity",
+            "  items:",
+            "  - id: " + parentSymbolicName,
+            "    name: nameInSuperItemMetadata",
+            "    item:",
+            "      type: "+ BasicEntity.class.getName(),
+            "  - id: " + symbolicName,
+            "    name: nameInItemMetadata",
+            "    item:",
+            "      type: "+ parentSymbolicName);
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName);
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "nameInItemMetadata");
+        
+        Entity app2 = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName,
+                "  name: nameInEntity");
+        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        assertEquals(entity2.getDisplayName(), "nameInEntity");
+    }
+    
+    @Test
+    public void testUsesDefaultNameInCatalogItemRatherThanItemMetadata() throws Exception {
+        String symbolicName = "my.catalog.app.id.load";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  id: " + symbolicName,
+            "  name: nameInItemMetadata",
+            "  version: " + TEST_VERSION,
+            "  item:",
+            "    type: "+ BasicEntity.class.getName(),
+            "    brooklyn.config:",
+            "      defaultDisplayName: defaultNameInItemEntity");
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName);
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "defaultNameInItemEntity");
+        
+        Entity app2 = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName,
+                "  name: nameInEntity");
+        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        assertEquals(entity2.getDisplayName(), "nameInEntity");
+    }
+    
+    @Test
+    public void testUsesDefaultNameInCatalogItemRatherThanItemOrSupertypeMetadata() throws Exception {
+        String parentSymbolicName = "mySyperType";
+        String symbolicName = "mySubType";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  version: " + TEST_VERSION,
+            "  itemType: entity",
+            "  items:",
+            "  - id: " + parentSymbolicName,
+            "    name: nameInSuperItemMetadata",
+            "    item:",
+            "      type: "+ BasicEntity.class.getName(),
+            "  - id: " + symbolicName,
+            "    name: nameInItemMetadata",
+            "    item:",
+            "      type: "+ parentSymbolicName,
+            "      brooklyn.config:",
+            "        defaultDisplayName: defaultNameInItemEntity");
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName);
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "defaultNameInItemEntity");
+    }
+    
+    @Test
+    public void testUsesDefaultNameInSupertypeWhenItemExtendsOtherItem() throws Exception {
+        String parentSymbolicName = "mySyperType";
+        String symbolicName = "mySubType";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  version: " + TEST_VERSION,
+            "  itemType: entity",
+            "  items:",
+            "  - id: " + parentSymbolicName,
+            "    name: nameInSuperItemMetadata",
+            "    item:",
+            "      type: "+ BasicEntity.class.getName(),
+            "      brooklyn.config:",
+            "        defaultDisplayName: defaultNameInSuperItemEntity",
+            "  - id: " + symbolicName,
+            "    name: nameInItemMetadata",
+            "    item:",
+            "      type: "+ parentSymbolicName);
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName);
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "defaultNameInSuperItemEntity");
+    }
+    
+    @Test
+    public void testUsesDefaultNameInEntityRatherThanItemMetadata() throws Exception {
+        String symbolicName = "my.catalog.app.id.load";
+        addCatalogItems(
+            "brooklyn.catalog:",
+            "  id: " + symbolicName,
+            "  name: nameInItemMetadata",
+            "  version: " + TEST_VERSION,
+            "  item:",
+            "    type: "+ BasicEntity.class.getName());
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: "+symbolicName,
+                "  brooklyn.config:",
+                "    defaultDisplayName: defaultNameInEntity");
+        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        assertEquals(entity.getDisplayName(), "defaultNameInEntity");
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicApplicationImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicApplicationImpl.java
@@ -19,13 +19,19 @@
 package org.apache.brooklyn.entity.stock;
 
 import org.apache.brooklyn.core.entity.AbstractApplication;
+import org.apache.brooklyn.util.text.Strings;
 
 public class BasicApplicationImpl extends AbstractApplication implements BasicApplication {
 
     @Override
     public void init() {
+        // Set the default name *before* calling super.init(), and only do so if we don't have an 
+        // explicit default. This is a belt-and-braces fix: before we overwrote the defaultDisplayName
+        // that was inferred from the catalog item name.
+        if (Strings.isBlank(getConfig(DEFAULT_DISPLAY_NAME))) {
+            setDefaultDisplayName("Application ("+getId()+")");
+        }
         super.init();
-        setDefaultDisplayName("Application ("+getId()+")");
     }
     
 }


### PR DESCRIPTION
Previously, if an entity in the catalog did not have an explicit display 
name then it got the name from the item’s metadata. This was fine in
simple use-cases, but bad if using sub-types or if entities wanted to
declare their own defaultDisplayName.

(Deletes `EntityNameYamlTest.testBrooklynCatalog`, as was spotted by @geomacy in https://github.com/apache/brooklyn-server/pull/200 after merge).