### PR TITLE
Remove lock on DSL objects - they are stateless

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -52,11 +52,9 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.javalang.Reflections;
-import org.apache.brooklyn.util.javalang.coerce.ClassCoercionException;
 import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.commons.beanutils.BeanUtils;
@@ -283,6 +281,8 @@ public class BrooklynDslCommon {
 
 
     protected static class DslRegexReplacement extends BrooklynDslDeferredSupplier<String> {
+
+        private static final long serialVersionUID = 737189899361183341L;
 
         private Object source;
         private Object pattern;
@@ -585,6 +585,8 @@ public class BrooklynDslCommon {
         }
 
         protected static class DslRegexReplacer extends BrooklynDslDeferredSupplier<Function<String, String>> {
+
+            private static final long serialVersionUID = -2900037495440842269L;
 
             private Object pattern;
             private Object replacement;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -420,24 +420,24 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         final Entity app = createAndStartApplication(loadYaml("test-referencing-entities.yaml"));
         waitForApplicationTasks(app);
         
-        Entity root1 = Tasks.resolving(new DslComponent(Scope.ROOT, "xxx").newTask(), Entity.class).context( ((EntityInternal)app).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity root1 = Tasks.resolving(new DslComponent(Scope.ROOT, "xxx").newTask(), Entity.class).context(app).embedResolutionInTask(true).get();
         Assert.assertEquals(root1, app);
         
-        Entity c1 = Tasks.resolving(new DslComponent("c1").newTask(), Entity.class).context( ((EntityInternal)app).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity c1 = Tasks.resolving(new DslComponent("c1").newTask(), Entity.class).context(app).embedResolutionInTask(true).get();
         Assert.assertEquals(c1, Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EntityPredicates.displayNameEqualTo("child 1"))));
         
-        Entity e1 = Tasks.resolving(new DslComponent(Scope.PARENT, "xxx").newTask(), Entity.class).context( ((EntityInternal)c1).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity e1 = Tasks.resolving(new DslComponent(Scope.PARENT, "xxx").newTask(), Entity.class).context(c1).embedResolutionInTask(true).get();
         Assert.assertEquals(e1, Iterables.getOnlyElement(Entities.descendantsAndSelf(app, EntityPredicates.displayNameEqualTo("entity 1"))));
         
-        Entity root2 = Tasks.resolving(new DslComponent(Scope.ROOT, "xxx").newTask(), Entity.class).context( ((EntityInternal)c1).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity root2 = Tasks.resolving(new DslComponent(Scope.ROOT, "xxx").newTask(), Entity.class).context(c1).embedResolutionInTask(true).get();
         Assert.assertEquals(root2, app);
         
-        Entity c1a = Tasks.resolving(BrooklynDslCommon.descendant("c1").newTask(), Entity.class).context( ((EntityInternal)e1).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity c1a = Tasks.resolving(BrooklynDslCommon.descendant("c1").newTask(), Entity.class).context(e1).embedResolutionInTask(true).get();
         Assert.assertEquals(c1a, c1);
-        Entity e1a = Tasks.resolving(BrooklynDslCommon.ancestor("e1").newTask(), Entity.class).context( ((EntityInternal)c1).getExecutionContext() ).embedResolutionInTask(true).get();
+        Entity e1a = Tasks.resolving(BrooklynDslCommon.ancestor("e1").newTask(), Entity.class).context(c1).embedResolutionInTask(true).get();
         Assert.assertEquals(e1a, e1);
         try {
-            Tasks.resolving(BrooklynDslCommon.ancestor("c1").newTask(), Entity.class).context( ((EntityInternal)e1).getExecutionContext() ).embedResolutionInTask(true).get();
+            Tasks.resolving(BrooklynDslCommon.ancestor("c1").newTask(), Entity.class).context(e1).embedResolutionInTask(true).get();
             Assert.fail("Should not have found c1 as ancestor of e1");
         } catch (Exception e) { /* expected */ }
     }
@@ -595,7 +595,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         return Tasks.resolving(Tasks.<Entity>builder().body(
             Functionals.callable(Suppliers.compose(EntityFunctions.config(key), Suppliers.ofInstance(entity))) ).build())
             .as(Entity.class)
-            .context( ((EntityInternal)entity).getExecutionContext() ).embedResolutionInTask(true)
+            .context(entity).embedResolutionInTask(true)
             .getMaybe();
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/dsl/DslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/dsl/DslTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.dsl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.ValueResolver;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Supplier;
+
+public class DslTest extends BrooklynAppUnitTestSupport {
+
+    private static final int MAX_PARALLEL_RESOLVERS = 50;
+    private static final int RESOLVER_ITERATIONS = 1000;
+
+    @Test
+    public void testAttributeWhenReadyEmptyDoesNotBlock() {
+        BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.attributeWhenReady(TestApplication.MY_ATTRIBUTE.getName());
+        Maybe<? super String> actualValue = Tasks.resolving(dsl).as(TestEntity.NAME.getType())
+                .context(app)
+                .description("Computing sensor "+TestEntity.NAME+" from "+dsl)
+                .timeout(ValueResolver.REAL_REAL_QUICK_WAIT)
+                .getMaybe();
+        assertTrue(actualValue.isAbsent());
+    }
+
+    @Test
+    public void testAttributeWhenReady() {
+        BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.attributeWhenReady(TestEntity.NAME.getName());
+        new AttributeWhenReadyTestWorker(app, TestEntity.NAME, dsl).run();
+    }
+
+    @Test(groups="Integration")
+    public void testAttributeWhenReadyConcurrent() {
+        final BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.attributeWhenReady(TestEntity.NAME.getName());
+        runConcurrentWorker(new Supplier<Runnable>() {
+            @Override
+            public Runnable get() {
+                return new AttributeWhenReadyTestWorker(app, TestEntity.NAME, dsl);
+            }
+        });
+    }
+
+    @Test
+    public void testSelf() {
+        BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.self();
+        new SelfTestWorker(app, dsl).run();
+    }
+
+    @Test(groups="Integration")
+    public void testSelfConcurrent() {
+        final BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.self();
+        runConcurrentWorker(new Supplier<Runnable>() {
+            @Override
+            public Runnable get() {
+                return new SelfTestWorker(app, dsl);
+            }
+        });
+    }
+
+    @Test
+    public void testParent() {
+        BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.parent();
+        new ParentTestWorker(app, dsl).run();
+    }
+
+    @Test(groups="Integration")
+    public void testParentConcurrent() {
+        final BrooklynDslDeferredSupplier<?> dsl = BrooklynDslCommon.parent();
+        runConcurrentWorker(new Supplier<Runnable>() {
+            @Override
+            public Runnable get() {
+                return new ParentTestWorker(app, dsl);
+            }
+        });
+    }
+
+    public void runConcurrentWorker(Supplier<Runnable> taskSupplier) {
+        Collection<Task<?>> results = new ArrayList<>();
+        for (int i = 0; i < MAX_PARALLEL_RESOLVERS; i++) {
+            Task<?> result = mgmt.getExecutionManager().submit(taskSupplier.get());
+            results.add(result);
+        }
+        for (Task<?> result : results) {
+            result.getUnchecked();
+        }
+    }
+    
+    private static class DslTestWorker implements Runnable {
+        protected TestApplication parent;
+        protected BrooklynDslDeferredSupplier<?> dsl;
+        protected EntitySpec<TestEntity> childSpec = EntitySpec.create(TestEntity.class);
+        protected Class<?> type;
+
+        public DslTestWorker(TestApplication parent, BrooklynDslDeferredSupplier<?> dsl, Class<?> type) {
+            this.parent = parent;
+            this.dsl = dsl;
+            this.type = type;
+        }
+
+        @Override
+        public void run() {
+            TestEntity entity = parent.createAndManageChild(childSpec);
+            for (int i = 0; i < RESOLVER_ITERATIONS; i++) {
+                preResolve(entity);
+                Maybe<?> actualValue = Tasks.resolving(dsl).as(type)
+                        .context(entity)
+                        .description("Computing sensor "+type+" from "+dsl)
+                        .timeout(Duration.ONE_MINUTE)
+                        .getMaybe();
+                postResolve(actualValue);
+            }
+        }
+
+        protected void preResolve(TestEntity entity) {
+        }
+
+        protected void postResolve(Maybe<?> actualValue) {
+        }
+    }
+
+    private static class AttributeWhenReadyTestWorker extends DslTestWorker {
+        private AttributeSensor<String> sensor;
+        private String expectedValue;
+
+        public AttributeWhenReadyTestWorker(TestApplication parent, AttributeSensor<String> sensor, BrooklynDslDeferredSupplier<?> dsl) {
+            super(parent, dsl, sensor.getType());
+            this.sensor = sensor;
+        }
+
+        @Override
+        protected void preResolve(TestEntity entity) {
+            expectedValue = Identifiers.makeRandomId(10);
+            entity.sensors().set(sensor, expectedValue);
+        }
+
+
+        @Override
+        protected void postResolve(Maybe<?> actualValue) {
+            assertEquals(actualValue.get(), expectedValue);
+        }
+
+    }
+
+    private static class SelfTestWorker extends DslTestWorker {
+        private TestEntity entity;
+
+        public SelfTestWorker(TestApplication parent, BrooklynDslDeferredSupplier<?> dsl) {
+            super(parent, dsl, Entity.class);
+        }
+
+        @Override
+        protected void preResolve(TestEntity entity) {
+            this.entity = entity;
+        }
+
+        @Override
+        protected void postResolve(Maybe<?> actualValue) {
+            assertEquals(actualValue.get(), entity);
+        }
+
+    }
+
+    private static class ParentTestWorker extends DslTestWorker {
+        public ParentTestWorker(TestApplication parent, BrooklynDslDeferredSupplier<?> dsl) {
+            super(parent, dsl, Entity.class);
+        }
+
+        @Override
+        protected void postResolve(Maybe<?> actualValue) {
+            assertEquals(actualValue.get(), parent);
+        }
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
@@ -119,7 +119,7 @@ public class TasksTest extends BrooklynAppUnitTestSupport {
     public void testErrorsResolvingPropagatesOrSwallowedAllCorrectly() throws Exception {
         app.config().set(TestEntity.CONF_OBJECT, ValueResolverTest.newThrowTask(Duration.ZERO));
         Task<Object> t = Tasks.builder().body(Functionals.callable(EntityFunctions.config(TestEntity.CONF_OBJECT), app)).build();
-        ValueResolver<Object> v = Tasks.resolving(t).as(Object.class).context(app.getExecutionContext());
+        ValueResolver<Object> v = Tasks.resolving(t).as(Object.class).context(app);
         
         ValueResolverTest.assertThrowsOnMaybe(v);
         ValueResolverTest.assertThrowsOnGet(v);


### PR DESCRIPTION
The same DSL object could be used in mutliple entities created from the same spec, so one entity resolving would block the rest even if they already have the values. The objects are stateless so need for a lock.