### PR TITLE
TestSshCommand checks all assertions rather than throwing first

### DIFF
--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
@@ -155,6 +155,15 @@ public class TestFrameworkAssertions {
         }
     }
 
+    public static <T> void checkActualAgainstAssertions(AssertionSupport support,
+            Map<String, Object> assertions, String target, T actual) {
+        try {
+            checkActualAgainstAssertions(assertions, target, actual);
+        } catch (Throwable t) {
+            support.fail(t);
+        }
+    }
+
     public static <T> void checkActualAgainstAssertions(Map<String, Object> assertions,
                                                          String target, T actual) {
         for (Map.Entry<String, Object> assertion : assertions.entrySet()) {

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSshCommandImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestSshCommandImpl.java
@@ -197,15 +197,17 @@ public class TestSshCommandImpl extends TargetableTestComponentImpl implements T
         LOG.debug("{}, Result is {}\nwith output [\n{}\n] and error [\n{}\n]", new Object[] {
             this, result.getExitCode(), shorten(result.getStdout()), shorten(result.getStderr())
         });
+        TestFrameworkAssertions.AssertionSupport support = new TestFrameworkAssertions.AssertionSupport();
         for (Map<String, Object> assertion : exitCodeAssertions()) {
-            checkActualAgainstAssertions(assertion, "exit code", result.getExitCode());
+            checkActualAgainstAssertions(support, assertion, "exit code", result.getExitCode());
         }
         for (Map<String, Object> assertion : getAssertions(this, ASSERT_OUT)) {
-            checkActualAgainstAssertions(assertion, "stdout", result.getStdout());
+            checkActualAgainstAssertions(support, assertion, "stdout", result.getStdout());
         }
         for (Map<String, Object> assertion : getAssertions(this, ASSERT_ERR)) {
-            checkActualAgainstAssertions(assertion, "stderr", result.getStderr());
+            checkActualAgainstAssertions(support, assertion, "stderr", result.getStderr());
         }
+        support.validate();
     }
 
     private Result executeDownloadedScript(SshMachineLocation machineLocation, String url, String scriptPath, Map<String, Object> env) {


### PR DESCRIPTION
Fixes build by restoring behaviour changed in #212, which broke `TestSshCommandTest.shouldNotBeUpIfAssertionsFail` because only one failure was in the exception message.