### PR TITLE
Misc OSGi fixes

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -126,12 +126,13 @@
         <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
         <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${xpp3.servicemix.version}</bundle> <!-- from com.thoughtworks.xstream/xstream -->
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kxml2/${kxml2.servicemix.version}</bundle>
 
         <!-- TODO: don't use wrap -->
         <bundle dependency="true">wrap:mvn:com.google.http-client/google-http-client/1.18.0-rc</bundle> <!-- from geoip -->
         <bundle dependency="true">wrap:mvn:com.maxmind.geoip2/geoip2/${maxmind.version}</bundle> <!-- from geoip2 -->
         <bundle dependency="true">wrap:mvn:com.maxmind.db/maxmind-db/${maxmind-db.version}</bundle>
-        <bundle dependency="true">wrap:mvn:xpp3/xpp3_min/1.1.4c</bundle> <!-- from com.thoughtworks.xstream/xstream -->
 
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${reflections.bundle.version}</bundle>
     </feature>

--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,7 +38,7 @@ limitations under the License.
             <cm:property name="ignoreCatalogErrors" value="true" />
             <cm:property name="ignorePersistenceErrors" value="true" />
             <cm:property name="highAvailabilityMode" value="DISABLED" />
-            <cm:property name="persistMode" value="DISABLED" />
+            <cm:property name="persistMode" value="AUTO" />
             <cm:property name="persistenceDir" value="" />
             <cm:property name="persistenceLocation" value="" />
             <cm:property name="persistPeriod" value="1s" />

--- a/policy/src/main/resources/catalog.bom
+++ b/policy/src/main/resources/catalog.bom
@@ -19,27 +19,32 @@ brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
     - id: org.apache.brooklyn.policy.ha.ConnectionFailureDetector
+      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ConnectionFailureDetector
         name: Connection Failure Detector
         description: HA policy for monitoring a host:port, 
     - id: org.apache.brooklyn.policy.ha.ServiceRestarter
+      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ServiceRestarter
         name: Service Restarter
         description: HA policy for restarting a service automatically, 
     - id: org.apache.brooklyn.policy.ha.SshMachineFailureDetector
+      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.SshMachineFailureDetector
         name: Ssh Connectivity Failure Detector
         description: HA policy for monitoring an SshMachine, 
-    - id: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
-      item:
-        type: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
+#    removed from catalog because it cannot currently be configured via catalog mechanisms
+#    - id: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
+#      item:
+#        type: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
     - id: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
       item:
         type: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
     - id: org.apache.brooklyn.policy.ha.ServiceReplacer
+      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ServiceReplacer
         name: Service Replacer
@@ -48,6 +53,7 @@ brooklyn.catalog:
       item:
         type: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
     - id: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
+      itemType: policy
       item:
         type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
         name: Auto-scaler

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
         <!-- This can be different, OSGi will pick it up -->
         <guava-swagger.version>18.0</guava-swagger.version>
         <xstream.version>1.4.8</xstream.version>
+        <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
+        <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson and resteasy versions -->
         <fasterxml.jackson.version>2.4.5</fasterxml.jackson.version>
         <resteasy.version>3.0.8.Final</resteasy.version>

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefConfig.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefConfig.java
@@ -32,10 +32,6 @@ public interface ChefConfig {
 
     public static final ConfigKey<String> CHEF_COOKBOOK_PRIMARY_NAME = ConfigKeys.newStringConfigKey("brooklyn.chef.cookbook.primary.name",
         "Namespace to use for passing data to Chef and for finding effectors");
-    
-    @Deprecated /** @deprecatd since 0.7.0 use #CHEF_COOKBOOK_URLS */
-    @SetFromFlag("cookbooks")
-    public static final MapConfigKey<String> CHEF_COOKBOOKS = new MapConfigKey<String>(String.class, "brooklyn.chef.cookbooksUrls");
 
     @SetFromFlag("cookbook_urls")
     public static final MapConfigKey<String> CHEF_COOKBOOK_URLS = new MapConfigKey<String>(String.class, "brooklyn.chef.cookbooksUrls");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefLifecycleEffectorTasks.java
@@ -166,7 +166,7 @@ public class ChefLifecycleEffectorTasks extends MachineLifecycleEffectorTasks im
         @SuppressWarnings("rawtypes")
         Map<String, String> cookbooks = (Map) 
             ConfigBag.newInstance( entity().getConfig(CHEF_COOKBOOK_URLS) )
-            .putIfAbsent( entity().getConfig(CHEF_COOKBOOKS) )
+            .putIfAbsent( entity().getConfig(CHEF_COOKBOOK_URLS) )
             .getAllConfig();
         if (cookbooks.isEmpty())
             log.warn("No cookbook_urls set for "+entity()+"; launch will likely fail subsequently");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefSoloDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefSoloDriver.java
@@ -54,7 +54,7 @@ public class ChefSoloDriver extends AbstractSoftwareProcessSshDriver implements 
         // TODO flag to force reinstallation
         DynamicTasks.queue(
                 ChefSoloTasks.installChef(getInstallDir(), false), 
-                ChefSoloTasks.installCookbooks(getInstallDir(), getRequiredConfig(CHEF_COOKBOOKS), false));
+                ChefSoloTasks.installCookbooks(getInstallDir(), getRequiredConfig(CHEF_COOKBOOK_URLS), false));
     }
 
     @Override

--- a/test-framework/src/main/resources/catalog.bom
+++ b/test-framework/src/main/resources/catalog.bom
@@ -42,6 +42,3 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
       item:
         type: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
-    - id: org.apache.brooklyn.test.framework.TargetableTestComponent
-      item:
-        type: org.apache.brooklyn.test.framework.TargetableTestComponent


### PR DESCRIPTION
* adds missing bundles for persistence
* enable persistence by default
* add missing entityType for policies (required)
* remove deprecated config key, causing duplicate name warning in logs
* remove TargetableTestComponent from catalog.bom - it's not a user-facing entity, meant to be subclassed