### PR TITLE
Added configuration for template substitution variable map

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -465,7 +465,8 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                         .body(new Callable<Object>() {
                             @Override
                             public Integer call() {
-                                return copyTemplate(input.source, input.destination, true, Collections.<String, Object>emptyMap());
+                                Map<String, Object> substitutions = MutableMap.copyOf(entity.config().get(SoftwareProcess.TEMPLATE_SUBSTITUTIONS)).asUnmodifiable();
+                                return copyTemplate(input.source, input.destination, true, substitutions);
                             }
                         })
                         .build();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -166,6 +166,13 @@ public interface SoftwareProcess extends Entity, Startable {
             "modify the machine so that a tty is not subsequently required.",
             false);
 
+    @SetFromFlag("substitutions")
+    MapConfigKey<Object> TEMPLATE_SUBSTITUTIONS = new MapConfigKey.Builder<Object>(Object.class, "template.substitutions")
+            .description("Map of values to be substituted for the keys in any templated files used by the entity")
+            .defaultValue(ImmutableMap.<String,Object>of())
+            .typeInheritance(ConfigInheritance.DEEP_MERGE)
+            .build();
+
     /**
      * Files to be copied to the server before pre-install.
      * <p>


### PR DESCRIPTION
Adds a new `ConfigKey<Map<?,?>>` to allow setting further template variable substitutions in YAML.
