### PR TITLE
DynamicGroup filters entities in its app, not the management context

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.BrooklynLogging;
 import org.apache.brooklyn.core.BrooklynLogging.LoggingLevel;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.internal.CollectionChangeListener;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.core.task.Tasks;
@@ -210,7 +211,7 @@ public class DynamicGroupImpl extends AbstractGroupImpl implements DynamicGroup 
             Collection<Entity> currentMembers = getMembers();
             Collection<Entity> toRemove = Sets.newLinkedHashSet(currentMembers);
 
-            for (Entity it : Iterables.filter(getManagementContext().getEntityManager().getEntities(), entityFilter())) {
+            for (Entity it : Iterables.filter(Entities.descendantsAndSelf(getApplication()), entityFilter())) {
                 toRemove.remove(it);
                 if (!currentMembers.contains(it)) {
                     if (log.isDebugEnabled()) log.debug("{} rescan detected new item {}", this, it);

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicGroupTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicGroupTest.java
@@ -169,9 +169,9 @@ public class DynamicGroupTest {
         final AttributeSensor<String> MY_ATTRIBUTE = Sensors.newStringSensor("test.myAttribute", "My test attribute");
         group.setEntityFilter(new Predicate<Entity>() {
             @Override public boolean apply(Entity input) {
-                if (!(input.getAttribute(MY_ATTRIBUTE) == "yes")) 
+                if (!("yes".equals(input.getAttribute(MY_ATTRIBUTE)))) {
                     return false;
-                if (input.equals(e1)) {
+                } else if (input.equals(e1)) {
                     LOG.info("testGroupDetectsChangedEntitiesMatchingFilter scanned e1 when MY_ATTRIBUTE is yes; not a bug, but indicates things may be running slowly");
                     return false;
                 }
@@ -539,6 +539,15 @@ public class DynamicGroupTest {
             t1.interrupt();
             t2.interrupt();
         }
+    }
+
+    @Test
+    public void testOnlyMatchesEntitiesInSameApplication() {
+        TestApplication app2 = TestApplication.Factory.newManagedInstanceForTests(app.getManagementContext());
+        TestEntity irrelevant = app2.createAndManageChild(EntitySpec.create(TestEntity.class));
+        group.setEntityFilter(Predicates.instanceOf(TestEntity.class));
+        Collection<Entity> members = group.getMembers();
+        assertFalse(members.contains(irrelevant), "collection should not contain " + irrelevant + ": " + members);
     }
 
     private <T> void assertContainsEventually(final Collection<? extends T> vals, final T val) {


### PR DESCRIPTION
I think this would be the expected behaviour.

The current behaviour would cause entities like [brooklyn-dns-etc-hosts-generator](https://github.com/brooklyncentral/brooklyn-dns/blob/9898438dd2c8ddbe258ab93b1b66b42818b8121a/brooklyn-dns-etc-hosts-generator.bom#L43-L49) to be overenthusiastic at best and a security hole/information leak at worst.