### PR TITLE
Fix LocalUsageManagerTest

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalUsageManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalUsageManagerTest.java
@@ -45,7 +45,7 @@ public class LocalUsageManagerTest extends BrooklynAppUnitTestSupport {
     // Also see {Application|Location}UsageTrackingTest for listener functionality
 
     @Override
-    protected boolean shouldSkipOnBoxBaseDirResolution() {
+    protected Boolean shouldSkipOnBoxBaseDirResolution() {
         return true;
     }
 


### PR DESCRIPTION
`shouldSkipOnBoxBaseDirResolution` return type was changed from boolean to
Boolean in super-class.