### PR TITLE
Change conditional entity to reflect service state of optional child

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntity.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.entity.stock;
 
+import java.util.Collection;
+
 import com.google.common.annotations.Beta;
 import com.google.common.reflect.TypeToken;
 
@@ -44,6 +46,10 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
  *         brooklyn.config:
  *           proxy.port: 8080
  *           loadbalancer.serverpool: $brooklyn:entity("servers")
+ *     conditional.entity.propagate: true
+ *     conditional.entity.sensors:
+ *       - $brooklyn:sensor("proxy.http.port")
+ *       - $brooklyn:sensor("main.uri")
  * </pre>
  */
 @Beta
@@ -51,11 +57,22 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface ConditionalEntity extends BasicStartable {
 
     @SetFromFlag("entitySpec")
-    ConfigKey<EntitySpec<?>> CONDITIONAL_ENTITY_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<?>>() { }, "conditional.entity.spec", "The entity specification to be created");
+    ConfigKey<EntitySpec<?>> CONDITIONAL_ENTITY_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<?>>() { },
+            "conditional.entity.spec", "The entity specification to be created");
 
     @SetFromFlag("create")
-    AttributeSensorAndConfigKey<Boolean, Boolean> CREATE_CONDITIONAL_ENTITY = ConfigKeys.newSensorAndConfigKey(Boolean.class, "conditional.entity.create", "Whether the entity should be created");
+    AttributeSensorAndConfigKey<Boolean, Boolean> CREATE_CONDITIONAL_ENTITY = ConfigKeys.newSensorAndConfigKey(Boolean.class,
+            "conditional.entity.create", "Whether the entity should be created");
 
-    AttributeSensor<Entity> CONDITIONAL_ENTITY = Sensors.newSensor(Entity.class, "conditional.entity", "The created entity");
+    @SetFromFlag("propagateSensors")
+    ConfigKey<Boolean> PROPAGATE_CONDITIONAL_ENTITY_SENSORS = ConfigKeys.newBooleanConfigKey(
+            "conditional.entity.propagate", "Whether sensors are to be propagated from the child entity", Boolean.TRUE);
+
+    @SetFromFlag("sensorsToPropagate")
+    ConfigKey<Collection<AttributeSensor<?>>> CONDITIONAL_ENTITY_SENSOR_LIST = ConfigKeys.newConfigKey(new TypeToken<Collection<AttributeSensor<?>>>() { },
+            "conditional.entity.sensors", "Collection of sensors that are to be propagated from the child entity (all usual sensors if not set, or empty)");
+
+    AttributeSensor<Entity> CONDITIONAL_ENTITY = Sensors.newSensor(Entity.class,
+            "conditional.entity", "The created entity");
 
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
@@ -33,10 +33,12 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ComputeServiceIndicatorsFromChildrenAndMembers;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.enricher.stock.Enrichers;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 
@@ -72,8 +74,11 @@ public class ConditionalEntityImpl extends BasicStartableImpl implements Conditi
                 child = addChild(EntitySpec.create(spec));
                 sensors().set(CONDITIONAL_ENTITY, child);
 
-                // Add enrichers for sensor propagateion
+                // Add enrichers for sensor propagation
                 enrichers().add(Enrichers.builder().propagating(Startable.SERVICE_UP).from(child).build());
+                enrichers().add(ServiceStateLogic.newEnricherFromChildrenState()
+                        .suppressDuplicates(true)
+                        .configure(ComputeServiceIndicatorsFromChildrenAndMembers.RUNNING_QUORUM_CHECK, QuorumCheck.QuorumChecks.all()));
                 if (Boolean.TRUE.equals(propagate)) {
                     if (sensors.isEmpty()) {
                         enrichers().add(Enrichers.builder().propagatingAllButUsualAnd().from(child).build());

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/ConditionalEntityImpl.java
@@ -19,26 +19,88 @@
 package org.apache.brooklyn.entity.stock;
 
 import java.util.Collection;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.enricher.stock.Enrichers;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.time.Duration;
 
 public class ConditionalEntityImpl extends BasicStartableImpl implements ConditionalEntity {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BasicStartableImpl.class);
+
     @Override
     public void start(Collection<? extends Location> locations) {
-        Entity child = sensors().get(CONDITIONAL_ENTITY);
-        EntitySpec<?> spec = config().get(CONDITIONAL_ENTITY_SPEC);
-        Boolean create = config().get(CREATE_CONDITIONAL_ENTITY);
+        try {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
+            sensors().set(Attributes.SERVICE_UP, false);
 
-        // Child not yet created; Entity spec is present; Create flag is true
-        if (child == null && spec != null && Boolean.TRUE.equals(create)) {
-            Entity created = addChild(EntitySpec.create(spec));
-            sensors().set(CONDITIONAL_ENTITY, created);
+            // Block startup until other dependent components are available
+            Object val = config().get(START_LATCH);
+            if (val != null) {
+                LOG.debug("Finished waiting for start-latch in {}", this);
+            }
+
+            Entity child = sensors().get(CONDITIONAL_ENTITY);
+            EntitySpec<?> spec = config().get(CONDITIONAL_ENTITY_SPEC);
+            Boolean create = config().get(CREATE_CONDITIONAL_ENTITY);
+            Boolean propagate = config().get(PROPAGATE_CONDITIONAL_ENTITY_SENSORS);
+            Set<AttributeSensor<?>> sensors = MutableSet.copyOf(config().get(CONDITIONAL_ENTITY_SENSOR_LIST));
+            Duration timeout = config().get(BrooklynConfigKeys.START_TIMEOUT);
+
+            addLocations(locations);
+            locations = Locations.getLocationsCheckingAncestors(locations, this);
+            LOG.info("Starting entity {}: {}", this, locations);
+
+            // Child not yet created; Entity spec is present; Create flag is true
+            if (child == null && spec != null && Boolean.TRUE.equals(create)) {
+                child = addChild(EntitySpec.create(spec));
+                sensors().set(CONDITIONAL_ENTITY, child);
+
+                // Add enrichers for sensor propagateion
+                enrichers().add(Enrichers.builder().propagating(Startable.SERVICE_UP).from(child).build());
+                if (Boolean.TRUE.equals(propagate)) {
+                    if (sensors.isEmpty()) {
+                        enrichers().add(Enrichers.builder().propagatingAllButUsualAnd().from(child).build());
+                    } else {
+                        enrichers().add(Enrichers.builder().propagating(sensors).from(child).build());
+                    }
+                }
+            }
+
+            // Start child if create flag is set; otherwise just set service.isUp
+            if (Boolean.TRUE.equals(create)) {
+                LOG.info("Starting child {}: {}", child, locations);
+                if (Entities.invokeEffectorWithArgs(this, child, Startable.START, locations).blockUntilEnded(timeout)) {
+                    LOG.debug("Successfully started {} by {}", child, this);
+                } else {
+                    throw new IllegalStateException(String.format("Timed out while %s was starting %s", this, child));
+                }
+            } else {
+                LOG.debug("No child created, setting SERVICE_UP to true");
+                sensors().set(Attributes.SERVICE_UP, true);
+            }
+
+            ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
+        } catch (Throwable t) {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
+            throw Exceptions.propagate(t);
         }
-        super.start(locations);
     }
-
 }
 


### PR DESCRIPTION
Adds an enricher that propagates `service.isUp` from the child entity, if one is created. This allows other entities to use the `service.isUp` sensor of the `ConditionalEntity` as a latch, without needing to know the identity (or even presence) of the child. A configuration setting enables propagation of other sensors from the child.