### PR TITLE
Config keys and parameters can now be marked as "pinned"

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogConfig.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogConfig.java
@@ -34,5 +34,7 @@ public @interface CatalogConfig {
      * a higher value appears higher in the list. the default is 1.
      * (negative values may be used to indicate advanced config which might not be shown unless requested.) */ 
     double priority() default 1;
-    
+
+     /** a pinned configuration means that it should be displayed, regardless of its priority */
+    boolean pinned() default false;
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
@@ -66,19 +66,20 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
                 "    - simple",
                 "    - name: explicit_name",
                 "    - name: third_input",
-                "      type: integer");
+                "      type: integer",
+                "      pinned: true");
         EntitySpec<?> item = mgmt().getTypeRegistry().createSpec(mgmt().getTypeRegistry().get(itemId), null, EntitySpec.class);
         List<SpecParameter<?>> inputs = item.getParameters();
         assertEquals(inputs.size(), 6);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
-        assertEquals(firstInput.isPinned(), true);
+        assertEquals(firstInput.isPinned(), false);
         assertEquals(firstInput.getConfigKey().getName(), "simple");
         assertEquals(firstInput.getConfigKey().getTypeToken(), TypeToken.of(String.class));
         
         SpecParameter<?> secondInput = inputs.get(1);
         assertEquals(secondInput.getLabel(), "explicit_name");
-        assertEquals(secondInput.isPinned(), true);
+        assertEquals(secondInput.isPinned(), false);
         assertEquals(secondInput.getConfigKey().getName(), "explicit_name");
         assertEquals(secondInput.getConfigKey().getTypeToken(), TypeToken.of(String.class));
         
@@ -110,7 +111,7 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
         assertEquals(inputs.size(), 4);
         SpecParameter<?> firstInput = inputs.get(0);
         assertEquals(firstInput.getLabel(), "simple");
-        assertTrue(firstInput.isPinned());
+        assertFalse(firstInput.isPinned());
         assertEquals(firstInput.getConfigKey().getName(), "simple");
         assertEquals(firstInput.getConfigKey().getTypeToken().getRawType().getName(), OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_SIMPLE_ENTITY);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -83,12 +83,12 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         }
     }
     
-    @Beta // TBD whether "pinned" stays
+    @Beta
     public BasicSpecParameter(String label, boolean pinned, ConfigKey<T> config) {
         this(label, pinned, config, null);
     }
 
-    @Beta // TBD whether "pinned" and "sensor" stay
+    @Beta // TBD whether "sensor" stay
     public <SensorType> BasicSpecParameter(String label, boolean pinned, ConfigKey<T> config, AttributeSensor<SensorType> sensor) {
         this.label = label;
         this.pinned = pinned;
@@ -228,6 +228,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
             String description = (String)inputDef.get("description");
             String type = (String)inputDef.get("type");
             Object defaultValue = inputDef.get("default");
+            Boolean pinned = (Boolean)inputDef.get("pinned");
             if (specialFlagTransformer != null) {
                 defaultValue = specialFlagTransformer.apply(defaultValue);
             }
@@ -257,7 +258,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
             } else {
                 configType = builder.build();
             }
-            return new BasicSpecParameter(Objects.firstNonNull(label, name), true, configType, sensorType);
+            return new BasicSpecParameter(Objects.firstNonNull(label, name), Objects.firstNonNull(pinned, Boolean.FALSE), configType, sensorType);
         }
 
         @SuppressWarnings({ "rawtypes" })
@@ -375,12 +376,14 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
             CatalogConfig catalogConfig = configKeyField.getAnnotation(CatalogConfig.class);
             String label = config.getName();
             Double priority = null;
+            Boolean pinned = Boolean.FALSE;
             if (catalogConfig != null) {
                 label = Maybe.fromNullable(catalogConfig.label()).or(config.getName());
                 priority = catalogConfig.priority();
+                pinned = catalogConfig.pinned();
             }
             @SuppressWarnings({ "unchecked", "rawtypes" })
