### PR TITLE
Comment out catalog items coming from brooklyn-libraries in Karaf dist

### DIFF
--- a/karaf/apache-brooklyn/src/main/resources/etc/default.catalog.bom
+++ b/karaf/apache-brooklyn/src/main/resources/etc/default.catalog.bom
@@ -1,370 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
-# this catalog bom is an illustration supplying a few useful sample items
-# and templates to get started using Brooklyn
 
 brooklyn.catalog:
-  version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
-  items:
-  - brooklyn.libraries:
-    - name: org.apache.brooklyn.karaf-init
-      version: "0.10.0.SNAPSHOT" # BROOKLYN_VERSION
-    include: classpath://catalog-classes.bom
+    version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
+    items:
+    - classpath://catalog-classes.bom
+    - id: server-template
+      itemType: template
+      name: "Template: Server"
+      description: |
+        Sample YAML to provision a server in a cloud with illustrative VM properties
+      item:
+        name: Server (Brooklyn Example)
 
-  - id: server
-    itemType: entity
-    description: |
-      Provision a server, with customizable provisioning.properties and credentials installed, 
-      but no other special software process or scripts executed.
-    item:
-      type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
-      name: Server
+        # this basic example shows how Brooklyn can provision a single raw VM
+        # in the cloud or location of your choice
 
-  - id: vanilla-bash-server
-    itemType: entity
-    description: |
-      Provision a server, with customizable provisioning.properties and credentials installed, 
-      but no other special software process or scripts executed.
-      The script should be supplied in "launch.command" as per docs on
-      org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess.
-    item:
-      type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
-      name: Server with Launch Script (bash)
+        services:
+        - type:           org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
+          name:           My VM
 
-  - id: load-balancer
-    itemType: entity
-    description: |
-      Create a load balancer which will point at members in the group entity
-      referred to by the config key "serverPool". 
-      The sensor advertising the port can be configured with the "member.sensor.portNumber" config key,
-      defaulting to `http.port`; all member entities which have published "service.up" will then be picked up.
-    item:
-      type: org.apache.brooklyn.entity.proxy.nginx.NginxController
-      name: Load Balancer (nginx)
+        # location can be e.g. `softlayer` or `jclouds:openstack-nova:https://9.9.9.9:9999/v2.0/`,
+        # or `localhost` or `byon:(hosts="10.9.1.1,10.9.1.2,produser2@10.9.2.{10,11,20-29}")`
+        location:
+          jclouds:aws-ec2:
+            # edit these to use your credential (or delete if credentials specified in brooklyn.properties)
+            identity:     <REPLACE>
+            credential:   <REPLACE>
 
-  - id: cluster
-    itemType: entity
-    description: |
-      Create a cluster of entities, resizable, with starting size "initialSize",
-      and using a spec supplied in the "memberSpec" key.
-    item:
-      type: org.apache.brooklyn.entity.group.DynamicCluster
+            region:       eu-central-1
 
-  - id: 1-server-template
-    itemType: template
-    name: "Template 1: Server"
-    description: |
-      Sample YAML to provision a server in a cloud with illustrative VM properties
-    item:
-      name: Server (Brooklyn Example)
-      
-      # this basic example shows how Brooklyn can provision a single raw VM
-      # in the cloud or location of your choice
-      
-      services:
-      - type:           server
-        name:           My VM
-      
-      # location can be e.g. `softlayer` or `jclouds:openstack-nova:https://9.9.9.9:9999/v2.0/`,
-      # or `localhost` or `byon:(hosts="10.9.1.1,10.9.1.2,produser2@10.9.2.{10,11,20-29}")` 
-      location:
-        jclouds:aws-ec2:
-          # edit these to use your credential (or delete if credentials specified in brooklyn.properties)      
-          identity:     <REPLACE>
-          credential:   <REPLACE>
-          
-          region:       eu-central-1
-          
-          # we want Ubuntu, with a lot of RAM
-          osFamily:     ubuntu
-          minRam:       8gb
-          
-          # set up this user and password (default is to authorize a public key)
-          user:         sample
-          password:     s4mpl3
+            # we want Ubuntu, with a lot of RAM
+            osFamily:     ubuntu
+            minRam:       8gb
 
