### PR TITLE
Fix jmxmp connector in karaf

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/org.apache.brooklyn.osgilauncher.cfg
+++ b/karaf/apache-brooklyn/src/main/resources/etc/org.apache.brooklyn.osgilauncher.cfg
@@ -38,22 +38,22 @@
 #ignorePersistenceErrors=true
 
 # The high availability mode. Possible values are:
-# - disabled: management node works in isolation - will not cooperate with any other standby/master nodes in management plane;
-# - auto: will look for other management nodes, and will allocate itself as standby or master based on other nodes' states;
-# - master: will startup as master - if there is already a master then fails immediately;
-# - standby: will start up as lukewarm standby with no state - if there is not already a master then fails immediately,
+# - DISABLED: management node works in isolation - will not cooperate with any other standby/master nodes in management plane;
+# - AUTO: will look for other management nodes, and will allocate itself as standby or master based on other nodes' states;
+# - MASTER: will startup as master - if there is already a master then fails immediately;
+# - STANDBY: will start up as lukewarm standby with no state - if there is not already a master then fails immediately,
 #   and if there is a master which subsequently fails, this node can promote itself;
-# - hot_standby: will start up as hot standby in read-only mode - if there is not already a master then fails immediately,
+# - HOT_STANDBY: will start up as hot standby in read-only mode - if there is not already a master then fails immediately,
 #   and if there is a master which subseuqently fails, this node can promote itself;
-# - hot_backup: will start up as hot backup in read-only mode - no master is required, and this node will not become a master
-#highAvailabilityMode=disabled
+# - HOT_BACKUP: will start up as hot backup in read-only mode - no master is required, and this node will not become a master
+#highAvailabilityMode=DISABLED
 
 # The persistence mode. Possible values are:
-# - disabled: will not read or persist any state;
-# - auto: will rebind to any existing state, or start up fresh if no state;
-# - rebind: will rebind to the existing state, or fail if no state available;
-# - clean: will start up fresh (removing any existing state)
-#persistMode=disabled
+# - DISABLED: will not read or persist any state;
+# - AUTO: will rebind to any existing state, or start up fresh if no state;
+# - REBIND: will rebind to the existing state, or fail if no state available;
+# - CLEAN: will start up fresh (removing any existing state)
+#persistMode=DISABLED
 
 # The directory to read/write persisted state (or container name if using an object store)
 #persistenceDir=

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -211,9 +211,9 @@
 
     <feature name="brooklyn-software-base"  version="${project.version}"  description="Brooklyn Software Base">
         <bundle>mvn:org.apache.brooklyn/brooklyn-software-base/${project.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}</bundle>
         <feature>brooklyn-software-winrm</feature>
         <feature>brooklyn-policy</feature>
-        <!-- python dependency required but not supported since karaf cannot handle its runtime bindings -->
     </feature>
 
     <feature name="brooklyn-jmxmp-agent" version="${project.version}" description="Brooklyn Secure JMXMP Agent">


### PR DESCRIPTION
e.g. tomcat failed to reach service-up because it couldn't create the JMXMP connector due to classloading problems.