### PR TITLE
catalog-classes.bom: don’t specify bundle id/version

### DIFF
--- a/karaf/init/src/main/resources/catalog-classes.bom
+++ b/karaf/init/src/main/resources/catalog-classes.bom
@@ -18,10 +18,8 @@
 brooklyn.catalog:
   version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
   items:
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.core
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.core
+  - itemType: entity
     items:
      - id: org.apache.brooklyn.entity.group.QuarantineGroup
        item:
@@ -63,10 +61,8 @@ brooklyn.catalog:
        item:
          type: org.apache.brooklyn.entity.group.DynamicFabric
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.policy
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    items:
+  # org.apache.brooklyn.policy
+  - items:
     - id: org.apache.brooklyn.policy.ha.ConnectionFailureDetector
       itemType: policy
       item:
@@ -110,10 +106,8 @@ brooklyn.catalog:
         name: Auto-scaler
         description: Policy that is attached to a Resizable entity and dynamically 
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-base
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+    # org.apache.brooklyn.software-base
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.machine.MachineEntity
       item:
@@ -167,10 +161,8 @@ brooklyn.catalog:
         name: Server Pool
         description: Creates a pre-allocated server pool, which other applications can deploy to
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-webapp
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-webapp
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
       item:
@@ -227,10 +219,8 @@ brooklyn.catalog:
         name: Controlled Dynamic Web-app Cluster
         description: A cluster of load-balanced web-apps, which can be dynamically re-sized
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-osgi
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-osgi
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
       item:
@@ -238,10 +228,8 @@ brooklyn.catalog:
         name: Karaf
         description: Apache Karaf is a small OSGi based runtime which provides a lightweight container onto which various components and applications can be deployed.
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-nosql
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-nosql
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.nosql.redis.RedisStore
       item:
@@ -366,10 +354,8 @@ brooklyn.catalog:
       item:
         type: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-network
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-network
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.network.bind.BindDnsServer
       description: BIND is an Internet Domain Name Server.
@@ -377,10 +363,8 @@ brooklyn.catalog:
         type: org.apache.brooklyn.entity.network.bind.BindDnsServer
         name: BIND
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-monitoring
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-monitoring
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.monitoring.monit.MonitNode
       item:
@@ -388,10 +372,8 @@ brooklyn.catalog:
         name: Monit Node
         description: Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-messaging
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-messaging
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
       item:
@@ -452,10 +434,8 @@ brooklyn.catalog:
         name: Storm Deployment
         description: A Storm cluster. Apache Storm is a distributed realtime computation system. 
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-database
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-database
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.database.crate.CrateNode
       item:
@@ -484,10 +464,8 @@ brooklyn.catalog:
         name: MariaDB Node
         description: MariaDB is an open source relational database management system (RDBMS)
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-cm-salt
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-cm-salt
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.cm.salt.SaltEntity
       item:
@@ -495,10 +473,8 @@ brooklyn.catalog:
         name: SaltEntity
         description: Software managed by Salt CM
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.software-cm-ansible
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.software-cm-ansible
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
       item:
@@ -506,10 +482,8 @@ brooklyn.catalog:
         name: AnsibleEntity
         description: Software managed by Ansible CM
 
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.test-framework
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    itemType: entity
+  # org.apache.brooklyn.test-framework
+  - itemType: entity
     items:
     - id: org.apache.brooklyn.test.framework.TestSshCommand
       item:


### PR DESCRIPTION
As discussed with @neykov and @Graeme-Miller 

Previously the `catalog-classes.bom` included the Brooklyn version number in which the bundles are to be found. This works well when installing and using Brooklyn, but these bundle version numbers make their way into the persisted state.

After upgrading Brooklyn and restarting, it uses the existing persisted state. The bundle with the old Brooklyn version is not in this new karaf install, so it fails with the exception below:

```
14:30:50,959 WARN  102 internal.CatalogInitialization [nager-HYVJ5hka-0] Error populating catalog (rethrowing): java.lang.IllegalStateException: Bundle from null failed to install: Bundle CatalogBundleDto{symbolicName=or
g.apache.brooklyn.core, version=0.10.0.20160711_1846, url=null} not previously registered, but URL is empty.
java.lang.IllegalStateException: Bundle from null failed to install: Bundle CatalogBundleDto{symbolicName=org.apache.brooklyn.core, version=0.10.0.20160711_1846, url=null} not previously registered, but URL is empty.
        at org.apache.brooklyn.core.mgmt.ha.OsgiManager.registerBundle(OsgiManager.java:122)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogUtils.installLibraries(CatalogUtils.java:160)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogDo.loadCatalogItems(CatalogDo.java:138)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogDo.loadThisCatalog(CatalogDo.java:115)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogDo.load(CatalogDo.java:98)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog.reset(BasicBrooklynCatalog.java:140)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog.reset(BasicBrooklynCatalog.java:127)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog.reset(BasicBrooklynCatalog.java:177)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogInitialization.populateCatalogImpl(CatalogInitialization.java:228)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.catalog.internal.CatalogInitialization.populateCatalog(CatalogInitialization.java:199)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindIteration.rebuildCatalog(RebindIteration.java:423)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindIteration.doRun(RebindIteration.java:239)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.InitialFullRebindIteration.doRun(InitialFullRebindIteration.java:69)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindIteration.run(RebindIteration.java:266)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.rebindImpl(RebindManagerImpl.java:558)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl$3.call(RebindManagerImpl.java:508)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl$3.call(RebindManagerImpl.java:506)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:519)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)[:1.8.0_91]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)[:1.8.0_91]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)[:1.8.0_91]
        at java.lang.Thread.run(Thread.java:745)[:1.8.0_91]
Caused by: java.lang.IllegalStateException: Bundle CatalogBundleDto{symbolicName=org.apache.brooklyn.core, version=0.10.0.20160711_1846, url=null} not previously registered, but URL is empty.
        at org.apache.brooklyn.core.mgmt.ha.OsgiManager.checkBundleInstalledThrowIfInconsistent(OsgiManager.java:168)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        at org.apache.brooklyn.core.mgmt.ha.OsgiManager.registerBundle(OsgiManager.java:113)[102:org.apache.brooklyn.core:0.10.0.20160712_1338]
        ... 21 more
```
