### PR TITLE
Yaml entity refs: support $brooklyn:self()

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -67,6 +67,9 @@ public class BrooklynDslCommon {
 
     // Access specific entities
 
+    public static DslComponent self() {
+        return new DslComponent(Scope.THIS, null);
+    }
     public static DslComponent entity(String id) {
         return new DslComponent(Scope.GLOBAL, id);
     }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -120,12 +120,10 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
                 case SCOPE_ROOT:
                     return Entities.catalogItemScopeRoot(entity);
                 case DESCENDANT:
-                    entitiesToSearch = Entities.descendants(entity);
-                    entitiesToSearch = Iterables.filter(entitiesToSearch, notSelfPredicate);
+                    entitiesToSearch = Entities.descendantsWithoutSelf(entity);
                     break;
                 case ANCESTOR:
-                    entitiesToSearch = Entities.ancestors(entity);
-                    entitiesToSearch = Iterables.filter(entitiesToSearch, notSelfPredicate);
+                    entitiesToSearch = Entities.ancestorsWithoutSelf(entity);
                     break;
                 case SIBLING:
                     entitiesToSearch = entity.getParent().getChildren();

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampConstants;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -44,6 +45,8 @@ import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -100,30 +103,36 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
         @Override
         public Entity call() throws Exception {
             Iterable<Entity> entitiesToSearch = null;
+            EntityInternal entity = getEntity();
+            Predicate<Entity> notSelfPredicate = Predicates.not(Predicates.<Entity>equalTo(entity));
+
             switch (scope) {
                 case THIS:
-                    return getEntity();
+                    return entity;
                 case PARENT:
-                    return getEntity().getParent();
+                    return entity.getParent();
                 case GLOBAL:
-                    entitiesToSearch = ((EntityManagerInternal)getEntity().getManagementContext().getEntityManager())
+                    entitiesToSearch = ((EntityManagerInternal)entity.getManagementContext().getEntityManager())
                         .getAllEntitiesInApplication( entity().getApplication() );
                     break;
                 case ROOT:
-                    return getEntity().getApplication();
+                    return entity.getApplication();
                 case SCOPE_ROOT:
-                    return Entities.catalogItemScopeRoot(getEntity());
+                    return Entities.catalogItemScopeRoot(entity);
                 case DESCENDANT:
-                    entitiesToSearch = Entities.descendants(getEntity());
+                    entitiesToSearch = Entities.descendants(entity);
+                    entitiesToSearch = Iterables.filter(entitiesToSearch, notSelfPredicate);
                     break;
                 case ANCESTOR:
-                    entitiesToSearch = Entities.ancestors(getEntity());
+                    entitiesToSearch = Entities.ancestors(entity);
+                    entitiesToSearch = Iterables.filter(entitiesToSearch, notSelfPredicate);
                     break;
                 case SIBLING:
-                    entitiesToSearch = getEntity().getParent().getChildren();
+                    entitiesToSearch = entity.getParent().getChildren();
+                    entitiesToSearch = Iterables.filter(entitiesToSearch, notSelfPredicate);
                     break;
                 case CHILD:
-                    entitiesToSearch = getEntity().getChildren();
+                    entitiesToSearch = entity.getChildren();
                     break;
                 default:
                     throw new IllegalStateException("Unexpected scope "+scope);
@@ -136,7 +145,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             
             // TODO may want to block and repeat on new entities joining?
             throw new NoSuchElementException("No entity matching id " + componentId+
-                (scope==Scope.GLOBAL ? "" : ", in scope "+scope+" wrt "+getEntity()+
+                (scope==Scope.GLOBAL ? "" : ", in scope "+scope+" wrt "+entity+
                 (scopeComponent!=null ? " ("+scopeComponent+" from "+entity()+")" : "")));
         }        
     }
@@ -170,6 +179,10 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
     @Deprecated /** @deprecated since 0.7.0 */
     public DslComponent component(String scopeOrId) {
         return new DslComponent(this, Scope.GLOBAL, scopeOrId);
+    }
+    
+    public DslComponent self() {
+        return new DslComponent(this, Scope.THIS, null);
     }
     
     public DslComponent parent() {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ByonLocationsYamlTest.java
@@ -239,7 +239,7 @@ public class ByonLocationsYamlTest extends AbstractYamlTest {
                 "    requiredOpenLoginPorts: [22, 1024]");
 
         Entity app = createStartWaitAndLogApplication(yaml);
-        DoNothingSoftwareProcess entity = (DoNothingSoftwareProcess) Iterables.find(Entities.descendants(app), Predicates.instanceOf(DoNothingSoftwareProcess.class));
+        DoNothingSoftwareProcess entity = (DoNothingSoftwareProcess) Iterables.find(Entities.descendantsAndSelf(app), Predicates.instanceOf(DoNothingSoftwareProcess.class));
         FixedListMachineProvisioningLocation<MachineLocation> loc = (FixedListMachineProvisioningLocation<MachineLocation>) Iterables.get(app.getLocations(), 0);
         
         // Machine should have been given the inbound-ports

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigInheritanceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigInheritanceYamlTest.java
@@ -788,7 +788,7 @@ public class ConfigInheritanceYamlTest extends AbstractYamlTest {
                 "          mykey3: myval3");
 
         Entity app = createStartWaitAndLogApplication(yaml);
-        Entity entity = Iterables.find(Entities.descendants(app), Predicates.instanceOf(TestEntity.class));
+        Entity entity = Iterables.find(Entities.descendantsAndSelf(app), Predicates.instanceOf(TestEntity.class));
 
         assertEquals(entity.config().get(entity.getEntityType().getConfigKey("map.type-merged")), 
                 ImmutableMap.<String, Object>of("mykey1", "myval1", "mykey2", "myval2", "mykey3", "myval3"));

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
@@ -116,7 +116,7 @@ public class EmptySoftwareProcessYamlTest extends AbstractYamlTest {
                 "    "+BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION.getName()+": true");
         waitForApplicationTasks(app);
 
-        EmptySoftwareProcess entity = Iterables.getOnlyElement(Entities.descendants(app, EmptySoftwareProcess.class));
+        EmptySoftwareProcess entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EmptySoftwareProcess.class));
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
         EntityAsserts.assertAttributeEqualsContinually(entity, Attributes.SERVICE_UP, true);
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptyWindowsProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptyWindowsProcessYamlTest.java
@@ -45,7 +45,7 @@ public class EmptyWindowsProcessYamlTest extends AbstractYamlTest {
                 "    onbox.base.dir.skipResolution: true");
         waitForApplicationTasks(app);
 
-        EmptyWindowsProcess entity = Iterables.getOnlyElement(Entities.descendants(app, EmptyWindowsProcess.class));
+        EmptyWindowsProcess entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EmptyWindowsProcess.class));
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
         EntityAsserts.assertAttributeEqualsContinually(entity, Attributes.SERVICE_UP, true);
         

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -422,10 +422,10 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(root1, app);
         
         Entity c1 = Tasks.resolving(new DslComponent("c1").newTask(), Entity.class).context( ((EntityInternal)app).getExecutionContext() ).embedResolutionInTask(true).get();
