### PR TITLE
Set default minRam to 1gb

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -103,7 +103,7 @@ public interface CloudLocationConfig {
         "Whether to require 64-bit OS images (true), 32-bit images (false), or either (null)");
     
     public static final ConfigKey<Object> MIN_RAM = new BasicConfigKey<Object>(Object.class, "minRam",
-        "Minimum amount of RAM, either as string (4gb) or number of MB (4096), for use in selecting the machine/hardware profile", null);
+        "Minimum amount of RAM, either as string (4gb) or number of MB (4096), for use in selecting the machine/hardware profile", "1gb");
     
     public static final ConfigKey<Integer> MIN_CORES = new BasicConfigKey<Integer>(Integer.class, "minCores",
         "Minimum number of cores, for use in selecting the machine/hardware profile", null);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1647,10 +1647,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         // Apply the template builder and options properties
         for (Map.Entry<ConfigKey<?>, CustomizeTemplateBuilder> entry : SUPPORTED_TEMPLATE_BUILDER_PROPERTIES.entrySet()) {
-            ConfigKey<?> name = entry.getKey();
-            CustomizeTemplateBuilder code = entry.getValue();
-            if (config.containsKey(name) && config.get(name) != null) {
-                code.apply(templateBuilder, config, config.get(name));
+            ConfigKey<?> key = entry.getKey();
+            Object val = config.containsKey(key) ? config.get(key) : key.getDefaultValue();
+            if (val != null) {
+                CustomizeTemplateBuilder code = entry.getValue();
+                code.apply(templateBuilder, config, val);
             }
         }
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsHardwareProfilesStubbedLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsHardwareProfilesStubbedLiveTest.java
@@ -63,6 +63,10 @@ public class JcloudsHardwareProfilesStubbedLiveTest extends AbstractJcloudsStubb
 
     @Test(groups={"Live", "Live-sanity"})
     public void testJcloudsCreateWithHardwareProfiles() throws Exception {
+        // default minRam is 1gb (but default smallest VM in softlayer is 1024mb so not a particularly useful test!)
+        obtainMachine();
+        assertTrue(template.getHardware().getRam() >= 1000, "template="+template);
+        
         obtainMachine(MutableMap.of(JcloudsLocationConfig.MIN_RAM, "4096"));
         assertTrue(template.getHardware().getRam() >= 4096, "template="+template);
         
@@ -76,4 +80,5 @@ public class JcloudsHardwareProfilesStubbedLiveTest extends AbstractJcloudsStubb
         obtainMachine(MutableMap.of(JcloudsLocationConfig.HARDWARE_ID, hardwareId));
         assertEquals(template.getHardware().getId(), hardwareId, "template="+template);
     }
+    
 }


### PR DESCRIPTION
Also changes JcloudsLocation’s template building so that if
a config key has a default value then that will be used, if there is
no explicit value (or empty value) set.