### PR TITLE
More jclouds location unit tests

### DIFF
--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedUnitTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedUnitTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import java.util.Map;
+
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
+import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Stubs out all comms with the cloud provider.
+ * 
+ * Expects sub-classes to call {@link #initNodeCreatorAndJcloudsLocation(NodeCreator, Map)} before
+ * the test methods are called.
+ */
+public abstract class AbstractJcloudsStubbedUnitTest extends AbstractJcloudsLiveTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractJcloudsStubbedUnitTest.class);
+
+    // TODO These values are hard-coded into the JcloudsStubTemplateBuilder, so best not to mess!
+    public static final String LOCATION_SPEC = "jclouds:aws-ec2:us-east-1";
+    
+    protected NodeCreator nodeCreator;
+    protected ComputeServiceRegistry computeServiceRegistry;
+    
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RecordingSshTool.clear();
+        RecordingWinRmTool.clear();
+    }
+    
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            RecordingSshTool.clear();
+            RecordingWinRmTool.clear();
+        }
+    }
+
+    @Override
+    protected LocalManagementContext newManagementContext() {
+        return LocalManagementContextForTests.builder(true).build();
+    }
+    
+    /**
+     * Expect sub-classes to call this - either in their {@link BeforeMethod} or at the very 
+     * start of the test method (to allow custom config per test).
+     */
+    protected void initNodeCreatorAndJcloudsLocation(NodeCreator nodeCreator, Map<?, ?> jcloudsLocationConfig) throws Exception {
+        this.nodeCreator = nodeCreator;
+        this.computeServiceRegistry = new StubbedComputeServiceRegistry(nodeCreator, false);
+
+        this.jcloudsLocation = (JcloudsLocation)managementContext.getLocationRegistry().getLocationManaged(
+                getLocationSpec(),
+                ImmutableMap.builder()
+                        .put(JcloudsLocationConfig.COMPUTE_SERVICE_REGISTRY, computeServiceRegistry)
+                        .put(JcloudsLocationConfig.TEMPLATE_BUILDER, JcloudsStubTemplateBuilder.create())
+                        .put(JcloudsLocationConfig.ACCESS_IDENTITY, "stub-identity")
+                        .put(JcloudsLocationConfig.ACCESS_CREDENTIAL, "stub-credential")
+                        .put(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshTool.class.getName())
+                        .put(WinRmMachineLocation.WINRM_TOOL_CLASS, RecordingWinRmTool.class.getName())
+                        .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS_PREDICATE, Predicates.alwaysTrue())
+                        .putAll(jcloudsLocationConfig)
+                        .build());
+    }
+
+    /**
+     * For overriding.
+     */
+    protected String getLocationSpec() {
+        return LOCATION_SPEC;
+    }
+}

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
@@ -60,7 +60,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloudsStubbedLiveTest {
+public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloudsStubbedUnitTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsByonLocationResolverStubbedRebindTest.class);
     
@@ -92,6 +92,8 @@ public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloud
         LOG.info("Test "+getClass()+" persisting to "+mementoDir);
         
         super.setUp();
+        
+        initNodeCreatorAndJcloudsLocation(newNodeCreator(), ImmutableMap.of());
     }
 
     @AfterMethod(alwaysRun=true)
@@ -110,7 +112,6 @@ public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloud
         origManagementContext = null;
     }
 
-    @Override
     protected NodeCreator newNodeCreator() {
         return new NodeCreatorForRebinding();
     }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedTest.java
@@ -41,6 +41,7 @@ import org.jclouds.compute.domain.Template;
 import org.jclouds.domain.LoginCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
