### PR TITLE
OnPublicNetworkEnricher config with sensor

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/network/OnSubnetNetworkEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/network/OnSubnetNetworkEnricherTest.java
@@ -196,6 +196,22 @@ public class OnSubnetNetworkEnricherTest extends BrooklynAppUnitTestSupport {
         assertAttributeEqualsEventually("stringHostAndPort.endpoint.mapped.subnet", ""+privateIp+":1234");
     }
     
+    @Test(groups="Broken")
+    public <T> void testTransformsWithDefaultPorts() throws Exception {
+        AttributeSensor<String> stringUriWithHttpNoPort = Sensors.newStringSensor("string.uriWithHttpNoPort");
+        AttributeSensor<String> stringUriWithHttpsNoPort = Sensors.newStringSensor("string.uriWithHttpsNoPort");
+
+        entity.sensors().set(Attributes.SUBNET_ADDRESS, privateIp);
+        entity.sensors().set(stringUriWithHttpNoPort, "http://"+publicIp+"/my/path");
+        entity.sensors().set(stringUriWithHttpsNoPort, "https://"+publicIp+"/my/path");
+        entity.addLocations(ImmutableList.of(machine));
+        
+        entity.enrichers().add(EnricherSpec.create(OnSubnetNetworkEnricher.class));
+
+        assertAttributeEqualsEventually("string.uriWithHttpNoPort.mapped.subnet", "http://"+privateIp+"/my/path");
+        assertAttributeEqualsEventually("string.uriWithHttpsNoPort.mapped.subnet", "https://"+privateIp+"/my/path");
+    }
+    
     @Test
     public <T> void testIgnoresNonMatchingSensors() throws Exception {
         AttributeSensor<URI> sensor1 = Sensors.newSensor(URI.class, "my.different");


### PR DESCRIPTION
I'm not entirely sure what the best way is to wire in and use the `OnPublicNetworkEnricher`. Two of the use-cases are:

1. in an environment with port-mappings (e.g. cloud's DNAT, or docker), look up the registered port mapping in the `PortForwardManager`. This is the existing behaviour.

2. Where a sensor (e.g. URI or hostAndPort) has been published with the subnet-address, publish an equivalent sensor using the public IP (so using the same port).

It is this second use-case that this PR enables.

For "normal clouds" (i.e. without DNAT), then option 2 is an obvious way to go. However:

* what if there isn't a public address? The "host.address" sensor would normally be populated with the private ip instead, so that would be used for the public url - but is that too misleading for a value of `main.uri.mapped.public`?

* what if there really is a DNAT rule set up for accessing this VM's port? Should our `OnPublicNetworkEnricher` prefer the DNAT rule (i.e. the entry in `PortForwardManager`) if it exists, but fall back to the "host.address" if it's not?