### PR TITLE
Fix SharedLocationSecurityGroupCustomizer.udpPortRanges

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/SharedLocationSecurityGroupCustomizer.java
@@ -93,7 +93,7 @@ public class SharedLocationSecurityGroupCustomizer extends BasicJcloudsLocationC
         this.tcpPortRanges = Networking.portRulesToRanges(tcpPortRanges);
     }
 
-    public void setUdpPortRanges(ImmutableList<String> udpPortRanges) {
+    public void setUdpPortRanges(List<String> udpPortRanges) {
         this.udpPortRanges = Networking.portRulesToRanges(udpPortRanges);
     }
 


### PR DESCRIPTION
Previously it was ImmutableList so could not be used from YAML; changed
to a normal List.