### PR TITLE
rest api: entity/spec returns unquoted text/x-yaml

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
@@ -221,9 +221,11 @@ public interface EntityApi {
             @ApiParam(value = "Entity ID or name", required = true)
             @PathParam("entity") String entity);
 
+    // see http://stackoverflow.com/questions/332129/yaml-mime-type for "@Produces"
     @GET
     @Path("/{entity}/spec")
     @ApiOperation(value = "Get the YAML spec used to create the entity, if available")
+    @Produces({"text/x-yaml", "application/x-yaml", "text/yaml", "text/plain", "application/yaml", MediaType.TEXT_PLAIN})
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Application or entity missing")
     })

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
@@ -218,6 +218,6 @@ public class EntityResource extends AbstractBrooklynRestResource implements Enti
         NamedStringTag spec = BrooklynTags.findFirst(BrooklynTags.YAML_SPEC_KIND, entity.tags().getTags());
         if (spec == null)
             return null;
-        return (String) WebResourceUtils.getValueForDisplay(spec.getContents(), true, true);
+        return (String) WebResourceUtils.getValueForDisplay(spec.getContents(), false, true);
     }
 }


### PR DESCRIPTION
Previously it returned json:
* it wrapped it in quotes.
* it did strange things with \n: the result rendered as “\n” rather than actual new-line characters (though it was more complicated than that - an angular UI did recognise the “\n” as a single character).