### PR TITLE
Fix or disable integration tests

### DIFF
--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/CouchbaseBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/CouchbaseBlueprintTest.java
@@ -22,22 +22,22 @@ import org.testng.annotations.Test;
 
 public class CouchbaseBlueprintTest extends AbstractBlueprintTest {
 
-    @Test(groups={"Live"})
+    @Test(groups={"Live", "Broken"})
     public void testCouchbaseNode() throws Exception {
         runTest("couchbase-node.yaml");
     }
 
-    @Test(groups={"Live"})
+    @Test(groups={"Live", "Broken"})
     public void testCouchbaseCluster() throws Exception {
         runTest("couchbase-cluster.yaml");
     }
 
-    @Test(groups={"Live"})
+    @Test(groups={"Live", "Broken"})
     public void testCouchbaseClusterSingleNode() throws Exception {
         runTest("couchbase-cluster-singleNode.yaml");
     }
     
-    @Test(groups={"Live"})
+    @Test(groups={"Live", "Broken"})
     public void testCouchbaseWithPillowfight() throws Exception {
         runTest("couchbase-w-pillowfight.yaml");
     }
@@ -53,7 +53,7 @@ public class CouchbaseBlueprintTest extends AbstractBlueprintTest {
      * This blueprint uses {minRam: 16384, minCores: 4}.
      * Suspect this is already fixed by Andrea Turli in latest jclouds.
      */
-    @Test(groups={"Live", "WIP"})
+    @Test(groups={"Live", "WIP", "Broken"})
     public void testCouchbaseWithLoadgen() throws Exception {
         runTest("couchbase-w-loadgen.yaml");
     }
@@ -62,7 +62,7 @@ public class CouchbaseBlueprintTest extends AbstractBlueprintTest {
      * FIXME Failed with "Unable to match required VM template constraints" - caused by NPE
      * (see error described at {@link #testCouchbaseWithLoadgen()}.
      */
-    @Test(groups={"Live", "WIP"})
+    @Test(groups={"Live", "WIP", "Broken"})
     public void testCouchbaseReplicationWithPillowfight() throws Exception {
         runTest("couchbase-replication-w-pillowfight.yaml");
     }

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/MongoDbBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/MongoDbBlueprintTest.java
@@ -24,27 +24,27 @@ public class MongoDbBlueprintTest extends AbstractBlueprintTest {
 
     // TODO Some tests are failing! Needs investigated.
 
-    @Test(groups={"Integration", "WIP"})
+    @Test(groups={"Integration", "WIP", "Broken"})
     public void testMongoSharded() throws Exception {
         runTest("mongo-sharded.yaml");
     }
 
-    @Test(groups={"Integration"})
+    @Test(groups={"Integration", "Broken"})
     public void testMongoReplicaSet() throws Exception {
         runTest("mongo-blueprint.yaml");
     }
 
-    @Test(groups={"Integration"})
+    @Test(groups={"Integration", "Broken"})
     public void testMongoClientAndSingleServer() throws Exception {
         runTest("mongo-client-single-server.yaml");
     }
 
-    @Test(groups={"Integration", "WIP"})
+    @Test(groups={"Integration", "WIP", "Broken"})
     public void testMongoScripts() throws Exception {
         runTest("mongo-scripts.yaml");
     }
 
-    @Test(groups="Integration")
+    @Test(groups={"Integration", "Broken"})
     public void testMongoSingleServer() throws Exception {
         runTest("mongo-single-server-blueprint.yaml");
     }

--- a/rest/rest-server/src/test/resources/vanilla-software-process-with-resource.yaml
+++ b/rest/rest-server/src/test/resources/vanilla-software-process-with-resource.yaml
@@ -23,7 +23,7 @@
 brooklyn.catalog:
   id: vanilla-software-resource-test
   version: "1.0"
-  itemType: tempalte
+  itemType: template
   libraries:
   - classpath://brooklyn/osgi/brooklyn-test-osgi-entities.jar
   item:


### PR DESCRIPTION
See individual commits for further description (copy-pasted here for your convenience):

```
commit 384de14a710e1bbbccebd83a0f61ab158f29f116
Author: Aled Sage <aled.sage@gmail.com>
Date:   Fri Sep 23 18:18:10 2016 +0100

    Re-write CreateUserPolicyTest to use RecordingSshTool
    
    Previously it use its own RecordingSshMachineLocation, so changing it
    to use our more standard mechanism.

commit ab5d7b84940a7802bf807e590c1ccf1c6808c05a
Author: Aled Sage <aled.sage@gmail.com>
Date:   Fri Sep 23 18:17:10 2016 +0100

    Fix vanilla-software-process-with-resource.yaml
    
    Typo of “tempalte” broke integration test, which broke
    org.apache.brooklyn.rest.test.entity.VanillaSoftwareProcessTest

commit 42a547913e86b1e8a1b4d1de2cf9f68df0f5dc4d
Author: Aled Sage <aled.sage@gmail.com>
Date:   Fri Sep 23 18:15:13 2016 +0100

    Mark blueprint integration tests as “Broken”
    
    The brooklyn-server repo does not include entities in brooklyn-library,
    such as MongoDB, so cannot be tested here.
    
    It should really be deleted (once we move them to a better home such
    as use of the test-framework, with QA running regularly against the
    catalog).
```