@@ -49,7 +50,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-public class JcloudsByonLocationResolverStubbedTest extends AbstractJcloudsStubbedLiveTest {
+public class JcloudsByonLocationResolverStubbedTest extends AbstractJcloudsStubbedUnitTest {
 
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(JcloudsByonLocationResolverStubbedTest.class);
@@ -57,6 +58,13 @@ public class JcloudsByonLocationResolverStubbedTest extends AbstractJcloudsStubb
     private final String nodeId = "mynodeid";
     private final String nodePublicAddress = "173.194.32.123";
     private final String nodePrivateAddress = "172.168.10.11";
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        initNodeCreatorAndJcloudsLocation(newNodeCreator(), ImmutableMap.of());
+    }
     
     protected LocalManagementContext newManagementContext() {
         // This really is stubbed; no live access to the cloud
@@ -68,7 +76,6 @@ public class JcloudsByonLocationResolverStubbedTest extends AbstractJcloudsStubb
 
     }
 
-    @Override
     protected NodeCreator newNodeCreator() {
         return new AbstractNodeCreator() {
             @Override

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedTest.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.location.jclouds;
 import static org.testng.Assert.assertEquals;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
@@ -45,7 +44,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStubbedLiveTest {
+public class JcloudsSshMachineLocationStubbedTest extends AbstractJcloudsStubbedUnitTest {
 
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(JcloudsImageChoiceStubbedLiveTest.class);
@@ -55,12 +54,12 @@ public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStu
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
+        super.setUp();
         privateAddresses = ImmutableList.of("172.168.10.11");
         publicAddresses = ImmutableList.of("173.194.32.123");
-        super.setUp();
+        initNodeCreatorAndJcloudsLocation(newNodeCreator(), ImmutableMap.of());
     }
     
-    @Override
     protected NodeCreator newNodeCreator() {
         return new AbstractNodeCreator() {
             @Override protected NodeMetadata newNode(String group, Template template) {
@@ -77,14 +76,7 @@ public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStu
         };
     }
 
-    protected Map<Object, Object> jcloudsLocationConfig(Map<Object, Object> defaults) {
-        return ImmutableMap.<Object, Object>builder()
-                .putAll(defaults)
-                .put(JcloudsLocationConfig.IMAGE_ID, "CENTOS_5_64")
-                .build();
-    }
-
-    @Test(groups={"Live", "Live-sanity"})
+    @Test
     public void testWithNoPrivateAddress() throws Exception {
         privateAddresses = ImmutableList.of();
         JcloudsSshMachineLocation machine = obtainMachine();
@@ -94,7 +86,7 @@ public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStu
         assertEquals(machine.getSubnetHostname(), publicAddresses.get(0));
     }
     
-    @Test(groups={"Live", "Live-sanity"})
+    @Test
     public void testWithPrivateAddress() throws Exception {
         JcloudsSshMachineLocation machine = obtainMachine();
         assertEquals(machine.getPrivateAddresses(), privateAddresses);
@@ -103,7 +95,7 @@ public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStu
         assertEquals(machine.getSubnetHostname(), privateAddresses.get(0));
     }
     
-    @Test(groups={"Live", "Live-sanity"})
+    @Test
     public void testSshConfigPassedToMachine() throws Exception {
         JcloudsSshMachineLocation machine = obtainMachine(ImmutableMap.of(
                 SshMachineLocation.LOCAL_TEMP_DIR.getName(), "/my/local/temp/dir",
@@ -114,11 +106,11 @@ public class JcloudsSshMachineLocationStubbedLiveTest extends AbstractJcloudsStu
         assertEquals(machine.config().get(SshTool.PROP_SSH_TRIES), Integer.valueOf(123));
     }
     
-    @Test(groups={"Live", "Live-sanity"})
+    @Test
     public void testWinrmConfigPassedToMachine() throws Exception {
         JcloudsWinRmMachineLocation machine = obtainWinrmMachine(ImmutableMap.of(
                 JcloudsLocation.OS_FAMILY_OVERRIDE.getName(), OsFamily.WINDOWS,
-                JcloudsLocation.WAIT_FOR_WINRM_AVAILABLE.getName(), "false",
+//                JcloudsLocation.WAIT_FOR_WINRM_AVAILABLE.getName(), "false",
                 WinRmMachineLocation.COPY_FILE_CHUNK_SIZE_BYTES.getName(), 123,
                 WinRmTool.PROP_EXEC_TRIES.getName(), 456));
         assertEquals(machine.config().get(WinRmMachineLocation.COPY_FILE_CHUNK_SIZE_BYTES), Integer.valueOf(123));

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/UnsupportedComputeService.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/UnsupportedComputeService.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.RunNodesException;
+import org.jclouds.compute.RunScriptOnNodesException;
+import org.jclouds.compute.domain.ComputeMetadata;
+import org.jclouds.compute.domain.ExecResponse;
+import org.jclouds.compute.domain.Hardware;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.extensions.ImageExtension;
+import org.jclouds.compute.extensions.SecurityGroupExtension;
+import org.jclouds.compute.options.RunScriptOptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.domain.Location;
+import org.jclouds.scriptbuilder.domain.Statement;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.util.concurrent.ListenableFuture;
+
+public class UnsupportedComputeService implements ComputeService {
+
+    @Override
+    public ComputeServiceContext getContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TemplateBuilder templateBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TemplateOptions templateOptions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends Hardware> listHardwareProfiles() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends Image> listImages() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Image getImage(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends ComputeMetadata> listNodes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> listNodesByIds(Iterable<String> ids) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends Location> listAssignableLocations() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, TemplateOptions templateOptions)
+            throws RunNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> createNodesInGroup(String group, int count) throws RunNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void resumeNode(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> resumeNodesMatching(Predicate<NodeMetadata> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void suspendNode(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> suspendNodesMatching(Predicate<NodeMetadata> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void destroyNode(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> destroyNodesMatching(Predicate<NodeMetadata> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rebootNode(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> rebootNodesMatching(Predicate<NodeMetadata> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NodeMetadata getNodeMetadata(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<ComputeMetadata> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<? extends NodeMetadata, ExecResponse> runScriptOnNodesMatching(Predicate<NodeMetadata> filter, String runScript)
+            throws RunScriptOnNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<? extends NodeMetadata, ExecResponse> runScriptOnNodesMatching(Predicate<NodeMetadata> filter, Statement runScript)
+            throws RunScriptOnNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<? extends NodeMetadata, ExecResponse> runScriptOnNodesMatching(Predicate<NodeMetadata> filter,
+            String runScript, RunScriptOptions options) throws RunScriptOnNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<? extends NodeMetadata, ExecResponse> runScriptOnNodesMatching(Predicate<NodeMetadata> filter,
+            Statement runScript, RunScriptOptions options) throws RunScriptOnNodesException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExecResponse runScriptOnNode(String id, Statement runScript, RunScriptOptions options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListenableFuture<ExecResponse> submitScriptOnNode(String id, String runScript, RunScriptOptions options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListenableFuture<ExecResponse> submitScriptOnNode(String id, Statement runScript, RunScriptOptions options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExecResponse runScriptOnNode(String id, Statement runScript) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExecResponse runScriptOnNode(String id, String runScript, RunScriptOptions options) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExecResponse runScriptOnNode(String id, String runScript) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ImageExtension> getImageExtension() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<SecurityGroupExtension> getSecurityGroupExtension() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Following on from @bostko's great changes in https://github.com/apache/brooklyn-server/pull/366 (to allow us to write more real unit tests, for JcloudsLocation testing), this PR converts the easiest tests into real unit tests.

@duncangrant you may well find this helpful for the JcloudsLocation customizer changes that you are making.