-  - id: 2-bash-web-server-template
-    itemType: template
-    name: "Template 2: Bash Web Server"
-    description: |
-      Sample YAML building on Template 1, 
-      adding bash commands to launch a Python-based web server
-      on port 8020
-    item:
-      name: Python Web Server (Brooklyn Example)
-      
-      # this example builds on the previous one, 
-      # adding some scripts to initialize the VM
-      
-      services:
-      - type:           vanilla-bash-server
-        name:           My Bash Web Server VM
-        brooklyn.config:
-          install.command: |
-            # install python if not present
-            which python || \
-              { sudo apt-get update && sudo apt-get install python ; } || \
-              { sudo yum update && sudo yum install python ; } || \
-              { echo WARNING: cannot install python && exit 1 ; }
+            # set up this user and password (default is to authorize a public key)
+            user:         sample
+            password:     s4mpl3
 
-          customize.command: |
-            # create the web page to serve
-            cat > index.html << EOF
-            
-            Hello world.
-            <p>
-            I am ${ENTITY_INFO}, ${MESSAGE:-a Brooklyn sample}.
-            <p>
-            Created at: `date`
-            <p>
-            I am running at ${HOSTNAME}, with on-box IP configuration:
-            <pre>
-            `ifconfig | grep inet`
-            </pre>
-            
-            EOF
-
-          launch.command: |
-            # launch in background (ensuring no streams open), and record PID to file
-            nohup python -m SimpleHTTPServer ${PORT:-8020} < /dev/null > output.txt 2>&1 &
-            echo $! > ${PID_FILE:-pid.txt}
-            sleep 5
-            ps -p `cat ${PID_FILE:-pid.txt}`
-            if [ $? -ne 0 ] ; then
-              cat output.txt
-              echo WARNING: python web server not running
-              exit 1
-            fi
-            
-          shell.env:
-            HOSTNAME:     $brooklyn:attributeWhenReady("host.name")
-            PORT:         $brooklyn:config("my.app.port")
-            ENTITY_INFO:  $brooklyn:component("this", "")
-            MESSAGE:      $brooklyn:config("my.message")
-            
-          # custom 
-          my.app.port:  8020
-          my.message:   "good to meet you"
-        
-        brooklyn.enrichers:
-        # publish the URL as a sensor; the GUI will pick this up (main.uri)
-        - type: org.apache.brooklyn.enricher.stock.Transformer
-          brooklyn.config:
-            uniqueTag: url-generator
-            enricher.sourceSensor: host.subnet.hostname
-            # use the definition from Attributes class, as it has a RendererHint so GUI makes it a link
-            enricher.targetSensor: $brooklyn:sensor("org.apache.brooklyn.core.entity.Attributes", "main.uri")
-            enricher.targetValue: 
-              $brooklyn:formatString:
-              - "http://%s:%s/" 
-              - $brooklyn:attributeWhenReady("host.subnet.hostname")
-              - $brooklyn:config("my.app.port")
-      
-      location:
-        jclouds:aws-ec2:
-          region:       eu-central-1
-          # edit these (or delete if credentials specified in brooklyn.properties)      
-          identity:     <REPLACE>
-          credential:   <REPLACE>
-        
-  - id: 3-bash-web-and-riak-template
-    itemType: template
-    name: "Template 3: Bash Web Server and Scaling Riak Cluster"
-    description: |
-      Sample YAML building on Template 2, 
-      composing that blueprint with a Riak cluster and injecting the URL
-    item:
-      name: Bash Web Server and Riak Cluster (Brooklyn Example)
-    
-      # this example *references* the previous one, 
-      # combining it with a stock blueprint for a Riak cluster,
-      # and shows how a sensor from the latter can be injected
-      
-      services:
-      
-      # reference template 2, overriding message to point at riak 
-      - type:           2-bash-web-server-template
-        brooklyn.config:
-          my.message:   $brooklyn:formatString("connected to Riak at %s",
-                            $brooklyn:entity("riak-cluster").attributeWhenReady("main.uri"))
-        # and clear the location defined there so it is taken from this template
-        locations:      []
-                            
-      # use the off-the-shelf Riak cluster
-      - type:           org.apache.brooklyn.entity.nosql.riak.RiakCluster
-        id:             riak-cluster
-        initialSize:    3
-        # and add a policy to scale based on ops per minute
-        brooklyn.policies:
-        - type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
-          brooklyn.config:
-            metric: riak.node.ops.1m.perNode
-            # more than 100 ops per second (6k/min) scales out, less than 50 scales back
-            # up to a max of 8 riak nodes here (can be changed in GUI / REST API afterwards)
-            metricLowerBound: 3000
-            metricUpperBound: 6000
-            minPoolSize: 3
-            maxPoolSize: 8
-            resizeUpStabilizationDelay: 30s
-            resizeDownStabilizationDelay: 5m
-          
-      location:
-        jclouds:aws-ec2:
-          region:       eu-central-1
-          # edit these (or delete if credentials specified in brooklyn.properties)      
-          identity:     <REPLACE>
-          credential:   <REPLACE>
-
-  - id: 4-resilient-bash-web-cluster-template
-    itemType: template
-    name: "Template 4: Resilient Load-Balanced Bash Web Cluster with Sensors"
-    description: |
-      Sample YAML to provision a cluster of the bash/python web server nodes,
-      with sensors configured, and a load balancer pointing at them,
-      and resilience policies for node replacement and scaling
-    item:
-      name: Resilient Load-Balanced Bash Web Cluster (Brooklyn Example)
-      
-      # this final example shows some of the advanced functionality:
-      # defining custom sensors, and a cluster with a "spec", 
-      # policies for resilience and scaling based on that sensor,
-      # and wiring a load balancer in front of the cluster
-      
-      # combining this with the riak cluster in the previous example
-      # is left as a suggested exercise for the user
-      
-      services:
-      
-      # define a cluster of the web nodes
-      - type:           cluster
-        name:           Cluster of Bash Web Nodes
-        id:             my-web-cluster
-        brooklyn.config:
-          initialSize:  1
-          memberSpec:
-            $brooklyn:entitySpec:
-              # template 2 is used as the spec for items in this cluster
-              # with a new message overwriting the previous,
-              # and a lot of sensors defined
-              type:           2-bash-web-server-template
-              name:           My Bash Web Server VM with Sensors
-              # and clear the location defined there so it is taken from this template
-              locations:      []
-              
-              brooklyn.config:
-                my.message:   "part of the cluster"
-              
-              brooklyn.initializers:
-              # make a simple request-count sensor, by counting the number of 200 responses in output.txt
-              - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
-                brooklyn.config:
-                  name: reqs.count
-                  targetType: int
-                  period: 5s
-                  command: "cat output.txt | grep HTTP | grep 200 | wc | awk '{print $1}'"
-              # and publish the port as a sensor so the load-balancer can pick it up
-              - type:           org.apache.brooklyn.core.sensor.StaticSensor
-                brooklyn.config:
-                  name:         app.port
-                  targetType:   int
-                  static.value: $brooklyn:config("my.app.port")
-              
-              brooklyn.enrichers:
-              # derive reqs.per_sec from reqs.count
-              - type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
-                brooklyn.config:
-                  enricher.sourceSensor: reqs.count
-                  enricher.targetSensor: reqs.per_sec
-                  enricher.delta.period: 1s
-              # and take an average over 30s for reqs.per_sec into reqs.per_sec.windowed_30s
-              - type: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
-                brooklyn.config:
-                  enricher.sourceSensor: reqs.per_sec
-                  enricher.targetSensor: reqs.per_sec.windowed_30s
-                  enricher.window.duration: 30s
-              
-              # emit failure sensor if a failure connecting to the service is sustained for 30s
-              - type: org.apache.brooklyn.policy.ha.ServiceFailureDetector
-                brooklyn.config:
-                  entityFailed.stabilizationDelay: 30s
-            
-              brooklyn.policies:
-              # restart if a failure is detected (with a max of one restart in 2m, sensor will propagate otherwise) 
-              - type: org.apache.brooklyn.policy.ha.ServiceRestarter
-                brooklyn.config:
-                  failOnRecurringFailuresInThisDuration: 2m
-        
-        # back at the cluster, create a total per-sec and some per-node average
-        brooklyn.enrichers:
-        - type: org.apache.brooklyn.enricher.stock.Aggregator
-          brooklyn.config:
-            enricher.sourceSensor: reqs.per_sec
-            enricher.targetSensor: reqs.per_sec
-            transformation: sum
-        - type: org.apache.brooklyn.enricher.stock.Aggregator
-          brooklyn.config:
-            enricher.sourceSensor: reqs.per_sec
-            enricher.targetSensor: reqs.per_sec.per_node
-            transformation: average
-        - type: org.apache.brooklyn.enricher.stock.Aggregator
-          brooklyn.config:
-            enricher.sourceSensor: reqs.per_sec.windowed_30s
-            enricher.targetSensor: reqs.per_sec.windowed_30s.per_node
-            transformation: average
-              
-        brooklyn.policies:
-        # resilience: if a per-node restart policy fails,
-        # just throw that node away and create a new one
-        - type: org.apache.brooklyn.policy.ha.ServiceReplacer
-        
-        # and scale based on reqs/sec
-        - type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
-          brooklyn.config:
-            # scale based on reqs/sec (though in a real-world situation, 
-            # reqs.per_sec.windowed_30s.per_node might be a better choice) 
-            metric: reqs.per_sec.per_node
-            
-            # really low numbers, so you can trigger a scale-out just by hitting reload a lot
-            metricUpperBound: 3
-            metricLowerBound: 1
-            
-            # sustain 3 reqs/sec for 2s and it will scale out
-            resizeUpStabilizationDelay: 2s
-            # only scale down when sustained for 1m
-            resizeDownStabilizationDelay: 1m
-      
-            maxPoolSize: 10
-            
-      # and add a load-balancer pointing at the cluster
-      - type:           load-balancer
-        id:             load-bal
-        brooklyn.config:
-          # point this load balancer at the cluster, specifying port to forward to
-          loadbalancer.serverpool:  $brooklyn:entity("my-web-cluster")
-          member.sensor.portNumber: app.port
-          # disable sticky sessions to allow easy validation of balancing via browser refresh
-          nginx.sticky: false
-      
-      brooklyn.enrichers:
-      # publish a few useful info sensors and KPI's to the root of the app
-      - type: org.apache.brooklyn.enricher.stock.Propagator
-        brooklyn.config:
-          uniqueTag:    propagate-load-balancer-url
-          producer:     $brooklyn:entity("load-bal")
-          propagating:
-          - main.uri
-      - type: org.apache.brooklyn.enricher.stock.Propagator
-        brooklyn.config:
-          uniqueTag:    propagate-reqs-per-sec
-          producer:     $brooklyn:entity("my-web-cluster")
-          propagating:
-          - reqs.per_sec
-          - reqs.per_sec.windowed_30s.per_node
-      
-      location:
-        jclouds:aws-ec2:
-          # edit these (or delete if credentials specified in brooklyn.properties)      
-          identity:     <REPLACE>
-          credential:   <REPLACE>
-          
-          region:       eu-central-1
-          minRam:       2gb