-            SpecParameter<?> param = new BasicSpecParameter(label, priority != null, config);
+            SpecParameter<?> param = new BasicSpecParameter(label, pinned, config);
             return new WeightedParameter(priority, param);
         }
 

--- a/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromClassTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromClassTest.java
@@ -53,20 +53,20 @@ public class BasicSpecParameterFromClassTest {
         @CatalogConfig(label="String Key", priority=3)
         ConfigKey<String> STRING_KEY = ConfigKeys.newStringConfigKey("string_key");
 
-        @CatalogConfig(label="Integer Key", priority=2)
-        ConfigKey<Integer> INTEGER_KEY = ConfigKeys.newIntegerConfigKey("integer_key");
+        @CatalogConfig(label="Integer Key", priority=2, pinned = true)
+        ConfigKey<Integer> INTEGER_PINNED_KEY = ConfigKeys.newIntegerConfigKey("integer_key");
 
         @SuppressWarnings("serial")
-        @CatalogConfig(label="Predicate Key", priority=1)
-        ConfigKey<Predicate<String>> PREDICATE_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "predicate_key");
+        @CatalogConfig(label="Predicate Key", priority=1, pinned = true)
+        ConfigKey<Predicate<String>> PREDICATE_PINNED_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "predicate_key");
 
         @SuppressWarnings("serial")
         @CatalogConfig(label="Hidden 1 Key", priority=-1)
         ConfigKey<Predicate<String>> HIDDEN1_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden1_key");
 
         @SuppressWarnings("serial")
-        @CatalogConfig(label="Hidden 2 Key", priority=-2)
-        ConfigKey<Predicate<String>> HIDDEN2_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden2_key");
+        @CatalogConfig(label="Hidden 2 Key", priority=-2, pinned = true)
+        ConfigKey<Predicate<String>> HIDDEN2_PINNED_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden2_key");
 
         ConfigKey<String> UNPINNNED2_KEY = ConfigKeys.newStringConfigKey("unpinned2_key");
         ConfigKey<String> UNPINNNED1_KEY = ConfigKeys.newStringConfigKey("unpinned1_key");
