### PR TITLE
Added attribute to DSL for immediate return of sensor data

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -120,6 +120,10 @@ public class BrooklynDslCommon {
         return new DslComponent(Scope.THIS, "").config(keyName);
     }
 
+    public static BrooklynDslDeferredSupplier<?> attribute(String sensorName) {
+        return new DslComponent(Scope.THIS, "").attribute(sensorName);
+    }
+
     public static BrooklynDslDeferredSupplier<?> attributeWhenReady(String sensorName) {
         return new DslComponent(Scope.THIS, "").attributeWhenReady(sensorName);
     }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -239,17 +239,25 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
         }
     }
 
+    public BrooklynDslDeferredSupplier<?> attribute(final String sensorName) {
+        return new AttributeWhenReady(this, sensorName, Predicates.notNull());
+    }
     public BrooklynDslDeferredSupplier<?> attributeWhenReady(final String sensorName) {
         return new AttributeWhenReady(this, sensorName);
     }
     protected static class AttributeWhenReady extends BrooklynDslDeferredSupplier<Object> {
-        private static final long serialVersionUID = 1740899524088902383L;
+        private static final long serialVersionUID = 1740899524088903494L;
         private final DslComponent component;
         private final String sensorName;
+        private final Predicate readyCondition;
 
         public AttributeWhenReady(DslComponent component, String sensorName) {
+            this(component, sensorName, null);
+        }
+        public AttributeWhenReady(DslComponent component, String sensorName, Predicate<?> readyCondition) {
             this.component = Preconditions.checkNotNull(component);
             this.sensorName = sensorName;
+            this.readyCondition = readyCondition;
         }
 
         @SuppressWarnings("unchecked")
@@ -260,7 +268,11 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             if (!(targetSensor instanceof AttributeSensor<?>)) {
                 targetSensor = Sensors.newSensor(Object.class, sensorName);
             }
-            return (Task<Object>) DependentConfiguration.attributeWhenReady(targetEntity, (AttributeSensor<?>)targetSensor);
+            if (readyCondition != null) {
+                return (Task<Object>) DependentConfiguration.attributeWhenReady(targetEntity, (AttributeSensor<?>) targetSensor, readyCondition);
+            } else {
+                return (Task<Object>) DependentConfiguration.attributeWhenReady(targetEntity, (AttributeSensor<?>) targetSensor);
+            }
         }
 
         @Override

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -240,7 +240,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
     }
 
     public BrooklynDslDeferredSupplier<?> attribute(final String sensorName) {
-        return new AttributeWhenReady(this, sensorName, Predicates.notNull());
+        return new AttributeWhenReady(this, sensorName, Predicates.alwaysTrue());
     }
     public BrooklynDslDeferredSupplier<?> attributeWhenReady(final String sensorName) {
         return new AttributeWhenReady(this, sensorName);


### PR DESCRIPTION
Allows constructs like the following, where `cluster.first` usually has the boolean false value, and therefore `attributeWhenReady` will block waiting for it to become true. This lets us use boolean valued sensors more effectively.
```YAML
memberSpec:
  $brooklyn:entitySpec:
    type: vanilla-software-process
      brooklyn.config:
        first: $brooklyn:parent().attribute("cluster.first")
```
    