--- a/karaf/init/src/main/resources/catalog-classes.bom
+++ b/karaf/init/src/main/resources/catalog-classes.bom
@@ -162,385 +162,385 @@ brooklyn.catalog:
         name: Server Pool
         description: Creates a pre-allocated server pool, which other applications can deploy to
 
-  # org.apache.brooklyn.software-webapp
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
-      iconUrl: classpath:///nodejs-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
-        name: Node.JS Application
-    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
-      iconUrl: classpath:///jboss-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
-        name: JBoss Application Server 7
-        description: AS7 - an open source Java application server from JBoss
-    - id: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
-      item:
-        type: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
-    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
-      item:
-        type: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
-    - id: org.apache.brooklyn.entity.proxy.nginx.NginxController
-      iconUrl: classpath:///nginx-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.proxy.nginx.NginxController
-        name: Nginx Server
-        description: A single Nginx server. Provides HTTP and reverse proxy services
-    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
-      iconUrl: classpath:///jboss-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
-        name: JBoss Application Server 6
-        description: AS6 -  an open source Java application server from JBoss
-    - id: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
-      iconUrl: classpath:///tomcat-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
-        name: Tomcat 8 Server
-    - id: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
-      item:
-        type: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
-    - id: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
-      iconUrl: classpath:///jetty-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
-        name: Jetty6 Server
-        description: Old version (v6 @ Mortbay) of the popular Jetty webapp container
-    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
-      item:
-        type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
-        name: Dynamic Web-app Cluster
-        description: A cluster of web-apps, which can be dynamically re-sized; this does not include a load-balancer
-    - id: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
-      iconUrl: classpath:///tomcat-logo.png
-      item:
-        type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
-        name: Tomcat 7 Server
-    - id: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
-      iconUrl: classpath:///geoscaling-logo.gif
-      item:
-        type: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
-    - id: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
-      item:
-        type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
-        name: Controlled Dynamic Web-app Cluster
-        description: A cluster of load-balanced web-apps, which can be dynamically re-sized
+#  # org.apache.brooklyn.software-webapp
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+#      iconUrl: classpath:///nodejs-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+#        name: Node.JS Application
+#    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+#      iconUrl: classpath:///jboss-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+#        name: JBoss Application Server 7
+#        description: AS7 - an open source Java application server from JBoss
+#    - id: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+#      item:
+#        type: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+#    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+#    - id: org.apache.brooklyn.entity.proxy.nginx.NginxController
+#      iconUrl: classpath:///nginx-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.proxy.nginx.NginxController
+#        name: Nginx Server
+#        description: A single Nginx server. Provides HTTP and reverse proxy services
+#    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+#      iconUrl: classpath:///jboss-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+#        name: JBoss Application Server 6
+#        description: AS6 -  an open source Java application server from JBoss
+#    - id: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+#      iconUrl: classpath:///tomcat-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+#        name: Tomcat 8 Server
+#    - id: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+#      item:
+#        type: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+#    - id: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+#      iconUrl: classpath:///jetty-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+#        name: Jetty6 Server
+#        description: Old version (v6 @ Mortbay) of the popular Jetty webapp container
+#    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+#        name: Dynamic Web-app Cluster
+#        description: A cluster of web-apps, which can be dynamically re-sized; this does not include a load-balancer
+#    - id: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+#      iconUrl: classpath:///tomcat-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+#        name: Tomcat 7 Server
+#    - id: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+#      iconUrl: classpath:///geoscaling-logo.gif
+#      item:
+#        type: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+#    - id: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+#      item:
+#        type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+#        name: Controlled Dynamic Web-app Cluster
+#        description: A cluster of load-balanced web-apps, which can be dynamically re-sized
 
