### PR TITLE
Move machine metrics to SoftwareProcess entity

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -27,6 +27,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Objects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
@@ -100,21 +116,6 @@ import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Equals;
 import org.apache.brooklyn.util.text.Strings;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.Beta;
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.base.Objects.ToStringHelper;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 /**
  * Default {@link Entity} implementation, which should be extended whenever implementing an entity.
@@ -144,7 +145,7 @@ import com.google.common.collect.Sets;
  * The legacy (pre 0.5) mechanism for creating entities is for others to call the constructor directly.
  * This is now deprecated.
  */
-public abstract class AbstractEntity extends AbstractBrooklynObject implements EntityLocal, EntityInternal {
+public abstract class AbstractEntity extends AbstractBrooklynObject implements EntityInternal {
     
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEntity.class);
     

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.Beta;
+
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -34,17 +36,13 @@ import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 import org.apache.brooklyn.api.mgmt.rebind.Rebindable;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.EntityMemento;
-import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
 import org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
-import org.apache.brooklyn.core.objs.BrooklynObjectInternal.SubscriptionSupportInternal;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-
-import com.google.common.annotations.Beta;
 
 /** 
  * Extended Entity interface with additional functionality that is purely-internal (i.e. intended 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
@@ -222,24 +222,37 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
     }
 
     public interface FeedSupport {
+
         Collection<Feed> getFeeds();
-        
+
         /**
          * Adds the given feed to this entity. The feed will automatically be re-added on brooklyn restart.
          */
+        <T extends Feed> T add(T feed);
+
+        /** @deprecated since 0.10.0; use {@link #add()} */
+        @Deprecated
         <T extends Feed> T addFeed(T feed);
-        
+
         /**
          * Removes the given feed from this entity. 
          * @return True if the feed existed at this entity; false otherwise
          */
+        boolean remove(Feed feed);
+
+        /** @deprecated since 0.10.0; use {@link #remove()} */
+        @Deprecated
         boolean removeFeed(Feed feed);
-        
+
         /**
          * Removes all feeds from this entity.
          * Use with caution as some entities automatically register feeds; this will remove those feeds as well.
          * @return True if any feeds existed at this entity; false otherwise
          */
+        boolean removeAll();
+
+        /** @deprecated since 0.10.0; use {@link #removeAll()} */
+        @Deprecated
         boolean removeAllFeeds();
     }
     

--- a/core/src/main/java/org/apache/brooklyn/feed/function/FunctionPollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/function/FunctionPollConfig.java
@@ -23,6 +23,8 @@ import groovy.lang.Closure;
 
 import java.util.concurrent.Callable;
 
+import com.google.common.base.Supplier;
+
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.feed.FeedConfig;
 import org.apache.brooklyn.core.feed.PollConfig;
@@ -30,14 +32,16 @@ import org.apache.brooklyn.util.groovy.GroovyJavaMethods;
 import org.apache.brooklyn.util.guava.Functionals;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 
