### PR TITLE
Adds a target configuration to the SSH command executing member tracker

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -196,7 +196,11 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
             "entity.group.added", "Group dynamically added to entity");
     public static final BasicNotificationSensor<Group> GROUP_REMOVED = new BasicNotificationSensor<Group>(Group.class,
             "entity.group.removed", "Group dynamically removed from entity");
-    
+
+    public static final AttributeSensor<String> ENTITY_ID = Attributes.ENTITY_ID;
+    public static final AttributeSensor<String> APPLICATION_ID = Attributes.APPLICATION_ID;
+    public static final AttributeSensor<String> CATALOG_ID = Attributes.CATALOG_ID;
+
     static {
         RendererHints.register(Entity.class, RendererHints.displayValue(EntityFunctions.displayName()));
     }
@@ -1615,7 +1619,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     // -------- INITIALIZATION --------------
 
     /**
-     * Default entity initialization, just calls {@link #initEnrichers()}.
+     * Default entity initialization sets ID sensors and calls {@link #initEnrichers()}.
      */
     public void init() {
         super.init();
@@ -1623,6 +1627,9 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         if (Strings.isNonBlank(getConfig(DEFAULT_DISPLAY_NAME))) {
             setDefaultDisplayName(getConfig(DEFAULT_DISPLAY_NAME));
         }
+        sensors().set(ENTITY_ID, getId());
+        sensors().set(APPLICATION_ID, getApplicationId());
+        sensors().set(CATALOG_ID, getCatalogItemId());
     }
     
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
@@ -42,7 +42,11 @@ import com.google.common.reflect.TypeToken;
  * This interface should be used to access {@link Sensor} definitions.
  */
 public interface Attributes {
-    
+
+    AttributeSensor<String> ENTITY_ID = Sensors.newStringSensor("entity.id");
+    AttributeSensor<String> APPLICATION_ID = Sensors.newStringSensor("application.id");
+    AttributeSensor<String> CATALOG_ID = Sensors.newStringSensor("catalog.id");
+
     BasicNotificationSensor<Void> LOCATION_CHANGED = new BasicNotificationSensor<Void>(
             Void.class, "entity.locationChanged", "Indicates that an entity's location has been changed");
 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractMultipleSensorAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractMultipleSensorAggregator.java
@@ -42,20 +42,19 @@ public abstract class AbstractMultipleSensorAggregator<U> extends AbstractAggreg
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractMultipleSensorAggregator.class);
 
-    
     /** access via {@link #getValues(Sensor)} */
     private final Map<String, Map<Entity,Object>> values = Collections.synchronizedMap(new LinkedHashMap<String, Map<Entity,Object>>());
 
-    public AbstractMultipleSensorAggregator() {}
+    public AbstractMultipleSensorAggregator() { }
 
     protected abstract Collection<Sensor<?>> getSourceSensors();
-    
+
     @Override
     protected void setEntityLoadingConfig() {
         super.setEntityLoadingConfig();
         Preconditions.checkNotNull(getSourceSensors(), "sourceSensors must be set");
     }
-    
+
     @Override
     protected void setEntityBeforeSubscribingProducerChildrenEvents() {
         BrooklynLogging.log(LOG, BrooklynLogging.levelDebugOrTraceIfReadOnly(producer),
@@ -95,7 +94,7 @@ public abstract class AbstractMultipleSensorAggregator<U> extends AbstractAggreg
                     vs = new LinkedHashMap<Entity,Object>();
                     values.put(sensor.getName(), vs);
                 }
-                
+
                 Object vo = vs.get(producer);
                 if (vo==null) {
                     Object initialVal;
@@ -107,11 +106,10 @@ public abstract class AbstractMultipleSensorAggregator<U> extends AbstractAggreg
                     vs.put(producer, initialVal != null ? initialVal : defaultMemberValue);
                     // NB: see notes on possible race, in Aggregator#onProducerAdded
                 }
-                
             }
         }
     }
-    
+
     @Override
     protected void onProducerRemoved(Entity producer) {
         synchronized (values) {
@@ -163,7 +161,7 @@ public abstract class AbstractMultipleSensorAggregator<U> extends AbstractAggreg
             return MutableMap.copyOf(sv).asUnmodifiable();
         }
     }
