### PR TITLE
Merge brooklyn.parameters in YAML files

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -27,6 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+
 import org.apache.brooklyn.api.mgmt.EntityManager;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.objs.BrooklynObject;
@@ -35,18 +45,9 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
-
-/** Defines a spec for creating a {@link BrooklynObject}.
+/**
+ * Defines a spec for creating a {@link BrooklynObject}.
  * <p>
  * In addition to the contract defined by the code,
  * subclasses should provide a public static <code>create(Class)</code>
@@ -54,7 +55,8 @@ import com.google.common.collect.Maps;
  * <p>
  * The spec is then passed to type-specific methods,
  * e.g. {@link EntityManager#createEntity(org.apache.brooklyn.api.entity.EntitySpec)}
- * to create a managed instance of the target type. */
+ * to create a managed instance of the target type.
+ */
 public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrooklynObjectSpec<T,SpecT>> implements Serializable {
 
     private static final long serialVersionUID = 3010955277740333030L;
@@ -134,7 +136,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
         Iterables.addAll(this.tags, tagsToReplace);
         return self();
     }
-    
+
     // TODO which semantics are correct? replace has been the behaviour;
     // add breaks tests and adds unwanted parameters,
     // but replacing will cause some desired parameters to be lost.
@@ -153,17 +155,16 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     @Beta
     public SpecT parametersAdd(List<? extends SpecParameter<?>> parameters) {
         // parameters follows immutable pattern, unlike the other fields
-        Builder<SpecParameter<?>> result = ImmutableList.<SpecParameter<?>>builder();
-        if (this.parameters!=null)
-            result.addAll(this.parameters);
-        result.addAll( checkNotNull(parameters, "parameters") );
-        this.parameters = result.build();
+        Set<SpecParameter<?>> params = MutableSet.<SpecParameter<?>>copyOf(this.parameters);
+        params.removeAll(parameters);
+        params.addAll(parameters);
+        this.parameters = ImmutableList.copyOf(params);
         return self();
     }
     /** replaces parameters with the given */
     @Beta
     public SpecT parametersReplace(List<? extends SpecParameter<?>> parameters) {
-        this.parameters = ImmutableList.copyOf( checkNotNull(parameters, "parameters") );
+        this.parameters = ImmutableList.copyOf(checkNotNull(parameters, "parameters"));
         return self();
     }
 
@@ -302,12 +303,12 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     }
 
     public <V> SpecT removeConfig(ConfigKey<V> key) {
-        config.remove( checkNotNull(key, "key") );
+        config.remove(checkNotNull(key, "key"));
         return self();
     }
 
     public <V> SpecT removeFlag(String key) {
-        flags.remove( checkNotNull(key, "key") );
+        flags.remove(checkNotNull(key, "key"));
         return self();
     }
 
@@ -323,7 +324,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     public Map<String, ?> getFlags() {
         return Collections.unmodifiableMap(flags);
     }
