### PR TITLE
Conveniences to make groups easier to configure in YAML

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
@@ -53,7 +53,20 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         private Integer number;
         private Object object;
 
+        // Factory method.
+        public static TestObject newTestObject(String string, Integer number, Object object) {
+            return new TestObject(string + "-suffix", number + 1, object);
+        }
+
+        // No-arg constructor.
         public TestObject() { }
+
+        // Parameterised constructor.
+        public TestObject(String string, Integer number, Object object) {
+            this.string = string;
+            this.number = number;
+            this.object = object;
+        }
 
         public String getString() { return string; }
         public void setString(String string) { this.string = string; }
@@ -270,6 +283,57 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         Assert.assertTrue(managementContextInjected.get());
         Assert.assertEquals(((TestObject) testObject).getNumber(), Integer.valueOf(7));
         Assert.assertEquals(((TestObject) testObject).getString(), "frog");
+
+        Object testObjectObject = ((TestObject) testObject).getObject();
+        Assert.assertTrue(testObjectObject instanceof SimpleTestPojo, "Expected a SimpleTestPojo: "+testObjectObject);
+    }
+
+    @Test
+    public void testBrooklynObjectWithParameterisedConstructor() throws Exception {
+        Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
+            "  brooklyn.config:",
+            "    test.confObject:",
+            "      $brooklyn:object:",
+            "        type: "+ObjectsYamlTest.class.getName()+"$TestObject",
+            "        constructor.args:",
+            "        - frog",
+            "        - 7",
+            "        - $brooklyn:object:",
+            "            type: org.apache.brooklyn.camp.brooklyn.SimpleTestPojo"
+        );
+
+        Object testObject = testEntity.getConfig(TestEntity.CONF_OBJECT);
+
+        Assert.assertTrue(testObject instanceof TestObject, "Expected a TestObject: "+testObject);
+        Assert.assertTrue(managementContextInjected.get());
+        Assert.assertEquals(((TestObject) testObject).getNumber(), Integer.valueOf(7));
+        Assert.assertEquals(((TestObject) testObject).getString(), "frog");
+
+        Object testObjectObject = ((TestObject) testObject).getObject();
+        Assert.assertTrue(testObjectObject instanceof SimpleTestPojo, "Expected a SimpleTestPojo: "+testObjectObject);
+    }
+
+    @Test
+    public void testBrooklynObjectWithFactoryMethod() throws Exception {
+        Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
+            "  brooklyn.config:",
+            "    test.confObject:",
+            "      $brooklyn:object:",
+            "        type: "+ObjectsYamlTest.class.getName()+"$TestObject",
+            "        factoryMethod.name: newTestObject",
+            "        factoryMethod.args:",
+            "        - frog",
+            "        - 7",
+            "        - $brooklyn:object:",
+            "            type: org.apache.brooklyn.camp.brooklyn.SimpleTestPojo"
+        );
+
+        Object testObject = testEntity.getConfig(TestEntity.CONF_OBJECT);
+
+        Assert.assertTrue(testObject instanceof TestObject, "Expected a TestObject: "+testObject);
+        Assert.assertTrue(managementContextInjected.get());
+        Assert.assertEquals(((TestObject) testObject).getNumber(), Integer.valueOf(8));
+        Assert.assertEquals(((TestObject) testObject).getString(), "frog-suffix");
 
         Object testObjectObject = ((TestObject) testObject).getObject();
         Assert.assertTrue(testObjectObject instanceof SimpleTestPojo, "Expected a SimpleTestPojo: "+testObjectObject);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityPredicates.java
@@ -29,6 +29,8 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.guava.SerializablePredicate;
 import org.apache.brooklyn.util.javalang.Reflections;
@@ -171,11 +173,35 @@ public class EntityPredicates {
     }
 
     // ---------------------------
-    
+
+    public static Predicate<Entity> attributeNotNull(final String attributeName) {
+        return attributeSatisfies(attributeName, Predicates.notNull());
+    }
+
+    public static <T> Predicate<Entity> attributeNotNull(final AttributeSensor<T> attribute) {
+        return attributeSatisfies(attribute, Predicates.<T>notNull());
+    }
+
+    public static Predicate<Entity> attributeEqualTo(final String attributeName, final Object val) {
+        return attributeSatisfies(attributeName, Predicates.equalTo(val));
+    }
+
     public static <T> Predicate<Entity> attributeEqualTo(final AttributeSensor<T> attribute, final T val) {
         return attributeSatisfies(attribute, Predicates.equalTo(val));
     }
