### PR TITLE
[BROOKLYN-356] Transformer value resolver test

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/enricher/TransformerEnricherWithDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/enricher/TransformerEnricherWithDslTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.enricher;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.enricher.stock.Transformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+public class TransformerEnricherWithDslTest extends BrooklynAppUnitTestSupport {
+    private static final Logger LOG = LoggerFactory.getLogger(TransformerEnricherWithDslTest.class);
+
+    int START_PORT = 10000;
+
+    @Test(groups="Broken")
+    // See https://issues.apache.org/jira/browse/BROOKLYN-356
+    public void testTransformerResolvesResolvableValues() {
+        testTransformerResolvesResolvableValues(START_PORT, 200);
+    }
+
+    @Test(groups={"Integration", "Broken"}, invocationCount=10)
+    // See https://issues.apache.org/jira/browse/BROOKLYN-356
+    public void testTransformerResolvesResolvableValuesIntegration() {
+        LOG.info("Starting 1000 iterations");
+        testTransformerResolvesResolvableValues(START_PORT, 1000);
+    }
+
+    private void testTransformerResolvesResolvableValues(int portStart, int portCount) {
+        // Note: The test gets progressively slower with iterations, probably due to the GC triggering much more frequently.
+        //       There's no memory leak, but doesn't seem right to be putting so much pressure on the GC with such a simple test.
+        AttributeSensor<Integer> sourceSensor = Sensors.newIntegerSensor("port");
+        AttributeSensor<String> targetSensor = Sensors.newStringSensor("port.transformed");
+        app.enrichers().add(EnricherSpec.create(Transformer.class)
+                .configure(Transformer.SOURCE_SENSOR, sourceSensor)
+                .configure(Transformer.TARGET_SENSOR, targetSensor)
+                .configure(Transformer.TARGET_VALUE,
+                        // Can only use the inner-most sensor, but including the
+                        // wrapping formatStrings amplifies the resolving effort, making
+                        // a bug more probable to manifest.
+                        BrooklynDslCommon.formatString("%s",
+                                BrooklynDslCommon.formatString("%d",
+                                        BrooklynDslCommon.attributeWhenReady("port")))));
+
+        int failures = 0;
+        for (int port = portStart; port < portStart + portCount; port++) {
+            app.sensors().set(sourceSensor, port);
+            try {
+                EntityAsserts.assertAttributeEqualsEventually(app, targetSensor, Integer.toString(port));
+            } catch (Exception e) {
+                failures++;
+                LOG.warn("Assertion failed, port=" + port + ", transformed sensor is " + app.sensors().get(targetSensor), e);
+            }
+        }
+
+        assertEquals(failures, 0, failures + " assertion failures while transforming sensor; see logs for detailed errors");
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
+++ b/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
@@ -84,6 +84,14 @@ public class BrooklynFeatureEnablement {
     public static final String FEATURE_RENAME_THREADS = "brooklyn.executionManager.renameThreads";
 
     /**
+     * Add a jitter to the startup of tasks for testing concurrency code.
+     * Use {@code brooklyn.executionManager.jitterThreads.maxDelay} to tune the maximum time task
+     * startup gets delayed in milliseconds. The actual time will be a random value between [0, maxDelay).
+     * Default is 200 milliseconds.
+     */
+    public static final String FEATURE_JITTER_THREADS = "brooklyn.executionManager.jitterThreads";
+
+    /**
      * When rebinding to state created from very old versions, the catalogItemId properties will be missing which
      * results in errors when OSGi bundles are used. When enabled the code tries to infer the catalogItemId from
      * <ul>
@@ -149,6 +157,7 @@ public class BrooklynFeatureEnablement {
         setDefault(FEATURE_DEFAULT_STANDBY_IS_HOT_PROPERTY, false);
         setDefault(FEATURE_USE_BROOKLYN_LIVE_OBJECTS_DATAGRID_STORAGE, false);
         setDefault(FEATURE_RENAME_THREADS, false);
+        setDefault(FEATURE_JITTER_THREADS, false);
         setDefault(FEATURE_BACKWARDS_COMPATIBILITY_INFER_CATALOG_ITEM_ON_REBIND, true);
         setDefault(FEATURE_AUTO_FIX_CATALOG_REF_ON_REBIND, false);
         setDefault(FEATURE_SSH_ASYNC_EXEC, false);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
@@ -754,7 +754,7 @@ public class BasicExecutionManager implements ExecutionManager {
         activeTaskCount.incrementAndGet();
         
         //set thread _before_ start time, so we won't get a null thread when there is a start-time
-        if (log.isTraceEnabled()) log.trace(""+this+" beforeStart, task: "+task);
+        if (log.isTraceEnabled()) log.trace(""+this+" beforeStart, task: "+task + " running on thread " + Thread.currentThread().getName());
         if (!task.isCancelled()) {
             Thread thread = Thread.currentThread();
             ((TaskInternal<?>)task).setThread(thread);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
@@ -516,13 +516,7 @@ public class BasicExecutionManager implements ExecutionManager {
             try {
                 T result = null;
                 Throwable error = null;
-                String oldThreadName = Thread.currentThread().getName();
                 try {
-                    if (RENAME_THREADS) {
-                        String newThreadName = oldThreadName+"-"+task.getDisplayName()+
-                            "["+task.getId().substring(0, 8)+"]";
-                        Thread.currentThread().setName(newThreadName);
-                    }
                     beforeStartAtomicTask(flags, task);
                     if (!task.isCancelled()) {
                         result = ((TaskInternal<T>)task).getJob().call();
@@ -530,9 +524,6 @@ public class BasicExecutionManager implements ExecutionManager {
                 } catch(Throwable e) {
                     error = e;
                 } finally {
-                    if (RENAME_THREADS) {
-                        Thread.currentThread().setName(oldThreadName);
-                    }
                     afterEndAtomicTask(flags, task);
                 }
                 if (error!=null) {


### PR DESCRIPTION
* Adds thread startup jittering so we can lure out any concurrency bugs hiding in the code base. Testing `core` with this results in a handful of failures. Similar problems are very apparent on the windows builds where the machines have a single CPU and are frequently failing. I'd enable this by default for testing only if it wasn't slowing the tests to a craw.
* Adds a test which shows the problem with the transformer resolver. It's failing under normal conditions infrequently, so use with the above enabled.

Tests are marked as `Broken` because there's no fix available for `BOOKLYN-356` yet so they might fail builds. The tests are otherwise fully implemented/working.