### PR TITLE
Clean up duplicated code in JcloudsLocationCustomizers

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/InboundPortsJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/InboundPortsJcloudsLocationCustomizer.java
@@ -35,7 +35,11 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.brooklyn.location.jclouds.networking.NetworkingEffectors.*;
 
+/**
+ * @deprecated Please use {@link org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer}
+ */
 @Beta
+@Deprecated
 public class InboundPortsJcloudsLocationCustomizer extends BasicJcloudsLocationCustomizer {
     public static final Logger LOG = LoggerFactory.getLogger(InboundPortsJcloudsLocationCustomizer.class);
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/InboundPortsJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/InboundPortsJcloudsLocationCustomizer.java
@@ -36,7 +36,8 @@ import org.slf4j.LoggerFactory;
 import static org.apache.brooklyn.location.jclouds.networking.NetworkingEffectors.*;
 
 /**
- * @deprecated Please use {@link org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer}
+ * @since 0.10.0
+ * @deprecated since 0.10.0. Please use {@link org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer}
  */
 @Beta
 @Deprecated

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
@@ -224,11 +224,15 @@ public class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLocation
      * @param permissions The set of permissions to be applied to the location
      */
     public JcloudsLocationSecurityGroupCustomizer addPermissionsToLocation(final JcloudsMachineLocation location, final Iterable<IpPermission> permissions) {
+        ComputeService computeService = location.getParent().getComputeService();
+        addPermissionsToLocationAndReturnSecurityGroup(computeService, location, permissions);
+        return this;
+    }
+
+    public Collection<SecurityGroup> addPermissionsToLocationAndReturnSecurityGroup(ComputeService computeService, final JcloudsMachineLocation location, final Iterable<IpPermission> permissions) {
         synchronized (JcloudsLocationSecurityGroupCustomizer.class) {
-            ComputeService computeService = location.getParent().getComputeService();
             String nodeId = location.getNode().getId();
-            addPermissionsToLocation(permissions, nodeId, computeService);
-            return this;
+            return addPermissionsToLocation(permissions, nodeId, computeService).values();
         }
     }
     /**

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/JcloudsLocationSecurityGroupCustomizer.java
@@ -22,12 +22,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -67,7 +70,6 @@ import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
 import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
-import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -168,13 +170,13 @@ public class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLocation
         return this;
     }
 
-    /** @see #addPermissionsToLocation(JcloudsSshMachineLocation, java.lang.Iterable) */
+    /** @see #addPermissionsToLocation(JcloudsMachineLocation, java.lang.Iterable) */
     public JcloudsLocationSecurityGroupCustomizer addPermissionsToLocation(final JcloudsMachineLocation location, IpPermission... permissions) {
         addPermissionsToLocation(location, ImmutableList.copyOf(permissions));
         return this;
     }
 
-    /** @see #addPermissionsToLocation(JcloudsSshMachineLocation, java.lang.Iterable) */
+    /** @see #addPermissionsToLocation(JcloudsMachineLocation, java.lang.Iterable) */
     public JcloudsLocationSecurityGroupCustomizer addPermissionsToLocation(final JcloudsMachineLocation location, SecurityGroupDefinition securityGroupDefinition) {
         addPermissionsToLocation(location, securityGroupDefinition.getPermissions());
         return this;
@@ -280,11 +282,11 @@ public class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLocation
      * @param computeService The compute service to use to apply the changes
      */
     @VisibleForTesting
-    void addPermissionsToLocation(Iterable<IpPermission> permissions, final String nodeId, ComputeService computeService) {
+    Map<String, SecurityGroup> addPermissionsToLocation(Iterable<IpPermission> permissions, final String nodeId, ComputeService computeService) {
         if (!computeService.getSecurityGroupExtension().isPresent()) {
             LOG.warn("Security group extension for {} absent; cannot update node {} with {}",
                     new Object[] {computeService, nodeId, permissions});
-            return;
+            return ImmutableMap.of();
         }
         final SecurityGroupExtension securityApi = computeService.getSecurityGroupExtension().get();
         final String locationId = computeService.getContext().unwrap().getId();
@@ -296,9 +298,12 @@ public class JcloudsLocationSecurityGroupCustomizer extends BasicJcloudsLocation
         SecurityGroup machineUniqueSecurityGroup = getSecurityGroup(nodeId, securityApi, locationId);
         MutableList<IpPermission> newPermissions = MutableList.copyOf(permissions);
         Iterables.removeAll(newPermissions, machineUniqueSecurityGroup.getIpPermissions());
+        MutableMap<String, SecurityGroup> addedSecurityGroups = MutableMap.of();
         for (IpPermission permission : newPermissions) {
-            addPermission(permission, machineUniqueSecurityGroup, securityApi);
+            SecurityGroup addedPermission = addPermission(permission, machineUniqueSecurityGroup, securityApi);
+            addedSecurityGroups.put(addedPermission.getId(), addedPermission);
         }
+        return addedSecurityGroups;
     }
 
     /**

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.location.jclouds.networking;
 
+import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -28,6 +29,7 @@ import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
 import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.net.Networking;
 import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.SecurityGroup;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.net.domain.IpPermission;
 import org.jclouds.net.domain.IpProtocol;
@@ -76,6 +78,12 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
     private RangeSet<Integer> udpPortRanges;
 
     /**
+     * Tested only on AWS only.
+     * It depends on the cloud provider and jclouds driver whether security group allows opening ICMP.
+     */
+    private Boolean openIcmp;
+
+    /**
      * Add a flag that disables this customizer.  It's isn't currently possible to add a customizer
      * based on a flag.  This flag makes it possible to write blueprints using the customizer but still
      * be able to disable it for clouds (e.g. bluebox) where the SG implementation has known issues.
@@ -104,6 +112,10 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
 
     public void setUdpPortRanges(List<String> udpPortRanges) {
         this.udpPortRanges = Networking.portRulesToRanges(udpPortRanges);
+    }
+
+    public void setOpenIcmp(Boolean openIcmp) {
+        this.openIcmp = openIcmp;
     }
 
     /**
@@ -137,15 +149,27 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
 
     @Override
     public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+        applySecurityGroupCustomizations(location, computeService, machine);
+    }
+
+    public Collection<SecurityGroup> applySecurityGroupCustomizations(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
         super.customize(location, computeService, machine);
 
-        if(!enabled) return;
+        if(!enabled) return ImmutableList.of();
 
         final JcloudsLocationSecurityGroupCustomizer instance = getInstance(getSharedGroupId(location));
 
         ImmutableList.Builder<IpPermission> builder = ImmutableList.<IpPermission>builder();
+
         builder.addAll(getIpPermissions(instance, tcpPortRanges, IpProtocol.TCP));
         builder.addAll(getIpPermissions(instance, udpPortRanges, IpProtocol.UDP));
+        if (Boolean.TRUE.equals(openIcmp)) {
+            builder.addAll(ImmutableList.of(
+                    IpPermission
+                            .builder().ipProtocol(IpProtocol.ICMP).fromPort(-1).toPort(-1)
+                            .cidrBlock(instance.getBrooklynCidrBlock())
+                            .build()));
+        }
 
         if (inboundPorts != null) {
             for (int inboundPort : inboundPorts) {
@@ -158,7 +182,16 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
                 builder.add(ipPermission);
             }
         }
-        instance.addPermissionsToLocation(machine, builder.build());
+
+        /**
+         * Same as
+         * {@link JcloudsLocationSecurityGroupCustomizer#addPermissionsToLocation(final JcloudsMachineLocation location, final Iterable<IpPermission>)}
+         * but with different return type.
+         */
+        synchronized (JcloudsLocationSecurityGroupCustomizer.class) {
+            String nodeId = machine.getNode().getId();
+            return instance.addPermissionsToLocation(builder.build(), nodeId, computeService).values();
+        }
     }
 
     private List<IpPermission> getIpPermissions(JcloudsLocationSecurityGroupCustomizer instance, RangeSet<Integer> portRanges, IpProtocol protocol) {
@@ -200,6 +233,3 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
         return JcloudsLocationSecurityGroupCustomizer.getInstance(sharedGroupId);
     }
 }
-
-
-

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
@@ -182,16 +182,7 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
                 builder.add(ipPermission);
             }
         }
