### PR TITLE
Create OptionalEntity to allow configurable addition of child entities

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import com.google.common.annotations.Beta;
+import com.google.common.reflect.TypeToken;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+/**
+ * An entity that creates an optional child, based on a configuration key value.
+ * <p>
+ * <pre>
+ * - type: org.apache.brooklyn.entity.stock.ConditionalEntity
+ *   brooklyn.config:
+ *     conditional.entity.create: $brooklyn:scopeRoot().config("enable.loadBalancer")
+ *     conditional.entity.spec:
+ *       $brooklyn:entitySpec:
+ *         type: load-balancer
+ *         brooklyn.config:
+ *           proxy.port: 8080
+ *           loadbalancer.serverpool: $brooklyn:entity("servers")
+ * </pre>
+ */
+@Beta
+@ImplementedBy(ConditionalEntityImpl.class)
+public interface ConditionalEntity extends BasicStartable {
+
+    @SetFromFlag("entitySpec")
+    ConfigKey<EntitySpec<?>> CONDITIONAL_ENTITY_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<?>>() { }, "conditional.entity.spec", "The entity specification to be created");
+
+    @SetFromFlag("create")
+    AttributeSensorAndConfigKey<Boolean, Boolean> CREATE_CONDITIONAL_ENTITY = ConfigKeys.newSensorAndConfigKey(Boolean.class, "conditional.entity.create", "Whether the entity should be created");
+
+    AttributeSensor<Entity> CONDITIONAL_ENTITY = Sensors.newSensor(Entity.class, "conditional.entity", "The created entity");
+
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import java.util.Collection;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+
+public class ConditionalEntityImpl extends BasicStartableImpl implements ConditionalEntity {
+
+    @Override
+    public void start(Collection<? extends Location> locations) {
+        Entity child = sensors().get(CONDITIONAL_ENTITY);
+        Boolean create = config().get(CREATE_CONDITIONAL_ENTITY);
+        if (Boolean.TRUE.equals(create) && child == null) {
+            EntitySpec<?> spec = Preconditions.checkNotNull(config().get(CONDITIONAL_ENTITY_SPEC));
+            Entity created = addChild(EntitySpec.create(spec));
+            sensors().set(CONDITIONAL_ENTITY, created);
+        }
+        super.start(locations);
+    }
+
+}
+

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/ConditionalEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/ConditionalEntityTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.core.location.SimulatedLocation;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+
+public class ConditionalEntityTest extends BrooklynAppUnitTestSupport {
+
+    private SimulatedLocation loc1;
+    private ConditionalEntity optional;
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        loc1 = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
+    }
+
+    @Test
+    public void testAddsConditionalWhenConfigured() throws Exception {
+        optional = app.addChild(EntitySpec.create(ConditionalEntity.class)
+                .configure(ConditionalEntity.CREATE_CONDITIONAL_ENTITY, true)
+                .configure(ConditionalEntity.CONDITIONAL_ENTITY_SPEC, EntitySpec.create(TestEntity.class)));
+        app.start(ImmutableList.of(loc1));
+
+        assertEquals(optional.getChildren().size(), 1);
+        Entity child = Iterables.getOnlyElement(optional.getChildren());
+        assertTrue(child instanceof TestEntity);
+        assertEquals(child, optional.sensors().get(ConditionalEntity.CONDITIONAL_ENTITY));
+    }
+
+    @Test
+    public void testConditionalSurvivesRestart() {
+        optional = app.addChild(EntitySpec.create(ConditionalEntity.class)
+                .configure(ConditionalEntity.CREATE_CONDITIONAL_ENTITY, true)
+                .configure(ConditionalEntity.CONDITIONAL_ENTITY_SPEC, EntitySpec.create(TestEntity.class)));
+        app.start(ImmutableList.of(loc1));
+        app.restart();
+
+        assertEquals(optional.getChildren().size(), 1);
+        Entity child = Iterables.getOnlyElement(optional.getChildren());
+        assertTrue(child instanceof TestEntity);
+        assertEquals(child, optional.sensors().get(ConditionalEntity.CONDITIONAL_ENTITY));
+    }
+
+    @Test
+    public void testDoesNotAddsConditionalWhenConfigured() throws Exception {
+        optional = app.addChild(EntitySpec.create(ConditionalEntity.class)
+                .configure(ConditionalEntity.CREATE_CONDITIONAL_ENTITY, false)
+                .configure(ConditionalEntity.CONDITIONAL_ENTITY_SPEC, EntitySpec.create(TestEntity.class)));
+        app.start(ImmutableList.of(loc1));
+
+        assertEquals(optional.getChildren().size(), 0);
+    }
+
+    @Test
+    public void testDoesNotAddsConditionalWhenNotConfigured() throws Exception {
+        optional = app.addChild(EntitySpec.create(ConditionalEntity.class)
+                .configure(ConditionalEntity.CONDITIONAL_ENTITY_SPEC, EntitySpec.create(TestEntity.class)));
+        app.start(ImmutableList.of(loc1));
+
+        assertEquals(optional.getChildren().size(), 0);
+    }
+
+}


### PR DESCRIPTION
Allows entity creation to be controlled using a configuration key value.