### PR TITLE
One instance of customizer at each customize step

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/location/MachineLocationCustomizer.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/MachineLocationCustomizer.java
@@ -25,6 +25,11 @@ import com.google.common.annotations.Beta;
  * <p>
  * Users are strongly encouraged to sub-class {@link BasicMachineLocationCustomizer}, to give
  * some protection against this {@link Beta} API changing in future releases.
+ * 
+ * Customizers can be instantiated on-demand, so the {@link #customize(MachineLocation)}
+ * and {@link #preRelease(MachineLocation)} methods may not be called on the same instance. 
+ * This is always true after a Brooklyn restart, and may be true at other times depending 
+ * how the customizer has been wired in.
  */
 @Beta
 public interface MachineLocationCustomizer {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.camp.brooklyn;
 import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,7 @@ import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.location.jclouds.ComputeServiceRegistry;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationResolver;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.SingleNodeCreator;
@@ -139,9 +141,9 @@ public class ConfigLocationInheritanceYamlTest extends AbstractYamlTest {
     public static class RecordingJcloudsLocation extends JcloudsLocation {
         public final List<ConfigBag> templateConfigs = Lists.newCopyOnWriteArrayList();
         
-        public Template buildTemplate(ComputeService computeService, ConfigBag config) {
+        public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
             templateConfigs.add(config);
-            return super.buildTemplate(computeService, config);
+            return super.buildTemplate(computeService, config, customizers);
         }
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
@@ -141,6 +141,7 @@ public class ConfigLocationInheritanceYamlTest extends AbstractYamlTest {
     public static class RecordingJcloudsLocation extends JcloudsLocation {
         public final List<ConfigBag> templateConfigs = Lists.newCopyOnWriteArrayList();
         
+        @Override
         public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
             templateConfigs.add(config);
             return super.buildTemplate(computeService, config, customizers);
@@ -161,6 +162,7 @@ public class ConfigLocationInheritanceYamlTest extends AbstractYamlTest {
                 return "jclouds-config-test";
             }
 
+            @Override
             protected Class<? extends JcloudsLocation> getLocationClass() {
                 return RecordingJcloudsLocation.class;
             }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.location.Machines;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer;
+import org.apache.brooklyn.location.jclouds.ComputeServiceRegistry;
+import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.options.TemplateOptions;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * The test is designed to ensure that when a customizer is configured in
+ * yaml with fields that are configured via DSL (forcing brooklyn to
+ * return a {@link org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon.DslObject})
+ * that only one customizer is instantiated so that state may be maintained between customize calls.
+ *
+ * e.g.
+ *
+ * brooklyn.config:
+ *   provisioning.properties:
+ *     customizers:
+ *     - $brooklyn:object:
+ *       type: org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer
+ *       object.fields:
+ *         - enabled: $brooklyn:config("kubernetes.sharedsecuritygroup.create")
+ *
+ */
+@Test(groups = {"Live", "Live-sanity"})
+public class JcloudsCustomizerInstantiationYamlDslTest extends JcloudsRebindStubYamlTest {
+
+    protected Entity origApp;
+
+    @Override
+    protected JcloudsLocation newJcloudsLocation(ComputeServiceRegistry computeServiceRegistry) throws Exception {
+        ByonComputeServiceStaticRef.setInstance(computeServiceRegistry);
+
+        String yaml = Joiner.on("\n").join(
+                "location:",
+                "  " + LOCATION_SPEC + ":",
+                "    imageId: " + IMAGE_ID,
+                "    jclouds.computeServiceRegistry:",
+                "      $brooklyn:object:",
+                "        type: " + ByonComputeServiceStaticRef.class.getName(),
+                "    " + SshMachineLocation.SSH_TOOL_CLASS.getName() + ": " + RecordingSshTool.class.getName(),
+                "    waitForSshable: false",
+                "    useJcloudsSshInit: false",
+                "services:\n" +
+                "- type: " + MachineEntity.class.getName(),
+                "  brooklyn.config:",
+                "    onbox.base.dir.skipResolution: true",
+                "    sshMonitoring.enabled: false",
+                "    metrics.usage.retrieve: false",
+                "    enabled: true",
+                "    provisioning.properties:",
+                "      customizer:",
+                "        $brooklyn:object:",
+                "          type: " + RecordingLocationCustomizer.class.getName(),
+                "          object.fields:",
+                "            enabled: $brooklyn:config(\"enabled\")");
+
+        EntitySpec<?> spec = mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, yaml, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+        origApp = mgmt().getEntityManager().createEntity(spec);
+
+        return (JcloudsLocation) Iterables.getOnlyElement(origApp.getLocations());
+    }
+
+    @Override
+    protected JcloudsMachineLocation obtainMachine(JcloudsLocation jcloudsLoc, Map<?, ?> props) throws Exception {
+        final MachineEntity entity = (MachineEntity) Iterables.getOnlyElement(origApp.getChildren());
+        origApp.invoke(Startable.START, ImmutableMap.<String, Object>of()).get();
+
+        // Assert all customize functions called
+        assertEquals(RecordingLocationCustomizer.calls.size(), 4,
+                "size=" + RecordingLocationCustomizer.calls.size() + "; calls=" + RecordingLocationCustomizer.calls);
+
+        // Assert same instance used for all calls
+        RecordingLocationCustomizer firstInstance = RecordingLocationCustomizer.calls.get(0).instance;
+        for (RecordingLocationCustomizer.CallParams call : RecordingLocationCustomizer.calls) {
+            assertSame(call.instance, firstInstance);
+        }
+
+        JcloudsMachineLocation machine =
+                Machines.findUniqueMachineLocation(entity.getLocations(), JcloudsMachineLocation.class).get();
+
+        return machine;
+    }
+
+
+    public static class RecordingLocationCustomizer extends BasicJcloudsLocationCustomizer {
+
+        public static final List<CallParams> calls = Lists.newCopyOnWriteArrayList();
+        private Boolean enabled;
+
+        @Override
+        public void customize(JcloudsLocation location, ComputeService computeService, TemplateBuilder templateBuilder) {
+            calls.add(new CallParams(this, "customize", MutableList.of(location, computeService, templateBuilder)));
+        }
+
+        @Override
+        public void customize(JcloudsLocation location, ComputeService computeService, Template template) {
+            calls.add(new CallParams(this, "customize", MutableList.of(location, computeService, template)));
+        }
+
+        @Override
+        public void customize(JcloudsLocation location, ComputeService computeService, TemplateOptions templateOptions) {
+            calls.add(new CallParams(this, "customize", MutableList.of(location, computeService, templateOptions)));
+        }
+
+        @Override
+        public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machine) {
+            calls.add(new CallParams(this, "customize", MutableList.of(location, computeService, machine)));
+        }
+
+        @Override
+        public void preRelease(JcloudsMachineLocation machine) {
+            calls.add(new CallParams(this, "preRelease", MutableList.of(machine)));
+        }
+
+        @Override
+        public void postRelease(JcloudsMachineLocation machine) {
+            calls.add(new CallParams(this, "postRelease", MutableList.of(machine)));
+        }
+
+        public static class CallParams {
+            RecordingLocationCustomizer instance;
+            String method;
+            List<?> args;
+
+            public CallParams(RecordingLocationCustomizer instance, String method, List<?> args) {
+                this.instance = instance;
+                this.method = method;
+                this.args = args;
+            }
+        }
+    }
+}

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
@@ -18,16 +18,25 @@
  */
 package org.apache.brooklyn.launcher.command.support;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
 import org.apache.brooklyn.location.jclouds.JcloudsUtil;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.FatalConfigurationRuntimeException;
 import org.apache.brooklyn.util.stream.Streams;
 import org.jclouds.blobstore.BlobStore;
@@ -42,14 +51,9 @@ import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.options.TemplateOptions;
 
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
 
 /**
  * Convenience for listing Cloud Compute and BlobStore details.
@@ -272,8 +276,10 @@ public abstract class CloudExplorerSupport implements Callable<Void> {
         protected void doCall(JcloudsLocation loc, String indent) throws Exception {
 
             ComputeService computeService = loc.getComputeService();
+            ConfigBag setup = loc.config().getBag();
+            Collection<JcloudsLocationCustomizer> customizers = loc.getCustomizers(setup);
 
-            Template template = loc.buildTemplate(computeService, loc.config().getBag());
+            Template template = loc.buildTemplate(computeService, setup, customizers);
             Image image = template.getImage();
             Hardware hardware = template.getHardware();
             org.jclouds.domain.Location location = template.getLocation();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -692,6 +692,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             Set<? extends NodeMetadata> nodes;
             Template template;
             Collection<JcloudsLocationCustomizer> customizers = getCustomizers(setup);
+            Collection<MachineLocationCustomizer> machineCustomizers = getMachineCustomizers(setup);
+            
             try {
                 // Setup the template
                 template = buildTemplate(computeService, setup, customizers);
@@ -1056,7 +1058,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                 LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
                 customizer.customize(this, computeService, machineLocation);
             }
-            for (MachineLocationCustomizer customizer : getMachineCustomizers(setup)) {
+            for (MachineLocationCustomizer customizer : machineCustomizers) {
                 LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
                 customizer.customize(machineLocation);
             }
@@ -1640,7 +1642,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
         return BrooklynImageChooser.cloneFor(chooser, computeService, config);
     }
-    
+
     /** returns the jclouds Template which describes the image to be built, for the given config and compute service */
     public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
         TemplateBuilder templateBuilder = (TemplateBuilder) config.get(TEMPLATE_BUILDER);
@@ -2727,7 +2729,10 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         Exception tothrow = null;
 
         ConfigBag setup = config().getBag();
-        for (JcloudsLocationCustomizer customizer : getCustomizers(setup)) {
+        Collection<JcloudsLocationCustomizer> customizers = getCustomizers(setup);
+        Collection<MachineLocationCustomizer> machineCustomizers = getMachineCustomizers(setup);
+        
+        for (JcloudsLocationCustomizer customizer : customizers) {
             try {
                 customizer.preRelease(machine);
             } catch (Exception e) {
@@ -2737,7 +2742,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                 if (tothrow==null) tothrow = e;
             }
         }
-        for (MachineLocationCustomizer customizer : getMachineCustomizers(setup)) {
+        for (MachineLocationCustomizer customizer : machineCustomizers) {
             customizer.preRelease(machine);
         }
 
@@ -2764,7 +2769,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         removeChild(machine);
 
-        for (JcloudsLocationCustomizer customizer : getCustomizers(setup)) {
+        for (JcloudsLocationCustomizer customizer : customizers) {
             try {
                 customizer.postRelease(machine);
             } catch (Exception e) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -203,13 +203,13 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
     /** @deprecated since 0.7.0; use {@link #JCLOUDS_LOCATION_CUSTOMIZERS} instead */
     @Deprecated
     public static final ConfigKey<String> JCLOUDS_LOCATION_CUSTOMIZER_TYPE = ConfigKeys.newStringConfigKey(
-            "customizerType", "Optional location customizer type (to be class-loaded and constructed with no-arg constructor)");
+            "customizerType", "Optional location customizer type (to be class-loaded and constructed with either a ConfigBag or no-arg constructor)");
 
     /** @deprecated since 0.7.0; use {@link #JCLOUDS_LOCATION_CUSTOMIZERS} instead */
     @Deprecated
     public static final ConfigKey<String> JCLOUDS_LOCATION_CUSTOMIZERS_SUPPLIER_TYPE = ConfigKeys.newStringConfigKey(
             "customizersSupplierType", "Optional type of a Supplier<Collection<JcloudsLocationCustomizer>> " +
-            "(to be class-loaded and constructed with ConfigBag or no-arg constructor)");
+            "(to be class-loaded and constructed with either a ConfigBag or no-arg constructor)");
 
     public static final ConfigKey<String> LOCAL_TEMP_DIR = SshTool.PROP_LOCAL_TEMP_DIR;
     

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -32,6 +32,10 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
  * Instances will be invoked with the {@link ConfigBag} being used to obtain a machine by the
  * {@link JcloudsLocation} if such a constructor exists. If not, the default no argument constructor
  * will be invoked.
+ *
+ * Customizers are not persisted so the pre and postRelease will not be called on the same instance as was used in
+ * provisioning.  However the customize functions will be called on the same instance unless brooklyn is stopped, in which
+ * case vm provisioning would fail anyway.
  */
 public interface JcloudsLocationCustomizer {
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -23,19 +23,21 @@ import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.options.TemplateOptions;
 
-import org.apache.brooklyn.util.core.config.ConfigBag;
-
 /**
  * Customization hooks to allow apps to perform specific customisation at each stage of jclouds machine provisioning.
  * For example, an app could attach an EBS volume to an EC2 node, or configure a desired availability zone.
  * <p>
- * Instances will be invoked with the {@link ConfigBag} being used to obtain a machine by the
- * {@link JcloudsLocation} if such a constructor exists. If not, the default no argument constructor
- * will be invoked.
- *
- * Customizers are not persisted so the pre and postRelease will not be called on the same instance as was used in
- * provisioning.  However the customize functions will be called on the same instance unless brooklyn is stopped, in which
- * case vm provisioning would fail anyway.
+ * Users are strongly encouraged to sub-class {@link org.apache.brooklyn.location.jclouds.BasicJcloudsLocationCustomizer}, 
+ * to give some protection against this API changing in future releases.
+ * <p>
+ * Customizers can be instantiated on-demand, so the {@link #postRelease(JcloudsMachineLocation)}
+ * and {@link #postRelease(JcloudsMachineLocation)} methods may not be called on the same instance 
+ * as was used in provisioning. This is always true after a Brooklyn restart, and may be true at 
+ * other times depending how the customizer has been wired in.
+ * <p>
+ * However the customize functions will be called sequentially on the same instance during provisioning,
+ * unless Brooklyn is stopped (or fails over to a high-availability standby), in which case VM 
+ * provisioning would abort anyway.
  */
 public interface JcloudsLocationCustomizer {
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -19,6 +19,7 @@
 
 package org.apache.brooklyn.location.jclouds;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -73,13 +74,13 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
     }
 
     @Override
-    public Template buildTemplate(ComputeService computeService, ConfigBag config) {
+    public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
         lastConfigBag = config;
         if (getConfig(BUILD_TEMPLATE_INTERCEPTOR) != null) {
             getConfig(BUILD_TEMPLATE_INTERCEPTOR).apply(config);
         }
         if (Boolean.TRUE.equals(getConfig(BUILD_TEMPLATE))) {
-            template = super.buildTemplate(computeService, config);
+            template = super.buildTemplate(computeService, config, customizers);
         }
         throw new RuntimeException(BAIL_OUT_FOR_TESTING);
     }
@@ -149,9 +150,9 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
     public static class CountingBailOutJcloudsLocation extends BailOutJcloudsLocation {
         int buildTemplateCount = 0;
         @Override
-        public Template buildTemplate(ComputeService computeService, ConfigBag config) {
+        public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
             buildTemplateCount++;
-            return super.buildTemplate(computeService, config);
+            return super.buildTemplate(computeService, config, customizers);
         }
     }
 


### PR DESCRIPTION
Change so that getCustomizers is only called once during provisioning.
This ensures that only a single instance of a customizer configured
with DSL will be called.  This means that state can be kept between
steps.