-
-        /**
-         * Same as
-         * {@link JcloudsLocationSecurityGroupCustomizer#addPermissionsToLocation(final JcloudsMachineLocation location, final Iterable<IpPermission>)}
-         * but with different return type.
-         */
-        synchronized (JcloudsLocationSecurityGroupCustomizer.class) {
-            String nodeId = machine.getNode().getId();
-            return instance.addPermissionsToLocation(builder.build(), nodeId, computeService).values();
-        }
+        return instance.addPermissionsToLocationAndReturnSecurityGroup(computeService, machine, builder.build());
     }
 
     private List<IpPermission> getIpPermissions(JcloudsLocationSecurityGroupCustomizer instance, RangeSet<Integer> portRanges, IpProtocol protocol) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizerTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizerTest.java
@@ -111,6 +111,14 @@ public class SharedLocationSecurityGroupCustomizerTest {
     }
 
     @Test
+    public void testInboundIcmpAddedToPermissions() {
+        customizer.setOpenIcmp(true);
+        when(sgCustomizer.getBrooklynCidrBlock()).thenReturn(Cidr.UNIVERSAL.toString());
+        customizer.customize(jcloudsLocation, computeService, mock(JcloudsMachineLocation.class));
+        assertPermissionsAdded(-1, -1, IpProtocol.ICMP);
+    }
+
+    @Test
     public void testInboundPortsAddedToPermissions() {
         when(mockOptions.getInboundPorts()).thenReturn(new int[]{5});
         when(sgCustomizer.getBrooklynCidrBlock()).thenReturn("10.10.10.10/24");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizerTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizerTest.java
@@ -141,7 +141,7 @@ public class SharedLocationSecurityGroupCustomizerTest {
 
     private void assertPermissionsAdded(int expectedFrom, int expectedTo, IpProtocol expectedProtocol) {
         ArgumentCaptor<List> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
-        verify(sgCustomizer).addPermissionsToLocation(any(JcloudsMachineLocation.class), listArgumentCaptor.capture());
+        verify(sgCustomizer).addPermissionsToLocationAndReturnSecurityGroup(any(ComputeService.class), any(JcloudsMachineLocation.class), listArgumentCaptor.capture());
         IpPermission ipPermission = (IpPermission) listArgumentCaptor.getValue().get(0);
         assertEquals(ipPermission.getFromPort(), expectedFrom);
         assertEquals(ipPermission.getToPort(), expectedTo);


### PR DESCRIPTION
Unite the code from 
https://github.com/apache/brooklyn-server/pull/276
and https://github.com/apache/brooklyn-server/pull/292
OPEN_INBOUND_PORTS_IN_SECURITY_GROUP_EFFECTOR tested after brooklyn restarts. All works fine.