-  # org.apache.brooklyn.software-osgi
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
-      iconUrl: classpath:///karaf-logo.png
-      item:
-        type: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
-        name: Karaf
-        description: Apache Karaf is a small OSGi based runtime which provides a lightweight container onto which various components and applications can be deployed.
+#  # org.apache.brooklyn.software-osgi
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
+#      iconUrl: classpath:///karaf-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
+#        name: Karaf
+#        description: Apache Karaf is a small OSGi based runtime which provides a lightweight container onto which various components and applications can be deployed.
 
-  # org.apache.brooklyn.software-nosql
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.nosql.redis.RedisStore
-      iconUrl: classpath:///redis-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.redis.RedisStore
-        name: Redis Server
-        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
-    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
-      iconUrl: classpath:///cassandra-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
-        name: Apache Cassandra Datacenter Cluster
-        description: Cassandra is a highly scalable, eventually 
-    - id: org.apache.brooklyn.entity.nosql.solr.SolrServer
-      iconUrl: classpath:///solr-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.nosql.solr.SolrServer
-        name: Apache Solr Node
-        description: Solr is the popular, blazing fast open source enterprise search 
-    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
-      iconUrl: classpath:///couchdb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
-        name: CouchDB Node
-    - id: org.apache.brooklyn.entity.nosql.redis.RedisShard
-      iconUrl: classpath:///redis-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.redis.RedisShard
-    - id: org.apache.brooklyn.entity.nosql.redis.RedisCluster
-      iconUrl: classpath:///redis-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.redis.RedisCluster
-        name: Redis Cluster
-        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
-    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
-      iconUrl: classpath:///hazelcast-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
-        name: Hazelcast Cluster
-        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
-    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
-      iconUrl: classpath:///couchdb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
-    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
-      iconUrl: classpath:///couchbase-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
-        name: CouchBase Node
-        description: Couchbase Server is an open source, distributed (shared-nothing architecture) 
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
-        name: MongoDB Sharded Deployment
-    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
-      iconUrl: classpath:///cassandra-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
-        name: Apache Cassandra Node
-        description: Cassandra is a highly scalable, eventually 
-    - id: org.apache.brooklyn.entity.nosql.riak.RiakNode
-      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.riak.RiakNode
-        name: Riak Node
-        description: Riak is a distributed NoSQL key-value data store that offers 
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
-    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
-        name: MongoDB Server
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
-        name: MongoDB Router
-    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
-    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
-    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
-      item:
-        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
-        name: Elastic Search Node
-        description: Elasticsearch is an open-source search server based on Lucene. 
-    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
-      iconUrl: classpath:///cassandra-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
-        name: Apache Cassandra Database Fabric
-        description: Cassandra is a highly scalable, eventually 
-    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
-      item:
-        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
-        name: Elastic Search Cluster
-        description: Elasticsearch is an open-source search server based on Lucene. 
-    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
-      iconUrl: classpath:///cassandra-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
-    - id: org.apache.brooklyn.entity.nosql.redis.RedisSlave
-      iconUrl: classpath:///redis-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.redis.RedisSlave
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
-    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
-      iconUrl: classpath:///couchbase-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
-        name: CouchBase Cluster
-        description: Couchbase is an open source, distributed (shared-nothing architecture) 
-    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
-      iconUrl: classpath:///couchbase-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
-    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
-      iconUrl: classpath:///hazelcast-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
-        name: Hazelcast Node
-        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
-    - id: org.apache.brooklyn.entity.nosql.riak.RiakCluster
-      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.riak.RiakCluster
-        name: Riak Cluster
-        description: Riak is a distributed NoSQL key-value data store that offers 
-    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
-      iconUrl: classpath:///mongodb-logo.png
-      item:
-        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+#  # org.apache.brooklyn.software-nosql
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.nosql.redis.RedisStore
+#      iconUrl: classpath:///redis-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.redis.RedisStore
+#        name: Redis Server
+#        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+#    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+#      iconUrl: classpath:///cassandra-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+#        name: Apache Cassandra Datacenter Cluster
+#        description: Cassandra is a highly scalable, eventually 
+#    - id: org.apache.brooklyn.entity.nosql.solr.SolrServer
+#      iconUrl: classpath:///solr-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.solr.SolrServer
+#        name: Apache Solr Node
+#        description: Solr is the popular, blazing fast open source enterprise search 
+#    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+#      iconUrl: classpath:///couchdb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+#        name: CouchDB Node
+#    - id: org.apache.brooklyn.entity.nosql.redis.RedisShard
+#      iconUrl: classpath:///redis-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.redis.RedisShard
+#    - id: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+#      iconUrl: classpath:///redis-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+#        name: Redis Cluster
+#        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+#    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+#      iconUrl: classpath:///hazelcast-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+#        name: Hazelcast Cluster
+#        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+#    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+#      iconUrl: classpath:///couchdb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+#    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+#      iconUrl: classpath:///couchbase-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+#        name: CouchBase Node
+#        description: Couchbase Server is an open source, distributed (shared-nothing architecture) 
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+#        name: MongoDB Sharded Deployment
+#    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+#      iconUrl: classpath:///cassandra-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+#        name: Apache Cassandra Node
+#        description: Cassandra is a highly scalable, eventually 
+#    - id: org.apache.brooklyn.entity.nosql.riak.RiakNode
+#      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.riak.RiakNode
+#        name: Riak Node
+#        description: Riak is a distributed NoSQL key-value data store that offers 
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+#        name: MongoDB Server
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+#        name: MongoDB Router
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+#    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+#        name: Elastic Search Node
+#        description: Elasticsearch is an open-source search server based on Lucene. 
+#    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+#      iconUrl: classpath:///cassandra-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+#        name: Apache Cassandra Database Fabric
+#        description: Cassandra is a highly scalable, eventually 
+#    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+#        name: Elastic Search Cluster
+#        description: Elasticsearch is an open-source search server based on Lucene. 
+#    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+#      iconUrl: classpath:///cassandra-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+#    - id: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+#      iconUrl: classpath:///redis-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+#    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+#      iconUrl: classpath:///couchbase-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+#        name: CouchBase Cluster
+#        description: Couchbase is an open source, distributed (shared-nothing architecture) 
+#    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+#      iconUrl: classpath:///couchbase-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+#    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+#      iconUrl: classpath:///hazelcast-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+#        name: Hazelcast Node
+#        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+#    - id: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+#      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+#        name: Riak Cluster
+#        description: Riak is a distributed NoSQL key-value data store that offers 
+#    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+#      iconUrl: classpath:///mongodb-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
 
