### PR TITLE
Fix memory leak where unused class references are kept around

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -664,7 +664,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
                     <configuration>
-                         <argLine>-Xms1G -Xmx1G -XX:MaxPermSize=256m -verbose:gc</argLine>
+                         <argLine>-Xms768m -Xmx768m -XX:MaxPermSize=256m -verbose:gc</argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
The BrooklynTypes cache was keeping references to classes indefinitely, preventing the OSGi class loaders and frameworks from being GCed.