### PR TITLE
Reduce decisions for HostAndPort which will be used in JcloudsLocation

### DIFF
--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -202,6 +202,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-software-winrm</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
@@ -375,7 +375,7 @@ public class JcloudsUtil implements JcloudsLocationConfig {
             return result.getHostText();
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
-            throw new IllegalStateException("Unable to connect SshClient to "+node+"; check that the node is accessible and that the SSH key exists and is correctly configured, including any passphrase defined", e);
+            throw new IllegalStateException("Unable to choose IP for "+node+"; check whether the node is reachable or whether it meets requirements of the HostAndPort tester: " + socketTester , e);
         } finally {
             executor.shutdownNow();
         }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverSoftlayerLiveTest.java
@@ -44,14 +44,14 @@ public class JcloudsByonLocationResolverSoftlayerLiveTest extends AbstractJcloud
     private String slVmHostname;
     
     private LocalManagementContext classManagementContext;
-    private JcloudsLocation classEc2Loc;
+    private JcloudsLocation classLoc;
     private JcloudsSshMachineLocation classVm;
 
     @BeforeClass(groups="Live")
     public void setUpClass() throws Exception {
         classManagementContext = newManagementContext();
-        classEc2Loc = (JcloudsLocation) classManagementContext.getLocationRegistry().getLocationManaged(SOFTLAYER_LOCATION_SPEC);
-        classVm = (JcloudsSshMachineLocation)classEc2Loc.obtain(MutableMap.<String,Object>builder()
+        classLoc = (JcloudsLocation) classManagementContext.getLocationRegistry().getLocationManaged(SOFTLAYER_LOCATION_SPEC);
+        classVm = (JcloudsSshMachineLocation)classLoc.obtain(MutableMap.<String,Object>builder()
                 .put("inboundPorts", ImmutableList.of(22))
                 .build());
         slVmUser = classVm.getUser();
@@ -64,7 +64,7 @@ public class JcloudsByonLocationResolverSoftlayerLiveTest extends AbstractJcloud
     public void tearDownClass() throws Exception {
         try {
             if (classVm != null) {
-                classEc2Loc.release(classVm);
+                classLoc.release(classVm);
             }
         } finally {
             if (classManagementContext != null) classManagementContext.terminate();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
@@ -18,9 +18,7 @@
  */
 package org.apache.brooklyn.location.jclouds.networking;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
@@ -38,19 +36,24 @@ import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsStubTemplateBuilder;
+import org.apache.brooklyn.location.jclouds.JcloudsWinRmMachineLocation;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
 import org.apache.brooklyn.location.jclouds.networking.JcloudsPortForwardingStubbedLiveTest.RecordingJcloudsPortForwarderExtension;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.CustomResponse;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.CustomResponseGenerator;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecParams;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
+import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool;
+import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
+import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.domain.LoginCredentials;
 import org.slf4j.Logger;
@@ -94,6 +97,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         addressChooser = new AddressChooser();
         customResponseGenerator = new CustomResponseGeneratorImpl();
         RecordingSshTool.clear();
+        RecordingWinRmTool.clear();
         super.setUp();
     }
     
@@ -104,6 +108,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
             super.tearDown();
         } finally {
             RecordingSshTool.clear();
+            RecordingWinRmTool.clear();
         }
     }
 
@@ -150,18 +155,11 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
                         .build());
     }
 
-    protected JcloudsSshMachineLocation obtainMachine(Map<?, ?> conf) throws Exception {
-        assertNotNull(jcloudsLocation);
-        JcloudsSshMachineLocation result = (JcloudsSshMachineLocation)jcloudsLocation.obtain(conf);
-        machines.add(checkNotNull(result, "result"));
-        return result;
-    }
-    
     /**
      * Only one public and one private; public is reachable;
      * With waitForSshable=true; pollForFirstReachableAddress=true; and custom reachable-predicate
      */