-  # org.apache.brooklyn.software-network
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.network.bind.BindDnsServer
-      description: BIND is an Internet Domain Name Server.
-      item:
-        type: org.apache.brooklyn.entity.network.bind.BindDnsServer
-        name: BIND
+#  # org.apache.brooklyn.software-network
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.network.bind.BindDnsServer
+#      description: BIND is an Internet Domain Name Server.
+#      item:
+#        type: org.apache.brooklyn.entity.network.bind.BindDnsServer
+#        name: BIND
 
-  # org.apache.brooklyn.software-monitoring
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.monitoring.monit.MonitNode
-      iconUrl: classpath:///monit-logo.png
-      item:
-        type: org.apache.brooklyn.entity.monitoring.monit.MonitNode
-        name: Monit Node
-        description: Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system
+#  # org.apache.brooklyn.software-monitoring
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.monitoring.monit.MonitNode
+#      iconUrl: classpath:///monit-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.monitoring.monit.MonitNode
+#        name: Monit Node
+#        description: Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system
 
-  # org.apache.brooklyn.software-messaging
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
-      iconUrl: classpath:///activemq-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
-        name: ActiveMQ Broker
-        description: ActiveMQ is an open source message broker which fully implements the Java Message Service 1.1 (JMS)
-    - id: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
-      iconUrl: classpath:///qpid-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
-        name: Qpid Broker
-        description: Apache Qpid is an open-source messaging system, implementing the Advanced Message Queuing Protocol (AMQP)
-    - id: org.apache.brooklyn.entity.messaging.storm.Storm
-      iconUrl: classpath:///apache-storm-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.storm.Storm
-        name: Storm Node
-        description: Apache Storm is a distributed realtime computation system. 
-    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
-      iconUrl: classpath:///kafka-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
-        name: Kafka
-        description: Apache Kafka is a distributed publish-subscribe messaging system
-    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
-      iconUrl: classpath:///activemq-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
-    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
-      iconUrl: classpath:///zookeeper_logo.gif
-      item:
-        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
-        name: ZooKeeper ensemble
-        description: A cluster of ZooKeeper servers. 
-    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
-      iconUrl: classpath:///zookeeper_logo.gif
-      item:
-        type: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
-    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
-      iconUrl: classpath:///activemq-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
-    - id: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
-      iconUrl: classpath:///qpid-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
-    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
-      iconUrl: classpath:///zookeeper_logo.gif
-      item:
-        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
-        name: ZooKeeper Node
-        description: Apache ZooKeeper is a server which enables 
-    - id: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
-      iconUrl: classpath:///RabbitMQLogo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
-        name: RabbitMQ Broker
-        description: RabbitMQ is an open source message broker software (i.e. message-oriented middleware) that implements the Advanced Message Queuing Protocol (AMQP) standard
-    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
-      iconUrl: classpath:///kafka-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
-    - id: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
-      iconUrl: classpath:///qpid-logo.jpeg
-      item:
-        type: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
-    - id: org.apache.brooklyn.entity.messaging.storm.StormDeployment
-      iconUrl: classpath:///apache-storm-logo.png
-      item:
-        type: org.apache.brooklyn.entity.messaging.storm.StormDeployment
-        name: Storm Deployment
-        description: A Storm cluster. Apache Storm is a distributed realtime computation system. 
+#  # org.apache.brooklyn.software-messaging
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+#      iconUrl: classpath:///activemq-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+#        name: ActiveMQ Broker
+#        description: ActiveMQ is an open source message broker which fully implements the Java Message Service 1.1 (JMS)
+#    - id: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+#      iconUrl: classpath:///qpid-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+#        name: Qpid Broker
+#        description: Apache Qpid is an open-source messaging system, implementing the Advanced Message Queuing Protocol (AMQP)
+#    - id: org.apache.brooklyn.entity.messaging.storm.Storm
+#      iconUrl: classpath:///apache-storm-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.storm.Storm
+#        name: Storm Node
+#        description: Apache Storm is a distributed realtime computation system. 
+#    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+#      iconUrl: classpath:///kafka-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+#        name: Kafka
+#        description: Apache Kafka is a distributed publish-subscribe messaging system
+#    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+#      iconUrl: classpath:///activemq-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+#    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+#      iconUrl: classpath:///zookeeper_logo.gif
+#      item:
+#        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+#        name: ZooKeeper ensemble
+#        description: A cluster of ZooKeeper servers. 
+#    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+#      iconUrl: classpath:///zookeeper_logo.gif
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+#    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+#      iconUrl: classpath:///activemq-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+#    - id: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+#      iconUrl: classpath:///qpid-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+#    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+#      iconUrl: classpath:///zookeeper_logo.gif
+#      item:
+#        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+#        name: ZooKeeper Node
+#        description: Apache ZooKeeper is a server which enables 
+#    - id: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+#      iconUrl: classpath:///RabbitMQLogo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+#        name: RabbitMQ Broker
+#        description: RabbitMQ is an open source message broker software (i.e. message-oriented middleware) that implements the Advanced Message Queuing Protocol (AMQP) standard
+#    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+#      iconUrl: classpath:///kafka-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+#    - id: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+#      iconUrl: classpath:///qpid-logo.jpeg
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+#    - id: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+#      iconUrl: classpath:///apache-storm-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+#        name: Storm Deployment
+#        description: A Storm cluster. Apache Storm is a distributed realtime computation system. 
 
