### PR TITLE
BROOKLYN-303: Fix EmptyWindowsProcess

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptyWindowsProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptyWindowsProcessYamlTest.java
@@ -32,14 +32,17 @@ import com.google.common.collect.Iterables;
 @Test
 public class EmptyWindowsProcessYamlTest extends AbstractYamlTest {
 
-    @Test(groups="Integration")
+    // takes couple of seconds unfortunately (why?!), but our only unit-test coverage of 
+    // EmptyWindowsProcess so including in unit tests anyway.
+    @Test
     public void testNoWinrm() throws Exception {
         Entity app = createAndStartApplication(
                 "location: byon:(hosts=\"1.2.3.4\",osFamily=windows)",
                 "services:",
                 "- type: "+EmptyWindowsProcess.class.getName(),
                 "  brooklyn.config:",
-                "    winrmMonitoring.enabled: false");
+                "    winrmMonitoring.enabled: false",
+                "    onbox.base.dir.skipResolution: true");
         waitForApplicationTasks(app);
 
         EmptyWindowsProcess entity = Iterables.getOnlyElement(Entities.descendants(app, EmptyWindowsProcess.class));

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/EmptyWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/EmptyWindowsProcessWinRmDriver.java
@@ -28,6 +28,8 @@ import org.apache.brooklyn.util.net.UserAndHostAndPort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+
 public class EmptyWindowsProcessWinRmDriver extends AbstractSoftwareProcessWinRmDriver implements VanillaWindowsProcessDriver {
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(EmptyWindowsProcessWinRmDriver.class);
@@ -41,7 +43,8 @@ public class EmptyWindowsProcessWinRmDriver extends AbstractSoftwareProcessWinRm
     @Override
     public void start() {
         WinRmMachineLocation machine = (WinRmMachineLocation) location;
-        UserAndHostAndPort winrmAddress = UserAndHostAndPort.fromParts(machine.getUser(), machine.getAddress().getHostName(), entity.getConfig(WinRmTool.PROP_PORT));
+        Integer port = entity.getConfig(WinRmTool.PROP_PORT);
+        UserAndHostAndPort winrmAddress = UserAndHostAndPort.fromParts(machine.getUser(), machine.getAddress().getHostName(), Optional.fromNullable(port));
         getEntity().sensors().set(Attributes.WINRM_ADDRESS, winrmAddress);
 
         super.start();

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/UserAndHostAndPort.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/UserAndHostAndPort.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.util.net;
 import java.io.Serializable;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.net.HostAndPort;
 
 public class UserAndHostAndPort implements Serializable {
@@ -29,6 +30,14 @@ public class UserAndHostAndPort implements Serializable {
 
     public static UserAndHostAndPort fromParts(String user, String host, int port) {
         return new UserAndHostAndPort(user, HostAndPort.fromParts(host, port));
+    }
+
+    public static UserAndHostAndPort fromParts(String user, String host, Optional<Integer> port) {
+        HostAndPort hostAndPort = port.isPresent() ? HostAndPort.fromParts(host, port.get()) : HostAndPort.fromString(host);
+        if (!port.isPresent() && hostAndPort.hasPort()) {
+            throw new IllegalArgumentException("optional port absent, but host '"+host+"' parsed as containing port");
+        }
+        return new UserAndHostAndPort(user, hostAndPort);
     }
 
     public static UserAndHostAndPort fromParts(String user, HostAndPort hostAndPort) {


### PR DESCRIPTION
Previously gave NPE in driver