### PR TITLE
Location DSL Updates

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/LocationSpecConfiguration.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/LocationSpecConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.spi.creation;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+
+import org.apache.brooklyn.api.location.LocationSpec;
+
+/**
+ * Captures the {@link LocationSpec} configuration defined in YAML. 
+ * 
+ * This class does not parse that output; it just stores it.
+ */
+public class LocationSpecConfiguration {
+
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(LocationSpecConfiguration.class);
+
+    private Map<String, Object> specConfiguration;
+
+    public LocationSpecConfiguration(Map<String, ?> specConfiguration) {
+        this.specConfiguration = Maps.newHashMap(checkNotNull(specConfiguration, "specConfiguration"));
+    }
+
+    public Map<String, Object> getSpecConfiguration() {
+        return specConfiguration;
+    }
+    
+    /**
+     * Allows BrooklynComponentTemplateResolver to traverse the configuration and resolve any entity specs
+     */
+    public void setSpecConfiguration(Map<String, Object> specConfiguration) {
+       this.specConfiguration =  specConfiguration;
+    }
+}

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -49,6 +49,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynYamlTypeInstantiator;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.EntitySpecConfiguration;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.LocationSpecConfiguration;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
 import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
@@ -176,6 +177,10 @@ public class BrooklynDslCommon {
 
     public static EntitySpecConfiguration entitySpec(Map<String, Object> arguments) {
         return new EntitySpecConfiguration(arguments);
+    }
+
+    public static LocationSpecConfiguration locationSpec(Map<String, Object> arguments) {
+        return new LocationSpecConfiguration(arguments);
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
@@ -18,39 +18,41 @@
  */
 package org.apache.brooklyn.entity.group;
 
+import java.util.List;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.factory.EntityFactory;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
-
 /**
- * When a dynamic fabric is started, it starts an entity in each of its locations. 
- * This entity will be the parent of each of the started entities. 
+ * When a dynamic fabric is started, it starts an entity in each of its locations.
+ * This entity will be the parent of each of the started entities.
  */
 @ImplementedBy(DynamicFabricImpl.class)
 @SuppressWarnings("serial")
 public interface DynamicFabric extends AbstractGroup, Startable, Fabric {
 
     public static final AttributeSensor<Integer> FABRIC_SIZE = Sensors.newIntegerSensor("fabric.size", "Fabric size");
-    
+
     @SetFromFlag("memberSpec")
     public static final ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
-            new TypeToken<EntitySpec<?>>() {}, "dynamiccfabric.memberspec", "entity spec for creating new cluster members", null);
+            new TypeToken<EntitySpec<?>>() {}, "dynamiccfabric.memberspec", "Entity specification for creating new cluster members", null);
 
-    @SetFromFlag("factory")
-    public static final ConfigKey<EntityFactory<?>> FACTORY = ConfigKeys.newConfigKey(
-        new TypeToken<EntityFactory<?>>() {}, "dynamicfabric.factory", "factory for creating new cluster members", null);
+    @SetFromFlag("locationSpecs")
+    public static final ConfigKey<List<LocationSpec<?>>> LOCATION_SPECS = ConfigKeys.newConfigKey(
+            new TypeToken<List<LocationSpec<?>>>() {}, "dynamiccfabric.locationspecs", "List of location specifications for starting new cluster members", null);
 
     @SetFromFlag("displayNamePrefix")
     public static final ConfigKey<String> DISPLAY_NAME_PREFIX = ConfigKeys.newStringConfigKey(
@@ -67,9 +69,7 @@ public interface DynamicFabric extends AbstractGroup, Startable, Fabric {
     public static final AttributeSensor<Lifecycle> SERVICE_STATE_ACTUAL = Attributes.SERVICE_STATE_ACTUAL;
 
     public void setMemberSpec(EntitySpec<?> memberSpec);
-    
-    public void setFactory(EntityFactory<?> factory);
-    
+
     public Integer getFabricSize();
 
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtils.java
@@ -33,6 +33,20 @@ import java.util.concurrent.Future;
 
 import javax.ws.rs.core.MediaType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Application;
@@ -70,19 +84,6 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.javalang.Reflections;
 import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.text.Strings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.io.Files;
 
 public class BrooklynRestResourceUtils {
 
@@ -365,13 +366,11 @@ public class BrooklynRestResourceUtils {
                 configureRenderingMetadata(spec, coreSpec);
 
                 coreSpec.child(toCoreEntitySpec(itemAndClass.clazz, name, configO, itemAndClass.catalogItemId)
-                    .configure(BrooklynCampConstants.PLAN_ID, "soleChildId"));
+                        .configure(BrooklynCampConstants.PLAN_ID, "soleChildId"));
                 coreSpec.enricher(Enrichers.builder()
-                    .propagatingAllBut(Attributes.SERVICE_UP, Attributes.SERVICE_NOT_UP_INDICATORS, 
-                        Attributes.SERVICE_STATE_ACTUAL, Attributes.SERVICE_STATE_EXPECTED, 
-                        Attributes.SERVICE_PROBLEMS)
-                        .from(new DslComponent(Scope.CHILD, "soleChildId").newTask())
-                        .build());
+                        .propagatingAllBut(Attributes.SERVICE_UP, Attributes.SERVICE_NOT_UP_INDICATORS,
+                                Attributes.SERVICE_STATE_ACTUAL, Attributes.SERVICE_STATE_EXPECTED, Attributes.SERVICE_PROBLEMS)
+                        .from(new DslComponent<Entity>(Scope.CHILD, "soleChildId").newTask()).build());
 
                 log.info("REST placing '{}' under management", spec.getName());
                 instance = (Application) mgmt.getEntityManager().createEntity(coreSpec);

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCaseImpl.java
@@ -59,7 +59,7 @@ public class RelativeEntityTestCaseImpl extends TargetableTestComponentImpl impl
         } else if (!(component.get() instanceof DslComponent)) {
             throw new IllegalArgumentException("Expected DslComponent value for component, found " + component.get());
         }
-        DslComponent finder = DslComponent.class.cast(component.get());
+        DslComponent<Entity> finder = DslComponent.class.cast(component.get());
         Task<Entity> task = Entities.submit(anchor, finder);
         return task.getUnchecked();
     }


### PR DESCRIPTION
- Adds a `$brooklyn:location()` command to the DSL to enable retrieval of location config keys
- Adds a `$brooklyn:locationSpec:` command to the DSL to enable defining `LocationSpec<?>` objects in YAML
- Updates `DynamicFabric` with configuration key that accepts a list of `LocationSpec<?>` objects that will be used as extra locations to create clusters
- Removed deprecated `EntityFactory` usage from fabric