-        Assert.assertEquals(c1, Entities.descendants(app, EntityPredicates.displayNameEqualTo("child 1")).iterator().next());
+        Assert.assertEquals(c1, Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EntityPredicates.displayNameEqualTo("child 1"))));
         
         Entity e1 = Tasks.resolving(new DslComponent(Scope.PARENT, "xxx").newTask(), Entity.class).context( ((EntityInternal)c1).getExecutionContext() ).embedResolutionInTask(true).get();
-        Assert.assertEquals(e1, Entities.descendants(app, EntityPredicates.displayNameEqualTo("entity 1")).iterator().next());
+        Assert.assertEquals(e1, Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EntityPredicates.displayNameEqualTo("entity 1"))));
         
         Entity root2 = Tasks.resolving(new DslComponent(Scope.ROOT, "xxx").newTask(), Entity.class).context( ((EntityInternal)c1).getExecutionContext() ).embedResolutionInTask(true).get();
         Assert.assertEquals(root2, app);
@@ -743,8 +743,8 @@ public class EntitiesYamlTest extends AbstractYamlTest {
 
         Entity app = createAndStartApplication(yaml);
         waitForApplicationTasks(app);
-        DynamicFabric fabric = Iterables.getOnlyElement(Entities.descendants(app, DynamicFabric.class));
-        Iterable<TestEntity> members = Entities.descendants(fabric, TestEntity.class);
+        DynamicFabric fabric = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, DynamicFabric.class));
+        Iterable<TestEntity> members = Entities.descendantsAndSelf(fabric, TestEntity.class);
         
         assertEquals(Iterables.size(members), 2);
     }
