### PR TITLE
Allow REST API to return the pinned config key and their constraints for catalog apps 

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogConfig.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogConfig.java
@@ -30,9 +30,11 @@ public @interface CatalogConfig {
     /** a label to be displayed when a config key is exposed as editable in the catalog */ 
     String label();
     
-    /** a priority used to determine the order in which config keys are displayed when presenting as editable in the catalog;
-     * a higher value appears higher in the list. the default is 1.
-     * (negative values may be used to indicate advanced config which might not be shown unless requested.) */ 
+    /** a priority used to determine the order in which config keys are displayed when presenting as editable in the
+     * catalog. The default is 1. */
     double priority() default 1;
-    
+
+     /** a pinned configuration means that the config key will always be displayed when presenting as editable in the
+      * catalog. The default is true. */
+    boolean pinned() default true;
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
@@ -66,7 +66,8 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
                 "    - simple",
                 "    - name: explicit_name",
                 "    - name: third_input",
-                "      type: integer");
+                "      type: integer",
+                "      pinned: false");
         EntitySpec<?> item = mgmt().getTypeRegistry().createSpec(mgmt().getTypeRegistry().get(itemId), null, EntitySpec.class);
         List<SpecParameter<?>> inputs = item.getParameters();
         assertEquals(inputs.size(), 6);
@@ -84,7 +85,7 @@ public class SpecParameterParsingTest  extends AbstractYamlTest {
         
         SpecParameter<?> thirdInput = inputs.get(2);
         assertEquals(thirdInput.getLabel(), "third_input");
-        assertEquals(thirdInput.isPinned(), true);
+        assertEquals(thirdInput.isPinned(), false);
         assertEquals(thirdInput.getConfigKey().getName(), "third_input");
         assertEquals(thirdInput.getConfigKey().getTypeToken(), TypeToken.of(Integer.class));
     }

--- a/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromClassTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromClassTest.java
@@ -50,23 +50,23 @@ public class BasicSpecParameterFromClassTest {
     }
 
     public interface SpecParameterTestEntity extends Entity {
-        @CatalogConfig(label="String Key", priority=3)
+        @CatalogConfig(label="String Key", priority=3, pinned = false)
         ConfigKey<String> STRING_KEY = ConfigKeys.newStringConfigKey("string_key");
 
         @CatalogConfig(label="Integer Key", priority=2)
-        ConfigKey<Integer> INTEGER_KEY = ConfigKeys.newIntegerConfigKey("integer_key");
+        ConfigKey<Integer> INTEGER_PINNED_KEY = ConfigKeys.newIntegerConfigKey("integer_key");
 
         @SuppressWarnings("serial")
         @CatalogConfig(label="Predicate Key", priority=1)
-        ConfigKey<Predicate<String>> PREDICATE_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "predicate_key");
+        ConfigKey<Predicate<String>> PREDICATE_PINNED_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "predicate_key");
 
         @SuppressWarnings("serial")
-        @CatalogConfig(label="Hidden 1 Key", priority=-1)
+        @CatalogConfig(label="Hidden 1 Key", priority=-1, pinned = false)
         ConfigKey<Predicate<String>> HIDDEN1_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden1_key");
 
         @SuppressWarnings("serial")
         @CatalogConfig(label="Hidden 2 Key", priority=-2)
-        ConfigKey<Predicate<String>> HIDDEN2_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden2_key");
+        ConfigKey<Predicate<String>> HIDDEN2_PINNED_KEY = ConfigKeys.newConfigKey(new TypeToken<Predicate<String>>() {}, "hidden2_key");
 
         ConfigKey<String> UNPINNNED2_KEY = ConfigKeys.newStringConfigKey("unpinned2_key");
         ConfigKey<String> UNPINNNED1_KEY = ConfigKeys.newStringConfigKey("unpinned1_key");
