### PR TITLE
Fix winrm4j in Karaf

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -220,8 +220,10 @@
         <feature>brooklyn-core</feature>
         <bundle dependency="true">mvn:io.cloudsoft.windows/winrm4j/${winrm4j.version}</bundle>
         <bundle dependency="true">mvn:io.cloudsoft.windows/winrm4j-client/${winrm4j.version}</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-karaf-httpcomponents-extension/${project.version}</bundle>
         <feature>cxf-jaxws</feature>
         <feature>cxf-http-async</feature>
+        <feature>cxf-ws-addr</feature>
     </feature>
 
     <feature name="brooklyn-policy"  version="${project.version}" description="Brooklyn Policies">

--- a/karaf/httpcomponent-extension/pom.xml
+++ b/karaf/httpcomponent-extension/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.brooklyn</groupId>
+    <artifactId>brooklyn-karaf</artifactId>
+    <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>brooklyn-karaf-httpcomponents-extension</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>Apache Http Component extension</name>
+  <description>
+    An OSGi fragment to extend the http component async bundle to see org.apache.http.ssl package
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <!-- TODO re-use pluginManagement to brooklyn-parent -->
+        <version>2.5.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Fragment-Host>org.apache.httpcomponents.httpasyncclient</Fragment-Host>
+            <Import-Package>
+                *,
+                org.apache.http.ssl;version="[4.4.0,4.5.0)"
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -61,6 +61,7 @@
   <modules>
     <module>init</module>
     <module>jetty-config</module>
+    <module>httpcomponent-extension</module>
     <module>features</module>
     <module>commands</module>
   </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <maxmind.version>0.8.1</maxmind.version>
         <maxmind-db.version>0.3.4</maxmind-db.version>
         <jna.version>4.0.0</jna.version>
-        <winrm4j.version>0.3.5</winrm4j.version>
+        <winrm4j.version>0.4.0</winrm4j.version>
         <karaf.version>4.0.4</karaf.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->


### PR DESCRIPTION
winrm4j version update has fixes for OSGi. Also adding an extension bundle to httpcomponents-asyncclient so that it's able to see `org.apache.http.ssl package` (that's fixed in later revision releases of the jar).