@@ -764,8 +764,8 @@ public class EntitiesYamlTest extends AbstractYamlTest {
 
         Entity app = createAndStartApplication(yaml);
         waitForApplicationTasks(app);
-        DynamicFabric fabric = Iterables.getOnlyElement(Entities.descendants(app, DynamicFabric.class));
-        Iterable<TestEntity> members = Entities.descendants(fabric, TestEntity.class);
+        DynamicFabric fabric = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, DynamicFabric.class));
+        Iterable<TestEntity> members = Entities.descendantsAndSelf(fabric, TestEntity.class);
         
         assertEquals(Iterables.size(members), 2);
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
@@ -70,7 +70,7 @@ public class EntityNameYamlTest extends AbstractYamlTest {
 
     protected void deployAndAssertDisplayName(String yaml, String expectedName) throws Exception {
         Entity app = createAndStartApplication(yaml);
-        Entity entity = Iterables.getOnlyElement(Entities.descendants(app, Predicates.instanceOf(TestEntity.class)));
+        Entity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, TestEntity.class));
         assertEquals(entity.getDisplayName(), expectedName);
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityPredicates;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+
+@Test
+public class EntityRefsYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(EntityRefsYamlTest.class);
+
+    @Test
+    public void testRefToSelf() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  test.confObject: $brooklyn:self()",
+                "  test.confName: $brooklyn:self().attributeWhenReady(\"mysensor\")");
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        
+        assertEquals(entity.getConfig(TestEntity.CONF_OBJECT), entity);
+        
+        entity.sensors().set(Sensors.newStringSensor("mysensor"), "myval");
+        assertEquals(entity.getConfig(TestEntity.CONF_NAME), "myval");
+    }
+
+    @Test
+    public void testRefToParent() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  name: entity1",
+                "  brooklyn.children:",
+                "  - type: " + TestEntity.class.getName(),
+                "    brooklyn.config:",
+                "      test.confObject: $brooklyn:parent()");
+        Entity parent = Iterables.getOnlyElement(app.getChildren());
+        Entity child = Iterables.getOnlyElement(parent.getChildren());
+        
+        assertEquals(child.getConfig(TestEntity.CONF_OBJECT), parent);
+    }
+
+    @Test
+    public void testRefToRoot() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  brooklyn.config:",
+                "    test.confObject: $brooklyn:root()");
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        
+        assertEquals(entity.getConfig(TestEntity.CONF_OBJECT), app);
+    }
+
+    @Test
+    public void testRefToScopeRoot() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  id: myCatalogItem",
+                "  item:",
+                "    type: "+ TestEntity.class.getName(),
+                "    brooklyn.children:",
+                "    - type: " + TestEntity.class.getName(),
+                "      brooklyn.config:",
+                "        test.confObject: $brooklyn:scopeRoot()");
+
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: myCatalogItem");
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        Entity child = Iterables.getOnlyElement(entity.getChildren());
+        
+        assertEquals(child.getConfig(TestEntity.CONF_OBJECT), entity);
+    }
+
+    @Test
+    public void testRefToEntityById() throws Exception {
+        // Tests for sibling, descendant and ancestor
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  brooklyn.config:",
+                "    conf.entity: $brooklyn:entity(\"childid\")",
+                "    conf.component: $brooklyn:component(\"childid\")",
+                "    conf.component.global: $brooklyn:component(\"global\", \"childid\")",
+                "  brooklyn.children:",
+                "  - type: " + TestEntity.class.getName(),
+                "    id: childid");
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        Entity child = Iterables.getOnlyElement(entity.getChildren());
+        
+        assertEquals(entity.getConfig(newConfigKey("conf.entity")), child);
+        assertEquals(entity.getConfig(newConfigKey("conf.component")), child);
+        assertEquals(entity.getConfig(newConfigKey("conf.component.global")), child);
+    }
+
+    @Test
+    public void testRefToRelative() throws Exception {
+        // Tests for sibling, descendant and ancestor
+        String duplicatedId = "myDuplicatedId";
+        
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  id: "+duplicatedId,
+                "  name: entity1",
+                "  brooklyn.config:",
+                "    conf1.sibling: $brooklyn:sibling(\""+duplicatedId+"\")",
+                "    conf1.descendant: $brooklyn:descendant(\""+duplicatedId+"\")",
+                "    conf1.sibling2: $brooklyn:component(\"sibling\", \""+duplicatedId+"\")",
+                "    conf1.descendant2: $brooklyn:component(\"descendant\", \""+duplicatedId+"\")",
+                "  brooklyn.children:",
+                "  - type: " + TestEntity.class.getName(),
+                "    id: "+duplicatedId,
+                "    name: entity1.1",
+                "- type: " + TestEntity.class.getName(),
+                "  id: "+duplicatedId,
+                "  name: entity2",
+                "  brooklyn.children:",
+                "  - type: " + TestEntity.class.getName(),
+                "    id: "+duplicatedId,
+                "    name: entity2.1",
+                "    brooklyn.config:",
+                "      conf2.1.sibling: $brooklyn:sibling(\""+duplicatedId+"\")",
+                "      conf2.1.ancestor: $brooklyn:ancestor(\""+duplicatedId+"\")",
+                "      conf2.1.sibling2: $brooklyn:component(\"sibling\", \""+duplicatedId+"\")",
+                "      conf2.1.ancestor2: $brooklyn:component(\"ancestor\", \""+duplicatedId+"\")",
+                "  - type: " + TestEntity.class.getName(),
+                "    id: "+duplicatedId,
+                "    name: entity2.2");
+        
+        Entities.dumpInfo(app);
+        
+        Entity entity1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity1"));
+        Entity entity1_1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity1.1"));
+        Entity entity2 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2"));
+        Entity entity2_1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2.1"));
+        Entity entity2_2 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2.2"));
+        
+        assertEquals(entity1.getConfig(newConfigKey("conf1.sibling")), entity2);
+        assertEquals(entity1.getConfig(newConfigKey("conf1.sibling2")), entity2);
+        assertEquals(entity1.getConfig(newConfigKey("conf1.descendant")), entity1_1);
+        assertEquals(entity1.getConfig(newConfigKey("conf1.descendant2")), entity1_1);
+        assertEquals(entity2_1.getConfig(newConfigKey("conf2.1.sibling")), entity2_2);
+        assertEquals(entity2_1.getConfig(newConfigKey("conf2.1.sibling2")), entity2_2);
+        assertEquals(entity2_1.getConfig(newConfigKey("conf2.1.ancestor")), entity2);
+        assertEquals(entity2_1.getConfig(newConfigKey("conf2.1.ancestor2")), entity2);
+    }
+
+    protected ConfigKey<Object> newConfigKey(String name) {
+        return ConfigKeys.newConfigKey(Object.class, name);
+    }
+    
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityNameTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityNameTest.java
@@ -45,14 +45,14 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName);
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "nameInItemMetadata");
         
         Entity app2 = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName,
                 "  name: nameInEntity");