@@ -82,11 +82,11 @@ public class BasicSpecParameterFromClassTest {
     public void testFullDefinition() {
         List<SpecParameter<?>> inputs = BasicSpecParameter.fromClass(mgmt, SpecParameterTestEntity.class);
         assertEquals(inputs.size(), 7);
-        assertInput(inputs.get(0), "String Key", true, SpecParameterTestEntity.STRING_KEY);
-        assertInput(inputs.get(1), "Integer Key", true, SpecParameterTestEntity.INTEGER_KEY);
-        assertInput(inputs.get(2), "Predicate Key", true, SpecParameterTestEntity.PREDICATE_KEY);
-        assertInput(inputs.get(3), "Hidden 1 Key", true, SpecParameterTestEntity.HIDDEN1_KEY);
-        assertInput(inputs.get(4), "Hidden 2 Key", true, SpecParameterTestEntity.HIDDEN2_KEY);
+        assertInput(inputs.get(0), "String Key", false, SpecParameterTestEntity.STRING_KEY);
+        assertInput(inputs.get(1), "Integer Key", true, SpecParameterTestEntity.INTEGER_PINNED_KEY);
+        assertInput(inputs.get(2), "Predicate Key", true, SpecParameterTestEntity.PREDICATE_PINNED_KEY);
+        assertInput(inputs.get(3), "Hidden 1 Key", false, SpecParameterTestEntity.HIDDEN1_KEY);
+        assertInput(inputs.get(4), "Hidden 2 Key", true, SpecParameterTestEntity.HIDDEN2_PINNED_KEY);
         assertInput(inputs.get(5), "unpinned1_key", false, SpecParameterTestEntity.UNPINNNED1_KEY);
         assertInput(inputs.get(6), "unpinned2_key", false, SpecParameterTestEntity.UNPINNNED2_KEY);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.objs;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -29,7 +30,6 @@ import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
-import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.testng.annotations.BeforeMethod;
@@ -86,6 +86,7 @@ public class BasicSpecParameterFromListTest {
         String description = "Some description";
         String inputType = "string";
         String defaultValue = "VALUE";
+        Boolean pinned = false;
         String constraint = "required";
         SpecParameter<?> input = parse(ImmutableMap.builder()
                 .put("name", name)
@@ -93,11 +94,12 @@ public class BasicSpecParameterFromListTest {
                 .put("description", description)
                 .put("type", inputType)
                 .put("default", defaultValue)
+                .put("pinned", pinned)
                 .put("constraints", constraint)
                 .build());
 
         assertEquals(input.getLabel(), label);
-        assertTrue(input.isPinned());
+        assertFalse(input.isPinned());
 
         ConfigKey<?> type = input.getConfigKey();
         assertEquals(type.getName(), name);
@@ -170,6 +172,19 @@ public class BasicSpecParameterFromListTest {
         parse(ImmutableMap.of(
                 "name", name,
                 "type", "missing_type"));
+    }
+
+    @Test
+    public void testDefaultPinned() {
+        String name = "pinned";
+        String label = "Is pinned";
+        String description = "Is pinned description";
+        SpecParameter<?> input = parse(ImmutableMap.of(
+                "name", name,
+                "label", label,
+                "description", description));
+
+        assertTrue(input.isPinned());
     }
 
     private SpecParameter<?> parse(Object def) {

--- a/policy/src/main/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/action/StopAfterDurationPolicy.java
@@ -33,7 +33,6 @@ import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.sensor.DurationSinceSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityConfigSummary.java
@@ -18,20 +18,29 @@
  */
 package org.apache.brooklyn.rest.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.ImmutableMap;
-
-import org.apache.brooklyn.config.ConfigKey;
-
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.text.StringPredicates;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
 public class EntityConfigSummary extends ConfigSummary {
 
     private static final long serialVersionUID = -1336134336883426030L;
+
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    private final Boolean pinned;
+
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    private final List<String> constraints;
 
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     private final Map<String, URI> links;
@@ -45,14 +54,30 @@ public class EntityConfigSummary extends ConfigSummary {
             @JsonProperty("label") String label,
             @JsonProperty("priority") Double priority,
             @JsonProperty("possibleValues") List<Map<String, String>> possibleValues,
+            @JsonProperty("pinned") Boolean pinned,
+            @JsonProperty("constraints") List<String> constraints,
             @JsonProperty("links") Map<String, URI> links) {
         super(name, type, description, defaultValue, reconfigurable, label, priority, possibleValues);
+        this.pinned = pinned;
+        this.constraints = (constraints == null) ? ImmutableList.<String>of() : ImmutableList.copyOf(constraints);
         this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
     }
 
-    public EntityConfigSummary(ConfigKey<?> config, String label, Double priority, Map<String, URI> links) {
+    public EntityConfigSummary(ConfigKey<?> config, String label, Double priority, Boolean pinned, Map<String, URI> links) {
         super(config, label, priority);
+        this.pinned = pinned;
+        this.constraints = !config.getConstraint().equals(Predicates.alwaysTrue())
+                ? ImmutableList.of((config.getConstraint().getClass().equals(StringPredicates.isNonBlank().getClass()) ? "required" : config.getConstraint().toString()))
+                : ImmutableList.<String>of();
         this.links = links != null ? ImmutableMap.copyOf(links) : null;
+    }
+
+    public Boolean isPinned() {
+        return pinned;
+    }
+
+    public List<String> getConstraints() {
+        return constraints;
     }
 
     @Override
@@ -63,10 +88,12 @@ public class EntityConfigSummary extends ConfigSummary {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EntityConfigSummary)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         EntityConfigSummary that = (EntityConfigSummary) o;
-        return Objects.equals(links, that.links);
+        if (pinned != that.pinned) return false;
+        if (constraints != null ? !constraints.equals(that.constraints) : that.constraints != null) return false;
+        return links != null ? links.equals(that.links) : that.links == null;
     }
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType;
@@ -82,8 +83,9 @@ public class CatalogTransformer {
             EntityDynamicType typeMap = BrooklynTypes.getDefinedEntityType(spec.getType());
             EntityType type = typeMap.getSnapshot();
 
+            AtomicInteger paramPriorityCnt = new AtomicInteger();
             for (SpecParameter<?> input: spec.getParameters())
-                config.add(EntityTransformer.entityConfigSummary(input));
+                config.add(EntityTransformer.entityConfigSummary(input, paramPriorityCnt));
             for (Sensor<?> x: type.getSensors())
                 sensors.add(SensorTransformer.sensorSummaryForCatalog(x));
             for (Effector<?> x: type.getEffectors())

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ItemDescriptors.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ItemDescriptors.java
@@ -211,7 +211,7 @@ public class ItemDescriptors {
                 }
 
                 EntityConfigSummary entityConfigSummary = EntityTransformer.entityConfigSummary(param.getConfigKey(),
-                    param.getLabel(), priority, MutableMap.<String,URI>of());
+                    param.getLabel(), priority, param.isPinned(), MutableMap.<String,URI>of());
                 config.add(entityConfigSummary);
             }
             itemDescriptor.put("config", config);

--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/RelativeEntityTestCase.java
@@ -21,12 +21,10 @@ package org.apache.brooklyn.test.framework;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
-import org.apache.brooklyn.core.sensor.Sensors;
 
 import com.google.common.base.Predicates;
 


### PR DESCRIPTION
Based on https://github.com/apache/brooklyn-server/pull/354

This expose a new `pinned` flag and `constraints` key to the REST API. It allows the following:
- A blueprint can specify a config key or parameter as pinned by using `@CatalogConfig(pinned = true)` or in yaml `pinned: true`
- In case of config keys or parameters pinned in YAML, the priority is auto incremented to keep the order (code lost in [this commit](https://github.com/apache/brooklyn-server/commit/6f624c78b1e7fe72c6df1ecd297b922721b2c023#diff-5310fbeb1f42a3a4cf0508ea441440baL82))