### PR TITLE
Fix CAS operations on AtomicBoolean

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynInitialization.java
@@ -61,14 +61,14 @@ public class BrooklynInitialization {
      * 
      */
     
-    public synchronized static void initAll() {
-        if (done.get()) return;
-        initTypeCoercionStandardAdapters();
-        initSecureKeysBouncyCastleProvider();
-        initNetworking();
-        initPortRanges();
-        initLegacyLanguageExtensions();
-        done.set(true);
+    public static void initAll() {
+        if (done.compareAndSet(false, true)) {
+            initTypeCoercionStandardAdapters();
+            initSecureKeysBouncyCastleProvider();
+            initNetworking();
+            initPortRanges();
+            initLegacyLanguageExtensions();
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/main/java/org/apache/brooklyn/core/location/PortRanges.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/PortRanges.java
@@ -22,22 +22,21 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.brooklyn.api.location.PortRange;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
-import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
-
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
+
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
 
 public class PortRanges {
 
@@ -246,13 +245,12 @@ public class PortRanges {
         }
     }
 
-    private static AtomicBoolean initialized = new AtomicBoolean(false); 
+    private static AtomicBoolean initialized = new AtomicBoolean(false);
+
     /** performs the language extensions required for this project */
     @SuppressWarnings("rawtypes")
     public static void init() {
-        if (initialized.get()) return;
-        synchronized (initialized) {
-            if (initialized.get()) return;
+        if (initialized.compareAndSet(false, true)) {
             TypeCoercions.registerAdapter(Integer.class, PortRange.class, new Function<Integer,PortRange>() {
                 public PortRange apply(Integer x) { return fromInteger(x); }
             });
@@ -262,12 +260,11 @@ public class PortRanges {
             TypeCoercions.registerAdapter(Iterable.class, PortRange.class, new Function<Iterable,PortRange>() {
                 public PortRange apply(Iterable x) { return fromIterable(x); }
             });
-            initialized.set(true);
         }
     }
-    
+
     static {
         init();
     }
-    
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -318,26 +318,24 @@ public class LocalManagementContext extends AbstractManagementContext {
     
     @Override
     public void terminate() {
-        synchronized (terminated) {
-            if (terminated.getAndSet(true)) {
-                log.trace("Already terminated management context "+this);
-                // no harm in doing it twice, but it makes logs ugly!
-                return;
-            }
-            log.debug("Terminating management context "+this);
-            
-            INSTANCES.remove(this);
-            super.terminate();
-            if (osgiManager!=null) {
-                osgiManager.stop();
-                osgiManager = null;
-            }
-            if (usageManager != null) usageManager.terminate();
-            if (execution != null) execution.shutdownNow();
-            if (gc != null) gc.shutdownNow();
-            
-            log.debug("Terminated management context "+this);
+        if (terminated.getAndSet(true)) {
+            log.trace("Already terminated management context "+this);
+            // no harm in doing it twice, but it makes logs ugly!
+            return;
         }
+        log.debug("Terminating management context "+this);
+
+        INSTANCES.remove(this);
+        super.terminate();
+        if (osgiManager!=null) {
+            osgiManager.stop();
+            osgiManager = null;
+        }
+        if (usageManager != null) usageManager.terminate();
+        if (execution != null) execution.shutdownNow();
+        if (gc != null) gc.shutdownNow();
+
+        log.debug("Terminated management context "+this);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedObjectStore.java
@@ -33,18 +33,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
 
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
-import org.apache.brooklyn.core.server.BrooklynServerConfig;
-import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.exceptions.FatalConfigurationRuntimeException;
-import org.apache.brooklyn.util.io.FileUtil;
-import org.apache.brooklyn.util.os.Os;
-import org.apache.brooklyn.util.os.Os.DeletionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,9 +47,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
-/**
- * @author Andrea Turli
- */
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.exceptions.FatalConfigurationRuntimeException;
+import org.apache.brooklyn.util.io.FileUtil;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.os.Os.DeletionResult;
+
 public class FileBasedObjectStore implements PersistenceObjectStore {
 
     private static final Logger log = LoggerFactory.getLogger(FileBasedObjectStore.class);
@@ -72,7 +69,7 @@ public class FileBasedObjectStore implements PersistenceObjectStore {
     private ManagementContext mgmt;
     private boolean prepared = false;
     private boolean deferredBackupNeeded = false;
-    private AtomicBoolean doneFirstContentiousWrite = new AtomicBoolean(false);
+    private boolean doneFirstContentiousWrite = false;
 
     /**
      * @param basedir
@@ -92,30 +89,26 @@ public class FileBasedObjectStore implements PersistenceObjectStore {
     public File getBaseDir() {
         return basedir;
     }
-    
-    public void prepareForMasterUse() {
-        if (doneFirstContentiousWrite.get())
-            return;
-        synchronized (this) {
-            if (doneFirstContentiousWrite.get())
-                return;
-            try {
-                if (deferredBackupNeeded) {
-                    // defer backup and path creation until first write
-                    // this way if node is standby or auto, the backup is not created superfluously
 
-                    File backup = backupDirByCopying(basedir);
-                    log.info("Persistence deferred backup, directory "+basedir+" backed up to "+backup.getAbsolutePath());
+    @Override
+    public synchronized void prepareForMasterUse() {
+        if (doneFirstContentiousWrite) return;
+        try {
+            if (deferredBackupNeeded) {
+                // defer backup and path creation until first write
+                // this way if node is standby or auto, the backup is not created superfluously
 
-                    deferredBackupNeeded = false;
-                }
-            } catch (Exception e) {
-                throw Exceptions.propagate(e);
+                File backup = backupDirByCopying(basedir);
+                log.info("Persistence deferred backup, directory "+basedir+" backed up to "+backup.getAbsolutePath());
+
+                deferredBackupNeeded = false;
+                doneFirstContentiousWrite = true;
             }
-            doneFirstContentiousWrite.getAndSet(true);
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
         }
     }
-    
+
     @Override
     public void createSubPath(String subPath) {
         if (!prepared) throw new IllegalStateException("Not yet prepared: "+this);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/JavaAppUtils.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/JavaAppUtils.java
@@ -235,26 +235,21 @@ public class JavaAppUtils {
 
     /** Setup renderer hints for the MXBean attributes. */
     public static void init() {
-        if (initialized.get()) return;
-        synchronized (initialized) {
-            if (initialized.get()) return;
+        if (initialized.getAndSet(true)) return;
 
-            RendererHints.register(UsesJavaMXBeans.USED_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.INIT_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.MAX_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.COMMITTED_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.NON_HEAP_MEMORY_USAGE, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.TOTAL_PHYSICAL_MEMORY_SIZE, RendererHints.displayValue(ByteSizeStrings.metric()));
-            RendererHints.register(UsesJavaMXBeans.FREE_PHYSICAL_MEMORY_SIZE, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.USED_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.INIT_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.MAX_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.COMMITTED_HEAP_MEMORY, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.NON_HEAP_MEMORY_USAGE, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.TOTAL_PHYSICAL_MEMORY_SIZE, RendererHints.displayValue(ByteSizeStrings.metric()));
+        RendererHints.register(UsesJavaMXBeans.FREE_PHYSICAL_MEMORY_SIZE, RendererHints.displayValue(ByteSizeStrings.metric()));
 
-            RendererHints.register(UsesJavaMXBeans.START_TIME, RendererHints.displayValue(Time.toDateString()));
-            RendererHints.register(UsesJavaMXBeans.UP_TIME, RendererHints.displayValue(Duration.millisToStringRounded()));
-            RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME, RendererHints.displayValue(Duration.millisToStringRounded()));
-            RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME_FRACTION_LAST, RendererHints.displayValue(MathFunctions.percent(4)));
-            RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME_FRACTION_IN_WINDOW, RendererHints.displayValue(MathFunctions.percent(4)));
-
-            initialized.set(true);
-        }
+        RendererHints.register(UsesJavaMXBeans.START_TIME, RendererHints.displayValue(Time.toDateString()));
+        RendererHints.register(UsesJavaMXBeans.UP_TIME, RendererHints.displayValue(Duration.millisToStringRounded()));
+        RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME, RendererHints.displayValue(Duration.millisToStringRounded()));
+        RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME_FRACTION_LAST, RendererHints.displayValue(MathFunctions.percent(4)));
+        RendererHints.register(UsesJavaMXBeans.PROCESS_CPU_TIME_FRACTION_IN_WINDOW, RendererHints.displayValue(MathFunctions.percent(4)));
     }
 
     static {


### PR DESCRIPTION
Change to use correct idiom when using `AtomicBoolean` to guard against multiple invocations.