-    
+
     /**
      * @return Read-only configuration values
      */

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -155,10 +155,14 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     @Beta
     public SpecT parametersAdd(List<? extends SpecParameter<?>> parameters) {
         // parameters follows immutable pattern, unlike the other fields
-        Set<SpecParameter<?>> params = MutableSet.<SpecParameter<?>>copyOf(this.parameters);
-        params.removeAll(parameters);
-        params.addAll(parameters);
-        this.parameters = ImmutableList.copyOf(params);
+        Set<SpecParameter<?>> params = MutableSet.<SpecParameter<?>>copyOf(parameters);
+        Set<SpecParameter<?>> current = MutableSet.<SpecParameter<?>>copyOf(this.parameters);
+        current.removeAll(params);
+
+        this.parameters = ImmutableList.<SpecParameter<?>>builder()
+                .addAll(params)
+                .addAll(current)
+                .build();
         return self();
     }
     /** replaces parameters with the given */

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -21,6 +21,9 @@ package org.apache.brooklyn.camp.brooklyn.spi.creation;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -38,9 +41,6 @@ import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Maybe;
-
-import com.google.common.annotations.Beta;
-import com.google.common.collect.ImmutableList;
 
 /**
  * Pattern for resolving "decorations" on service specs / entity specs, such as policies, enrichers, etc.
@@ -181,20 +181,14 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
     public static class SpecParameterResolver extends BrooklynEntityDecorationResolver<SpecParameter<?>> {
 
         protected SpecParameterResolver(BrooklynYamlTypeInstantiator.Factory instantiator) { super(instantiator); }
-        @Override protected String getDecorationKind() { return "Spec Parameter initializer"; }
+
+        @Override
+        protected String getDecorationKind() { return "Spec Parameter initializer"; }
 
         @Override
         public void decorate(EntitySpec<?> entitySpec, ConfigBag attrs) {
             List<? extends SpecParameter<?>> explicitParams = buildListOfTheseDecorationsFromEntityAttributes(attrs);
-            // TODO see discussion at EntitySpec.parameters; 
-            // maybe we should instead inherit always, or 
-            // inherit except where it is set as config and then add the new explicit ones
-            if (!explicitParams.isEmpty()) {
-                entitySpec.parameters(explicitParams);
-            }
-            if (entitySpec.getParameters().isEmpty()) {
-                entitySpec.parameters(BasicSpecParameter.fromSpec(instantiator.loader.getManagementContext(), entitySpec));
-            }
+            BasicSpecParameter.addParameters(entitySpec, explicitParams, instantiator.loader);
         }
 
         @Override

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/TestSensorAndEffectorInitializer.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/TestSensorAndEffectorInitializer.java
@@ -20,6 +20,10 @@ package org.apache.brooklyn.camp.brooklyn;
 
 import java.util.Map;
 
+import org.testng.Assert;
+
+import com.google.common.base.Preconditions;
+
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -28,9 +32,7 @@ import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.testng.Assert;
-
-import com.google.common.base.Preconditions;
+import org.apache.brooklyn.util.text.Strings;
 
 public class TestSensorAndEffectorInitializer implements EntityInitializer {
 
@@ -47,7 +49,7 @@ public class TestSensorAndEffectorInitializer implements EntityInitializer {
                 @Override
                 public String call(ConfigBag parameters) {
                     Object name = parameters.getStringKey("name");
-                    entity().sensors().set(Sensors.newStringSensor(SENSOR_LAST_HELLO), ""+name);
+                    entity().sensors().set(Sensors.newStringSensor(SENSOR_LAST_HELLO), Strings.toString(name));
                     return helloWord()+" "+name;
                 }
             }).build();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
@@ -69,7 +69,7 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
                 "      type: integer");
         EntitySpec<?> item = mgmt().getTypeRegistry().createSpec(mgmt().getTypeRegistry().get(itemId), null, EntitySpec.class);
         List<SpecParameter<?>> inputs = item.getParameters();
-        assertEquals(inputs.size(), 3);
+        assertEquals(inputs.size(), 6);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
         assertEquals(firstInput.isPinned(), true);
@@ -107,7 +107,7 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
                 "      type: " + OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(itemId);
         List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
+        assertEquals(inputs.size(), 4);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
         assertTrue(firstInput.isPinned());

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -107,7 +108,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         SpecParameter<String> SIMPLE_PARAM = new BasicSpecParameter<>("simple", true, SIMPLE_CONFIG);
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
-        assertEquals(ImmutableSet.copyOf(spec.getParameters()), ImmutableList.of(SIMPLE_PARAM));
+        assertTrue(Iterables.tryFind(spec.getParameters(), Predicates.<SpecParameter<?>>equalTo(SIMPLE_PARAM)).isPresent());
     }
 
     @Test(dataProvider = "brooklynTypes")
@@ -141,7 +142,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 4);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
     }
 
@@ -164,7 +165,17 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        switch (type.getSimpleName()) {
+            case "ConfigEntityForTest":
+                assertEquals(params.size(), 3);
+                break;
+            case "ConfigPolicyForTest":
+                assertEquals(params.size(), 2);
+                break;
+            case "ConfigLocationForTest":
+                assertEquals(params.size(), 7);
+                break;
+        }
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
@@ -190,7 +201,17 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 2);
+        switch (type.getSimpleName()) {
+            case "ConfigEntityForTest":
+                assertEquals(params.size(), 4);
+                break;
+            case "ConfigPolicyForTest":
+                assertEquals(params.size(), 3);
+                break;
+            case "ConfigLocationForTest":
+                assertEquals(params.size(), 8);
+                break;
+        }
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, nameEqualTo("override")).isPresent());
     }
@@ -217,7 +238,17 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        switch (type.getSimpleName()) {
+            case "ConfigEntityForTest":
+                assertEquals(params.size(), 4);
+                break;
+            case "ConfigPolicyForTest":
+                assertEquals(params.size(), 3);
+                break;
+            case "ConfigLocationForTest":
+                assertEquals(params.size(), 8);
+                break;
+        }
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("override")).isPresent());
     }
@@ -271,7 +302,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 3);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         Optional<ConfigKey<?>> config = Iterables.tryFind(spec.getConfig().keySet(), ConfigPredicates.nameEqualTo("simple"));
         assertTrue(config.isPresent());
@@ -326,7 +357,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         EntitySpec<?> parentSpec = (EntitySpec<?>) catalog.createSpec((CatalogItem)item);
         EntitySpec<?> spec = parentSpec.getChildren().get(0);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 3);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
@@ -347,7 +378,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 4);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
@@ -369,7 +400,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 4);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
@@ -391,7 +422,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 4);
         assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
         assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
@@ -506,7 +537,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         CatalogItem<?, ?> item = catalog.getCatalogItem(ConfigEntityForTest.class.getSimpleName() + "WithParams", TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
         List<SpecParameter<?>> params = spec.getParameters();
-        assertEquals(params.size(), 1);
+        assertEquals(params.size(), 3);
         assertTrue(Iterables.tryFind(params, nameEqualTo("num")).isPresent());
 
         Application app = (Application) createAndStartApplication(
@@ -537,7 +568,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + BasicApplication.class.getName());
         List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
+        assertEquals(inputs.size(), 4);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
     }
@@ -550,7 +581,7 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "  brooklyn.parameters:",
                 "  - simple");
         List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
+        assertEquals(inputs.size(), 4);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
@@ -18,12 +18,22 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
+import static org.apache.brooklyn.core.objs.SpecParameterPredicates.labelEqualTo;
+import static org.apache.brooklyn.core.objs.SpecParameterPredicates.nameEqualTo;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Iterator;
 import java.util.List;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Application;
@@ -37,8 +47,10 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.entity.AbstractApplication;
 import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
@@ -46,13 +58,7 @@ import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.entity.stock.BasicApplication;
-import org.testng.SkipException;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
+import org.apache.brooklyn.entity.stock.BasicStartable;
 
 public class SpecParameterUnwrappingTest extends AbstractYamlTest {
     private static final String SYMBOLIC_NAME = "my.catalog.app.id.load";
@@ -134,18 +140,13 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
 
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
-        List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
-        SpecParameter<?> firstInput = inputs.get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
     }
 
     @Test(dataProvider="brooklynTypes")
-    public void testDepentantCatalogsInheritParameters(Class<? extends BrooklynObject> type) {
-        if (type == ConfigLocationForTest.class) {
-            //TODO
-            throw new SkipException("Locations don't inherit parameters, should migrate to the type registry first");
-        }
+    public void testDependantCatalogsInheritParameters(Class<? extends BrooklynObject> type) {
         addCatalogItems(
                 "brooklyn.catalog:",
                 "  version: " + TEST_VERSION,
@@ -158,18 +159,18 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "      - simple",
                 "  - id: " + SYMBOLIC_NAME,
                 "    item:",
-                "      type: paramItem:" + TEST_VERSION);
+                "      type: paramItem");
 
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
-        List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
-        SpecParameter<?> firstInput = inputs.get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
 
     @Test(dataProvider="brooklynTypes")
-    public void testDepentantCatalogsOverrideParameters(Class<? extends BrooklynObject> type) {
+    public void testDependantCatalogsExtendsParameters(Class<? extends BrooklynObject> type) {
         addCatalogItems(
                 "brooklyn.catalog:",
                 "  version: " + TEST_VERSION,
@@ -182,17 +183,128 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "      - simple",
                 "  - id: " + SYMBOLIC_NAME,
                 "    item:",
-                // Don't set explicit version, not supported by locations
                 "      type: paramItem",
                 "      brooklyn.parameters:",
                 "      - override");
 
         CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
         AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
-        List<SpecParameter<?>> inputs = spec.getParameters();
-        assertEquals(inputs.size(), 1);
-        SpecParameter<?> firstInput = inputs.get(0);
-        assertEquals(firstInput.getLabel(), "override");
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 2);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, nameEqualTo("override")).isPresent());
+    }
+
+    @Test(dataProvider="brooklynTypes")
+    public void testDependantCatalogMergesParameters(Class<? extends BrooklynObject> type) {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: paramItem",
+                "    item:",
+                "      type: " + type.getName(),
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        label: simple",
+                "  - id: " + SYMBOLIC_NAME,
+                "    item:",
+                "      type: paramItem",
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        label: override");
+
+        CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
+        AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("override")).isPresent());
+    }
+
+    @Test
+    public void testDependantCatalogConfigOverridesParameters() {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: paramItem",
+                "    item:",
+                "      type: " + ConfigEntityForTest.class.getName(),
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        default: biscuits",
+                "      brooklyn.config:",
+                "        simple: value",
+                "  - id: " + SYMBOLIC_NAME,
+                "    item:",
+                "      type: paramItem",
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        default: rabbits");
+
+        CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
+        AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        Optional<ConfigKey<?>> config = Iterables.tryFind(spec.getConfig().keySet(), ConfigPredicates.nameEqualTo("simple"));
+        assertTrue(config.isPresent());
+        Object value = spec.getConfig().get(config.get());
+        assertEquals(value, "value");
+    }
+
+    @Test
+    public void testCatalogConfigOverridesParameters() {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: " + SYMBOLIC_NAME,
+                "    item:",
+                "      type: " + ConfigEntityForTest.class.getName(),
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        default: biscuits",
+                "      brooklyn.config:",
+                "        simple: value");
+
+        CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
+        AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        Optional<ConfigKey<?>> config = Iterables.tryFind(spec.getConfig().keySet(), ConfigPredicates.nameEqualTo("simple"));
+        assertTrue(config.isPresent());
+        Object value = spec.getConfig().get(config.get());
+        assertEquals(value, "value");
+    }
+
+    @Test
+    public void testDependantCatalogConfigReplacesParameters() {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: paramItem",
+                "    item:",
+                "      type: " + ConfigEntityForTest.class.getName(),
+                "      brooklyn.config:",
+                "        simple: value",
+                "  - id: " + SYMBOLIC_NAME,
+                "    item:",
+                "      type: paramItem",
+                "      brooklyn.parameters:",
+                "      - name: simple",
+                "        default: rabbits");
+
+        CatalogItem<?, ?> item = catalog.getCatalogItem(SYMBOLIC_NAME, TEST_VERSION);
+        AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        Optional<ConfigKey<?>> config = Iterables.tryFind(spec.getConfig().keySet(), ConfigPredicates.nameEqualTo("simple"));
+        assertTrue(config.isPresent());
+        Object value = spec.getConfig().get(config.get());
+        assertEquals(value, "value");
     }
 
     @Test
@@ -213,8 +325,10 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         @SuppressWarnings({ "rawtypes", "unchecked"})
         EntitySpec<?> parentSpec = (EntitySpec<?>) catalog.createSpec((CatalogItem)item);
         EntitySpec<?> spec = parentSpec.getChildren().get(0);
-        SpecParameter<?> firstInput = spec.getParameters().get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
 
     @Test
@@ -234,8 +348,8 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
         assertEquals(params.size(), 1);
-        SpecParameter<?> firstInput = params.get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
 
 
@@ -256,8 +370,8 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
         assertEquals(params.size(), 1);
-        SpecParameter<?> firstInput = params.get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
 
     @Test
@@ -278,8 +392,8 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
                 "- type: " + ver(SYMBOLIC_NAME));
         List<SpecParameter<?>> params = spec.getParameters();
         assertEquals(params.size(), 1);
-        SpecParameter<?> firstInput = params.get(0);
-        assertEquals(firstInput.getLabel(), "simple");
+        assertTrue(Iterables.tryFind(params, nameEqualTo("simple")).isPresent());
+        assertTrue(Iterables.tryFind(params, labelEqualTo("simple")).isPresent());
     }
 
     @Test
@@ -350,6 +464,69 @@ public class SpecParameterUnwrappingTest extends AbstractYamlTest {
         Entity c2 = childIter.next();
         assertEquals(c2.config().get(refConfigKey), testValue);
         assertFalse(childIter.hasNext());
+    }
+
+    private static final ConfigKey<Integer> NUM = ConfigKeys.newIntegerConfigKey("num");
+
+    @Test
+    public void testParameterDefaultsUsedInConfig() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "    - id: " + ConfigEntityForTest.class.getSimpleName() + "WithParams",
+                "      itemType: entity",
+                "      item:",
+                "        type: " + ConfigEntityForTest.class.getName(),
+                "        brooklyn.parameters:",
+                "          - name: num",
+                "            type: integer",
+                "            default: 1234",
+                "        brooklyn.children:",
+                "          - type: " + BasicStartable.class.getName(),
+                "            name: s",
+                "            brooklyn.config:",
+                "              test: $brooklyn:parent().config(\"num\")",
+                "    - id: " + SYMBOLIC_NAME,
+                "      itemType: entity",
+                "      item:",
+                "        type: " + BasicApplication.class.getName(),
+                "        brooklyn.children:",
+                "          - type: " + ConfigEntityForTest.class.getSimpleName() + "WithParams",
+                "            name: a",
+                "          - type: " + ConfigEntityForTest.class.getSimpleName() + "WithParams",
+                "            name: b",
+                "            brooklyn.config:",
+                "              num: 5678",
+                "          - type: " + ConfigEntityForTest.class.getSimpleName() + "WithParams",
+                "            name: c",
+                "            brooklyn.config:",
+                "              test: $brooklyn:config(\"num\")");
+
+        CatalogItem<?, ?> item = catalog.getCatalogItem(ConfigEntityForTest.class.getSimpleName() + "WithParams", TEST_VERSION);
+        AbstractBrooklynObjectSpec<?,?> spec = createSpec(item);
+        List<SpecParameter<?>> params = spec.getParameters();
+        assertEquals(params.size(), 1);
+        assertTrue(Iterables.tryFind(params, nameEqualTo("num")).isPresent());
+
+        Application app = (Application) createAndStartApplication(
+                "services:",
+                "  - type: " + ver(SYMBOLIC_NAME));
+
+        Optional<Entity> s = Iterables.tryFind(mgmt().getEntityManager().getEntitiesInApplication(app), EntityPredicates.displayNameEqualTo("s"));
+        assertTrue(s.isPresent());
+        assertEquals(s.get().config().get(ConfigKeys.newIntegerConfigKey("test")).intValue(), 1234);
+
+        Iterable<Entity> children = app.getChildren();
+        Optional<Entity> a = Iterables.tryFind(children, EntityPredicates.displayNameEqualTo("a"));
+        assertTrue(a.isPresent());
+        assertEquals(a.get().config().get(NUM).intValue(), 1234);
+        Optional<Entity> b = Iterables.tryFind(children, EntityPredicates.displayNameEqualTo("b"));
+        assertTrue(b.isPresent());
+        assertEquals(b.get().config().get(NUM).intValue(), 5678);
+        Optional<Entity> c = Iterables.tryFind(children, EntityPredicates.displayNameEqualTo("c"));
+        assertTrue(c.isPresent());
+        assertEquals(c.get().config().get(ConfigKeys.newIntegerConfigKey("test")).intValue(), 1234);
     }
 
     @Test

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -390,10 +390,11 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
      * @see EntitySpec#parameters(List)
      */
     public static void addParameters(AbstractBrooklynObjectSpec<?, ?> spec, List<? extends SpecParameter<?>> explicitParams, BrooklynClassLoadingContext loader) {
+        if (spec.getParameters().isEmpty()) {
+            spec.parametersAdd(BasicSpecParameter.fromSpec(loader.getManagementContext(), spec));
+        }
         if (explicitParams.size() > 0) {
             spec.parametersAdd(explicitParams);
-        } else {
-            spec.parametersAdd(BasicSpecParameter.fromSpec(loader.getManagementContext(), spec));
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -26,6 +26,16 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -47,16 +57,6 @@ import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.apache.brooklyn.util.time.Duration;
-
-import com.google.common.annotations.Beta;
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 public class BasicSpecParameter<T> implements SpecParameter<T>{
     private static final long serialVersionUID = -4728186276307619778L;
@@ -130,9 +130,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         if (getClass() != obj.getClass())
             return false;
         BasicSpecParameter<?> other = (BasicSpecParameter<?>) obj;
-        return Objects.equal(label,  other.label) &&
-                pinned == other.pinned &&
-                Objects.equal(configKey, other.configKey);
+        return Objects.equal(configKey, other.configKey);
     }
 
     @Override
@@ -384,5 +382,19 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         }
     }
 