-    
+
     @Override
     protected abstract Object compute();
 }

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Enrichers.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Enrichers.java
@@ -161,7 +161,11 @@ public class Enrichers {
         }
         /** as {@link #combining(Collection)} but the collection of values comes from the given sensor on multiple entities */
         public <S> AggregatorBuilder<S, Object> aggregating(AttributeSensor<S> val) {
-            return new AggregatorBuilder<S,Object>(val);
+            return new AggregatorBuilder<S, Object>(val);
+        }
+        /** as {@link #combining(Collection)} but the collection of values comes from the given sensor on multiple entities */
+        public <S> AggregatorBuilder<S, Object> aggregating(AttributeSensor<S> keySensor, AttributeSensor<S> valueSensor) {
+            return new AggregatorBuilder<S, Object>(keySensor, valueSensor);
         }
         /** creates an {@link UpdatingMap} enricher: 
          * {@link UpdatingMapBuilder#from(AttributeSensor)} and {@link UpdatingMapBuilder#computing(Function)} are required
@@ -182,13 +186,15 @@ public class Enrichers {
 
 
     protected abstract static class AbstractAggregatorBuilder<S, T, B extends AbstractAggregatorBuilder<S, T, B>> extends AbstractEnricherBuilder<B> {
-        protected final AttributeSensor<S> aggregating;
+        protected AttributeSensor<S> aggregating;
+        protected AttributeSensor<S> keySensor;
+        protected AttributeSensor<S> valueSensor;
         protected AttributeSensor<T> publishing;
         protected Entity fromEntity;
         /** @deprecated since 0.7.0, kept for backwards compatibility for rebind, but not used otherwise */
         @Deprecated protected Function<? super Collection<S>, ? extends T> computing;
         // use supplier so latest values of other fields can be used
-        protected Supplier<Function<? super Collection<S>, ? extends T>> computingSupplier;
+        protected Supplier<Function<? super Collection<S>, ? extends T>> computingSupplier = Suppliers.ofInstance(null);
         protected Boolean fromMembers;
         protected Boolean fromChildren;
         protected Boolean excludingBlank;
