### PR TITLE
don't hold lock on EntityManagementSupport for longer than needed

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -234,22 +234,23 @@ public class EntityManagementSupport {
                 
                 nonDeploymentManagementContext.setMode(NonDeploymentManagementContextMode.MANAGEMENT_STARTED);
                 
-                /*
-                 * - set derived/inherited config values
-                 * - publish all queued sensors
-                 * - start all queued executions (e.g. subscription delivery)
-                 * [above happens in exactly this order, at each entity]
-                 * then: the entity internally knows it fully managed (ManagementSupport.isManaged() returns true -- though not sure we need that);
-                 * subsequent sensor events and executions occur directly (no queueing)
-                 */
-                
-                if (!isReadOnly()) {
-                    nonDeploymentManagementContext.getSubscriptionManager().startDelegatingForPublishing();
-                }
-                
-                // TODO more of the above
-                // TODO custom started activities
-                // (elaborate or remove ^^^ ? -AH, Sept 2014)
+            }
+            
+            /* on start, we want to:
+             * - set derived/inherited config values (not needed, the specs should have taken care of that?)
+             * - publish all queued sensors (done below)
+             * - start all queued executions 
+             *   (e.g. subscription delivery - done below? are there others and if so how are they unlocked?
+             *   curious where the "start queued tasks" logic is; must be somewhere as it all seems to have been working fine (Aug 2016)) 
+             * [in exactly this order, at each entity]
+             * then subsequent sensor events and executions occur directly (no queueing)
+             * 
+             * NOTE: should happen out of synch block in case something is potentially long running;
+             * should happen quickly tough, state might get messy and errors occur if stopped while starting!
+             */                
+            
+            if (!isReadOnly()) {
+                nonDeploymentManagementContext.getSubscriptionManager().startDelegatingForPublishing();
             }
             
             if (!isReadOnly()) {


### PR DESCRIPTION
fixes a deadlock observed with a screwy blueprints, when:

"item added" callback:  locking EntityManagementSupport to get subscription context, while updating members
```
        at org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport.getSubscriptionContext(EntityManagementSupport.java:362)
        - waiting to lock <0x0000000088908188> (a org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport)
        at org.apache.brooklyn.core.entity.AbstractEntity$BasicSubscriptionSupport.getSubscriptionContext(AbstractEntity.java:1519)
        at org.apache.brooklyn.core.entity.AbstractEntity$BasicSensorSupport.emitInternal(AbstractEntity.java:1191)
        at org.apache.brooklyn.core.entity.AbstractEntity$BasicSensorSupport.emit(AbstractEntity.java:1184)
        at org.apache.brooklyn.core.entity.EntityDynamicType.addSensorIfAbsent(EntityDynamicType.java:204)
        at org.apache.brooklyn.core.entity.AbstractEntity$BasicSensorSupport.set(AbstractEntity.java:1093)
        at org.apache.brooklyn.entity.group.AbstractGroupImpl.addMember(AbstractGroupImpl.java:134)
        - locked <0x0000000085f0fa30> (a java.util.LinkedHashSet)
        at org.apache.brooklyn.entity.group.DynamicGroupImpl.onEntityAdded(DynamicGroupImpl.java:126)
        - locked <0x0000000085f0fb28> (a java.lang.Object)
        at org.apache.brooklyn.entity.group.DynamicGroupImpl$MyEntitySetChangeListener.onItemAdded(DynamicGroupImpl.java:154)
```

publishing on management started, locking members in order to deliver, while handling onManagementStarted
```
        at org.apache.brooklyn.entity.group.AbstractGroupImpl.getMembers(AbstractGroupImpl.java:269)
        - waiting to lock <0x0000000085f0fa30> (a java.util.LinkedHashSet)
        at sun.reflect.GeneratedMethodAccessor108.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.brooklyn.core.objs.proxy.EntityProxyImpl.invoke(EntityProxyImpl.java:188)
        at com.sun.proxy.$Proxy181.getMembers(Unknown Source)
        at org.apache.brooklyn.core.mgmt.internal.AbstractSubscriptionManager$2.apply(AbstractSubscriptionManager.java:130)
        at org.apache.brooklyn.core.mgmt.internal.AbstractSubscriptionManager$2.apply(AbstractSubscriptionManager.java:128)
        at org.apache.brooklyn.core.mgmt.internal.LocalSubscriptionManager.publish(LocalSubscriptionManager.java:221)
        at org.apache.brooklyn.core.mgmt.internal.QueueingSubscriptionManager.startDelegatingForPublishing(QueueingSubscriptionManager.java:91)
        - locked <0x00000000889016a8> (a org.apache.brooklyn.core.mgmt.internal.QueueingSubscriptionManager)
        at org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport.onManagementStarted(EntityManagementSupport.java:247)
        - locked <0x0000000088908188> (a org.apache.brooklyn.core.mgmt.internal.EntityManagementSupport)
        at org.apache.brooklyn.core.mgmt.internal.LocalEntityManager.manageRecursive(LocalEntityManager.java:392)
        at org.apache.brooklyn.core.mgmt.internal.LocalEntityManager.manage(LocalEntityManager.java:278)
        at org.apache.brooklyn.core.mgmt.internal.LocalEntityManager.createEntity(LocalEntityManager.java:152)
        at org.apache.brooklyn.core.mgmt.EntityManagementUtils.createUnstarted(EntityManagementUtils.java:83)
```

my blueprint had a static sensor waiting on an attribute from another static sensor, which is possibly why...