-  # org.apache.brooklyn.software-database
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.database.crate.CrateNode
-      iconUrl: classpath:///crate-logo.png
-      item:
-        type: org.apache.brooklyn.entity.database.crate.CrateNode
-    - id: org.apache.brooklyn.entity.database.mysql.MySqlNode
-      iconUrl: classpath:///mysql-logo-110x57.png
-      item:
-        type: org.apache.brooklyn.entity.database.mysql.MySqlNode
-        name: MySql Node
-        description: MySql is an open source relational database management system (RDBMS)
-    - id: org.apache.brooklyn.entity.database.mysql.MySqlCluster
-      iconUrl: classpath:///mysql-logo-110x57.png
-      item:
-        type: org.apache.brooklyn.entity.database.mysql.MySqlCluster
-        name: MySql Master-Slave cluster
-        description: Sets up a cluster of MySQL nodes using master-slave relation and binary logging
-    - id: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
-      iconUrl: classpath:///postgresql-logo-200px.png
-      item:
-        type: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
-        name: PostgreSQL Node
-        description: PostgreSQL is an object-relational database management system (ORDBMS)
-    - id: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
-      item:
-        type: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
-    - id: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
-      iconUrl: classpath:///mariadb-logo-180x119.png
-      item:
-        type: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
-        name: MariaDB Node
-        description: MariaDB is an open source relational database management system (RDBMS)
+#  # org.apache.brooklyn.software-database
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.database.crate.CrateNode
+#      iconUrl: classpath:///crate-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.database.crate.CrateNode
+#    - id: org.apache.brooklyn.entity.database.mysql.MySqlNode
+#      iconUrl: classpath:///mysql-logo-110x57.png
+#      item:
+#        type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+#        name: MySql Node
+#        description: MySql is an open source relational database management system (RDBMS)
+#    - id: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+#      iconUrl: classpath:///mysql-logo-110x57.png
+#      item:
+#        type: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+#        name: MySql Master-Slave cluster
+#        description: Sets up a cluster of MySQL nodes using master-slave relation and binary logging
+#    - id: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+#      iconUrl: classpath:///postgresql-logo-200px.png
+#      item:
+#        type: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+#        name: PostgreSQL Node
+#        description: PostgreSQL is an object-relational database management system (ORDBMS)
+#    - id: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+#      item:
+#        type: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+#    - id: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+#      iconUrl: classpath:///mariadb-logo-180x119.png
+#      item:
+#        type: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+#        name: MariaDB Node
+#        description: MariaDB is an open source relational database management system (RDBMS)
 
