### PR TITLE
Test relative entities

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -61,14 +61,24 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
     private final DslComponent scopeComponent;
     private final Scope scope;
 
+    /**
+     * Resolve componentId in the {@link Scope#GLOBAL} scope.
+     */
     public DslComponent(String componentId) {
         this(Scope.GLOBAL, componentId);
     }
-    
+
+    /**
+     * Resolve componentId in scope relative to the current
+     * {@link BrooklynTaskTags#getTargetOrContextEntity) target or context} entity.
+     */
     public DslComponent(Scope scope, String componentId) {
         this(null, scope, componentId);
     }
-    
+
+    /**
+     * Resolve componentId in scope relative to scopeComponent.
+     */
     public DslComponent(DslComponent scopeComponent, Scope scope, String componentId) {
         Preconditions.checkNotNull(scope, "scope");
         this.scopeComponent = scopeComponent;

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
@@ -83,15 +83,15 @@ public class StaticSensor<T> extends AddSensor<T> {
             public T call() throws Exception {
                 Maybe<T> v = resolveValue.get();
                 if (!v.isPresent()) {
-                    log.debug(this+" not setting sensor "+sensor+"; cannot resolve "+value+" after timeout " + timeout);
+                    log.debug(this+" not setting sensor "+sensor+" on "+entity+"; cannot resolve "+value+" after timeout " + timeout);
                     return null;
                 }
-                log.debug(this+" setting sensor "+sensor+" to "+v.get());
+                log.debug(this+" setting sensor "+sensor+" to "+v.get()+" on "+entity);
                 return entity.sensors().set(sensor, v.get());
             }
         }
-        Task<T> setValue = Tasks.<T>builder().displayName("setting " + sensor).body(new SetValue()).build();
+        Task<T> setValue = Tasks.<T>builder().displayName("Setting " + sensor + " on " + entity).body(new SetValue()).build();
 
-        Entities.submit(entity, Tasks.sequential("resolving and setting " + sensor, resolveValue, setValue));
+        Entities.submit(entity, Tasks.sequential("Resolving and setting " + sensor + " on " + entity, resolveValue, setValue));
     }
 }

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCase.java
@@ -30,9 +30,6 @@ import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 
-/**
- * Created by graememiller on 04/12/2015.
- */
 @ImplementedBy(value = InfrastructureDeploymentTestCaseImpl.class)
 public interface InfrastructureDeploymentTestCase extends TargetableTestComponent {
 

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseImpl.java
@@ -32,9 +32,6 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.Sensors;
 
-/**
- * Created by graememiller on 04/12/2015.
- */
 public class InfrastructureDeploymentTestCaseImpl extends TestCaseImpl implements InfrastructureDeploymentTestCase {
 
     @Override

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCase.java
@@ -27,9 +27,6 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
-/**
- * Created by graememiller on 11/12/2015.
- */
 @ImplementedBy(value = LoopOverGroupMembersTestCaseImpl.class)
 public interface LoopOverGroupMembersTestCase extends TargetableTestComponent {
 

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseImpl.java
@@ -75,7 +75,12 @@ public class LoopOverGroupMembersTestCaseImpl extends TargetableTestComponentImp
             try {
                 TargetableTestComponent targetableTestComponent = this.addChild(testSpecCopy);
                 targetableTestComponent.start(locations);
-                logger.debug("Task of {} successfully run, targetting {}", this, member);
+                if (Lifecycle.RUNNING.equals(targetableTestComponent.sensors().get(Attributes.SERVICE_STATE_ACTUAL))) {
+                    logger.debug("Task of {} successfully run, targetting {}", this, member);
+                } else {
+                    logger.warn("Problem in child test-case of {}, targetting {}", this, member);
+                    allSuccesful = false;
+                }
             } catch (Throwable t) {
                 Exceptions.propagateIfFatal(t);
                 logger.warn("Problem in child test-case of "+this+", targetting "+member, t);

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseImpl.java
@@ -35,9 +35,6 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
-/**
- * Created by graememiller on 11/12/2015.
- */
 public class LoopOverGroupMembersTestCaseImpl extends TargetableTestComponentImpl implements LoopOverGroupMembersTestCase {
 
     private static final Logger logger = LoggerFactory.getLogger(LoopOverGroupMembersTestCaseImpl.class);

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCase.java
@@ -22,8 +22,6 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 
 /**
  * This implementation will start all child entities in parallel.
- *
- * @author Chris Burke
  */
 @ImplementedBy(value = ParallelTestCaseImpl.class)
 public interface ParallelTestCase extends TargetableTestComponent {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/ParallelTestCaseImpl.java
@@ -33,8 +33,6 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 
 /**
  * This implementation will start all child entities in parallel.
- * 
- * @author Chris Burke
  */
 public class ParallelTestCaseImpl extends TargetableTestComponentImpl implements ParallelTestCase {
 

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.test.framework;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.Sensors;
+
+import com.google.common.base.Predicates;
+
+/**
+ * A test case that resolves target ID relative to an anchor entity.
+ * <p>
+ * For example, to run tests against a named child of an entity:
+ * <pre>
+ * services
+ * - id: app
+ *   brooklyn.children:
+ *     id: child-id
+ * - id: test-case
+ *   brooklyn.config:
+ *     anchor: $brooklyn:component("app").descendant("child-id")
+ * </pre>
+ * The anchor entity is resolved from the <code>anchor</code>, <code>target</code> or
+ * <code>targetId</code>, in order of preference. The latter two are useful when using
+ * the test with with entities like {@link LoopOverGroupMembersTestCase}. Values for
+ * <code>target</code> will be overwritten with the resolved entity so child test
+ * cases work as expected.
+ */
+@ImplementedBy(RelativeEntityTestCaseImpl.class)
+public interface RelativeEntityTestCase extends TargetableTestComponent {
+
+    AttributeSensorAndConfigKey<Entity, Entity> ANCHOR = ConfigKeys.newSensorAndConfigKey(Entity.class,
+            "anchor",
+            "Entity from which component should be resolved.");
+
+    ConfigKey<DslComponent> COMPONENT = ConfigKeys.builder(DslComponent.class)
+            .name("component")
+            .description("The component to resolve against target")
+            .constraint(Predicates.<DslComponent>notNull())
+            .build();
+
+}

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.test.framework;
+
+import java.util.Collection;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class RelativeEntityTestCaseImpl extends TargetableTestComponentImpl implements RelativeEntityTestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RelativeEntityTestCaseImpl.class);
+
+    @Override
+    public Entity resolveTarget() {
+        Entity anchor = config().get(ANCHOR);
+        if (anchor == null) {
+            anchor = super.resolveTarget();
+        }
+        if (anchor == null) {
+            throw new IllegalArgumentException("No anchor entity found for " + this);
+        }
+        sensors().set(ANCHOR, anchor);
+        Maybe<Object> component = config().getRaw(COMPONENT);
+        if (component.isAbsentOrNull()) {
+            throw new IllegalArgumentException("No component found for " + this);
+        } else if (!(component.get() instanceof DslComponent)) {
+            throw new IllegalArgumentException("Expected DslComponent value for component, found " + component.get());
+        }
+        DslComponent finder = DslComponent.class.cast(component.get());
+        Task<Entity> task = Entities.submit(anchor, finder);
+        return task.getUnchecked();
+    }
+
+    @Override
+    public void start(Collection<? extends Location> locations) {
+        sensors().set(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STARTING);
+
+        Entity target = resolveTarget();
+        if (target == null) {
+            LOG.debug("Tasks NOT successfully run. RelativeEntityTestCaseImpl target unset");
+            setServiceState(false, Lifecycle.ON_FIRE);
+            return;
+        }
+        config().set(BaseTest.TARGET_ENTITY, target);
+
+        boolean success = true;
+        try {
+            for (Entity child : getChildren()) {
+                if (child instanceof Startable) {
+                    Startable test = Startable.class.cast(child);
+                    test.start(locations);
+                    if (Lifecycle.RUNNING.equals(child.sensors().get(Attributes.SERVICE_STATE_ACTUAL))) {
+                        LOG.debug("Task of {} successfully run, targeting {}", this, target);
+                    } else {
+                        LOG.warn("Problem in child test-case of {}, targeting {}", this, target);
+                        success = false;
+                    }
+                } else {
+                    LOG.info("Ignored child of {} that is not Startable: {}", this, child);
+                }
+                if (!success) {
+                    break;
+                }
+            }
+        } catch (Throwable t) {
+            Exceptions.propagateIfFatal(t);
+            LOG.warn("Problem in child test-case of " + this + ", targeting " + target, t);
+            success = false;
+        }
+
+        if (success) {
+            LOG.debug("Tasks successfully run. Update state of {} to RUNNING.", this);
+            setServiceState(true, Lifecycle.RUNNING);
+        } else {
+            LOG.debug("Tasks NOT successfully run. Update state of {} to ON_FIRE.", this);
+            setServiceState(false, Lifecycle.ON_FIRE);
+        }
+    }
+
+    @Override
+    public void stop() {
+        sensors().set(Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPING);
+        try {
+            for (Entity child : this.getChildren()) {
+                if (child instanceof Startable) ((Startable) child).stop();
+            }
+            LOG.debug("Tasks successfully run. Update state of {} to STOPPED.", this);
+            setServiceState(false, Lifecycle.STOPPED);
+        } catch (Throwable t) {
+            LOG.debug("Tasks NOT successfully run. Update state of {} to ON_FIRE.", this);
+            setServiceState(false, Lifecycle.ON_FIRE);
+            throw Exceptions.propagate(t);
+        }
+    }
+
+    @Override
+    public void restart() {
+        final Collection<Location> locations = Lists.newArrayList(getLocations());
+        stop();
+        start(locations);
+    }
+
+    /**
+     * Sets the state of the Entity. Useful so that the GUI shows the correct icon.
+     *
+     * @param serviceUpState     Whether or not the entity is up.
+     * @param serviceStateActual The actual state of the entity.
+     */
+    private void setServiceState(final boolean serviceUpState, final Lifecycle serviceStateActual) {
+        sensors().set(SERVICE_UP, serviceUpState);
+        sensors().set(Attributes.SERVICE_STATE_ACTUAL, serviceStateActual);
+    }
+
+}

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TargetableTestComponent.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TargetableTestComponent.java
@@ -28,8 +28,6 @@ import org.apache.brooklyn.util.time.Duration;
 
 /**
  * Entity that can target another entity for the purpouse of testing
- *
- * @author m4rkmckenna
  */
 @ImplementedBy(value = TargetableTestComponentImpl.class)
 public interface TargetableTestComponent extends Entity, Startable {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
@@ -22,8 +22,6 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 
 /**
  * Entity that logically groups other test entities
- *
- * @author m4rkmckenna
  */
 @ImplementedBy(value = TestCaseImpl.class)
 public interface TestCase extends TargetableTestComponent {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestEffector.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestEffector.java
@@ -31,8 +31,6 @@ import java.util.Map;
 
 /**
  * Entity that invokes an effector on another entity
- *
- * @author m4rkmckenna
  */
 @ImplementedBy(value = TestEffectorImpl.class)
 public interface TestEffector extends BaseTest {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestEffectorImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestEffectorImpl.java
@@ -43,9 +43,6 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 
-/**
- *
- */
 public class TestEffectorImpl extends TargetableTestComponentImpl implements TestEffector {
     private static final Logger LOG = LoggerFactory.getLogger(TestEffectorImpl.class);
 

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
@@ -39,8 +39,6 @@ import org.apache.brooklyn.util.text.Strings;
 
 /**
  * Utility class to evaluate test-framework assertions
- *
- * @author m4rkmckenna on 11/11/2015.
  */
 public class TestFrameworkAssertions {
 

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
@@ -25,8 +25,6 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
  * Entity that makes a HTTP Request and tests the response
- *
- * @author johnmccabe
  */
 @ImplementedBy(value = TestHttpCallImpl.class)
 public interface TestHttpCall extends BaseTest {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSensor.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSensor.java
@@ -25,8 +25,6 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 /**
  * Entity that tests a sensor value on another entity
- *
- * @author m4rkmckenna
  */
 @ImplementedBy(value = TestSensorImpl.class)
 public interface TestSensor extends BaseTest {

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/InfrastructureDeploymentTestCaseTest.java
@@ -47,9 +47,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 
-/**
- * @author Graeme Miller on 27/10/2015.
- */
 @SuppressWarnings("serial")
 public class InfrastructureDeploymentTestCaseTest {
 

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/LoopOverGroupMembersTestCaseTest.java
@@ -47,12 +47,8 @@ import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.util.collections.MutableSet;
-import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Identifiers;
 
-/**
- * @author Graeme Miller on 27/10/2015.
- */
 public class LoopOverGroupMembersTestCaseTest {
 
     private TestApplication app;

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.test.framework;
+
+import static org.apache.brooklyn.test.Asserts.assertTrue;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.sensor.StaticSensor;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.entity.group.Cluster;
+import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class RelativeEntityTestCaseTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testParentAndChildScope() {
+        TestEntity parent = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "parent-plan"));
+        TestEntity child = parent.addChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "child-plan"));
+
+        parent.sensors().set(TestEntity.NAME, "parent");
+        child.sensors().set(TestEntity.NAME, "child");
+
+        app.start(ImmutableList.of(app.newSimulatedLocation()));
+
+        TestCase testCase = app.createAndManageChild(EntitySpec.create(TestCase.class)
+                .child(relativeEntityTestCaseEntitySpec(parent, "child-plan", DslComponent.Scope.CHILD, "child"))
+                .child(relativeEntityTestCaseEntitySpec(child, "parent-plan", DslComponent.Scope.PARENT, "parent")));
+
+        testCase.start(app.getLocations());
+        assertTrue(testCase.sensors().get(Attributes.SERVICE_UP), "Test case did not pass: " + testCase);
+    }
+
+    @Test
+    public void testSiblingScope() {
+        TestEntity brother = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "brother-plan"));
+        TestEntity sister = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "sister-plan"));
+
+        brother.sensors().set(TestEntity.NAME, "brother");
+        sister.sensors().set(TestEntity.NAME, "sister");
+
+        app.start(ImmutableList.of(app.newSimulatedLocation()));
+
+        TestCase testCase = app.createAndManageChild(EntitySpec.create(TestCase.class)
+                .child(relativeEntityTestCaseEntitySpec(brother, "sister-plan", DslComponent.Scope.SIBLING, "sister"))
+                .child(relativeEntityTestCaseEntitySpec(sister, "brother-plan", DslComponent.Scope.SIBLING, "brother")));
+
+        testCase.start(app.getLocations());
+        assertTrue(testCase.sensors().get(Attributes.SERVICE_UP), "Test case did not pass: " + testCase);
+    }
+
+    @Test
+    public void testCombinationWithLoopOverGroupMembersTest() {
+        final String sensorName = TestEntity.NAME.getName();
+        final String sensorValue = "test-sensor-value";
+        EntityInitializer staticSensor = new StaticSensor<>(ConfigBag.newInstance(ImmutableMap.of(
+                StaticSensor.SENSOR_NAME, sensorName,
+                StaticSensor.STATIC_VALUE, sensorValue)));
+
+        // Application entities
+
+        EntitySpec<TestEntity> childSpec = EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "child-plan")
+                .addInitializer(staticSensor);
+        EntitySpec<TestEntity> groupMemberSpec = EntitySpec.create(TestEntity.class)
+                .configure(BrooklynCampConstants.PLAN_ID, "group-member-plan")
+                .child(childSpec);
+        Entity cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.MEMBER_SPEC, groupMemberSpec)
+                .configure(Cluster.INITIAL_SIZE, 3));
+
+        // Start the cluster.
+        app.start(ImmutableList.of(app.newSimulatedLocation()));
+
+        LoopOverGroupMembersTestCase groupTest = app.createAndManageChild(EntitySpec.create(LoopOverGroupMembersTestCase.class)
+                .configure(LoopOverGroupMembersTestCase.TARGET_ENTITY, cluster)
+                .configure(LoopOverGroupMembersTestCase.TEST_SPEC, relativeEntityTestCaseEntitySpec(
+                        /* set by group-loop */ null, "child-plan", DslComponent.Scope.CHILD, sensorValue)));
+
+        groupTest.start(app.getLocations());
+
+        // Specifically check the result of the loop test.
+        assertTrue(groupTest.sensors().get(Attributes.SERVICE_UP), "Test case did not pass: " + groupTest);
+    }
+
+    private EntitySpec<RelativeEntityTestCase> relativeEntityTestCaseEntitySpec(
+            Entity testRoot, String targetEntityPlanId, DslComponent.Scope scope, String expectedSensorValue) {
+        EntitySpec<TestSensor> sensorTest = sensorHasValueTest(TestEntity.NAME, expectedSensorValue);
+
+        return EntitySpec.create(RelativeEntityTestCase.class)
+                .configure(RelativeEntityTestCase.TARGET_ENTITY, testRoot)
+                .configure(RelativeEntityTestCase.COMPONENT, new DslComponent(scope, targetEntityPlanId))
+                .child(sensorTest);
+    }
+
+    private EntitySpec<TestSensor> sensorHasValueTest(Sensor<?> sensorName, Object expectedValue) {
+        return EntitySpec.create(TestSensor.class)
+                .configure(TestSensor.SENSOR_NAME, sensorName.getName())
+                .configure(TestSensor.ASSERTIONS, ImmutableMap.of(
+                        TestFrameworkAssertions.EQUAL_TO, expectedValue));
+    }
+
+}

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestEffectorTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestEffectorTest.java
@@ -41,9 +41,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-/**
- * @author m4rkmckenna on 27/10/2015.
- */
 public class TestEffectorTest {
 
     private TestApplication app;

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
@@ -35,10 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-
-/**
- * @author m4rkmckenna on 11/11/2015.
- */
 public class TestFrameworkAssertionsTest {
     private static final Logger LOG = LoggerFactory.getLogger(TestFrameworkAssertionsTest.class);
 

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestHttpCallTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestHttpCallTest.java
@@ -38,9 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-/**
- * @author m4rkmckenna on 12/11/2015.
- */
 public class TestHttpCallTest {
 
 

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestSensorTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestSensorTest.java
@@ -43,9 +43,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author m4rkmckenna on 27/10/2015.
- */
 public class TestSensorTest {
 
     private static final AttributeSensorAndConfigKey<Boolean, Boolean> BOOLEAN_SENSOR = ConfigKeys.newSensorAndConfigKey(Boolean.class, "boolean-sensor", "Boolean Sensor");

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestEntity.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestEntity.java
@@ -27,10 +27,6 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 
-/**
- * @author m4rkmckenna on 27/10/2015.
- */
-
 @ImplementedBy(TestEntityImpl.class)
 public interface TestEntity extends Entity, Startable {
 

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestEntityImpl.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestEntityImpl.java
@@ -19,16 +19,11 @@
 
 package org.apache.brooklyn.test.framework.entity;
 
-import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.core.annotation.EffectorParam;
-import org.apache.brooklyn.core.entity.AbstractEntity;
-import org.apache.brooklyn.test.framework.entity.TestEntity;
-
 import java.util.Collection;
 
-/**
- * @author m4rkmckenna on 27/10/2015.
- */
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+
 public class TestEntityImpl extends AbstractEntity implements TestEntity {
     @Override
     public void start(final Collection<? extends Location> locations) {
@@ -49,7 +44,7 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     }
 
     @Override
-    public TestPojo complexEffector(@EffectorParam(name = "stringValue") final String stringValue, @EffectorParam(name = "booleanValue") final Boolean booleanValue, @EffectorParam(name = "longValue") final Long longValue) {
+    public TestPojo complexEffector(final String stringValue, final Boolean booleanValue, final Long longValue) {
         sensors().set(COMPLEX_EFFECTOR_INVOKED, Boolean.TRUE);
         sensors().set(COMPLEX_EFFECTOR_STRING, stringValue);
         sensors().set(COMPLEX_EFFECTOR_BOOLEAN, booleanValue);
@@ -58,7 +53,7 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     }
 
     @Override
-    public String effectorReturnsString(@EffectorParam(name = "stringToReturn") String stringToReturn) {
+    public String effectorReturnsString(String stringToReturn) {
         return stringToReturn;
     }
 }

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestInfrastructure.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestInfrastructure.java
@@ -22,10 +22,6 @@ package org.apache.brooklyn.test.framework.entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 
-/**
- * Created by graememiller on 17/12/2015.
- */
-
 @ImplementedBy(TestInfrastructureImpl.class)
 public interface TestInfrastructure extends BasicApplication {
 }

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestInfrastructureImpl.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/entity/TestInfrastructureImpl.java
@@ -28,9 +28,6 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.entity.stock.BasicApplicationImpl;
 
-/**
- * Created by graememiller on 17/12/2015.
- */
 public class TestInfrastructureImpl extends BasicApplicationImpl implements TestInfrastructure {
 
     private final AttributeSensorAndConfigKey<Location, Location> DEPLOYMENT_LOCATION = ConfigKeys.newSensorAndConfigKey(


### PR DESCRIPTION
Adds an entity for test cases that need to resolve their target from another entity. For example, to make assertions on the child of a group member.