-        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        BasicEntity entity2 = Iterables.getOnlyElement(Entities.descendantsAndSelf(app2, BasicEntity.class));
         assertEquals(entity2.getDisplayName(), "nameInEntity");
     }
     
@@ -78,14 +78,14 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName);
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "nameInItemMetadata");
         
         Entity app2 = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName,
                 "  name: nameInEntity");
-        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        BasicEntity entity2 = Iterables.getOnlyElement(Entities.descendantsAndSelf(app2, BasicEntity.class));
         assertEquals(entity2.getDisplayName(), "nameInEntity");
     }
     
@@ -105,14 +105,14 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName);
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "defaultNameInItemEntity");
         
         Entity app2 = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName,
                 "  name: nameInEntity");
-        BasicEntity entity2 = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app2), BasicEntity.class));
+        BasicEntity entity2 = Iterables.getOnlyElement(Entities.descendantsAndSelf(app2, BasicEntity.class));
         assertEquals(entity2.getDisplayName(), "nameInEntity");
     }
     
@@ -139,7 +139,7 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName);
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "defaultNameInItemEntity");
     }
     
@@ -166,7 +166,7 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(
                 "services:",
                 "- type: "+symbolicName);
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "defaultNameInSuperItemEntity");
     }
     
@@ -186,7 +186,7 @@ public class CatalogYamlEntityNameTest extends AbstractYamlTest {
                 "- type: "+symbolicName,
                 "  brooklyn.config:",
                 "    defaultDisplayName: defaultNameInEntity");