-  # org.apache.brooklyn.software-cm-salt
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.cm.salt.SaltEntity
-      iconUrl: classpath:///saltstack-logo.png
-      item:
-        type: org.apache.brooklyn.entity.cm.salt.SaltEntity
-        name: SaltEntity
-        description: Software managed by Salt CM
+#  # org.apache.brooklyn.software-cm-salt
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.cm.salt.SaltEntity
+#      iconUrl: classpath:///saltstack-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.cm.salt.SaltEntity
+#        name: SaltEntity
+#        description: Software managed by Salt CM
 
-  # org.apache.brooklyn.software-cm-ansible
-  - itemType: entity
-    items:
-    - id: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-      iconUrl: classpath:///ansible-logo.png
-      item:
-        type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-        name: AnsibleEntity
-        description: Software managed by Ansible CM
+#  # org.apache.brooklyn.software-cm-ansible
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+#      iconUrl: classpath:///ansible-logo.png
+#      item:
+#        type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+#        name: AnsibleEntity
+#        description: Software managed by Ansible CM
 
   # org.apache.brooklyn.test-framework
   - itemType: entity


### PR DESCRIPTION
brooklyn-libraries features are not installed at boot so can't reference them in the default catalog. The reason is that brooklyn-libraries is not yet built when the Karaf dist is assembled.