### PR TITLE
Upgrade to Karaf 4.0.8

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -293,9 +293,15 @@
                     </supportedProjectTypes>
                     <instructions>
                         <Export-Package>brooklyn.*,org.apache.brooklyn.*</Export-Package>
+                        <!--
+                          org.apache.brooklyn.rt.felix and org.apache.felix.framework are not used by code paths when working in Karaf
+                          javax.annotation;version=[1.2,2) is needed to force wiring the Brooklyn class space to javax.annotation-api.
+                            Avoids rewiring down the line when brooklyn-rest-resources is loaded.
+                        -->
                         <Import-Package>
                             !org.apache.brooklyn.rt.felix,
                             !org.apache.felix.framework,
+                            javax.annotation;version="[1.2,2)",
                             *
                         </Import-Package>
                     </instructions>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -186,8 +186,7 @@
         <feature>pax-jetty</feature>
     </feature>
 
-    <feature name="brooklyn-rest-resources" version="${project.version}" description="Brooklyn REST Resources">
-        <bundle>mvn:org.apache.brooklyn/brooklyn-rest-resources/${project.version}</bundle>
+    <feature name="brooklyn-rest-resources-prereqs" version="${project.version}" description="Brooklyn REST Resources Prerequisites">
         <feature>brooklyn-core</feature>
         <feature>brooklyn-rest-api</feature>
         <feature>brooklyn-camp-brooklyn</feature>
@@ -204,6 +203,11 @@
         <config name="org.apache.cxf.osgi">
             org.apache.cxf.servlet.context = /v1
         </config>
+    </feature>
+
+    <feature name="brooklyn-rest-resources" version="${project.version}" description="Brooklyn REST Resources">
+        <feature>brooklyn-rest-resources-prereqs</feature>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-rest-resources/${project.version}</bundle>
     </feature>
 
     <feature name="brooklyn-commands"  version="${project.version}"  description="Brooklyn Shell Commands">

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -41,7 +41,6 @@
     <!-- pax-exam -->
     <pax.exam.version>4.7.0</pax.exam.version>
     <pax.url.version>2.4.3</pax.url.version>
-    <ops4j.base.version>1.5.0</ops4j.base.version>
     <tinybundles.version>1.0.0</tinybundles.version>
 
     <!-- feature repositories -->
@@ -59,21 +58,6 @@
     <module>features</module>
     <module>commands</module>
   </modules>
-  
-  <dependencyManagement>
-      <dependencies>
-          <dependency>
-              <groupId>org.ops4j.base</groupId>
-              <artifactId>ops4j-base-lang</artifactId>
-              <version>${ops4j.base.version}</version>
-          </dependency>
-          <dependency>
-              <groupId>org.ops4j.base</groupId>
-              <artifactId>ops4j-base-util-property</artifactId>
-              <version>${ops4j.base.version}</version>
-          </dependency>
-      </dependencies>
-  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -679,7 +679,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.5.4</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.51</bouncycastle.version>
         <sshj.version>0.12.0</sshj.version>
-        <felix.framework.version>5.4.0</felix.framework.version>
+        <felix.framework.version>5.6.1</felix.framework.version>
         <reflections.version>0.9.9-RC1</reflections.version>
         <jetty.version>9.2.13.v20150730</jetty.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
@@ -167,12 +167,8 @@
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
         <winrm4j.version>0.4.0</winrm4j.version>
-        <karaf.version>4.0.4</karaf.version>
-        <!--
-            Fixes double User-Agent issue leading to split Nexus repo.
-            Caused by karaf-maven-plugin depending on wagon-http 2.8 having the bug.
-         -->
-        <karaf.plugin.version>4.0.6</karaf.plugin.version>
+        <karaf.version>4.0.8</karaf.version>
+        <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>


### PR DESCRIPTION
Behaves much better using Karaf 4.0.8 - I can successfully start Karaf and run the REST API with web client.
Needs more testing, also needs confirming whether all previous changes are needed.

---

4.0.6 description


Changes due to:
- avoid rewiring from system bundle to javax.annotation-api at a later stage, leading to rewiring. Introduce a dependency on javax.annotation-api as early as possible (from brooklyn-core in this case)
- Reorder bundle loading - rest-resources after karaf-init because it depends on the ManagementContext service

Do not merge as Karaf 4.0.6 has an error which prevents rest-resources from loading. For more details see https://issues.apache.org/jira/browse/KARAF-4720, https://github.com/apache/karaf/pull/241. 
4.0.7 is just about to be released, the patch wasn't included in it - [1](http://mail-archives.apache.org/mod_mbox/karaf-dev/201609.mbox/%3CC62ED563-59A5-4336-8DF8-9DEB50406FA2%40cloudsoftcorp.com%3E], [2](http://mail-archives.apache.org/mod_mbox/karaf-dev/201609.mbox/%3CCAOcK%3DCNHvkwg94ObSTJzG8ybOiaHOupiu5j02JPhvnK32voPWg%40mail.gmail.com%3E)

Probably will be included in 4.0.8. I'm leaving the changes here to be reused for that migration.