@@ -197,10 +203,15 @@ public class Enrichers {
         protected Predicate<Object> valueFilter;
         protected Object defaultValueForUnreportedSensors;
         protected Object valueToReportIfNoSensors;
-        
+
         public AbstractAggregatorBuilder(AttributeSensor<S> aggregating) {
             super(Aggregator.class);
             this.aggregating = aggregating;
+        }
+        public AbstractAggregatorBuilder(AttributeSensor<S> keySensor, AttributeSensor<S> valueSensor) {
+            super(MapAggregator.class);
+            this.keySensor = keySensor;
+            this.valueSensor = valueSensor;
         }
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <T2 extends T> AggregatorBuilder<S,T2> publishing(AttributeSensor<? extends T2> val) {
@@ -259,7 +270,6 @@ public class Enrichers {
             };
             return self();
         }
-
         public B computingAverage() {
             this.computingSupplier = new Supplier<Function<? super Collection<S>, ? extends T>>() {
                 @Override
@@ -283,6 +293,10 @@ public class Enrichers {
             this.entityFilter = val;
             return self();
         }
+        public B valueFilter(Predicate<Object> val) {
+            this.valueFilter = val;
+            return self();
+        }
         public B excludingBlank() {
             this.excludingBlank = true;
             return self();
@@ -293,42 +307,33 @@ public class Enrichers {
             return "aggregator:"+publishing.getName();
         }
         public EnricherSpec<?> build() {
-            Predicate<Object> valueFilter;
-            if (Boolean.TRUE.equals(excludingBlank)) {
-                valueFilter = new Predicate<Object>() {
-                    @Override public boolean apply(Object input) {
-                        return (input != null) &&
-                                ((input instanceof CharSequence) ? Strings.isNonBlank((CharSequence)input) : true);
-                    }
-                };
-                // above kept for deserialization; not sure necessary
-                valueFilter = StringPredicates.isNonBlank(); 
-            } else {
-                valueFilter = null;
-            }
-            // FIXME excludingBlank; use valueFilter? exclude means ignored entirely or substituted for defaultMemberValue?
             return super.build().configure(MutableMap.builder()
                             .putIfNotNull(Aggregator.PRODUCER, fromEntity)
                             .put(Aggregator.TARGET_SENSOR, publishing)
-                            .put(Aggregator.SOURCE_SENSOR, aggregating)
+                            .putIfNotNull(Aggregator.SOURCE_SENSOR, aggregating)
+                            .putIfNotNull(MapAggregator.KEY_SENSOR, keySensor)
+                            .putIfNotNull(MapAggregator.VALUE_SENSOR, valueSensor)
                             .putIfNotNull(Aggregator.FROM_CHILDREN, fromChildren)
                             .putIfNotNull(Aggregator.FROM_MEMBERS, fromMembers)
                             .putIfNotNull(Aggregator.TRANSFORMATION, computingSupplier.get())
                             .putIfNotNull(Aggregator.FROM_HARDCODED_PRODUCERS, fromHardcodedProducers)
+                            .putIfNotNull(Aggregator.EXCLUDE_BLANK, excludingBlank)
                             .putIfNotNull(Aggregator.ENTITY_FILTER, entityFilter)
                             .putIfNotNull(Aggregator.VALUE_FILTER, valueFilter)
                             .putIfNotNull(Aggregator.DEFAULT_MEMBER_VALUE, defaultValueForUnreportedSensors)
                             .build());
         }
-        
+
         @Override
         public String toString() {
             return Objects.toStringHelper(this)
                     .omitNullValues()
                     .add("aggregating", aggregating)
+                    .add("keySensor", keySensor)
+                    .add("valueSensor", valueSensor)
                     .add("publishing", publishing)
                     .add("fromEntity", fromEntity)
-                    .add("computing", computingSupplier)
+                    .add("computing", computingSupplier.get())
                     .add("fromMembers", fromMembers)
                     .add("fromChildren", fromChildren)
                     .add("excludingBlank", excludingBlank)
@@ -638,6 +643,8 @@ public class Enrichers {
         protected AttributeSensor<String> publishing;
         protected Entity fromEntity;
         protected String separator;
+        protected String keyValueSeparator;
+        protected Boolean joinMapEntries;
         protected Boolean quote;
         protected Integer minimum;
         protected Integer maximum;
@@ -652,6 +659,14 @@ public class Enrichers {
         }
         public B separator(String separator) {
             this.separator = separator;
+            return self();
+        }
+        public B keyValueSeparator(String keyValueSeparator) {
+            this.keyValueSeparator = keyValueSeparator;
+            return self();
+        }
+        public B joinMapEntries(Boolean joinMapEntries) {
+            this.joinMapEntries = joinMapEntries;
             return self();
         }
         public B quote(Boolean quote) {
@@ -677,6 +692,8 @@ public class Enrichers {
                             .put(Joiner.TARGET_SENSOR, publishing)
                             .put(Joiner.SOURCE_SENSOR, transforming)
                             .putIfNotNull(Joiner.SEPARATOR, separator)
+                            .putIfNotNull(Joiner.KEY_VALUE_SEPARATOR, keyValueSeparator)
+                            .putIfNotNull(Joiner.JOIN_MAP_ENTRIES, joinMapEntries)
                             .putIfNotNull(Joiner.QUOTE, quote)
                             .putIfNotNull(Joiner.MINIMUM, minimum)
                             .putIfNotNull(Joiner.MAXIMUM, maximum)
@@ -756,6 +773,9 @@ public class Enrichers {
     public static class AggregatorBuilder<S, T> extends AbstractAggregatorBuilder<S, T, AggregatorBuilder<S, T>> {
         public AggregatorBuilder(AttributeSensor<S> aggregating) {
             super(aggregating);
+        }
+        public AggregatorBuilder(AttributeSensor<S> keySensor, AttributeSensor<S> valueSensor) {
+            super(keySensor, valueSensor);
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/MapAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/MapAggregator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.enricher.stock;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.text.StringPredicates;
+
+/**
+ * Building on {@link AbstractMultipleSensorAggregator} for a pair of source sensors(on multiple children and/or members)
+ * that are used as key-value pairs in a generated Map.
+ */
+@SuppressWarnings("serial")
+public class MapAggregator<U> extends AbstractMultipleSensorAggregator<U> {
+
+    public static final ConfigKey<Sensor<?>> KEY_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.keySensor");
+    public static final ConfigKey<Sensor<?>> VALUE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.valueSensor");
+
+    public static final ConfigKey<Boolean> EXCLUDE_BLANK = Aggregator.EXCLUDE_BLANK;
+
+    private Sensor<?> keySensor;
+    private Sensor<?> valueSensor;
+
+    public MapAggregator() { }
+
+    @Override
+    protected Predicate<?> getDefaultValueFilter() {
+        if (config().get(EXCLUDE_BLANK)) {
+            return StringPredicates.isNonBlank();
+        } else {
+            return Predicates.alwaysTrue();
+        }
+    }
+
+    @Override
+    protected Object compute() {
+        Map<Entity, Object> ks = MutableMap.copyOf(Maps.filterValues(getValues(keySensor), valueFilter));
+        Map<Entity, Object> vs = MutableMap.copyOf(Maps.filterValues(getValues(valueSensor), valueFilter));
+        MutableMap<Object, Object> result = MutableMap.of();
+        for (Entity entity : ks.keySet()) {
+            if (vs.containsKey(entity)) {
+                result.put(ks.get(entity), vs.get(entity));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    protected Collection<Sensor<?>> getSourceSensors() {
+        keySensor = config().get(KEY_SENSOR);
+        valueSensor = config().get(VALUE_SENSOR);
+        return ImmutableList.<Sensor<?>>of(keySensor, valueSensor);
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityTypeTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityTypeTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import static org.apache.brooklyn.core.entity.AbstractEntity.APPLICATION_ID;
+import static org.apache.brooklyn.core.entity.AbstractEntity.CATALOG_ID;
 import static org.apache.brooklyn.core.entity.AbstractEntity.CHILD_ADDED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.CHILD_REMOVED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.CONFIG_KEY_ADDED;
@@ -25,6 +27,7 @@ import static org.apache.brooklyn.core.entity.AbstractEntity.CONFIG_KEY_REMOVED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.EFFECTOR_ADDED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.EFFECTOR_CHANGED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.EFFECTOR_REMOVED;
+import static org.apache.brooklyn.core.entity.AbstractEntity.ENTITY_ID;
 import static org.apache.brooklyn.core.entity.AbstractEntity.GROUP_ADDED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.GROUP_REMOVED;
 import static org.apache.brooklyn.core.entity.AbstractEntity.LOCATION_ADDED;
@@ -44,6 +47,14 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -58,13 +69,6 @@ import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 
 public class EntityTypeTest extends BrooklynAppUnitTestSupport {
     private static final AttributeSensor<String> TEST_SENSOR = Sensors.newStringSensor("test.sensor");
@@ -73,6 +77,7 @@ public class EntityTypeTest extends BrooklynAppUnitTestSupport {
     private RecordingSensorEventListener<Sensor> listener;
 
     public final static Set<Sensor<?>> DEFAULT_SENSORS = ImmutableSet.<Sensor<?>>of(
+            ENTITY_ID, APPLICATION_ID, CATALOG_ID,
             SENSOR_ADDED, SENSOR_REMOVED,
             CONFIG_KEY_ADDED, CONFIG_KEY_REMOVED,
             EFFECTOR_ADDED, EFFECTOR_REMOVED, EFFECTOR_CHANGED,


### PR DESCRIPTION
Adds `ENTITY`, `MEMBER` and `ALL_MEMBERS` as targets for `SshCommandMembershipTrackingPolicy`, updates `Joiner` to handle map entries as key-value pairs, adds `MapAggregator` to generate maps from entity sensor pairs and adds new `ENTITY_ID`, `APPLICATION_ID` and `CATALOG_ID` default sensors to entities.