### PR TITLE
TypeCoerce string to byte[]

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
@@ -92,6 +92,12 @@ public class CommonAdaptorTypeCoercions {
                 return new String(input);
             }
         });
+        registerAdapter(String.class, byte[].class, new Function<String,byte[]>() {
+            @Override
+            public byte[] apply(String input) {
+                return input.getBytes();
+            }
+        });
         registerAdapter(Collection.class, Set.class, new Function<Collection,Set>() {
             @SuppressWarnings("unchecked")
             @Override

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
@@ -349,6 +349,11 @@ public class TypeCoercionsTest {
         assertEquals(coerce("1.0", Number.class), (Number) Double.valueOf(1.0));
     }
 
+    @Test
+    public void testCoerceStringToByteArray() {
+        assertEquals(coerce("abc", byte[].class), "abc".getBytes());
+    }
+
     @Test(expectedExceptions = org.apache.brooklyn.util.javalang.coerce.ClassCoercionException.class)
     public void testInvalidCoercionThrowsClassCoercionException() {
         coerce(new Object(), TypeToken.of(Integer.class));


### PR DESCRIPTION
An alternative impl would have been to treat the given string as base64 encoded. But I don't think that is what people would expect as the default. However, by using a simple `string.getBytes()` there are two downsides:
* can't pass in some byte array values, e.g. in UI effector parameter (would require base64 for that)
* it's using the default of the JVM (e.g. rather than explicitly using UTF-8)

I think that's good enough though - thoughts?

My use-case is in a test case I wrote for a HTTP client entity, where an effector takes a parameter of type `byte[]` and uses that as the payload of a POST request. The most common situation I think is where one wants to just pass a "normal" string body.