+    /**
+     * Adds the given list of {@link SpecParameter parameters} to the provided
+     * {@link AbstractBrooklynObjectSpec spec} or generates a list from the
+     * spec if the provided list is empty.
+     *
+     * @see EntitySpec#parameters(List)
+     */
+    public static void addParameters(AbstractBrooklynObjectSpec<?, ?> spec, List<? extends SpecParameter<?>> explicitParams, BrooklynClassLoadingContext loader) {
+        if (explicitParams.size() > 0) {
+            spec.parametersAdd(explicitParams);
+        } else {
+            spec.parametersAdd(BasicSpecParameter.fromSpec(loader.getManagementContext(), spec));
+        }
+    }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/SpecParameterPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/SpecParameterPredicates.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs;
+
+import com.google.common.base.Predicate;
+
+import org.apache.brooklyn.api.objs.SpecParameter;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.text.Strings;
+
+public class SpecParameterPredicates {
+
+    /**
+     * Returns true if the {@link SpecParameter parameter name} is the same as
+     * that on the specified paramater.
+     */
+    public static Predicate<SpecParameter<?>> sameName(final SpecParameter<?> param) {
+        return new SameName(param);
+    }
+
+    /** @see #sameName(SpecParameter) */
+    protected static class SameName implements Predicate<SpecParameter<?>> {
+        private final SpecParameter<?> param;
+
+        public SameName(SpecParameter<?> param) {
+            this.param = param;
+        }
+
+        @Override
+        public boolean apply(SpecParameter<?> input) {
+            return input.getConfigKey().getName().equals(param.getConfigKey().getName());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("sameName(%s)",Strings.toString(param));
+        }
+    }
+
+    /**
+     * Returns true if the {@link SpecParameter#getLabel() label} is the same as
+     * the specified string.
+     */
+    public static Predicate<SpecParameter<?>> labelEqualTo(final String label) {
+        return new LabelEqualTo(label);
+    }
+
+    /** @see #labelEqualTo(String) */
+    protected static class LabelEqualTo implements Predicate<SpecParameter<?>> {
+        private final String label;
+
+        public LabelEqualTo(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public boolean apply(SpecParameter<?> input) {
+            return input.getLabel().equals(label);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("labelEqualTo(%s)",Strings.toString(label));
+        }
+    }
+
+    /**
+     * Returns true if the {@link ConfigKey#getName() config key name} is the same
+     * as the specified string.
+     */
+    public static Predicate<SpecParameter<?>> nameEqualTo(final String name) {
+        return new NameEqualTo(name);
+    }
+
+    /** @see #nameEqualTo(String) */
+    protected static class NameEqualTo implements Predicate<SpecParameter<?>> {
+        private final String name;
+
+        public NameEqualTo(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean apply(SpecParameter<?> input) {
+            return input.getConfigKey().getName().equals(name);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("nameEqualTo(%s)",Strings.toString(name));
+        }
+    }
+
+}


### PR DESCRIPTION
Implements behaviour required to merge `brooklyn.parameters` sections of specifications in YAML files, allowing addition of new parameters to entities without having to specify the complete list again.