### PR TITLE
BROOKLYN-349: fix DSL resolution in location

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsLocationExternalConfigYamlLiveTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsLocationExternalConfigYamlLiveTest.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.camp.brooklyn;
 
 import static org.testng.Assert.assertEquals;
 
-import java.io.File;
 import java.io.StringReader;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -31,8 +30,6 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
@@ -48,7 +45,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 
 // also see ExternalConfigYamlTest
-public class JcloudsLocationExternalConfigYamlTest extends AbstractYamlRebindTest {
+public class JcloudsLocationExternalConfigYamlLiveTest extends AbstractYamlRebindTest {
 
     private static final Logger log = LoggerFactory.getLogger(ExternalConfigYamlTest.class);
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindStubYamlTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+
+import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.location.jclouds.ComputeServiceRegistry;
+import org.apache.brooklyn.location.jclouds.JcloudsRebindStubTest;
+import org.testng.annotations.AfterMethod;
+
+/**
+ * Implementation notes. This relies on the test {@link JcloudsRebindStubTest#testRebind()}.
+ * It changes the setup for the test in the following ways:
+ * <ul>
+ *   <li>Location is defined in YAML, and refers to the external config for the identity/credential.
+ *   <li>When creating management context, it also creates {@link BrooklynCampPlatformLauncherNoServer}.
+ *   <li>It uses {@link JcloudsRebindStubYamlTest#ByonComputeServiceStaticRef} to allow
+ *       the test's {@link ComputeServiceRegistry} to be wired up via YAML.
+ * </ul>
+ * 
+ * See {@link JcloudsRebindStubTest} for explanation why this is "Live" - it will not create VMs,
+ * but does retrieve list of images etc.
+ */
+public abstract class JcloudsRebindStubYamlTest extends JcloudsRebindStubTest {
+
+    protected BrooklynCampPlatformLauncherNoServer origLauncher;
+    protected BrooklynCampPlatformLauncherNoServer newLauncher;
+
+    @Override
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            ByonComputeServiceStaticRef.clearInstance();
+            if (origLauncher != null) origLauncher.stopServers();
+            if (newLauncher != null) newLauncher.stopServers();
+        }
+    }
+    
+    @Override
+    protected LocalManagementContext createOrigManagementContext() {
+        origLauncher = new BrooklynCampPlatformLauncherNoServer() {
+            @Override
+            protected LocalManagementContext newMgmtContext() {
+                return JcloudsRebindStubYamlTest.super.createOrigManagementContext();
+            }
+        };
+        origLauncher.launch();
+        LocalManagementContext mgmt = (LocalManagementContext) origLauncher.getBrooklynMgmt();
+        return mgmt;
+    }
+
+    @Override
+    protected LocalManagementContext createNewManagementContext(final File mementoDir, final HighAvailabilityMode haMode) {
+        newLauncher = new BrooklynCampPlatformLauncherNoServer() {
+            @Override
+            protected LocalManagementContext newMgmtContext() {
+                return JcloudsRebindStubYamlTest.super.createNewManagementContext(mementoDir, haMode);
+            }
+        };
+        newLauncher.launch();
+        return (LocalManagementContext) newLauncher.getBrooklynMgmt();
+    }
+    
+    public static class ByonComputeServiceStaticRef {
+        private static volatile ComputeServiceRegistry instance;
+
+        public ComputeServiceRegistry asComputeServiceRegistry() {
+            return checkNotNull(instance, "instance");
+        }
+        static void setInstance(ComputeServiceRegistry val) {
+            instance = val;
+        }
+        static void clearInstance() {
+            instance = null;
+        }
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindWithYamlDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindWithYamlDslTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.testng.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.location.jclouds.ComputeServiceRegistry;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsRebindStubTest;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecCmd;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * This is primarily to test https://issues.apache.org/jira/browse/BROOKLYN-349
+ * 
+ * As per the other {@link JcloudsRebindStubTest} tests, it will connect to SoftLayer to retrieve
+ * image details (so needs real credentials), but it will then stub out the VM creation.
+ * 
+ * It could do with some cleanup at some point:
+ * <ul>
+ *   <li>There is an NPE at AddMachineMetrics$2.apply(AddMachineMetrics.java:111), despite having set
+ *       "metrics.usage.retrieve: false". Perhaps even with that set it will poll once before being disabled?!
+ *   <li>When "stopping" the dummy machine, it fails when executing commands against the real SoftLayer:
+ *       <pre>
+ *       2016-09-21 17:49:22,776 ERROR Cannot retry after server error, command has exceeded retry limit 5: [method=org.jclouds.softlayer.features.VirtualGuestApi.public abstract org.jclouds.softlayer.domain.VirtualGuest org.jclouds.softlayer.features.VirtualGuestApi.getVirtualGuest(long)[123], request=GET https://api.softlayer.com/rest/v3/SoftLayer_Virtual_Guest/123/getObject?objectMask=id%3Bhostname%3Bdomain%3BfullyQualifiedDomainName%3BpowerState%3BmaxCpu%3BmaxMemory%3BstatusId%3BoperatingSystem.passwords%3BprimaryBackendIpAddress%3BprimaryIpAddress%3BactiveTransactionCount%3BblockDevices.diskImage%3Bdatacenter%3BtagReferences%3BprivateNetworkOnlyFlag%3BsshKeys HTTP/1.1]
+ *       </pre>
+ *       Presumably we need to stub out that call as well somehow!
+ * </ul>
+ */
+@Test(groups={"Live", "Live-sanity"})
+public class JcloudsRebindWithYamlDslTest extends JcloudsRebindStubTest {
+
+    private BrooklynCampPlatformLauncherNoServer origLauncher;
+    private BrooklynCampPlatformLauncherNoServer newLauncher;
+
+    @Override
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            ByonComputeServiceStaticRef.clearInstance();
+            if (origLauncher != null) origLauncher.stopServers();
+            if (newLauncher != null) newLauncher.stopServers();
+        }
+    }
+    
+    @Override
+    protected LocalManagementContext createOrigManagementContext() {
+        origLauncher = new BrooklynCampPlatformLauncherNoServer() {
+            @Override
+            protected LocalManagementContext newMgmtContext() {
+                return JcloudsRebindWithYamlDslTest.super.createOrigManagementContext();
+            }
+        };
+        origLauncher.launch();
+        LocalManagementContext mgmt = (LocalManagementContext) origLauncher.getBrooklynMgmt();
+        return mgmt;
+    }
+
+    @Override
+    protected LocalManagementContext createNewManagementContext(final File mementoDir) {
+        newLauncher = new BrooklynCampPlatformLauncherNoServer() {
+            @Override
+            protected LocalManagementContext newMgmtContext() {
+                return JcloudsRebindWithYamlDslTest.super.createNewManagementContext(mementoDir);
+            }
+        };
+        newLauncher.launch();
+        return (LocalManagementContext) newLauncher.getBrooklynMgmt();
+    }
+    
+    @Override
+    protected JcloudsLocation newJcloudsLocation(ComputeServiceRegistry computeServiceRegistry) throws Exception {
+        ByonComputeServiceStaticRef.setInstance(computeServiceRegistry);
+        
+        String symbolicName = "my.catalog.app.id.load";
+        String catalogYaml = Joiner.on("\n").join(
+            "brooklyn.catalog:",
+            "  id: " + symbolicName,
+            "  version: \"0.1.2\"",
+            "  itemType: entity",
+            "  item:",
+            "    brooklyn.parameters:",
+            "    - name: password",
+            "      default: myYamlPassword",
+            "    type: "+ MachineEntity.class.getName());
+        mgmt().getCatalog().addItems(catalogYaml, true);
+
+        String yaml = Joiner.on("\n").join(
+                "location:",
+                "  jclouds:softlayer:",
+                "    jclouds.computeServiceRegistry:",
+                "      $brooklyn:object:",
+                "        type: "+ByonComputeServiceStaticRef.class.getName(),
+                "    "+SshMachineLocation.SSH_TOOL_CLASS.getName() + ": " + RecordingSshTool.class.getName(),
+                "    waitForSshable: false",
+                "    useJcloudsSshInit: false",
+                "services:\n"+
+                "- type: "+symbolicName,
+                "  brooklyn.config:",
+                "    onbox.base.dir.skipResolution: true",
+                "    sshMonitoring.enabled: false",
+                "    metrics.usage.retrieve: false",
+                "    provisioning.properties:",
+                "      password: $brooklyn:config(\"password\")");
+        
+        EntitySpec<?> spec = 
+                mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, yaml, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+        final Entity app = mgmt().getEntityManager().createEntity(spec);
+        final MachineEntity entity = (MachineEntity) Iterables.getOnlyElement(app.getChildren());
+        app.invoke(Startable.START, ImmutableMap.<String, Object>of()).get();
+        
+        // Execute ssh (with RecordingSshTool), and confirm was given resolved password
+        entity.execCommand("mycmd");
+        Map<?, ?> constructorProps = RecordingSshTool.getLastConstructorProps();
+        ExecCmd execCmd = RecordingSshTool.getLastExecCmd();
+        assertEquals(constructorProps.get("password"), "myYamlPassword", "constructorProps: "+constructorProps+"; execProps: "+execCmd.props);
+        
+        return (JcloudsLocation) Iterables.getOnlyElement(app.getLocations());
+    }
+
+    public static class ByonComputeServiceStaticRef {
+        private static volatile ComputeServiceRegistry instance;
+
+        public ComputeServiceRegistry asComputeServiceRegistry() {
+            return checkNotNull(instance, "instance");
+        }
+        static void setInstance(ComputeServiceRegistry val) {
+            instance = val;
+        }
+        static void clearInstance() {
+            instance = null;
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.ByteArrayOutputStream;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,6 +54,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 
 /** Provides utilities for making Tasks easier to work with in Brooklyn.
  * Main thing at present is to supply (and find) wrapped entities for tasks to understand the
@@ -122,21 +124,42 @@ public class BrooklynTaskTags extends TaskTags {
         return new WrappedEntity(TARGET_ENTITY, entity);
     }
 
-    public static Entity getWrappedEntityOfType(Task<?> t, String wrappingType) {
+    public static WrappedEntity getWrappedEntityTagOfType(Task<?> t, String wrappingType) {
         if (t==null) return null;
-        return getWrappedEntityOfType(t.getTags(), wrappingType);
+        return getWrappedEntityTagOfType(t.getTags(), wrappingType);
     }
-    public static Entity getWrappedEntityOfType(Collection<?> tags, String wrappingType) {
+    public static WrappedEntity getWrappedEntityTagOfType(Collection<?> tags, String wrappingType) {
         for (Object x: tags)
             if ((x instanceof WrappedEntity) && ((WrappedEntity)x).wrappingType.equals(wrappingType))
-                return ((WrappedEntity)x).entity;
+                return (WrappedEntity)x;
         return null;
+    }
+
+    public static Entity getWrappedEntityOfType(Task<?> t, String wrappingType) {
+        WrappedEntity wrapper = getWrappedEntityTagOfType(t, wrappingType);
+        return (wrapper == null) ? null : wrapper.entity;
+    }
+    public static Entity getWrappedEntityOfType(Collection<?> tags, String wrappingType) {
+        WrappedEntity wrapper = getWrappedEntityTagOfType(tags, wrappingType);
+        return (wrapper == null) ? null : wrapper.entity;
     }
 
     public static Entity getContextEntity(Task<?> task) {
         return getWrappedEntityOfType(task, CONTEXT_ENTITY);
     }
 
+    public static Object getTargetOrContextEntityTag(Task<?> task) {
+        if (task == null) return null;
+        Object result = getWrappedEntityTagOfType(task, CONTEXT_ENTITY);
+        if (result!=null) return result;
+        result = getWrappedEntityTagOfType(task, TARGET_ENTITY);
+        if (result!=null) return result;
+        result = Tasks.tag(task, Entity.class, false);
+        if (result!=null) return result;
+        
+        return null;
+    }
+    
     public static Entity getTargetOrContextEntity(Task<?> t) {
         if (t==null) return null;
         Entity result = getWrappedEntityOfType(t, CONTEXT_ENTITY);

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -620,6 +620,15 @@ public class ConfigBag {
         return this;
     }
 
+    /**
+     * Whether this config bag is "sealed" (i.e. whether no more modifications can be made to it).
+     * This method is for information only - it should not be overridden to try to change the 
+     * semantics, as internal methods access the (private) field directly.
+     */
+    protected final boolean isSealed() {
+        return sealed;
+    }
+    
     // TODO why have both this and mutable
     /** @see #getAllConfigMutable() */
     public Map<String, Object> getAllConfigRaw() {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/TaskBuilder.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/TaskBuilder.java
@@ -123,6 +123,12 @@ public class TaskBuilder<T> {
         return this;
     }
     
+    /** adds a tag to the given task */
+    public TaskBuilder<T> tagIfNotNull(Object tag) {
+        if (tag != null) tags.add(tag);
+        return this;
+    }
+    
     /** adds a flag to the given task */
     public TaskBuilder<T> flag(String flag, Object value) {
         flags.put(flag, value);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
@@ -337,8 +337,13 @@ public class ValueResolver<T> implements DeferredSupplier<T> {
                             }
                         } };
                     String description = getDescription();
-                    TaskBuilder<Object> tb = Tasks.<Object>builder().body(callable).displayName("Resolving dependent value").description(description);
+                    TaskBuilder<Object> tb = Tasks.<Object>builder()
+                            .body(callable)
+                            .displayName("Resolving dependent value")
+                            .description(description)
+                            .tagIfNotNull(BrooklynTaskTags.getTargetOrContextEntityTag(Tasks.current()));
                     if (isTransientTask) tb.tag(BrooklynTaskTags.TRANSIENT_TASK_TAG);
+                    
                     Task<Object> vt = exec.submit(tb.build());
                     // TODO to handle immediate resolution, it would be nice to be able to submit 
                     // so it executes in the current thread,

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
@@ -43,7 +43,6 @@ import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore;
-import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
 import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistMode;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
@@ -301,6 +300,7 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
         return hotStandby(RebindOptions.create());
     }
 
+    @SuppressWarnings("unchecked")
     protected T hotStandby(RebindOptions options) throws Exception {
         if (newApp != null || newManagementContext != null) {
             throw new IllegalStateException("already rebound - use switchOriginalToNewManagementContext() if you are trying to rebind multiple times");

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
@@ -180,6 +180,10 @@ public class RecordingSshTool implements SshTool {
         return execScriptCmds.get(execScriptCmds.size()-1);
     }
     
+    public static Map<?,?> getLastConstructorProps() {
+        return constructorProps.get(constructorProps.size()-1);
+    }
+    
     public RecordingSshTool(Map<?,?> props) {
         constructorProps.add(props);
     }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -312,7 +313,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
             Optional<NodeMetadata> node = getOptionalNode();
             if (node.isPresent()) {
                 HostAndPort sshHostAndPort = getSshHostAndPort();
-                LoginCredentials creds = getLoginCredentials();
+                Supplier<LoginCredentials> creds = getLoginCredentialsSupplier();
                 hostname = jcloudsParent.getPublicHostname(node.get(), Optional.of(sshHostAndPort), creds, config().getBag());
                 requestPersist();
 
@@ -355,7 +356,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
                 // If we can't get the node (i.e. the cloud provider doesn't know that id, because it has
                 // been terminated), then we don't care as much about getting the right id!
                 HostAndPort sshHostAndPort = getSshHostAndPort();
-                LoginCredentials creds = getLoginCredentials();
+                Supplier<LoginCredentials> creds = getLoginCredentialsSupplier();
                 privateHostname = jcloudsParent.getPrivateHostname(node.get(), Optional.of(sshHostAndPort), creds, config().getBag());
 
             } else {
@@ -496,6 +497,14 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
         }
     }
 
+    private Supplier<LoginCredentials> getLoginCredentialsSupplier() {
+        return new Supplier<LoginCredentials>() {
+            @Override public LoginCredentials get() {
+                return getLoginCredentials();
+            }
+        };
+    }
+    
     private LoginCredentials getLoginCredentials() {
         OsCredential creds = LocationConfigUtils.getOsCredential(new ResolvingConfigBag(getManagementContext(), config().getBag()));
         

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsAddressesLiveTest.java
@@ -107,11 +107,12 @@ public class JcloudsAddressesLiveTest extends AbstractJcloudsLiveTest {
         assertNotNull(subnetIp, msg);
         assertReachableFromMachine(machine, subnetIp, msg);
 
-        // hostname is reachable from inside; not necessarily reachable from outside
+        // hostname is reachable from inside; for AWS machines, it is also reachable from outside
         assertNotNull(hostname, msg);
         assertReachableFromMachine(machine, hostname, msg);
         
         assertNotNull(subnetHostname, msg);
+        assertReachable(machine, subnetHostname, msg);
         assertReachableFromMachine(machine, subnetHostname, msg);
     }
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubTest.java
@@ -18,13 +18,12 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
@@ -32,8 +31,6 @@ import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
-import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.RunNodesException;
 import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
@@ -44,7 +41,6 @@ import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.Volume;
 import org.jclouds.compute.domain.internal.HardwareImpl;
 import org.jclouds.compute.domain.internal.NodeMetadataImpl;
-import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.domain.internal.LocationImpl;
@@ -81,8 +77,8 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsRebindStubTest.class);
 
     public static final String PROVIDER = AbstractJcloudsLiveTest.SOFTLAYER_PROVIDER;
-    public static final String SOFTLAYER_LOCATION_SPEC = "jclouds:" + PROVIDER;
-    public static final String SOFTLAYER_IMAGE_ID = "UBUNTU_14_64";
+    public static final String LOCATION_SPEC = "jclouds:" + PROVIDER;
+    public static final String IMAGE_ID = "UBUNTU_14_64";
     
     protected List<ManagementContext> mgmts;
     protected Multimap<ManagementContext, JcloudsSshMachineLocation> machines;
@@ -172,7 +168,7 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
                         Predicates.<Image>alwaysTrue(), // supportsImage, 
                         (String)null, // hypervisor
                         false),
-                SOFTLAYER_IMAGE_ID,
+                IMAGE_ID,
                 new OperatingSystem(
                         OsFamily.CENTOS, 
                         "myOsName", 
@@ -192,7 +188,7 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
 
         JcloudsLocation origJcloudsLoc = newJcloudsLocation(computeServiceRegistry);
     
-        JcloudsSshMachineLocation origMachine = (JcloudsSshMachineLocation) origJcloudsLoc.obtain(ImmutableMap.of("imageId", SOFTLAYER_IMAGE_ID));
+        JcloudsSshMachineLocation origMachine = (JcloudsSshMachineLocation) obtainMachine(origJcloudsLoc, ImmutableMap.of("imageId", IMAGE_ID));
         
         String origHostname = origMachine.getHostname();
         NodeMetadata origNode = origMachine.getNode();
@@ -215,6 +211,10 @@ public class JcloudsRebindStubTest extends RebindTestFixtureWithApp {
         assertFalse(newTemplate.isPresent(), "newTemplate="+newTemplate);
         
         assertEquals(newJcloudsLoc.getProvider(), origJcloudsLoc.getProvider());
+    }
+    
+    protected JcloudsMachineLocation obtainMachine(JcloudsLocation jcloudsLoc, Map<?,?> props) throws Exception {
+        return (JcloudsMachineLocation) jcloudsLoc.obtain(ImmutableMap.of("imageId", IMAGE_ID));
     }
     
     protected JcloudsLocation newJcloudsLocation(ComputeServiceRegistry computeServiceRegistry) throws Exception {


### PR DESCRIPTION
There are two parts to fixing this:

1. Fix for NPE in `JcloudsLocation.getComputeService`: we are more careful when copying the `ResolvingConfigBag`, so we don't resolve all the values too early when copying it from one `ResolvingConfigBag` to another.

2. Fix for creation of DSL tasks (e.g. in `DslComponent.newTask()`) so that we pass through the current task's context entity when we create the DSL task.

For (2), it's not clear to me if that is the right fix. The alternative would be to ensure that it is the entity's `ExecutionContext` that is used to execute the created task (which would thus automatically set the entity-context as a tag on the task). Presumably we are currently sometimes using the vanilla management context's `ExecutionContext` instead.