### PR TITLE
Move tests temporary folders to the target folder

### DIFF
--- a/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
@@ -71,6 +71,7 @@ public class CleanOrphanedLocationsIntegrationTest extends AbstractCleanOrphaned
 
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.builderDefault().build();
         brooklynProperties.put(BrooklynServerConfig.MGMT_BASE_DIR.getName(), "");
+        brooklynProperties.put(BrooklynServerConfig.OSGI_CACHE_DIR, "target/" + BrooklynServerConfig.OSGI_CACHE_DIR.getDefaultValue());
 
         managementContext = new LocalManagementContext(brooklynProperties);
 


### PR DESCRIPTION
On Windows some leftover files remain in the `osgi/cache` folder, triggering the rat plugin failure. It's a temporary folder so move it to the build folder.