### PR TITLE
Fix VanillaJavaApp's stdin and env

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/VanillaJavaAppSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/VanillaJavaAppSshDriver.java
@@ -101,8 +101,8 @@ public class VanillaJavaAppSshDriver extends JavaSoftwareProcessSshDriver implem
 
         ScriptHelper helper = newScript(CUSTOMIZING+"-classpath")
                 .body.append(String.format("ls -1 \"%s\"", Os.mergePaths(getRunDir(), "lib")))
+                .noExtraOutput()
                 .gatherOutput();
-        helper.setFlag(SshTool.PROP_NO_EXTRA_OUTPUT, true);
         int result = helper.execute();
         if (result != 0) {
             throw new IllegalStateException("Error listing classpath files: " + helper.getResultStderr());


### PR DESCRIPTION
The output from the classpath gathering step currently includes Brooklyn's "Executed ... , result: 0" info, which means that classpaths look like this:

CLASSPATH="/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib/derby-10.12.1.1.jar:/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib/my-app-1.0.jar:/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib/**Executed**:/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib**/tmp/brooklyn-20160629-191833075-b9bF-customizing-classpath_VanillaJ.sh,**:/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib/**result**:/tmp/brooklyn-sam/apps/l8wk2l74in/entities/VanillaJavaApp_zn86w6blx8/lib/**0**"

Did something change internally? It's hard to believe that this has always been the case.