-        BasicEntity entity = Iterables.getOnlyElement(Iterables.filter(Entities.descendants(app), BasicEntity.class));
+        BasicEntity entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, BasicEntity.class));
         assertEquals(entity.getDisplayName(), "defaultNameInEntity");
     }
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/policy/CreatePasswordSensorIntegrationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/policy/CreatePasswordSensorIntegrationTest.java
@@ -44,7 +44,7 @@ public class CreatePasswordSensorIntegrationTest extends AbstractYamlTest {
         final Entity app = createAndStartApplication(loadYaml("EmptySoftwareProcessWithPassword.yaml"));
 
         waitForApplicationTasks(app);
-        EmptySoftwareProcess entity = Iterables.getOnlyElement(Entities.descendants(app, EmptySoftwareProcess.class));
+        EmptySoftwareProcess entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EmptySoftwareProcess.class));
 
         assertPasswordLength(entity, PASSWORD_1, 15);
 

--- a/camp/camp-brooklyn/src/test/resources/test-referencing-entities.yaml
+++ b/camp/camp-brooklyn/src/test/resources/test-referencing-entities.yaml
@@ -114,7 +114,7 @@ services:
       brooklyn.config:
         test.reference.root: $brooklyn:root()
         test.reference.scope_root: $brooklyn:scopeRoot()
-        test.reference.app: $brooklyn:parent().parent().descendant("app1")
+        test.reference.app: $brooklyn:parent().parent().self()
         test.reference.entity1: $brooklyn:component("e1")
         test.reference.entity2: $brooklyn:component("e2")
         test.reference.child1: $brooklyn:component("c1")

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -661,6 +661,17 @@ public class Entities {
     }
 
     /**
+     * Returns the entity's children, its children's children, and so on.
+     *
+     * @see #descendants(Entity, Predicate, boolean)
+     */
+    public static Iterable<Entity> descendantsWithoutSelf(Entity root) {
+        Set<Entity> result = Sets.newLinkedHashSet();
+        descendantsWithoutSelf(root, result);
+        return result;
+    }
+
+    /**
      * Return all descendants of given entity of the given type, potentially including the given root.
      *
      * @see #descendants(Entity)
@@ -707,12 +718,17 @@ public class Entities {
         return result;
     }
 
-    private static Iterable<Entity> descendantsWithoutSelf(Entity root) {
+    /** Returns the entity's parent, its parent's parent, and so on. */
+    public static Iterable<Entity> ancestorsWithoutSelf(Entity root) {
         Set<Entity> result = Sets.newLinkedHashSet();
-        descendantsWithoutSelf(root, result);
+        Entity parent = (root != null) ? root.getParent() : null;
+        while (parent != null) {
+            result.add(parent);
+            parent = parent.getParent();
+        }
         return result;
     }
