### PR TITLE
Adds the ability for you to fetch all children of an activity

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.rest.api;
 
 import io.swagger.annotations.Api;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.brooklyn.rest.domain.TaskSummary;
 
@@ -44,8 +45,7 @@ public interface ActivityApi {
             @ApiResponse(code = 404, message = "Could not find task")
     })
     public TaskSummary get(
-            @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId
-            );
+            @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId);
 
     @GET
     @Path("/{task}/children")
@@ -54,6 +54,17 @@ public interface ActivityApi {
             @ApiResponse(code = 404, message = "Could not find task")
     })
     public List<TaskSummary> children(
+            @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId);
+
+    @GET
+    @Path("/{task}/children/recurse")
+    @ApiOperation(
+            value = "Fetch all child tasks details as Map<String,TaskSummary> map key == Task ID",
+            response = Map.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Could not find task")
+    })
+    public Map<String,TaskSummary> getAllChildrenAsMap(
             @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId);
 
     @GET


### PR DESCRIPTION
Example 
GET http://localhost:8081/v1/activities/abc123/children/recurse

```
{
    "sCxsLgvm": {
        "id": "sCxsLgvm",
        "displayName": "invoking start[locations] on 1 node",
        "description": "",
        "entityId": "z81e0jl9j4",
        "entityDisplayName": "simple-app",
        "tags": [
            "SUB-TASK",
            {
                "type": "org.apache.brooklyn.core.test.entity.LocalManagementContextForTests"
            },
            {
                "wrappingType": "contextEntity",
                "entity": {
                    "type": "org.apache.brooklyn.api.entity.Entity",
                    "id": "z81e0jl9j4"
                }
            }
        ],
        "submitTimeUtc": 1466502440778,
        "startTimeUtc": 1466502440778,
        "endTimeUtc": 1466502441114,
        "currentStatus": "Completed",
        "result": [
            null
        ],
        "isError": false,
        "isCancelled": false,
        "children": [
            {
                "link": "/activities/WfYmdAuS",
                "metadata": {
                    "id": "WfYmdAuS",
                    "taskName": "start",
                    "entityId": "cmfr998e06",
                    "entityDisplayName": "simple-ent"
                }
            }
        ],
        "submittedByTask": {
            "link": "/activities/umIaqimp",
            "metadata": {
                "id": "umIaqimp",
                "taskName": "start",
                "entityId": "z81e0jl9j4",
                "entityDisplayName": "simple-app"
            }
        },
        "detailedStatus": "Completed after 336ms\n\nResult: [null]",
        "streams": {},
        "links": {
            "self": "/activities/sCxsLgvm",
            "children": "/activities/sCxsLgvm/children",
            "entity": "/applications/z81e0jl9j4/entities/z81e0jl9j4"
        }
    },
    "WfYmdAuS": {
        "id": "WfYmdAuS",
        "displayName": "start",
        "description": "Invoking effector start on simple-ent with parameters {locations=[LocalhostMachineProvisioningLocation{id=g1zmb43lie, name=localhost}]}",
        "entityId": "cmfr998e06",
        "entityDisplayName": "simple-ent",
        "tags": [
            "EFFECTOR",
            "SUB-TASK",
            {
                "wrappingType": "contextEntity",
                "entity": {
                    "type": "org.apache.brooklyn.api.entity.Entity",
                    "id": "cmfr998e06"
                }
            },
            {
                "type": "org.apache.brooklyn.core.test.entity.LocalManagementContextForTests"
            },
            {
                "wrappingType": "targetEntity",
                "entity": {
                    "type": "org.apache.brooklyn.api.entity.Entity",
                    "id": "cmfr998e06"
                }
            },
            {
                "entityId": "cmfr998e06",
                "effectorName": "start"
            }
        ],
        "submitTimeUtc": 1466502440778,
        "startTimeUtc": 1466502440778,
        "endTimeUtc": 1466502441114,
        "currentStatus": "Completed",
        "result": null,
        "isError": false,
        "isCancelled": false,
        "children": [
            {
                "link": "/activities/X9MqBujF",
                "metadata": {
                    "id": "X9MqBujF",
                    "taskName": "provisioning (localhost)",
                    "entityId": "cmfr998e06",
                    "entityDisplayName": "simple-ent"
                }
            },
            {
                "link": "/activities/ErGE1oPr",
                "metadata": {
                    "id": "ErGE1oPr",
                    "taskName": "pre-start",
                    "entityId": "cmfr998e06",
                    "entityDisplayName": "simple-ent"
                }
            },
            {
                "link": "/activities/ud8TXRaU",
                "metadata": {
                    "id": "ud8TXRaU",
                    "taskName": "start (processes)",
                    "entityId": "cmfr998e06",
                    "entityDisplayName": "simple-ent"
                }
            },
            {
                "link": "/activities/J1Kkj2xF",
                "metadata": {
                    "id": "J1Kkj2xF",
                    "taskName": "post-start",
                    "entityId": "cmfr998e06",
                    "entityDisplayName": "simple-ent"
                }
            }
        ],
        "submittedByTask": {
            "link": "/activities/sCxsLgvm",
            "metadata": {
                "id": "sCxsLgvm",
                "taskName": "invoking start[locations] on 1 node",
                "entityId": "z81e0jl9j4",
                "entityDisplayName": "simple-app"
            }
        },
        "detailedStatus": "Completed after 336ms\n\nNo return value (null)",
        "streams": {},
        "links": {
            "self": "/activities/WfYmdAuS",
            "children": "/activities/WfYmdAuS/children",
            "entity": "/applications/z81e0jl9j4/entities/cmfr998e06"
        }
    },
    "X9MqBujF": {
        "id": "X9MqBujF",
        "displayName": "provisioning (localhost)",
        "description": "",
        "entityId": "cmfr998e06",
        "entityDisplayName": "simple-ent",
        "tags": [
            "SUB-TASK",
            {
                "wrappingType": "contextEntity",
                "entity": {
                    "type": "org.apache.brooklyn.api.entity.Entity",
                    "id": "cmfr998e06"
                }
            },
            {
                "type": "org.apache.brooklyn.core.test.entity.LocalManagementContextForTests"
            }
        ],
        "submitTimeUtc": 1466502440782,
        "startTimeUtc": 1466502440782,
        "endTimeUtc": 1466502440799,
        "currentStatus": "Completed",
        "result": {
            "type": "org.apache.brooklyn.api.location.Location",
            "id": "fe4jz35nvm"
        },
        "isError": false,
        "isCancelled": false,
        "children": [],
        "submittedByTask": {
            "link": "/activities/WfYmdAuS",
            "metadata": {
                "id": "WfYmdAuS",
                "taskName": "start",
                "entityId": "cmfr998e06",
                "entityDisplayName": "simple-ent"
            }
        },
        "detailedStatus": "Completed after 17ms\n\nResult: SshMachineLocation[localhost:null@chimera.local/192.168.4.161:22(id=fe4jz35nvm)]",
        "streams": {},
        "links": {
            "self": "/activities/X9MqBujF",
            "children": "/activities/X9MqBujF/children",
            "entity": "/applications/z81e0jl9j4/entities/cmfr998e06"
        }
    },
########################
# RESPONSE TRUNCATED #
########################
}
```