### PR TITLE
Fix calculation of currently used memory by the JVM

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -237,7 +237,7 @@ public class BrooklynGarbageCollector {
 
     public static String makeBasicUsageString() {
         int present = (int)Math.round(100.0*SoftlyPresent.getUsageTracker().getPercentagePresent());
-        return Strings.makeSizeString(Runtime.getRuntime().maxMemory() - Runtime.getRuntime().freeMemory())+" / "+
+        return Strings.makeSizeString(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())+" / "+
             Strings.makeSizeString(Runtime.getRuntime().maxMemory()) 
             + (Runtime.getRuntime().maxMemory() > Runtime.getRuntime().totalMemory() ? 
                 " ("+ Strings.makeSizeString(Runtime.getRuntime().totalMemory()) +" real)"


### PR DESCRIPTION
Before the change I was getting readings like `brooklyn gc (after) - using 2.59 GB / 2.86 GB (1268 MB real) memory with `-DXmx=3G`. `2.86` is `maxMemory` same as `Xmx`. `1268` is `totalMemory` which is the currently allocated memory by the JVM from the operating system. The used memory can't be more than the `totalMemory`.

Confirmed the new readings by comparing to jconsole.

The PR reverts to the previous version of the expression (cc @ahgittin).