-    
+
     /**
      * Side-effects {@code result} to return descendants (not including {@code root}).
      */
@@ -726,20 +742,6 @@ public class Entities {
             tovisit.addAll(e.getChildren());
         }
     }
-
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     
     /**
      * @deprecated since 0.10.0; see {@link #descendantsAndSelf(Entity, Predicate)}

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -104,7 +104,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -618,26 +617,35 @@ public class Entities {
 
     /**
      * Return all descendants of given entity matching the given predicate and optionally the entity itself.
-     *
+     * 
      * @see {@link EntityPredicates} for useful second arguments.
      */
+    @SuppressWarnings("unused")
     public static Iterable<Entity> descendants(Entity root, Predicate<? super Entity> matching, boolean includeSelf) {
-        Iterable<Entity> descs = Iterables.concat(Iterables.transform(root.getChildren(), new Function<Entity,Iterable<Entity>>() {
-            @Override
-            public Iterable<Entity> apply(Entity input) {
-                return descendants(input);
-            }
-        }));
-        return Iterables.filter(Iterables.concat(descs, Collections.singleton(root)), matching);
+        if (false) {
+            // Keeping this unused code, so that anonymous inner class numbers don't change!
+            Iterable<Entity> descs = Iterables.concat(Iterables.transform(root.getChildren(), new Function<Entity,Iterable<Entity>>() {
+                @Override
+                public Iterable<Entity> apply(Entity input) {
+                    return descendants(input);
+                }
+            }));
+            return Iterables.filter(Iterables.concat(descs, Collections.singleton(root)), matching);
+        }
+        if (includeSelf) {
+            return descendantsAndSelf(root, matching);
+        } else {
+            return Iterables.filter(descendantsWithoutSelf(root), matching);
+        }
     }
 
     /**
-     * Returns the entity  matching the given predicate
+     * Returns the entities matching the given predicate.
      *
      * @see #descendants(Entity, Predicate, boolean)
      */