@@ -82,11 +82,11 @@ public class BasicSpecParameterFromClassTest {
     public void testFullDefinition() {
         List<SpecParameter<?>> inputs = BasicSpecParameter.fromClass(mgmt, SpecParameterTestEntity.class);
         assertEquals(inputs.size(), 7);
-        assertInput(inputs.get(0), "String Key", true, SpecParameterTestEntity.STRING_KEY);
-        assertInput(inputs.get(1), "Integer Key", true, SpecParameterTestEntity.INTEGER_KEY);
-        assertInput(inputs.get(2), "Predicate Key", true, SpecParameterTestEntity.PREDICATE_KEY);
-        assertInput(inputs.get(3), "Hidden 1 Key", true, SpecParameterTestEntity.HIDDEN1_KEY);
-        assertInput(inputs.get(4), "Hidden 2 Key", true, SpecParameterTestEntity.HIDDEN2_KEY);
+        assertInput(inputs.get(0), "String Key", false, SpecParameterTestEntity.STRING_KEY);
+        assertInput(inputs.get(1), "Integer Key", true, SpecParameterTestEntity.INTEGER_PINNED_KEY);
+        assertInput(inputs.get(2), "Predicate Key", true, SpecParameterTestEntity.PREDICATE_PINNED_KEY);
+        assertInput(inputs.get(3), "Hidden 1 Key", false, SpecParameterTestEntity.HIDDEN1_KEY);
+        assertInput(inputs.get(4), "Hidden 2 Key", true, SpecParameterTestEntity.HIDDEN2_PINNED_KEY);
         assertInput(inputs.get(5), "unpinned1_key", false, SpecParameterTestEntity.UNPINNNED1_KEY);
         assertInput(inputs.get(6), "unpinned2_key", false, SpecParameterTestEntity.UNPINNNED2_KEY);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.objs;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -55,7 +56,7 @@ public class BasicSpecParameterFromListTest {
         String name = "minRam";
         SpecParameter<?> input = parse(name);
         assertEquals(input.getLabel(), name);
-        assertTrue(input.isPinned());
+        assertFalse(input.isPinned());
         ConfigKey<?> type = input.getConfigKey();
         assertEquals(type.getName(), name);
         assertEquals(type.getTypeToken(), TypeToken.of(String.class));
@@ -86,6 +87,7 @@ public class BasicSpecParameterFromListTest {
         String description = "Some description";
         String inputType = "string";
         String defaultValue = "VALUE";
+        Boolean pinned = true;
         String constraint = "required";
         SpecParameter<?> input = parse(ImmutableMap.builder()
                 .put("name", name)
@@ -93,6 +95,7 @@ public class BasicSpecParameterFromListTest {
                 .put("description", description)
                 .put("type", inputType)
                 .put("default", defaultValue)
+                .put("pinned", pinned)
                 .put("constraints", constraint)
                 .build());
 
@@ -121,7 +124,7 @@ public class BasicSpecParameterFromListTest {
                 "default", defaultValue));
 
         assertEquals(input.getLabel(), name);
-        assertTrue(input.isPinned());
+        assertFalse(input.isPinned());
 
         ConfigKey<?> type = input.getConfigKey();
         assertEquals(type.getName(), name);
@@ -170,6 +173,19 @@ public class BasicSpecParameterFromListTest {
         parse(ImmutableMap.of(
                 "name", name,
                 "type", "missing_type"));
+    }
+
+    @Test
+    public void testDefaultPinned() {
+        String name = "pinned";
+        String label = "Is pinned";
+        String description = "Is pinned description";
+        SpecParameter<?> input = parse(ImmutableMap.of(
+                "name", name,
+                "label", label,
+                "description", description));
+
+        assertFalse(input.isPinned());
     }
 
     private SpecParameter<?> parse(Object def) {

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
@@ -33,6 +33,9 @@ public class EntityConfigSummary extends ConfigSummary {
 
     private static final long serialVersionUID = -1336134336883426030L;
 
+    @JsonSerialize
+    private final boolean pinned;
+
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     private final Map<String, URI> links;
 
@@ -45,13 +48,16 @@ public class EntityConfigSummary extends ConfigSummary {
             @JsonProperty("label") String label,
             @JsonProperty("priority") Double priority,
             @JsonProperty("possibleValues") List<Map<String, String>> possibleValues,
+            @JsonProperty("pinned") boolean pinned,
             @JsonProperty("links") Map<String, URI> links) {
         super(name, type, description, defaultValue, reconfigurable, label, priority, possibleValues);
+        this.pinned = pinned;
         this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
     }
 
-    public EntityConfigSummary(ConfigKey<?> config, String label, Double priority, Map<String, URI> links) {
+    public EntityConfigSummary(ConfigKey<?> config, String label, Double priority, boolean pinned, Map<String, URI> links) {
         super(config, label, priority);
+        this.pinned = pinned;
         this.links = links != null ? ImmutableMap.copyOf(links) : null;
     }
 
@@ -63,10 +69,11 @@ public class EntityConfigSummary extends ConfigSummary {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EntityConfigSummary)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         EntityConfigSummary that = (EntityConfigSummary) o;
-        return Objects.equals(links, that.links);
+        if (pinned != that.pinned) return false;
+        return links.equals(that.links);
     }
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType;
@@ -82,8 +83,9 @@ public class CatalogTransformer {
             EntityDynamicType typeMap = BrooklynTypes.getDefinedEntityType(spec.getType());
             EntityType type = typeMap.getSnapshot();
 
+            AtomicInteger paramPriorityCnt = new AtomicInteger();
             for (SpecParameter<?> input: spec.getParameters())
-                config.add(EntityTransformer.entityConfigSummary(input));
+                config.add(EntityTransformer.entityConfigSummary(input, paramPriorityCnt));
             for (Sensor<?> x: type.getSensors())
                 sensors.add(SensorTransformer.sensorSummaryForCatalog(x));
             for (Effector<?> x: type.getEffectors())

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/EntityTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/EntityTransformer.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Application;
@@ -119,9 +120,9 @@ public class EntityTransformer {
             }));
     }
 
-    public static EntityConfigSummary entityConfigSummary(ConfigKey<?> config, String label, Double priority, Map<String, URI> links) {
+    public static EntityConfigSummary entityConfigSummary(ConfigKey<?> config, String label, Double priority, boolean pinned, Map<String, URI> links) {
         Map<String, URI> mapOfLinks =  links==null ? null : ImmutableMap.copyOf(links);
-        return new EntityConfigSummary(config, label, priority, mapOfLinks);
+        return new EntityConfigSummary(config, label, priority, pinned, mapOfLinks);
     }
 
     public static PolicyConfigSummary policyConfigSummary(ConfigKey<?> config, String label, Double priority, Map<String, URI> links) {
@@ -162,7 +163,7 @@ public class EntityTransformer {
             SensorTransformer.addNamedAction(lb, na, entity.getConfig(config), config, entity);
         }
     
-        return entityConfigSummary(config, label, priority, lb.build());
+        return entityConfigSummary(config, label, priority, false, lb.build());
     }
 
     public static URI applicationUri(Application entity, UriBuilder ub) {
@@ -177,12 +178,16 @@ public class EntityTransformer {
         CatalogConfig catalogConfig = configKeyField!=null ? configKeyField.getAnnotation(CatalogConfig.class) : null;
         String label = catalogConfig==null ? null : catalogConfig.label();
         Double priority = catalogConfig==null ? null : catalogConfig.priority();
-        return entityConfigSummary(config, label, priority, null);
+        boolean pinned = catalogConfig!=null && catalogConfig.pinned();
+        return entityConfigSummary(config, label, priority, pinned, null);
     }
 
-    public static EntityConfigSummary entityConfigSummary(SpecParameter<?> input) {
-        Double priority = input.isPinned() ? Double.valueOf(1d) : null;
-        return entityConfigSummary(input.getConfigKey(), input.getLabel(), priority, null);
+    public static EntityConfigSummary entityConfigSummary(SpecParameter<?> input, AtomicInteger paramPriorityCnt) {
+        // Increment the priority because the config container is a set. Server-side we are using an ordered set
+        // which results in correctly ordered items on the wire (as a list). Clients which use the java bindings
+        // though will push the items in an unordered set - so give them means to recover the correct order.
+        Double priority = input.isPinned() ? Double.valueOf(paramPriorityCnt.incrementAndGet()) : null;
+        return entityConfigSummary(input.getConfigKey(), input.getLabel(), priority, input.isPinned(), null);
     }
 
     public static PolicyConfigSummary policyConfigSummary(SpecParameter<?> input) {

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ItemDescriptors.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ItemDescriptors.java
@@ -211,7 +211,7 @@ public class ItemDescriptors {
                 }
 
                 EntityConfigSummary entityConfigSummary = EntityTransformer.entityConfigSummary(param.getConfigKey(),
-                    param.getLabel(), priority, MutableMap.<String,URI>of());
+                    param.getLabel(), priority, param.isPinned(), MutableMap.<String,URI>of());
                 config.add(entityConfigSummary);
             }
             itemDescriptor.put("config", config);


### PR DESCRIPTION
The new behaviour is as follow:
- By default, config keys and parameters are `pinned = false`
- A blueprint can specify a config key or parameter as pinned by using `@CatalogConfig(pinned = true)` or in yaml `pinned: true`
- In case of config keys or parameters pinned in YAML, the priority is auto incremented to keep the order (code lost in [this commit](https://github.com/apache/brooklyn-server/commit/6f624c78b1e7fe72c6df1ecd297b922721b2c023#diff-5310fbeb1f42a3a4cf0508ea441440baL82))

Tests have been updated. Changes in docs and JSGUI coming soon.