### PR TITLE
Fix adding multiple RendererHints for percentage enricher

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
@@ -90,7 +90,10 @@ public class PercentageEnricher extends AbstractEnricher implements SensorEventL
 
         subscriptions().subscribe(MutableMap.of("notifyOfInitialValue", true), producer, sourceCurrentSensor, this);
         subscriptions().subscribe(MutableMap.of("notifyOfInitialValue", true), producer, sourceTotalSensor, this);
-        RendererHints.register(targetSensor, RendererHints.displayValue(MathFunctions.percent(2)));
+
+        if (RendererHints.getHintsFor(targetSensor).isEmpty()) {
+            RendererHints.register(targetSensor, RendererHints.displayValue(MathFunctions.percent(2)));
+        }
     }
 
     @Override


### PR DESCRIPTION
Stops long stream of `WARN` log messages when using `PercentageEnricher` on a sensor that already has a `RendererHint` applied