-import com.google.common.base.Supplier;
-
 public class FunctionPollConfig<S, T> extends PollConfig<S, T, FunctionPollConfig<S, T>> {
 
     private Callable<?> callable;
     
     public static <T> FunctionPollConfig<?, T> forSensor(AttributeSensor<T> sensor) {
         return new FunctionPollConfig<Object, T>(sensor);
+    }
+
+    public static FunctionPollConfig<?, Void> forMultiple() {
+        return new FunctionPollConfig<Object, Void>(PollConfig.NO_SENSOR);
     }
     
     public FunctionPollConfig(AttributeSensor<T> sensor) {

--- a/core/src/main/java/org/apache/brooklyn/feed/shell/ShellPollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/shell/ShellPollConfig.java
@@ -26,13 +26,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.feed.PollConfig;
 import org.apache.brooklyn.feed.ssh.SshPollValue;
 import org.apache.brooklyn.util.collections.MutableList;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Maps;
 
 public class ShellPollConfig<T> extends PollConfig<SshPollValue, T, ShellPollConfig<T>> {
 
@@ -47,6 +47,14 @@ public class ShellPollConfig<T> extends PollConfig<SshPollValue, T, ShellPollCon
         public boolean apply(@Nullable SshPollValue input) {
             return input != null && input.getExitStatus() == 0;
         }};
+
+    public static <T> ShellPollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new ShellPollConfig<T>(sensor);
+    }
+
+    public static ShellPollConfig<Void> forMultiple() {
+        return new ShellPollConfig<Void>(PollConfig.NO_SENSOR);
+    }
 
     public ShellPollConfig(AttributeSensor<T> sensor) {
         super(sensor);

--- a/core/src/main/java/org/apache/brooklyn/feed/ssh/SshPollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/ssh/SshPollConfig.java
@@ -26,16 +26,16 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.core.feed.PollConfig;
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableMap;
-
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.feed.PollConfig;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 
 public class SshPollConfig<T> extends PollConfig<SshPollValue, T, SshPollConfig<T>> {
 
@@ -47,6 +47,14 @@ public class SshPollConfig<T> extends PollConfig<SshPollValue, T, SshPollConfig<
         public boolean apply(@Nullable SshPollValue input) {
             return input != null && input.getExitStatus() == 0;
         }};
+
+    public static <T> SshPollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new SshPollConfig<T>(sensor);
+    }
+
+    public static SshPollConfig<Void> forMultiple() {
+        return new SshPollConfig<Void>(PollConfig.NO_SENSOR);
+    }
 
     public SshPollConfig(AttributeSensor<T> sensor) {
         super(sensor);

--- a/core/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterPollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterPollConfig.java
@@ -18,15 +18,23 @@
  */
 package org.apache.brooklyn.feed.windows;
 
-import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.core.feed.PollConfig;
-
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.feed.PollConfig;
 
 public class WindowsPerformanceCounterPollConfig<T> extends PollConfig<Object, T, WindowsPerformanceCounterPollConfig<T>>{
 
     private String performanceCounterName;
+
+    public static <T> WindowsPerformanceCounterPollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new WindowsPerformanceCounterPollConfig<T>(sensor);
+    }
+
+    public static WindowsPerformanceCounterPollConfig<Void> forMultiple() {
+        return new WindowsPerformanceCounterPollConfig<Void>(PollConfig.NO_SENSOR);
+    }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public WindowsPerformanceCounterPollConfig(AttributeSensor<T> sensor) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicTasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicTasks.java
@@ -265,12 +265,12 @@ public class DynamicTasks {
 
     /** @see #queue(org.apache.brooklyn.api.mgmt.TaskAdaptable)  */
     public static <T> Task<T> queue(String name, Callable<T> job) {
-        return DynamicTasks.queue(Tasks.<T>builder().displayName(name).body(job).build());
+        return DynamicTasks.queue(Tasks.create(name, job));
     }
 
     /** @see #queue(org.apache.brooklyn.api.mgmt.TaskAdaptable)  */
     public static <T> Task<T> queue(String name, Runnable job) {
-        return DynamicTasks.queue(Tasks.<T>builder().displayName(name).body(job).build());
+        return DynamicTasks.queue(Tasks.<T>create(name, job));
     }
 
     /** queues the task if needed, i.e. if it is not yet submitted (so it will run), 

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.CountdownTimer;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,14 @@ public class Tasks {
         if (current instanceof TaskInternal)
             ((TaskInternal<?>)current).resetBlockingTask(); 
     }
-    
+
+    public static <T> Task<T> create(String name, Callable<T> job) {
+        return Tasks.<T>builder().displayName(name).body(job).build();
+    }
+    public static <T> Task<T> create(String name, Runnable job) {
+        return Tasks.<T>builder().displayName(name).body(job).build();
+    }
+
     /** convenience for setting "blocking details" on any task where the current thread is running,
      * while the passed code is executed; often used from groovy as
      * <pre>{@code withBlockingDetails("sleeping 5s") { Thread.sleep(5000); } }</pre>

--- a/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
@@ -151,10 +151,10 @@ public class AutoScalerPolicy extends AbstractPolicy {
             this.resizeUpIterationMax = val; return this;
         }
         public Builder resizeDownIterationIncrement(Integer val) {
-            this.resizeUpIterationIncrement = val; return this;
+            this.resizeDownIterationIncrement = val; return this;
         }
         public Builder resizeDownIterationMax(Integer val) {
-            this.resizeUpIterationMax = val; return this;
+            this.resizeDownIterationMax = val; return this;
         }
 
         public Builder minPeriodBetweenExecs(Duration val) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefAttributePollConfig.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefAttributePollConfig.java
@@ -18,15 +18,23 @@
  */
 package org.apache.brooklyn.entity.chef;
 
-import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.core.feed.PollConfig;
-
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.feed.PollConfig;
 
 public class ChefAttributePollConfig<T> extends PollConfig<Object, T, ChefAttributePollConfig<T>>{
 
     private String chefAttributePath;
+
+    public static <T> ChefAttributePollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new ChefAttributePollConfig<T>(sensor);
+    }
+
+    public static ChefAttributePollConfig<Void> forMultiple() {
+        return new ChefAttributePollConfig<Void>(PollConfig.NO_SENSOR);
+    }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public ChefAttributePollConfig(AttributeSensor<T> sensor) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/AddMachineMetrics.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/AddMachineMetrics.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.machine;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.FluentIterable;
+import com.google.common.primitives.Doubles;
+
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher;
+import org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.feed.ssh.SshFeed;
+import org.apache.brooklyn.feed.ssh.SshPollConfig;
+import org.apache.brooklyn.feed.ssh.SshPollValue;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+
+/**
+ * Adds a {@link SSHFeed feed} with sensors returning details about the machine the entity is running on.
+ * <p>
+ * The machine must be SSHable and running Linux.
+ *
+ * @since 0.10.0
+ */
+@Beta
+public class AddMachineMetrics implements EntityInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AddMachineMetrics.class);
+
+    static {
+        MachineAttributes.init();
+    }
+
+    @Override
+    public void apply(EntityLocal entity) {
+        SshFeed machineMetricsFeed = createMachineMetricsFeed(entity);
+        ((EntityInternal) entity).feeds().add(machineMetricsFeed);
+        addMachineMetricsEnrichers(entity);
+        LOG.info("Configured machine metrics feed and enrichers on {}", entity);
+    }
+
+    public static void addMachineMetricsEnrichers(EntityLocal entity) {
+        entity.enrichers().add(EnricherSpec.create(YamlTimeWeightedDeltaEnricher.class)
+                .configure(YamlTimeWeightedDeltaEnricher.SOURCE_SENSOR, MachineAttributes.USED_MEMORY)
+                .configure(YamlTimeWeightedDeltaEnricher.TARGET_SENSOR, MachineAttributes.USED_MEMORY_DELTA_PER_SECOND_LAST));
+        entity.enrichers().add(EnricherSpec.create(YamlRollingTimeWindowMeanEnricher.class)
+                .configure(YamlRollingTimeWindowMeanEnricher.SOURCE_SENSOR, MachineAttributes.USED_MEMORY_DELTA_PER_SECOND_LAST)
+                .configure(YamlRollingTimeWindowMeanEnricher.TARGET_SENSOR, MachineAttributes.USED_MEMORY_DELTA_PER_SECOND_IN_WINDOW));
+    }
+
+    public static SshFeed createMachineMetricsFeed(EntityLocal entity) {
+        boolean retrieveUsageMetrics = entity.config().get(SoftwareProcess.RETRIEVE_USAGE_METRICS);
+        return SshFeed.builder()
+                .period(Duration.THIRTY_SECONDS)
+                .entity(entity)
+                .poll(SshPollConfig.forSensor(MachineAttributes.UPTIME)
+                        .command("cat /proc/uptime")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Duration>constant(null))
+                        .onSuccess(new Function<SshPollValue, Duration>() {
+                            @Override
+                            public Duration apply(SshPollValue input) {
+                                return Duration.seconds(Double.valueOf(Strings.getFirstWord(input.getStdout())));
+                            }
+                        }))
+                .poll(SshPollConfig.forSensor(MachineAttributes.LOAD_AVERAGE)
+                        .command("uptime")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Double>constant(null))
+                        .onSuccess(new Function<SshPollValue, Double>() {
+                            @Override
+                            public Double apply(SshPollValue input) {
+                                String loadAverage = Strings.getFirstWordAfter(input.getStdout(), "load average:").replace(",", "");
+                                return Double.valueOf(loadAverage);
+                            }
+                        }))
+                .poll(SshPollConfig.forSensor(MachineAttributes.CPU_USAGE)
+                        .command("ps -A -o pcpu")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Double>constant(null))
+                        .onSuccess(new Function<SshPollValue, Double>() {
+                            @Override
+                            public Double apply(SshPollValue input) {
+                                Double cpu = 0d;
+                                Iterable<String> stdout = Splitter.on(CharMatcher.BREAKING_WHITESPACE).omitEmptyStrings().split(input.getStdout());
+                                for (Double each : FluentIterable.from(stdout).skip(1).transform(Doubles.stringConverter())) { cpu += each; }
+                                return cpu / 100d;
+                            }
+                        }))
+                .poll(SshPollConfig.forSensor(MachineAttributes.USED_MEMORY)
+                        .command("free | grep Mem:")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Long>constant(null))
+                        .onSuccess(new Function<SshPollValue, Long>() {
+                            @Override
+                            public Long apply(SshPollValue input) {
+                                List<String> memoryData = Splitter.on(" ").omitEmptyStrings().splitToList(Strings.getFirstLine(input.getStdout()));
+                                return Long.parseLong(memoryData.get(2));
+                            }
+                        }))
+                .poll(SshPollConfig.forSensor(MachineAttributes.FREE_MEMORY)
+                        .command("free | grep Mem:")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Long>constant(null))
+                        .onSuccess(new Function<SshPollValue, Long>() {
+                            @Override
+                            public Long apply(SshPollValue input) {
+                                List<String> memoryData = Splitter.on(" ").omitEmptyStrings().splitToList(Strings.getFirstLine(input.getStdout()));
+                                return Long.parseLong(memoryData.get(3));
+                            }
+                        }))
+                .poll(SshPollConfig.forSensor(MachineAttributes.TOTAL_MEMORY)
+                        .command("free | grep Mem:")
+                        .enabled(retrieveUsageMetrics)
+                        .onFailureOrException(Functions.<Long>constant(null))
+                        .onSuccess(new Function<SshPollValue, Long>() {
+                            @Override
+                            public Long apply(SshPollValue input) {
+                                List<String> memoryData = Splitter.on(" ").omitEmptyStrings().splitToList(Strings.getFirstLine(input.getStdout()));
+                                return Long.parseLong(memoryData.get(1));
+                            }
+                        }))
+                .build();
+    }
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineAttributes.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineAttributes.java
@@ -52,6 +52,7 @@ public class MachineAttributes {
     public static final AttributeSensor<Long> FREE_MEMORY = Sensors.newLongSensor("machine.memory.free", "Current free memory");
     public static final AttributeSensor<Long> TOTAL_MEMORY = Sensors.newLongSensor("machine.memory.total", "Total memory");
     public static final AttributeSensor<Long> USED_MEMORY = Sensors.newLongSensor("machine.memory.used", "Current memory usage");
+
     public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_LAST = Sensors.newDoubleSensor("memory.used.delta", "Change in memory usage per second");
     public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_IN_WINDOW = Sensors.newDoubleSensor("memory.used.windowed", "Average change in memory usage over 30s");
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineEntity.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineEntity.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.entity.machine;
 
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
 import org.apache.brooklyn.core.effector.MethodEffector;
@@ -30,13 +29,6 @@ import org.apache.brooklyn.util.time.Duration;
 @Catalog(name="Machine Entity", description="Represents a machine, providing metrics about it (e.g. obtained from ssh)")
 @ImplementedBy(MachineEntityImpl.class)
 public interface MachineEntity extends EmptySoftwareProcess {
-
-    AttributeSensor<Duration> UPTIME = MachineAttributes.UPTIME;
-    AttributeSensor<Double> LOAD_AVERAGE = MachineAttributes.LOAD_AVERAGE;
-    AttributeSensor<Double> CPU_USAGE = MachineAttributes.CPU_USAGE;
-    AttributeSensor<Long> FREE_MEMORY = MachineAttributes.FREE_MEMORY;
-    AttributeSensor<Long> TOTAL_MEMORY = MachineAttributes.TOTAL_MEMORY;
-    AttributeSensor<Long> USED_MEMORY = MachineAttributes.USED_MEMORY;
 
     MethodEffector<String> EXEC_COMMAND = new MethodEffector<String>(MachineEntity.class, "execCommand");
     MethodEffector<String> EXEC_COMMAND_TIMEOUT = new MethodEffector<String>(MachineEntity.class, "execCommandTimeout");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -27,7 +27,14 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -36,12 +43,10 @@ import org.apache.brooklyn.api.entity.drivers.EntityDriverManager;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
-import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
-import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -53,13 +58,13 @@ import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.entity.machine.MachineAttributes;
 import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.feed.function.FunctionPollConfig;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -67,15 +72,6 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.CountdownTimer;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Functions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
-import com.google.common.reflect.TypeToken;
 
 /**
  * An {@link Entity} representing a piece of software which can be installed, run, and controlled.
@@ -85,15 +81,16 @@ import com.google.common.reflect.TypeToken;
  * It exposes sensors for service state (Lifecycle) and status (String), and for host info, log file location.
  */
 public abstract class SoftwareProcessImpl extends AbstractEntity implements SoftwareProcess, DriverDependentEntity {
-    private static final Logger log = LoggerFactory.getLogger(SoftwareProcessImpl.class);
-    
+
+    private static final Logger LOG = LoggerFactory.getLogger(SoftwareProcessImpl.class);
+
     private transient SoftwareProcessDriver driver;
 
     /** @see #connectServiceUpIsRunning() */
-    private volatile FunctionFeed serviceProcessIsRunning;
+    private transient FunctionFeed serviceProcessIsRunning;
 
     protected boolean connectedSensors = false;
-    
+
     public SoftwareProcessImpl() {
         super(MutableMap.of(), null);
     }
@@ -340,7 +337,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         // whereas on start the *driver* calls connectSensors, before calling postStart,
         // ie waiting for the entity truly to be started before calling postStart;
         // TODO feels like that confusion could be eliminated with a single place for pre/post logic!)
-        log.debug("disconnecting sensors for "+this+" in entity.preStop");
+        LOG.debug("disconnecting sensors for "+this+" in entity.preStop");
         disconnectSensors();
         
         // Must set the serviceProcessIsRunning explicitly to false - we've disconnected the sensors
@@ -387,18 +384,18 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             connectSensors();
         } else {
             long delay = (long) (Math.random() * configuredMaxDelay.toMilliseconds());
-            log.debug("Scheduled reconnection of sensors on {} in {}ms", this, delay);
+            LOG.debug("Scheduled reconnection of sensors on {} in {}ms", this, delay);
             Timer timer = new Timer();
             timer.schedule(new TimerTask() {
                 @Override public void run() {
                     try {
                         if (getManagementSupport().isNoLongerManaged()) {
-                            log.debug("Entity {} no longer managed; ignoring scheduled connect sensors on rebind", SoftwareProcessImpl.this);
+                            LOG.debug("Entity {} no longer managed; ignoring scheduled connect sensors on rebind", SoftwareProcessImpl.this);
                             return;
                         }
                         connectSensors();
                     } catch (Throwable e) {
-                        log.warn("Problem connecting sensors on rebind of "+SoftwareProcessImpl.this, e);
+                        LOG.warn("Problem connecting sensors on rebind of "+SoftwareProcessImpl.this, e);
                         Exceptions.propagateIfFatal(e);
                     }
                 }
@@ -439,28 +436,27 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         //Only if the expected state is ON_FIRE then the entity has permanently failed.
         Transition expectedState = getAttribute(SERVICE_STATE_EXPECTED);
         if (expectedState == null || expectedState.getState() != Lifecycle.RUNNING) {
-            log.warn("On rebind of {}, not calling software process rebind hooks because expected state is {}", this, expectedState);
+            LOG.warn("On rebind of {}, not calling software process rebind hooks because expected state is {}", this, expectedState);
             return;
         }
 
         Lifecycle actualState = getAttribute(SERVICE_STATE_ACTUAL);
         if (actualState == null || actualState != Lifecycle.RUNNING) {
-            log.warn("Rebinding entity {}, even though actual state is {}. Expected state is {}", new Object[] {this, actualState, expectedState});
+            LOG.warn("Rebinding entity {}, even though actual state is {}. Expected state is {}", new Object[] { this, actualState, expectedState });
         }
 
         // e.g. rebinding to a running instance
         // FIXME For rebind, what to do about things in STARTING or STOPPING state?
         // FIXME What if location not set?
-        log.info("Rebind {} connecting to pre-running service", this);
+        LOG.info("Rebind {} connecting to pre-running service", this);
         
         MachineLocation machine = getMachineOrNull();
         if (machine != null) {
             initDriver(machine);
             driver.rebind();
-            if (log.isDebugEnabled()) log.debug("On rebind of {}, re-created driver {}", this, driver);
+            LOG.debug("On rebind of {}, re-created driver {}", this, driver);
         } else {
-            log.info("On rebind of {}, no MachineLocation found (with locations {}) so not generating driver",
-                    this, getLocations());
+            LOG.info("On rebind of {}, no MachineLocation found (with locations {}) so not generating driver", this, getLocations());
         }
         
         callRebindHooks();
@@ -491,7 +487,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
         if (raw2.isPresentAndNonNull()) {
             Object pp = raw2.get();
             if (!(pp instanceof Map)) {
-                log.debug("When obtaining provisioning properties for "+this+" to deploy to "+location+", detected that coercion was needed, so coercing sooner than we would otherwise");
+                LOG.debug("When obtaining provisioning properties for "+this+" to deploy to "+location+", detected that coercion was needed, so coercing sooner than we would otherwise");
                 pp = config().get(PROVISIONING_PROPERTIES);
             }
             result.putAll((Map<?,?>)pp);
@@ -548,7 +544,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             if ((driver instanceof AbstractSoftwareProcessDriver) && machine.equals(((AbstractSoftwareProcessDriver)driver).getLocation())) {
                 return driver; //just reuse
             } else {
-                log.warn("driver/location change is untested for {} at {}; changing driver and continuing", this, machine);
+                LOG.warn("driver/location change is untested for {} at {}; changing driver and continuing", this, machine);
                 return newDriver(machine);
             }
         } else {
@@ -558,7 +554,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     
     // TODO Find a better way to detect early death of process.
     public void waitForEntityStart() {
-        if (log.isDebugEnabled()) log.debug("waiting to ensure {} doesn't abort prematurely", this);
+        LOG.debug("waiting to ensure {} doesn't abort prematurely", this);
         Duration startTimeout = getConfig(START_TIMEOUT);
         CountdownTimer timer = startTimeout.countdownTimer();
         boolean isRunningResult = false;
@@ -568,7 +564,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             Time.sleep(delay);
             try {
                 isRunningResult = driver.isRunning();
-                if (log.isDebugEnabled()) log.debug("checked {}, 'is running' returned: {}", this, isRunningResult);
+                LOG.debug("checked {}, 'is running' returned: {}", this, isRunningResult);
             } catch (Exception  e) {
                 Exceptions.propagateIfFatal(e);
 
@@ -576,13 +572,13 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
                 if (driver != null) {
                     String msg = "checked " + this + ", 'is running' threw an exception; logging subsequent exceptions at debug level";
                     if (firstFailure == null) {
-                        log.error(msg, e);
+                        LOG.error(msg, e);
                     } else {
-                        log.debug(msg, e);
+                        LOG.debug(msg, e);
                     }
                 } else {
                     // provide extra context info, as we're seeing this happen in strange circumstances
-                    log.error(this+" concurrent start and shutdown detected", e);
+                    LOG.error(this+" concurrent start and shutdown detected", e);
                 }
                 if (firstFailure == null) {
                     firstFailure = e;
@@ -598,7 +594,7 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
             if (firstFailure != null) {
                 msg += "; check failed at least once with exception: " + firstFailure.getMessage() + ", see logs for details";
             }
-            log.warn(msg+" (throwing)");
+            LOG.warn(msg+" (throwing)");
             ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
             throw new IllegalStateException(msg, firstFailure);
         }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -58,7 +58,6 @@ import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
-import org.apache.brooklyn.entity.machine.MachineAttributes;
 import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.feed.function.FunctionPollConfig;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -712,9 +712,10 @@ public abstract class MachineLifecycleEffectorTasks {
         Maybe<MachineLocation> machine = Machines.findUniqueMachineLocation(entity().getLocations());
         Task<List<?>> stoppingProcess = null;
         if (canStop(stopProcessMode, entity())) {
-            stoppingProcess = Tasks.parallel(
-                        DynamicTasks.queue("stopping (process)", new StopProcessesAtMachineTask()),
-                        DynamicTasks.queue("stopping (feeds)", new StopFeedsAtMachineTask()));
+            stoppingProcess = Tasks.parallel("stopping",
+                    Tasks.create("stopping (process)", new StopProcessesAtMachineTask()),
+                    Tasks.create("stopping (feeds)", new StopFeedsAtMachineTask()));
+            DynamicTasks.queue(stoppingProcess);
         }
 
         Task<StopMachineDetails<Integer>> stoppingMachine = null;

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxAttributePollConfig.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxAttributePollConfig.java
@@ -21,16 +21,24 @@ package org.apache.brooklyn.feed.jmx;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.brooklyn.api.sensor.AttributeSensor;
-import org.apache.brooklyn.core.feed.PollConfig;
-
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.feed.PollConfig;
 
 public class JmxAttributePollConfig<T> extends PollConfig<Object, T, JmxAttributePollConfig<T>>{
 
     private ObjectName objectName;
     private String attributeName;
+
+    public static <T> JmxAttributePollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new JmxAttributePollConfig<T>(sensor);
+    }
+
+    public static JmxAttributePollConfig<Void> forMultiple() {
+        return new JmxAttributePollConfig<Void>(PollConfig.NO_SENSOR);
+    }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public JmxAttributePollConfig(AttributeSensor<T> sensor) {

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxOperationPollConfig.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxOperationPollConfig.java
@@ -39,6 +39,14 @@ public class JmxOperationPollConfig<T> extends PollConfig<Object, T, JmxOperatio
     private List<String> signature = Collections.emptyList();
     private List<?> params = Collections.emptyList();
 
+    public static <T> JmxOperationPollConfig<T> forSensor(AttributeSensor<T> sensor) {
+        return new JmxOperationPollConfig<T>(sensor);
+    }
+
+    public static JmxOperationPollConfig<Void> forMultiple() {
+        return new JmxOperationPollConfig<Void>(PollConfig.NO_SENSOR);
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public JmxOperationPollConfig(AttributeSensor<T> sensor) {
         super(sensor);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityEc2LiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityEc2LiveTest.java
@@ -40,12 +40,12 @@ public class MachineEntityEc2LiveTest extends AbstractEc2LiveTest {
         
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
-                assertNotNull(server.getAttribute(MachineEntity.UPTIME));
-                assertNotNull(server.getAttribute(MachineEntity.LOAD_AVERAGE));
-                assertNotNull(server.getAttribute(MachineEntity.CPU_USAGE));
-                assertNotNull(server.getAttribute(MachineEntity.FREE_MEMORY));
-                assertNotNull(server.getAttribute(MachineEntity.TOTAL_MEMORY));
-                assertNotNull(server.getAttribute(MachineEntity.USED_MEMORY));
+                assertNotNull(server.getAttribute(MachineAttributes.UPTIME));
+                assertNotNull(server.getAttribute(MachineAttributes.LOAD_AVERAGE));
+                assertNotNull(server.getAttribute(MachineAttributes.CPU_USAGE));
+                assertNotNull(server.getAttribute(MachineAttributes.FREE_MEMORY));
+                assertNotNull(server.getAttribute(MachineAttributes.TOTAL_MEMORY));
+                assertNotNull(server.getAttribute(MachineAttributes.USED_MEMORY));
             }});
         
         String result = server.execCommand("MY_ENV=myval && echo start $MY_ENV");


### PR DESCRIPTION
Moves the sensor feed for machine metrics to the SoftwareProcess, controlled by a configuration key with default set to _false_ normally and _true_ for `MachineEntity`. Also contributes static helper methods for feed `PollConfig` creation.