### PR TITLE
Fix tests out of memory crashes

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -664,7 +664,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
                     <configuration>
-                         <argLine>-Xms768m -Xmx768m -XX:MaxPermSize=256m -verbose:gc</argLine>
+                         <argLine>-Xms1G -Xmx1G -XX:MaxPermSize=256m -verbose:gc</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Note that this will make the project fail on 32 bit JDKs, at least on Windows.