-    public static Iterable<Entity> descendants(Entity root, Predicate<? super Entity> matching) {
-        return descendants(root, matching, true);
+    public static Iterable<Entity> descendantsAndSelf(Entity root, Predicate<? super Entity> matching) {
+        return Iterables.filter(descendantsAndSelf(root), matching);
     }
 
     /**
@@ -645,8 +653,11 @@ public class Entities {
      *
      * @see #descendants(Entity, Predicate, boolean)
      */
-    public static Iterable<Entity> descendants(Entity root) {
-        return descendants(root, Predicates.alwaysTrue(), true);
+    public static Iterable<Entity> descendantsAndSelf(Entity root) {
+        Set<Entity> result = Sets.newLinkedHashSet();
+        result.add(root);
+        descendantsWithoutSelf(root, result);
+        return result;
     }
 
     /**
@@ -655,34 +666,107 @@ public class Entities {
      * @see #descendants(Entity)
      * @see Iterables#filter(Iterable, Class)
      */
-    public static <T extends Entity> Iterable<T> descendants(Entity root, Class<T> ofType) {
-        return Iterables.filter(descendants(root), ofType);
+    public static <T extends Entity> Iterable<T> descendantsAndSelf(Entity root, Class<T> ofType) {
+        return Iterables.filter(descendantsAndSelf(root), ofType);
     }
 
     /** Returns the entity, its parent, its parent, and so on. */
+    @SuppressWarnings("unused")
+    public static Iterable<Entity> ancestorsAndSelf(final Entity root) {
+        if (false) {
+            // Keeping this unused code, so that anonymous inner class numbers don't change!
+            return new Iterable<Entity>() {
+                @Override
+                public Iterator<Entity> iterator() {
+                    return new Iterator<Entity>() {
+                        Entity next = root;
+                        @Override
+                        public boolean hasNext() {
+                            return next!=null;
+                        }
+                        @Override
+                        public Entity next() {
+                            Entity result = next;
+                            next = next.getParent();
+                            return result;
+                        }
+                        @Override
+                        public void remove() {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
+                }
+            };
+        }
+        Set<Entity> result = Sets.newLinkedHashSet();
+        Entity current = root;
+        while (current != null) {
+            result.add(current);
+            current = current.getParent();
+        }
+        return result;
+    }
+
+    private static Iterable<Entity> descendantsWithoutSelf(Entity root) {
+        Set<Entity> result = Sets.newLinkedHashSet();
+        descendantsWithoutSelf(root, result);
+        return result;
+    }
+    
+    /**
+     * Side-effects {@code result} to return descendants (not including {@code root}).
+     */
+    private static void descendantsWithoutSelf(Entity root, Collection<Entity> result) {
+        Stack<Entity> tovisit = new Stack<Entity>();
+        tovisit.add(root);
+
+        while (!tovisit.isEmpty()) {
+            Entity e = tovisit.pop();
+            result.addAll(e.getChildren());
+            tovisit.addAll(e.getChildren());
+        }
+    }
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    /**
+     * @deprecated since 0.10.0; see {@link #descendantsAndSelf(Entity, Predicate)}
+     */
+    public static Iterable<Entity> descendants(Entity root, Predicate<? super Entity> matching) {
+        return descendantsAndSelf(root, matching);
+    }
+
+    /**
+     * @deprecated since 0.10.0; see {@link #descendantsAndSelf(Entity)}
+     */
+    public static Iterable<Entity> descendants(Entity root) {
+        return descendantsAndSelf(root);
+    }
+
+    /**
+     * @deprecated since 0.10.0; see {@link #descendantsAndSelf(Entity)}
+     */
+    public static <T extends Entity> Iterable<T> descendants(Entity root, Class<T> ofType) {
+        return descendantsAndSelf(root, ofType);
+    }
+
+    /**
+     * @deprecated since 0.10.0; see {@link #ancestorsAndSelf(Entity)}
+     */
     public static Iterable<Entity> ancestors(final Entity root) {
-        return new Iterable<Entity>() {
-            @Override
-            public Iterator<Entity> iterator() {
-                return new Iterator<Entity>() {
-                    Entity next = root;
-                    @Override
-                    public boolean hasNext() {
-                        return next!=null;
-                    }
-                    @Override
-                    public Entity next() {
-                        Entity result = next;
-                        next = next.getParent();
-                        return result;
-                    }
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
-            }
-        };
+        return ancestorsAndSelf(root);
     }
 
     /**

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
@@ -313,7 +313,7 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         assertEquals(e1e.size(), 5);
 
         newApp = (TestApplication) rebind();
-        Entity e2 = Iterables.getOnlyElement( Entities.descendants(newApp, EntityPredicates.idEqualTo(e1.getId())) );
+        Entity e2 = Iterables.getOnlyElement( Entities.descendantsAndSelf(newApp, EntityPredicates.idEqualTo(e1.getId())) );
         Collection<Enricher> e2e = e2.getEnrichers();
         log.info("enrichers2: "+e2e);
         Entities.dumpInfo(e2);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -310,7 +310,7 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         origE.tags().addTag(origApp);
 
         newApp = rebind();
-        MyEntity newE = Iterables.getOnlyElement( Entities.descendants(newApp, MyEntity.class) );
+        MyEntity newE = Iterables.getOnlyElement( Entities.descendantsAndSelf(newApp, MyEntity.class) );
 
         assertTrue(newE.tags().containsTag("foo"), "tags are "+newE.tags().getTags());
         assertFalse(newE.tags().containsTag("bar"));

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -297,17 +297,17 @@ public class DynamicClusterTest extends BrooklynAppUnitTestSupport {
         cluster.start(ImmutableList.of(loc));
 
         cluster.resize(4);
-        assertEquals(Iterables.size(Entities.descendants(cluster, TestEntity.class)), 4);
+        assertEquals(Iterables.size(Entities.descendantsAndSelf(cluster, TestEntity.class)), 4);
         
         // check delta of 2 and delta of 1, because >1 is handled differently to =1
         cluster.resize(2);
-        assertEquals(Iterables.size(Entities.descendants(cluster, TestEntity.class)), 2);
+        assertEquals(Iterables.size(Entities.descendantsAndSelf(cluster, TestEntity.class)), 2);
         cluster.resize(1);
-        assertEquals(Iterables.size(Entities.descendants(cluster, TestEntity.class)), 1);
+        assertEquals(Iterables.size(Entities.descendantsAndSelf(cluster, TestEntity.class)), 1);
         cluster.resize(1);
-        assertEquals(Iterables.size(Entities.descendants(cluster, TestEntity.class)), 1);
+        assertEquals(Iterables.size(Entities.descendantsAndSelf(cluster, TestEntity.class)), 1);
         cluster.resize(0);
-        assertEquals(Iterables.size(Entities.descendants(cluster, TestEntity.class)), 0);
+        assertEquals(Iterables.size(Entities.descendantsAndSelf(cluster, TestEntity.class)), 0);
     }
 
     

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
@@ -163,7 +163,7 @@ public abstract class AbstractBlueprintTest {
         
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
-                for (Entity entity : Entities.descendants(app)) {
+                for (Entity entity : Entities.descendantsAndSelf(app)) {
                     assertNotEquals(entity.getAttribute(Attributes.SERVICE_STATE_ACTUAL), Lifecycle.ON_FIRE);
                     assertNotEquals(entity.getAttribute(Attributes.SERVICE_UP), false);
                     

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
@@ -81,7 +81,7 @@ public class Windows7zipBlueprintLiveTest extends AbstractBlueprintTest {
         
         Predicate<Application> asserter = new Predicate<Application>() {
             @Override public boolean apply(Application app) {
-                VanillaWindowsProcess entity = Iterables.getOnlyElement(Entities.descendants(app, VanillaWindowsProcess.class));
+                VanillaWindowsProcess entity = Iterables.getOnlyElement(Entities.descendantsAndSelf(app, VanillaWindowsProcess.class));
                 String winRMAddress = entity.getAttribute(AdvertiseWinrmLoginPolicy.VM_USER_CREDENTIALS); 
                 String ipPort = Strings.getFirstWordAfter(winRMAddress, "@");
                 String user = Strings.getFirstWord(winRMAddress);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
@@ -178,7 +178,7 @@ public class EntityConfigResource extends AbstractBrooklynRestResource implement
             ConfigKey ck = findConfig(entity, configName);
             ((EntityInternal) entity).config().set(ck, TypeCoercions.coerce(newValue, ck.getTypeToken()));
             if (Boolean.TRUE.equals(recurse)) {
-                for (Entity e2 : Entities.descendants(entity, Predicates.alwaysTrue(), false)) {
+                for (Entity e2 : Entities.descendantsWithoutSelf(entity)) {
                     ((EntityInternal) e2).config().set(ck, newValue);
                 }
             }
@@ -198,7 +198,7 @@ public class EntityConfigResource extends AbstractBrooklynRestResource implement
         LOG.debug("REST setting config " + configName + " on " + entity + " to " + newValue);
         ((EntityInternal) entity).config().set(ck, TypeCoercions.coerce(newValue, ck.getTypeToken()));
         if (Boolean.TRUE.equals(recurse)) {
-            for (Entity e2 : Entities.descendants(entity, Predicates.alwaysTrue(), false)) {
+            for (Entity e2 : Entities.descendantsWithoutSelf(entity)) {
                 ((EntityInternal) e2).config().set(ck, newValue);
             }
         }


### PR DESCRIPTION
- Adds proper test coverage
- Fixes sibling/descendant/ancestor so will never return self