-    
+
+    public static <T> Predicate<Entity> attributeNotEqualTo(final String attributeName, final Object val) {
+        return attributeSatisfies(attributeName, Predicates.not(Predicates.equalTo(val)));
+    }
+
+    public static <T> Predicate<Entity> attributeNotEqualTo(final AttributeSensor<T> attribute, final T val) {
+        return attributeSatisfies(attribute, Predicates.not(Predicates.equalTo(val)));
+    }
+
+    public static Predicate<Entity> attributeSatisfies(final String attributeName, final Predicate<Object> condition) {
+        return new AttributeSatisfies<Object>(Sensors.newSensor(Object.class, attributeName), condition);
+    }
+
     public static <T> Predicate<Entity> attributeSatisfies(final AttributeSensor<T> attribute, final Predicate<T> condition) {
         return new AttributeSatisfies<T>(attribute, condition);
     }
@@ -208,22 +234,50 @@ public class EntityPredicates {
         };
     }
     
-    public static <T> Predicate<Entity> attributeNotEqualTo(final AttributeSensor<T> attribute, final T val) {
-        return attributeSatisfies(attribute, Predicates.not(Predicates.equalTo(val)));
+    // ---------------------------
+
+    public static <T> Predicate<Entity> configNotNull(final String configKeyName) {
+        return configSatisfies(configKeyName, Predicates.notNull());
     }
 
-    // ---------------------------
+    public static <T> Predicate<Entity> configNotNull(final ConfigKey<T> configKey) {
+        return configSatisfies(configKey, Predicates.<T>notNull());
+    }
+
+    public static <T> Predicate<Entity> configNotNull(final HasConfigKey<T> configKey) {
+        return configNotNull(configKey.getConfigKey());
+    }
+
+    public static <T> Predicate<Entity> configEqualTo(final String configKeyName, final Object val) {
+        return configSatisfies(configKeyName, Predicates.equalTo(val));
+    }
 
     public static <T> Predicate<Entity> configEqualTo(final ConfigKey<T> configKey, final T val) {
         return configSatisfies(configKey, Predicates.equalTo(val));
     }
 
-    public static <T> Predicate<Entity> configSatisfies(final ConfigKey<T> configKey, final Predicate<T> condition) {
-        return new ConfigKeySatisfies<T>(configKey, condition);
-    }
-
     public static <T> Predicate<Entity> configEqualTo(final HasConfigKey<T> configKey, final T val) {
         return configEqualTo(configKey.getConfigKey(), val);
+    }
+
+    public static <T> Predicate<Entity> configNotEqualTo(final String configKeyName, final Object val) {
+        return configSatisfies(configKeyName, Predicates.not(Predicates.equalTo(val)));
+    }
+
+    public static <T> Predicate<Entity> configNotEqualTo(final ConfigKey<T> configKey, final T val) {
+        return configSatisfies(configKey, Predicates.not(Predicates.equalTo(val)));
+    }
+
+    public static <T> Predicate<Entity> configNotEqualTo(final HasConfigKey<T> configKey, final T val) {
+        return configNotEqualTo(configKey.getConfigKey(), val);
+    }
+
+    public static Predicate<Entity> configSatisfies(final String configKeyName, final Predicate<Object> condition) {
+        return new ConfigKeySatisfies<Object>(ConfigKeys.newConfigKey(Object.class, configKeyName), condition);
+    }
+
+    public static <T> Predicate<Entity> configSatisfies(final ConfigKey<T> configKey, final Predicate<T> condition) {
+        return new ConfigKeySatisfies<T>(configKey, condition);
     }
 
     public static <T> Predicate<Entity> configSatisfies(final HasConfigKey<T> configKey, final Predicate<T> condition) {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityFunctionsTest.java
@@ -49,6 +49,9 @@ public class EntityFunctionsTest extends BrooklynAppUnitTestSupport {
     public void testAttribute() throws Exception {
         entity.sensors().set(TestEntity.NAME, "myname");
         assertEquals(EntityFunctions.attribute(TestEntity.NAME).apply(entity), "myname");
+        assertEquals(EntityFunctions.attribute(TestEntity.NAME.getName()).apply(entity), "myname");
+        assertEquals(EntityFunctions.attribute(TestEntity.NAME, "%s - suffix").apply(entity), "myname - suffix");
+        assertEquals(EntityFunctions.attribute(TestEntity.NAME.getName(), "%s - suffix").apply(entity), "myname - suffix");
         assertNull(EntityFunctions.attribute(TestEntity.SEQUENCE).apply(entity));
     }
 
@@ -57,24 +60,27 @@ public class EntityFunctionsTest extends BrooklynAppUnitTestSupport {
         entity.sensors().set(TestEntity.NAME, "myname");
         assertEquals(EntityFunctions.attribute(entity, TestEntity.NAME).apply(new Object()), "myname");
     }
-    
+
     @Test
     public void testConfig() throws Exception {
         entity.config().set(TestEntity.CONF_NAME, "myname");
         assertEquals(EntityFunctions.config(TestEntity.CONF_NAME).apply(entity), "myname");
+        assertEquals(EntityFunctions.config(TestEntity.CONF_NAME.getName()).apply(entity), "myname");
+        assertEquals(EntityFunctions.config(TestEntity.CONF_NAME, "%s - suffix").apply(entity), "myname - suffix");
+        assertEquals(EntityFunctions.config(TestEntity.CONF_NAME.getName(), "%s - suffix").apply(entity), "myname - suffix");
         assertNull(EntityFunctions.config(TestEntity.CONF_OBJECT).apply(entity));
     }
-    
+
     @Test
     public void testDisplayName() throws Exception {
         assertEquals(EntityFunctions.displayName().apply(entity), "mydisplayname");
     }
-    
+
     @Test
     public void testId() throws Exception {
         assertEquals(EntityFunctions.id().apply(entity), entity.getId());
     }
-    
+
     @Test
     public void testLocationMatching() throws Exception {
         entity.addLocations(ImmutableList.of(loc));

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityPredicatesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityPredicatesTest.java
@@ -40,7 +40,7 @@ public class EntityPredicatesTest extends BrooklynAppUnitTestSupport {
     private TestEntity entity;
     private BasicGroup group;
     private Location loc;
-    
+
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
@@ -55,33 +55,73 @@ public class EntityPredicatesTest extends BrooklynAppUnitTestSupport {
         assertTrue(EntityPredicates.applicationIdEqualTo(app.getId()).apply(entity));
         assertFalse(EntityPredicates.applicationIdEqualTo("wrongid").apply(entity));
     }
-    
+
     @Test
     public void testIdEqualTo() throws Exception {
         assertTrue(EntityPredicates.idEqualTo(entity.getId()).apply(entity));
         assertFalse(EntityPredicates.idEqualTo("wrongid").apply(entity));
     }
-    
+
+    @Test
+    public void testAttributeNotNull() throws Exception {
+        entity.sensors().set(TestEntity.NAME, "myname");
+        assertTrue(EntityPredicates.attributeNotNull(TestEntity.NAME).apply(entity));
+        assertTrue(EntityPredicates.attributeNotNull(TestEntity.NAME.getName()).apply(entity));
+        assertFalse(EntityPredicates.attributeNotNull(TestEntity.SEQUENCE).apply(entity));
+        assertFalse(EntityPredicates.attributeNotNull(TestEntity.SEQUENCE.getName()).apply(entity));
+    }
+
     @Test
     public void testAttributeEqualTo() throws Exception {
         entity.sensors().set(TestEntity.NAME, "myname");
         assertTrue(EntityPredicates.attributeEqualTo(TestEntity.NAME, "myname").apply(entity));
+        assertTrue(EntityPredicates.attributeEqualTo(TestEntity.NAME.getName(), "myname").apply(entity));
         assertFalse(EntityPredicates.attributeEqualTo(TestEntity.NAME, "wrongname").apply(entity));
+        assertFalse(EntityPredicates.attributeEqualTo(TestEntity.NAME.getName(), "wrongname").apply(entity));
     }
-    
+
+    @Test
+    public void testAttributeNotEqualTo() throws Exception {
+        entity.sensors().set(TestEntity.NAME, "myname");
+        assertFalse(EntityPredicates.attributeNotEqualTo(TestEntity.NAME, "myname").apply(entity));
+        assertFalse(EntityPredicates.attributeNotEqualTo(TestEntity.NAME.getName(), "myname").apply(entity));
+        assertTrue(EntityPredicates.attributeNotEqualTo(TestEntity.NAME, "wrongname").apply(entity));
+        assertTrue(EntityPredicates.attributeNotEqualTo(TestEntity.NAME.getName(), "wrongname").apply(entity));
+    }
+
+    @Test
+    public void testConfigNotNull() throws Exception {
+        entity.config().set(TestEntity.CONF_NAME, "myname");
+        assertTrue(EntityPredicates.configNotNull(TestEntity.CONF_NAME).apply(entity));
+        assertTrue(EntityPredicates.configNotNull(TestEntity.CONF_NAME.getName()).apply(entity));
+        assertFalse(EntityPredicates.configNotNull(TestEntity.CONF_OBJECT).apply(entity));
+        assertFalse(EntityPredicates.configNotNull(TestEntity.CONF_OBJECT.getName()).apply(entity));
+    }
+
     @Test
     public void testConfigEqualTo() throws Exception {
         entity.config().set(TestEntity.CONF_NAME, "myname");
         assertTrue(EntityPredicates.configEqualTo(TestEntity.CONF_NAME, "myname").apply(entity));
+        assertTrue(EntityPredicates.configEqualTo(TestEntity.CONF_NAME.getName(), "myname").apply(entity));
         assertFalse(EntityPredicates.configEqualTo(TestEntity.CONF_NAME, "wrongname").apply(entity));
+        assertFalse(EntityPredicates.configEqualTo(TestEntity.CONF_NAME.getName(), "wrongname").apply(entity));
     }
-    
+
+    @Test
+    public void testConfigNotEqualTo() throws Exception {
+        entity.config().set(TestEntity.CONF_NAME, "myname");
+        assertFalse(EntityPredicates.configNotEqualTo(TestEntity.CONF_NAME, "myname").apply(entity));
+        assertFalse(EntityPredicates.configNotEqualTo(TestEntity.CONF_NAME.getName(), "myname").apply(entity));
+        assertTrue(EntityPredicates.configNotEqualTo(TestEntity.CONF_NAME, "wrongname").apply(entity));
+        assertTrue(EntityPredicates.configNotEqualTo(TestEntity.CONF_NAME.getName(), "wrongname").apply(entity));
+    }
+
     @Test
     public void testDisplayNameEqualTo() throws Exception {
         assertTrue(EntityPredicates.displayNameEqualTo("mydisplayname").apply(entity));
         assertFalse(EntityPredicates.displayNameEqualTo("wrongname").apply(entity));
     }
-    
+
     @Test
     public void testDisplayNameSatisfies() throws Exception {
         assertTrue(EntityPredicates.displayNameSatisfies(StringPredicates.matchesRegex("myd.*me")).apply(entity));
@@ -94,7 +134,7 @@ public class EntityPredicatesTest extends BrooklynAppUnitTestSupport {
         assertFalse(EntityPredicates.isChildOf(entity).apply(entity));
         assertFalse(EntityPredicates.isChildOf(entity).apply(app));
     }
-    
+
     @Test
     public void testIsMemberOf() throws Exception {
         group.addMember(entity);
@@ -102,14 +142,14 @@ public class EntityPredicatesTest extends BrooklynAppUnitTestSupport {
         assertFalse(EntityPredicates.isMemberOf(group).apply(app));
         assertFalse(EntityPredicates.isMemberOf(group).apply(group));
     }
-    
+
     @Test
     public void testManaged() throws Exception {
         assertTrue(EntityPredicates.isManaged().apply(entity));
         Entities.unmanage(entity);
         assertFalse(EntityPredicates.isManaged().apply(entity));
     }
-    
+
     @Test
     public void testWithLocation() throws Exception {
         entity.addLocations(ImmutableList.of(loc));


### PR DESCRIPTION
* Extends `$brooklyn:object()` syntax to support parameterised constructors and static factory methods
* Adds variants of `EntityPredicates.config*()` and `attribute*()` that accept strings
* Adds variants of `EntityFunctions.config()` and `attribute()` that accept strings
* Adds variants of `EntityFunctions.config()` and `attribute()` that accept format specifier
