### PR TITLE
Tidy tests to always terminate ManagementContext

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlLocationTest.java
@@ -65,10 +65,15 @@ public class CatalogYamlLocationTest extends AbstractYamlTest {
         return false;
     }
 
-    @AfterMethod
-    public void tearDown() {
-        for (RegisteredType ci : mgmt().getTypeRegistry().getMatching(RegisteredTypePredicates.IS_LOCATION)) {
-            mgmt().getCatalog().deleteCatalogItem(ci.getSymbolicName(), ci.getVersion());
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            for (RegisteredType ci : mgmt().getTypeRegistry().getMatching(RegisteredTypePredicates.IS_LOCATION)) {
+                mgmt().getCatalog().deleteCatalogItem(ci.getSymbolicName(), ci.getVersion());
+            }
+        } finally {
+            super.tearDown();
         }
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalUsageManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalUsageManagerTest.java
@@ -67,7 +67,7 @@ public class LocalUsageManagerTest extends BrooklynAppUnitTestSupport {
     public void testAddUsageListenerInstance() throws Exception {
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
         brooklynProperties.put(UsageManager.USAGE_LISTENERS, ImmutableList.of(new RecordingStaticUsageListener()));
-        mgmt = LocalManagementContextForTests.newInstance(brooklynProperties);
+        replaceManagementContext(LocalManagementContextForTests.newInstance(brooklynProperties));
         assertUsageListenerCalledWhenApplicationStarted();
     }
 
@@ -75,7 +75,7 @@ public class LocalUsageManagerTest extends BrooklynAppUnitTestSupport {
     public void testAddUsageListenerViaProperties() throws Exception {
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
         brooklynProperties.put(UsageManager.USAGE_LISTENERS, RecordingStaticUsageListener.class.getName());
-        mgmt = LocalManagementContextForTests.newInstance(brooklynProperties);
+        replaceManagementContext(LocalManagementContextForTests.newInstance(brooklynProperties));
         assertUsageListenerCalledWhenApplicationStarted();
     }
 
@@ -83,7 +83,7 @@ public class LocalUsageManagerTest extends BrooklynAppUnitTestSupport {
     public void testErrorWhenConfiguredClassIsNotAUsageListener() {
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
         brooklynProperties.put(UsageManager.USAGE_LISTENERS, Integer.class.getName());
-        mgmt = LocalManagementContextForTests.newInstance(brooklynProperties);
+        replaceManagementContext(LocalManagementContextForTests.newInstance(brooklynProperties));
     }
 
     private void assertUsageListenerCalledWhenApplicationStarted() {

--- a/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/BasicSpecParameterFromListTest.java
@@ -25,14 +25,12 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
-import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
-import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.util.text.StringPredicates;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
@@ -42,13 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 
-public class BasicSpecParameterFromListTest {
-    private ManagementContext mgmt;
-
-    @BeforeMethod(alwaysRun=true)
-    public void setUp() {
-        mgmt = LocalManagementContextForTests.newInstance();
-    }
+public class BasicSpecParameterFromListTest extends BrooklynMgmtUnitTestSupport {
 
     @Test
     public void testInlineName() {

--- a/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.test;
 
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -53,17 +54,29 @@ public class BrooklynMgmtUnitTestSupport {
     @AfterMethod(alwaysRun=true)
     public void tearDown() throws Exception {
         try {
-            if (mgmt != null) Entities.destroyAll(mgmt);
-        } catch (Throwable t) {
-            LOG.error("Caught exception in tearDown method", t);
-            // we should fail here, except almost always that masks a primary failure in the test itself,
-            // so it would be extremely unhelpful to do so. if we could check if test has not already failed,
-            // that would be ideal, but i'm not sure if that's possible with TestNG. ?
+            destroyManagementContextSafely(mgmt);
         } finally {
             mgmt = null;
         }
     }
 
+    protected void replaceManagementContext(ManagementContext newMgmt) {
+        destroyManagementContextSafely(mgmt);
+        mgmt = (ManagementContextInternal) newMgmt;
+    }
+    
+    protected void destroyManagementContextSafely(ManagementContext mgmt) {
+        try {
+            if (mgmt != null) Entities.destroyAll(mgmt);
+        } catch (Throwable t) {
+            LOG.error("Caught exception destroying management context "+mgmt, t);
+            // If failing during teardown...
+            // we should fail here, except almost always that masks a primary failure in the test itself,
+            // so it would be extremely unhelpful to do so. if we could check if test has not already failed,
+            // that would be ideal, but i'm not sure if that's possible with TestNG. ?
+        }
+    }
+    
     protected BrooklynProperties getBrooklynProperties() {
         return null;
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessStopsDuringStartTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessStopsDuringStartTest.java
@@ -57,6 +57,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -82,6 +83,7 @@ public class SoftwareProcessStopsDuringStartTest extends BrooklynAppUnitTestSupp
         executor = Executors.newCachedThreadPool();
     }
     
+    @AfterMethod(alwaysRun=true)
     @Override
     public void tearDown() throws Exception {
         if (executor != null) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.CustomResponse;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecCmdPredicates;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecParams;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -65,6 +66,7 @@ public class VanillaSoftwareProcessTest extends BrooklynAppUnitTestSupport {
         RecordingSshTool.clear();
     }
 
+    @AfterMethod(alwaysRun=true)
     @Override
     public void tearDown() throws Exception {
         super.tearDown();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessTest.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool;
 import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool.ExecParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,6 +61,7 @@ public class VanillaWindowsProcessTest extends BrooklynAppUnitTestSupport {
         RecordingWinRmTool.clear();
     }
 
+    @AfterMethod(alwaysRun=true)
     @Override
     public void tearDown() throws Exception {
         super.tearDown();


### PR DESCRIPTION
If we leave the management context running, it will not be garbage collected (because its threads reference it, so it's not just about reachability from the test class). This memory leak causes our tests to get slower and slower on the jenkins build server.