### PR TITLE
Fix AssemblyTest (increase timeout for FeaturesService)

### DIFF
--- a/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/AssemblyTest.java
@@ -49,6 +49,7 @@ public class AssemblyTest {
     private BundleContext bc;
 
     @Inject
+    @Filter(timeout = 120000)
     protected FeaturesService featuresService;
 
     /**

--- a/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScannerTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScannerTest.java
@@ -60,12 +60,15 @@ public class CatalogBomScannerTest {
     public static final String KARAF_INIT_BLUEPRINT_BOMSCANNER_PID = "org.apache.brooklyn.core.catalog.bomscanner";
 
     @Inject
+    @Filter(timeout = 120000)
     protected FeaturesService featuresService;
 
     @Inject
+    @Filter(timeout = 120000)
     protected ConfigurationAdmin configAdmin;
 
     @Inject
+    @Filter(timeout = 120000)
     protected ManagementContext managementContext;
 
     /**

--- a/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/DefaultBomLoadTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/core/catalog/internal/DefaultBomLoadTest.java
@@ -53,6 +53,7 @@ public class DefaultBomLoadTest {
     BootFinished bootFinished;
 
     @Inject
+    @Filter(timeout = 120000)
     protected ManagementContext managementContext;
 
 

--- a/karaf/itest/src/test/java/org/apache/brooklyn/launcher/osgi/OsgiLauncherTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/launcher/osgi/OsgiLauncherTest.java
@@ -55,9 +55,11 @@ public class OsgiLauncherTest {
     private static final String TEST_KEY_IN_CFG = "test.key.in.cfg";
 
     @Inject
+    @Filter(timeout = 120000)
     protected ManagementContext mgmt;
 
     @Inject
+    @Filter(timeout = 120000)
     protected ConfigurationAdmin configAdmin;
 
     /**

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/CustomSecurityProviderTest.java
@@ -53,6 +53,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.tinybundles.core.TinyBundles;
 import org.osgi.framework.Constants;
 
@@ -69,9 +70,11 @@ public class CustomSecurityProviderTest {
      * installed
      */
     @Inject
+    @Filter(timeout = 120000)
     BootFinished bootFinished;
     
     @Inject
+    @Filter(timeout = 120000)
     ManagementContext managementContext;
 
     @Configuration

--- a/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
+++ b/karaf/itest/src/test/java/org/apache/brooklyn/security/StockSecurityProviderTest.java
@@ -62,6 +62,7 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.ops4j.pax.exam.util.Filter;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -77,9 +78,11 @@ public class StockSecurityProviderTest {
      * installed
      */
     @Inject
+    @Filter(timeout = 120000)
     BootFinished bootFinished;
     
     @Inject
+    @Filter(timeout = 120000)
     ManagementContext managementContext;
 
     @Configuration


### PR DESCRIPTION
@neykov setting these timeouts seems to fix `AssemblyTest` for me locally. I've added the timeout to everywhere else that we do `@Inject` in itests (I saw a failure in `OsgiLauncherTest` for `gave up waiting for service org.apache.brooklyn.api.mgmt.ManagementContext`).