-    @Test(groups = {"Live", "Live-sanity"})
+    @Test
     public void testMachineUsesVanillaPublicAddress() throws Exception {
         initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1"), ImmutableList.of("2.1.1.1"), ImmutableMap.of());
         reachableIp = "1.1.1.1";
@@ -173,6 +171,27 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         
         addressChooser.assertCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
+
+        assertEquals(machine.getAddress().getHostAddress(), reachableIp);
+        assertEquals(machine.getHostname(), reachableIp);
+        assertEquals(machine.getSubnetIp(), "2.1.1.1");
+    }
+
+    /**
+     * Similar to {@link #testMachineUsesVanillaPublicAddress()}, except for a windows machine.
+     */
+    @Test
+    public void testWindowsMachineUsesVanillaPublicAddress() throws Exception {
+        initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1"), ImmutableList.of("2.1.1.1"), ImmutableMap.of());
+        reachableIp = "1.1.1.1";
+
+        JcloudsWinRmMachineLocation machine = newWinrmMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
+                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .build());
+        
+        addressChooser.assertCalled();
+        assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
         assertEquals(machine.getHostname(), reachableIp);
@@ -197,7 +216,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
-        assertEquals(machine.getHostname(), "1.1.1.1");
+        assertEquals(machine.getHostname(), "1.1.1.1"); // preferes public, even if that was not reachable
         assertEquals(machine.getSubnetIp(), reachableIp);
     }
 
@@ -219,7 +238,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
-        assertEquals(machine.getHostname(), "1.1.1.1");
+        assertEquals(machine.getHostname(), reachableIp);
         assertEquals(machine.getSubnetIp(), "2.1.1.1");
     }
 
@@ -227,7 +246,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
      * Multiple private addresses; chooses the reachable one;
      * With waitForSshable=true; pollForFirstReachableAddress=true; and custom reachable-predicate
      */
-    @Test(enabled = false, groups = "WIP")
+    @Test
     public void testMachineUsesReachablePrivateAddress() throws Exception {
         initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1"), ImmutableList.of("2.1.1.1", "2.1.1.2", "2.1.1.2"), ImmutableMap.of());
         reachableIp = "2.1.1.2";
@@ -241,8 +260,8 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
-        assertEquals(machine.getHostname(), reachableIp);
-        assertEquals(machine.getSubnetIp(), reachableIp);
+        assertEquals(machine.getHostname(), "1.1.1.1"); // prefers public, even if that was not reachable
+        assertEquals(machine.getSubnetIp(), "2.1.1.1"); // TODO uses first, rather than "reachable"; is that ok?
     }
 
     /**
@@ -313,6 +332,34 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(machine.getSubnetIp(), "2.1.1.1");
     }
     
+    /**
+     * Similar to {@link #testMachineUsesVanillaPublicAddress()}, except for a windows machine.
+     */
+    @Test
+    public void testWindowsReachabilityChecksWithPortForwarding() throws Exception {
+        initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1"), ImmutableList.of("2.1.1.1"), ImmutableMap.of());
+        reachableIp = "1.2.3.4";
+                
+        PortForwardManager pfm = new PortForwardManagerImpl();
+        RecordingJcloudsPortForwarderExtension portForwarder = new RecordingJcloudsPortForwarderExtension(pfm);
+        
+        JcloudsWinRmMachineLocation machine = newWinrmMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
+                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocation.USE_PORT_FORWARDING, true)
+                .put(JcloudsLocation.PORT_FORWARDER, portForwarder)
+                .build());
+        
+        addressChooser.assertNotCalled();
+        assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_HOST.getName()), reachableIp);
+        assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_PORT.getName()), 12345);
+
+        assertEquals(machine.getAddress().getHostAddress(), "1.2.3.4");
+        assertEquals(machine.getPort(), 12345);
+        assertEquals(machine.getHostname(), "1.2.3.4"); // TODO Different impl from JcloudsSshMachineLocation!
+        assertEquals(machine.getSubnetIp(), "2.1.1.1");
+    }
+    
     @Test
     public void testMachineUsesFirstPublicAddress() throws Exception {
         initNodeCreatorAndJcloudsLocation(ImmutableList.of("10.10.10.1", "10.10.10.2"), ImmutableList.of("1.1.1.1", "1.1.1.2", "1.1.1.2"), ImmutableMap.of());
@@ -334,6 +381,19 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         return obtainMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
                 .put(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshTool.class.getName())
                 .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS_PREDICATE, addressChooser)
+                .putAll(additionalConfig)
+                .build());
+    }
+    
+    protected JcloudsWinRmMachineLocation newWinrmMachine() throws Exception {
+        return newWinrmMachine(ImmutableMap.<ConfigKey<?>, Object>of());
+    }
+    
+    protected JcloudsWinRmMachineLocation newWinrmMachine(Map<? extends ConfigKey<?>, ?> additionalConfig) throws Exception {
+        return obtainWinrmMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
+                .put(WinRmMachineLocation.WINRM_TOOL_CLASS, RecordingWinRmTool.class.getName())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS_PREDICATE, addressChooser)
+                .put(JcloudsLocation.OS_FAMILY_OVERRIDE, OsFamily.WINDOWS)
                 .putAll(additionalConfig)
                 .build());
     }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
