### PR TITLE
ensures locations are made available to location registry when catalog is reset

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -154,6 +154,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                         cdto.setManagementContext((ManagementContextInternal) mgmt);
                     }
                     setManagementContext = true;
+                    onAdditionUpdateOtherRegistries(cdto);
                 }
             }
             if (!setManagementContext) {
@@ -163,6 +164,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             if (log.isTraceEnabled()) {
                 log.trace("Scheduling item for persistence addition: {}", entry.getId());
             }
+            
             mgmt.getRebindManager().getChangeListener().onManaged(entry);
         }
 
@@ -951,14 +953,18 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (log.isTraceEnabled()) {
             log.trace("Scheduling item for persistence addition: {}", itemDto.getId());
         }
+        onAdditionUpdateOtherRegistries(itemDto);
+        mgmt.getRebindManager().getChangeListener().onManaged(itemDto);
+
+        return itemDto;
+    }
+
+    private void onAdditionUpdateOtherRegistries(CatalogItemDtoAbstract<?, ?> itemDto) {
         if (itemDto.getCatalogItemType() == CatalogItemType.LOCATION) {
             @SuppressWarnings("unchecked")
             CatalogItem<Location,LocationSpec<?>> locationItem = (CatalogItem<Location, LocationSpec<?>>) itemDto;
             ((BasicLocationRegistry)mgmt.getLocationRegistry()).updateDefinedLocation(locationItem);
         }
-        mgmt.getRebindManager().getChangeListener().onManaged(itemDto);
-
-        return itemDto;
     }
 
     /** returns item DTO if item is an allowed duplicate, or null if it should be added (there is no duplicate), 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -159,13 +159,13 @@ public class CatalogInitialization implements ManagementContextInjectable {
      *   after a master -> standby -> master cycle)
      * @param needsInitialItemsLoaded whether the catalog needs the initial items loaded
      * @param needsAdditionalItemsLoaded whether the catalog needs the additions loaded
-     * @param optionalExcplicitItemsForResettingCatalog
+     * @param optionalExplicitItemsForResettingCatalog
      *   if supplied, the catalog is reset to contain only these items, before calling any other initialization
      *   for use primarily when rebinding
      */
-    public void populateCatalog(ManagementNodeState nodeState, boolean needsInitialItemsLoaded, boolean needsAdditionsLoaded, Collection<CatalogItem<?, ?>> optionalExcplicitItemsForResettingCatalog) {
+    public void populateCatalog(ManagementNodeState nodeState, boolean needsInitialItemsLoaded, boolean needsAdditionsLoaded, Collection<CatalogItem<?, ?>> optionalExplicitItemsForResettingCatalog) {
         if (log.isDebugEnabled()) {
-            String message = "Populating catalog for "+nodeState+", needsInitial="+needsInitialItemsLoaded+", needsAdditional="+needsAdditionsLoaded+", explicitItems="+(optionalExcplicitItemsForResettingCatalog==null ? "null" : optionalExcplicitItemsForResettingCatalog.size())+"; from "+JavaClassNames.callerNiceClassAndMethod(1);
+            String message = "Populating catalog for "+nodeState+", needsInitial="+needsInitialItemsLoaded+", needsAdditional="+needsAdditionsLoaded+", explicitItems="+(optionalExplicitItemsForResettingCatalog==null ? "null" : optionalExplicitItemsForResettingCatalog.size())+"; from "+JavaClassNames.callerNiceClassAndMethod(1);
             if (!ManagementNodeState.isHotProxy(nodeState)) {
                 log.debug(message);
             } else {
@@ -196,7 +196,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
                     }
                 }
 
-                populateCatalogImpl(catalog, needsInitialItemsLoaded, needsAdditionsLoaded, optionalExcplicitItemsForResettingCatalog);
+                populateCatalogImpl(catalog, needsInitialItemsLoaded, needsAdditionsLoaded, optionalExplicitItemsForResettingCatalog);
                 if (nodeState == ManagementNodeState.MASTER) {
                     // TODO ideally this would remain false until it has *persisted* the changed catalog;
                     // if there is a subsequent startup failure the forced additions will not be persisted,

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -674,9 +674,9 @@ public class DependentConfiguration {
         protected List<AttributeAndSensorCondition<?>> abortSensorConditions = Lists.newArrayList();
         protected String blockingDetails;
         protected Duration timeout;
-        protected Maybe<V> onTimeout;
+        protected Maybe<V> onTimeout = Maybe.absent();
         protected  boolean ignoreUnmanaged = WaitInTaskForAttributeReady.DEFAULT_IGNORE_UNMANAGED;
-        protected Maybe<V> onUnmanaged;
+        protected Maybe<V> onUnmanaged = Maybe.absent();
 
         protected Builder(Entity source, AttributeSensor<T> sensor) {
             this.source = source;


### PR DESCRIPTION

(longer term the location registry should be removed in favour of pure catalog,
but this is a tactical fix)

also minor fix w dep config seeing null values