### PR TITLE
Rebind when entity starting: report notUpIndicator for reason

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicEntityRebindSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicEntityRebindSupport.java
@@ -248,6 +248,10 @@ public class BasicEntityRebindSupport extends AbstractBrooklynObjectRebindSuppor
             LOG.warn("Entity {} goes on-fire because it was in state {} on rebind", entity, expectedState);
             LOG.warn("not-up-indicators={}", entity.getAttribute(Attributes.SERVICE_NOT_UP_INDICATORS));
             ServiceStateLogic.setExpectedState(entity, Lifecycle.ON_FIRE);
+            ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(
+                    entity, 
+                    "Task aborted on rebind", 
+                    "Set to on-fire (from previous expected state "+expectedState+") because tasks aborted on rebind");
         }
         super.instanceRebind(instance);
     }


### PR DESCRIPTION
Entity is reported as on-fire if the starting/stopping task was
aborted due to a Brooklyn rebind. This will set the
SERVICE_NOT_IP_INDICATORS to say what the problem is.