### PR TITLE
Serialize complex objects as JSON in shell.env.

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -131,7 +131,7 @@ public abstract class AbstractYamlTest {
     protected Entity createAndStartApplication(String input) throws Exception {
         return createAndStartApplication(input, MutableMap.<String,String>of());
     }
-    protected Entity createAndStartApplication(String input, Map<String,String> startParameters) throws Exception {
+    protected Entity createAndStartApplication(String input, Map<String,?> startParameters) throws Exception {
         EntitySpec<?> spec = 
             mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, input, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
         final Entity app = brooklynMgmt.getEntityManager().createEntity(spec);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,6 +150,22 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.util.json;
+package org.apache.brooklyn.util.core.json;
 
 import java.io.IOException;
 import java.util.Map;

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.util.core.json;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class BrooklynObjectsJsonMapper {
+    public static ObjectMapper newMapper(ManagementContext mgmt) {
+        ConfigurableSerializerProvider sp = new ConfigurableSerializerProvider();
+        sp.setUnknownTypeSerializer(new ErrorAndToStringUnknownTypeSerializer());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializerProvider(sp);
+        mapper.setVisibilityChecker(new PossiblyStrictPreferringFieldsVisibilityChecker());
+
+        SimpleModule mapperModule = new SimpleModule("Brooklyn", new Version(0, 0, 0, "ignored", null, null));
+
+        new BidiSerialization.ManagementContextSerialization(mgmt).install(mapperModule);
+        new BidiSerialization.EntitySerialization(mgmt).install(mapperModule);
+        new BidiSerialization.LocationSerialization(mgmt).install(mapperModule);
+
+        mapperModule.addSerializer(new MultimapSerializer());
+        mapper.registerModule(mapperModule);
+        return mapper;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/ConfigurableSerializerProvider.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/ConfigurableSerializerProvider.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.util.json;
+package org.apache.brooklyn.util.core.json;
 
 import java.io.IOException;
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/ErrorAndToStringUnknownTypeSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/ErrorAndToStringUnknownTypeSerializer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.util.json;
+package org.apache.brooklyn.util.core.json;
 
 import java.io.IOException;
 import java.io.NotSerializableException;

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/MultimapSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/MultimapSerializer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.util.json;
+package org.apache.brooklyn.util.core.json;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/PossiblyStrictPreferringFieldsVisibilityChecker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/PossiblyStrictPreferringFieldsVisibilityChecker.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.rest.util.json;
+package org.apache.brooklyn.util.core.json;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
@@ -57,7 +57,7 @@ public class PossiblyStrictPreferringFieldsVisibilityChecker implements Visibili
         return BidiSerialization.isStrictSerialization() ? vizStrict : vizDefault;
     }
     
-    @Override public boolean isGetterVisible(Method m) { 
+    @Override public boolean isGetterVisible(Method m) {
         return viz().isGetterVisible(m);
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ContextResolver;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/WebResourceUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/WebResourceUtils.java
@@ -32,7 +32,6 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.rest.domain.ApiError;
 import org.apache.brooklyn.rest.util.json.BrooklynJacksonJsonProvider;
-import org.apache.brooklyn.util.core.osgi.Compat;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.apache.brooklyn.util.net.Urls;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
@@ -34,12 +34,11 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
 import org.apache.brooklyn.rest.util.OsgiCompat;
+import org.apache.brooklyn.util.core.json.BrooklynObjectsJsonMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 @Provider
@@ -153,23 +152,7 @@ public class BrooklynJacksonJsonProvider extends JacksonJsonProvider implements
             throw new IllegalStateException("No management context available for creating ObjectMapper");
         }
 
-        ConfigurableSerializerProvider sp = new ConfigurableSerializerProvider();
-        sp.setUnknownTypeSerializer(new ErrorAndToStringUnknownTypeSerializer());
-
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializerProvider(sp);
-        mapper.setVisibilityChecker(new PossiblyStrictPreferringFieldsVisibilityChecker());
-
-        SimpleModule mapperModule = new SimpleModule("Brooklyn", new Version(0, 0, 0, "ignored", null, null));
-
-        new BidiSerialization.ManagementContextSerialization(mgmt).install(mapperModule);
-        new BidiSerialization.EntitySerialization(mgmt).install(mapperModule);
-        new BidiSerialization.LocationSerialization(mgmt).install(mapperModule);
-
-        mapperModule.addSerializer(new MultimapSerializer());
-        mapper.registerModule(mapperModule);
-
-        return mapper;
+        return BrooklynObjectsJsonMapper.newMapper(mgmt);
     }
 
 }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonSerializerTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonSerializerTest.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.json.BidiSerialization;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializer.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.core.json.BrooklynObjectsJsonMapper;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ShellEnvironmentSerializer {
+    private ObjectMapper mapper;
+    
+    public ShellEnvironmentSerializer(ManagementContext mgmt) {
+        mapper = BrooklynObjectsJsonMapper.newMapper(mgmt);
+    }
+
+    public String serialize(Object value) {
+        if (value == null) return null;
+        if (value instanceof String) return (String)value;
+        try {
+            String str = mapper.writeValueAsString(value);
+            // Avoid dealing with unquoting and unescaping the serialized result is a string
+            if (isString(str)) {
+                return value.toString();
+            } else {
+                return str;
+            }
+        } catch (JsonProcessingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    protected boolean isString(String str) {
+        return str.length() > 0 && str.charAt(0) == '"';
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
+    ShellEnvironmentSerializer ser;
+
+    @Override
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+        ser = new ShellEnvironmentSerializer(mgmt);
+    }
+
+    @Test
+    public void testSerialize() {
+        String str = "some string \" with ' special; characters {}[]";
+        Date dt = new Date();
+        String appExpected = "{\"type\":\"org.apache.brooklyn.api.entity.Entity\",\"id\":\"" + app.getId() + "\"}";
+        assertSerialize(str, str);
+        assertSerialize(3.14, "3.14");
+        assertSerialize(3.140, "3.14");
+        assertSerialize(.140, "0.14");
+        assertSerialize(0.140, "0.14");
+        assertSerialize(Boolean.TRUE, "true");
+        assertSerialize(Boolean.FALSE, "false");
+        assertSerialize(dt, Long.toString(dt.getTime()));
+        assertSerialize(null, null);
+        assertSerialize(ImmutableList.of(str, 3.14, 0.14));
+        assertSerialize(ImmutableMap.of("string", str, "num1", 3.14, "num2", 0.14));
+        assertSerialize(app, appExpected);
+        assertSerialize(ImmutableList.of(app), "[" + appExpected + "]");
+        assertSerialize(ImmutableMap.of("app", app), "{\"app\":" + appExpected + "}");
+        assertSerialize(mgmt, "{\"type\":\"org.apache.brooklyn.core.test.entity.LocalManagementContextForTests\"}");
+        // TODO Fails with java.lang.OutOfMemoryError: GC overhead limit exceeded
+        // https://issues.apache.org/jira/browse/BROOKLYN-304
+        // assertSerialize(getClass().getClassLoader(), "???");
+    }
+
+    private void assertSerialize(Object actual, String expected) {
+        assertEquals(ser.serialize(actual), expected);
+    }
+    private void assertSerialize(Object obj) {
+        String serialized = ser.serialize(obj);
+        Gson gson = new GsonBuilder().create();
+        assertEquals(obj, gson.fromJson(serialized, Object.class));
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessShellEnvironmentTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessShellEnvironmentTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.entity.software.base;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+public class SoftwareProcessShellEnvironmentTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testEnvironment() {
+        final EnvRecordingLocation recordingMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(EnvRecordingLocation.class)
+                .configure("address", "127.0.0.1"));
+        VanillaSoftwareProcess entity = app.createAndManageChild(EntitySpec.create(VanillaSoftwareProcess.class));
+        Date dt = new Date();
+        Integer someInt = 12;
+        String someString = "simple string";
+        String specialString = "some \"\\\" escaped string ' ; to\" [] {}";
+        entity.config().set(VanillaSoftwareProcess.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>builder()
+                .put("some_int", someInt)
+                .put("some_string", someString)
+                .put("some_boolean", Boolean.TRUE)
+                .put("some_map", ImmutableMap.of(
+                        "more_keys", "more_values",
+                        "some_more_keys", "some_more_values",
+                        "special_value", specialString))
+                .put("some_list", ImmutableList.of(
+                        "idx1",
+                        "idx2",
+                        specialString))
+                .put("some_time", dt)
+                .put("some_bean", new SimpleBean("bean-string", -1))
+                .put("self", entity)
+                .build());
+
+        app.start(ImmutableList.of(recordingMachine));
+        Map<String, ?> env = recordingMachine.getRecordedEnv().iterator().next();
+
+        String escapedString = "\"" + specialString.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        assertEquals(env.get("some_int"), someInt.toString());
+        assertEquals(env.get("some_string"), someString);
+        assertEquals(env.get("some_boolean"), Boolean.TRUE.toString());
+        assertEquals(env.get("some_map"), "{\"more_keys\":\"more_values\",\"some_more_keys\":\"some_more_values\",\"special_value\":" + escapedString + "}");
+        assertEquals(env.get("some_list"), "[\"idx1\",\"idx2\"," + escapedString + "]");
+        assertEquals(env.get("some_time"), Long.toString(dt.getTime()));
+        assertEquals(env.get("some_bean"), "{\"propString\":\"bean-string\",\"propInt\":-1}");
+        assertEquals(env.get("self"), "{\"type\":\"org.apache.brooklyn.api.entity.Entity\",\"id\":\"" + entity.getId() + "\"}");
+    }
+
+    public static class SimpleBean {
+        private String propString;
+        private int propInt;
+        public SimpleBean() {}
+        public SimpleBean(String propString, int propInt) {
+            super();
+            this.propString = propString;
+            this.propInt = propInt;
+        }
+        public String getPropString() {
+            return propString;
+        }
+        public void setPropString(String propString) {
+            this.propString = propString;
+        }
+        public int getPropInt() {
+            return propInt;
+        }
+        public void setPropInt(int propInt) {
+            this.propInt = propInt;
+        }
+    }
+
+    public static class EnvRecordingLocation extends SshMachineLocation {
+        private List<Map<String, ?>> env = Lists.newCopyOnWriteArrayList();
+
+        @Override
+        public int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
+            recordEnv(env);
+            return 0;
+        }
+
+        private void recordEnv(Map<String, ?> env) {
+            this.env.add(env);
+        }
+        
+        public List<Map<String, ?>> getRecordedEnv() {
+            return env;
+        }
+    }
+}

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
@@ -242,7 +242,13 @@ public class Reflections {
 
     /** Invokes a suitable constructor, supporting varargs and primitives */
     public static <T> Optional<T> invokeConstructorWithArgs(Class<T> clazz, Object[] argsArray, boolean setAccessible) {
-        Reflections reflections = new Reflections(clazz.getClassLoader());
+        ClassLoader cl = clazz.getClassLoader();
+        // if bootstrap class loader
+        if (cl == null) {
+            // The classloader isn't actually used so anything non-null will work
+            cl = ClassLoader.getSystemClassLoader();
+        }
+        Reflections reflections = new Reflections(cl);
         return invokeConstructorWithArgs(reflections, clazz, argsArray, setAccessible);
     }
 

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/ReflectionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/ReflectionsTest.java
@@ -56,6 +56,11 @@ public class ReflectionsTest {
         assertNoDuplicates(fields);
     }
     
+    @Test
+    public void testConstructLangObject() {
+        Reflections.invokeConstructorWithArgs(java.util.Date.class);
+    }
+    
     public static interface MyInterface {
         public static final int MY_FIELD = 0;
         public void mymethod();


### PR DESCRIPTION
Serialize complex objects to JSON instead of calling toString() when building the shell environment variables for `SoftwareProcess`.

```
brooklyn.catalog:
  id: mapping-entity
  item:
    type: VanillaSoftwareProcess
    env:
      MAPPINGS: $brooklyn:config("mappings")

services:
- type:  mapping-entity
  brooklyn.config:
    mappings:
      key1: val1
      key2: val2
```

Will result in an `MAPPINGS={"key1":"val1","key2":"val2"} ` environment variable.