### PR TITLE
brooklyn-server karaf: don’t depend on library

### DIFF
--- a/karaf/apache-brooklyn/pom.xml
+++ b/karaf/apache-brooklyn/pom.xml
@@ -128,7 +128,6 @@
             <bootFeature>brooklyn-jsgui</bootFeature>
             <bootFeature>brooklyn-rest-resources</bootFeature>
             <bootFeature>brooklyn-commands</bootFeature>
-            <bootFeature>brooklyn-commands</bootFeature>
           </bootFeatures>
         </configuration>
       </plugin>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -336,11 +336,16 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-test-framework/${project.version}</bundle>
     </feature>
 
-    <!-- Don't load all bundles out of the box in the long run. Let users cherry pick what they need. -->
-    <feature name="brooklyn-software-all" version="${project.version}" description="Brooklyn All Software Entities">
+    <feature name="brooklyn-server-software-all" version="${project.version}" description="Brooklyn All Core Entities">
         <feature>brooklyn-software-base</feature>
         <feature>brooklyn-jmxmp-agent</feature>
         <feature>brooklyn-jmxrmi-agent</feature>
+        <feature>brooklyn-test-framework</feature>
+    </feature>
+
+    <!-- TODO Not including this in the init features; need to move this to brooklyn-dist first! -->
+    <!-- TODO Don't load all bundles out of the box in the long run. Let users cherry pick what they need. -->
+    <feature name="brooklyn-library-all" version="${project.version}" description="Brooklyn All Library Entities">
         <feature>brooklyn-software-network</feature>
         <feature>brooklyn-software-cm</feature>
         <feature>brooklyn-software-osgi</feature>
@@ -349,12 +354,11 @@
         <feature>brooklyn-software-messaging</feature>
         <feature>brooklyn-software-nosql</feature>
         <feature>brooklyn-software-monitoring</feature>
-        <feature>brooklyn-test-framework</feature>
     </feature>
 
     <feature name="brooklyn-osgi-launcher" version="${project.version}" description="Brooklyn init">
         <feature>brooklyn-core</feature>
-        <feature>brooklyn-software-all</feature>
+        <feature>brooklyn-server-software-all</feature>
         <feature>brooklyn-locations-jclouds</feature>
         <bundle>mvn:org.apache.brooklyn/brooklyn-launcher-common/${project.version}</bundle>
         <bundle start-level="90">mvn:org.apache.brooklyn/brooklyn-karaf-init/${project.version}</bundle>


### PR DESCRIPTION
Don’t depend on bundles that are in brooklyn-library when building
brooklyn-server: they won’t be available yet.

Long-term solution is to move all of this into brooklyn-dist, and 
then we can re-enable these.