### PR TITLE
JmxService tests marked as integration

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/JmxFeedTest.java
@@ -157,7 +157,8 @@ public class JmxFeedTest {
         feed = null;
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxAttributePollerReturnsMBeanAttribute() throws Exception {
         GeneralisedDynamicMBean mbean = jmxService.registerMBean(ImmutableMap.of(attributeName, 42), objectName);
 
@@ -177,7 +178,8 @@ public class JmxFeedTest {
         assertSensorEventually(intAttribute, 64, TIMEOUT_MS);
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxAttributeSensor() throws Exception {
         GeneralisedDynamicMBean mbean = jmxService.registerMBean(ImmutableMap.of(attributeName, 42), objectName);
 
@@ -203,7 +205,8 @@ public class JmxFeedTest {
         assertSensorEventually(sensor, 64, TIMEOUT_MS);
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxAttributeOfTypeTabularDataProviderConvertedToMap() throws Exception {
         // Create the CompositeType and TabularData
         CompositeType compositeType = new CompositeType(
@@ -244,7 +247,8 @@ public class JmxFeedTest {
                 TIMEOUT_MS);
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxOperationPolledForSensor() throws Exception {
         // This is awful syntax...
         final int opReturnVal = 123;
@@ -272,7 +276,8 @@ public class JmxFeedTest {
             }});
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxOperationWithArgPolledForSensor() throws Exception {
         // This is awful syntax...
         MBeanParameterInfo paramInfo = new MBeanParameterInfo("param1", String.class.getName(), "my param1");
@@ -297,7 +302,8 @@ public class JmxFeedTest {
         assertSensorEventually(stringAttribute, "myprefix"+"suffix", TIMEOUT_MS);
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxNotificationSubscriptionForSensor() throws Exception {
         final String one = "notification.one", two = "notification.two";
         final StandardEmitterMBean mbean = jmxService.registerMBean(ImmutableList.of(one, two), objectName);
@@ -327,7 +333,8 @@ public class JmxFeedTest {
             }});
     }
     
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxNotificationSubscriptionForSensorParsingNotification() throws Exception {
         final String one = "notification.one", two = "notification.two";
         final StandardEmitterMBean mbean = jmxService.registerMBean(ImmutableList.of(one, two), objectName);
@@ -355,7 +362,8 @@ public class JmxFeedTest {
             }});
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxNotificationMultipleSubscriptionUsingListener() throws Exception {
         final String one = "notification.one";
         final String two = "notification.two";
@@ -383,7 +391,8 @@ public class JmxFeedTest {
     }
 
     // Test reproduces functionality used in Monterey, for Venue entity being told of requestActor
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testSubscribeToJmxNotificationAndEmitCorrespondingNotificationSensor() throws Exception {
         TestApplication app2 = new TestApplicationImpl();
         final EntityWithEmitter entity = new EntityWithEmitter(app2);

--- a/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/feed/jmx/RebindJmxFeedTest.java
@@ -81,12 +81,14 @@ public class RebindJmxFeedTest extends RebindTestFixtureWithApp {
         super.tearDown();
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxFeedIsPersisted() throws Exception {
         runJmxFeedIsPersisted(false);
     }
 
-    @Test
+    // Integration because the expected port might not be available
+    @Test(groups="Integration")
     public void testJmxFeedIsPersistedWithPreCreatedJmxHelper() throws Exception {
         runJmxFeedIsPersisted(true);
     }


### PR DESCRIPTION
These tests expect a specific port to be available, which may not be true
in a shared jenkins environment. Therefore marking them as "Integration".

Also moves newJmxServiceRetrying into JmxService.

---
Longer term, we could rewrite the JmxService tests in one of two ways (but I suggest we don't tackle those right now):

1. First (and simplest), we could use the `newJmxServiceRetrying` so that it tries different ports until one starts. We'd need to rewrite the test so that the entity didn't hard-code an expected port. We'd first start the `JmxService`, and then set the config/attribute on the entity.

2. We could try to pass in port `0` to the `JmxService` so that it allocates any available port. That looks a bit harder (the port is passed inside the `JMXServiceURL`. A very quick try at missing the port out from that led to other issues with `connectorServer.start()` (and with needing to get the real address that includes the port only after having started the connectorServer).