### PR TITLE
Fix LocalhostMachineProvisioningLocationTest

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
@@ -24,47 +24,42 @@ import static org.testng.Assert.fail;
 
 import java.net.ServerSocket;
 
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.api.location.NoMachinesAvailableException;
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.core.location.PortRanges;
+import org.apache.brooklyn.core.location.geo.HostGeoInfo;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.net.Networking;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.api.location.LocationSpec;
-import org.apache.brooklyn.api.location.MachineProvisioningLocation;
-import org.apache.brooklyn.api.location.NoMachinesAvailableException;
-import org.apache.brooklyn.api.location.PortRange;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.location.PortRanges;
-import org.apache.brooklyn.core.location.geo.HostGeoInfo;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-import org.apache.brooklyn.location.ssh.SshMachineLocation;
 
-public class LocalhostMachineProvisioningLocationTest {
+public class LocalhostMachineProvisioningLocationTest extends BrooklynMgmtUnitTestSupport {
 
     private static final Logger log = LoggerFactory.getLogger(LocalhostMachineProvisioningLocationTest.class);
     
-    private LocalManagementContext mgmt;
-
-    @BeforeMethod
-    @AfterClass
-    protected void clearStatics() {
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         LocalhostMachineProvisioningLocation.clearStaticData();
     }
     
-    @BeforeClass
-    protected void setup() {
-        mgmt = LocalManagementContextForTests.newInstance();
-    }
-    
-    @AfterClass
-    protected void teardown() {
-        Entities.destroyAll(mgmt);
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            LocalhostMachineProvisioningLocation.clearStaticData();
+        }
     }
     
     protected LocalhostMachineProvisioningLocation newLocalhostProvisioner() {


### PR DESCRIPTION
Use @BeforeMethod rather than @BeforeClass for test setup/teardown

The PR build for https://github.com/apache/brooklyn-server/pull/355 (see https://builds.apache.org/job/brooklyn-server-pull-requests/org.apache.brooklyn$brooklyn-core/1138/consoleFull) shows all but the first test in `LocalhostMachineProvisioningLocationTest` failing with the exception:

```
2016-09-27 21:49:31,219 INFO  TESTNG FAILED: "Surefire test" - org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocationTest.obtainLowNumberedPortsAutomatically() finished in 0 ms
java.lang.IllegalStateException: Management context no longer running
	at org.apache.brooklyn.core.mgmt.internal.LocalManagementContext.getLocationManager(LocalManagementContext.java:270)
	at org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocationTest.newLocalhostProvisioner(LocalhostMachineProvisioningLocationTest.java:71)
	at org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocationTest.obtainLowNumberedPortsAutomatically(LocalhostMachineProvisioningLocationTest.java:161)
```

Looking at the console output, there are tests from other classes run between the first and subsequent tests in `LocalhostMachineProvisioningLocationTest`. Presumably one of these spotted that there was a management context left running, and terminated it?!

The fix should be simple: to change the test to use `@BeforeMethod` and `@AfterMethod` like our other tests do.

Not sure why jenkins/surefire ran the tests in a strange order. Hopefully it's not running the tests concurrently, but was instead just interleaving tests from different classes?