### PR TITLE
BROOKLYN-338: BrooklynApi fixes for karaf

### DIFF
--- a/rest/rest-client/pom.xml
+++ b/rest/rest-client/pom.xml
@@ -144,5 +144,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>*,org.jboss.resteasy.client.core.marshallers</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
These aren’t enough to fix BROOKLYN-338, but it’s a start:
* Ensures rest-client imports the resteasy marshallers package,
  which it calls with reflection (via the resteasy ProxyBuilder).
* Passes the ProxyBuilder a classloader that has access to the 
  rest-api classes and to rest-client’s classloader (which thus 
  can access the marshallers).