@@ -183,7 +183,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
      * Only one public and one private; private is reachable;
      * With waitForSshable=true; pollForFirstReachableAddress=true; and custom reachable-predicate
      */
-    @Test(enabled = false, groups = "WIP")
+    @Test
     public void testMachineUsesVanillaPrivateAddress() throws Exception {
         initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1"), ImmutableList.of("2.1.1.1"), ImmutableMap.of());
         reachableIp = "2.1.1.1";
@@ -197,7 +197,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
-        assertEquals(machine.getHostname(), reachableIp);
+        assertEquals(machine.getHostname(), "1.1.1.1");
         assertEquals(machine.getSubnetIp(), reachableIp);
     }
 
@@ -205,7 +205,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
      * Multiple public addresses; chooses the reachable one;
      * With waitForSshable=true; pollForFirstReachableAddress=true; and custom reachable-predicate
      */
-    @Test(enabled = false, groups = "WIP")
+    @Test
     public void testMachineUsesReachablePublicAddress() throws Exception {
         initNodeCreatorAndJcloudsLocation(ImmutableList.of("1.1.1.1", "1.1.1.2", "1.1.1.2"), ImmutableList.of("2.1.1.1"), ImmutableMap.of());
         reachableIp = "1.1.1.2";
@@ -219,7 +219,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsLiveTest 
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
         assertEquals(machine.getAddress().getHostAddress(), reachableIp);
-        assertEquals(machine.getHostname(), reachableIp);
+        assertEquals(machine.getHostname(), "1.1.1.1");
         assertEquals(machine.getSubnetIp(), "2.1.1.1");
     }
 

--- a/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
@@ -48,10 +48,12 @@ public class RecordingWinRmTool implements WinRmTool {
     
     public static class ExecParams {
         public final ExecType type;
+        public final Map<?, ?> constructorProps;
         public final List<String> commands;
         
-        public ExecParams(ExecType type, List<String> commands) {
+        public ExecParams(ExecType type, Map<?, ?> constructorProps, List<String> commands) {
             this.type = type;
+            this.constructorProps = constructorProps;
             this.commands = commands;
         }
         
@@ -59,6 +61,7 @@ public class RecordingWinRmTool implements WinRmTool {
         public String toString() {
             return Objects.toStringHelper(this)
                     .add("type", type)
+                    .add("constructorProps", constructorProps)
                     .add("commands", commands)
                     .toString();
         }
@@ -118,28 +121,31 @@ public class RecordingWinRmTool implements WinRmTool {
     public static ExecParams getLastExec() {
         return execs.get(execs.size()-1);
     }
+
+    private final Map<?, ?> ownConstructorProps;
     
     public RecordingWinRmTool(Map<?,?> props) {
         constructorProps.add(props);
+        ownConstructorProps = props;
     }
     
     @Override
     public WinRmToolResponse executeCommand(List<String> commands) {
-        ExecParams execParams = new ExecParams(ExecType.COMMAND, commands);
+        ExecParams execParams = new ExecParams(ExecType.COMMAND, ownConstructorProps, commands);
         execs.add(execParams);
         return generateResponse(execParams);
     }
 
     @Override
     public WinRmToolResponse executePs(List<String> commands) {
-        ExecParams execParams = new ExecParams(ExecType.POWER_SHELL, commands);
+        ExecParams execParams = new ExecParams(ExecType.POWER_SHELL, ownConstructorProps, commands);
         execs.add(execParams);
         return generateResponse(execParams);
     }
 
     @Override
     public WinRmToolResponse copyToServer(InputStream source, String destination) {
-        execs.add(new ExecParams(ExecType.COPY_TO_SERVER, ImmutableList.of(new String(Streams.readFully(source)))));
+        execs.add(new ExecParams(ExecType.COPY_TO_SERVER, ownConstructorProps, ImmutableList.of(new String(Streams.readFully(source)))));
         return new WinRmToolResponse("", "", 0);
     }
 


### PR DESCRIPTION
Use managementHostAndPort for all customizations made in
- obtainOnce(ConfigBag)
- registerMachineLocation(ConfigBag, NodeMetadata)