### PR TITLE
Don't allow multiple context entities in a task's tags

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -101,7 +101,6 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
         return TaskBuilder.<Entity>builder()
                 .displayName(toString())
                 .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
-                .tagIfNotNull(BrooklynTaskTags.getTargetOrContextEntityTag(Tasks.current()))
                 .body(new EntityInScopeFinder(scopeComponent, scope, componentId))
                 .build();
     }
@@ -373,7 +372,6 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             return Tasks.builder()
                     .displayName("retrieving config for "+keyName)
                     .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
-                    .tagIfNotNull(BrooklynTaskTags.getTargetOrContextEntityTag(Tasks.current()))
                     .dynamic(false)
                     .body(new Callable<Object>() {
                         @Override
@@ -454,7 +452,6 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             return Tasks.<Sensor<?>>builder()
                     .displayName("looking up sensor for "+sensorName)
                     .dynamic(false)
-                    .tagIfNotNull(BrooklynTaskTags.getTargetOrContextEntityTag(Tasks.current()))
                     .body(new Callable<Sensor<?>>() {
                         @Override
                         public Sensor<?> call() throws Exception {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/dsl/DslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/dsl/DslTest.java
@@ -272,7 +272,7 @@ public class DslTest extends BrooklynAppUnitTestSupport {
     }
 
     // Different from testParentConcurrent() only in the execution context the task is submitted in (global vs app)
-    @Test(invocationCount=10, groups="Broken") //fails ~4 times
+    @Test(invocationCount=10)
     public void testResolveInDifferentContext() throws InterruptedException, ExecutionException {
         final TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         Task<Maybe<Entity>> result = app.getExecutionContext().submit(new Callable<Maybe<Entity>>() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
@@ -35,7 +35,9 @@ import org.apache.brooklyn.api.mgmt.ExecutionManager;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskTags;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -112,6 +114,16 @@ public class BrooklynTaskTags extends TaskTags {
     public static final String CALLER_ENTITY = "callerEntity";
     public static final String TARGET_ENTITY = "targetEntity";
     
+    /**
+     * Marks a task as running in the context of the entity. This means
+     * resolving any relative/context sensitive values against that entity.
+     * Using the entity in APIs where it is implicit - a prominent example
+     * being {@link DynamicTasks}.
+     *
+     * The result from the call should be used only when reading tags (for example
+     * to compare whether the tag already exists). The only place where the value is
+     * added to the entity tags is {@link AbstractManagementContext#getExecutionContext(Entity)}.
+     */
     public static WrappedEntity tagForContextEntity(Entity entity) {
         return new WrappedEntity(CONTEXT_ENTITY, entity);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -320,7 +320,6 @@ public class InternalEntityFactory extends InternalFactory {
          * TODO It would be nice if these schedule tasks were grouped in a bucket! 
          */
         ((EntityInternal)entity).getExecutionContext().submit(Tasks.builder().dynamic(false).displayName("Entity initialization")
-                .tag(BrooklynTaskTags.tagForContextEntity(entity))
                 .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
                 .body(new Runnable() {
             @Override

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
@@ -375,8 +375,7 @@ public class ValueResolver<T> implements DeferredSupplier<T> {
                     TaskBuilder<Object> tb = Tasks.<Object>builder()
                             .body(callable)
                             .displayName("Resolving dependent value")
-                            .description(description)
-                            .tagIfNotNull(BrooklynTaskTags.getTargetOrContextEntityTag(Tasks.current()));
+                            .description(description);
                     if (isTransientTask) tb.tag(BrooklynTaskTags.TRANSIENT_TASK_TAG);
                     
                     // Note that immediate resolution is handled by using ImmediateSupplier (using an instanceof check), 

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
@@ -38,9 +38,6 @@ import org.apache.brooklyn.core.mgmt.BrooklynTaskTags.WrappedEntity;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.util.core.task.TaskInternal;
-import org.apache.brooklyn.util.core.task.Tasks;
-import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.guava.Functionals;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.Duration;
@@ -186,29 +183,79 @@ public class TasksTest extends BrooklynAppUnitTestSupport {
         assertTrue(t.get(Duration.TEN_SECONDS));
     }
 
-    @Test(groups="Broken")
-    public void testSingleExecutionContextEntity() {
+    @Test
+    public void testSingleExecutionContextEntityWithTask() {
+        // Should cause an exception to be thrown in future releases. For now will log a warning.
+        // Until then make sure the task is tagged only with the context of the executor.
         final TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
-        // context entity here = none
-        Task<Collection<Entity>> task = Tasks.<Collection<Entity>>builder()
+        Task<Void> task = Tasks.<Void>builder()
             .tag(BrooklynTaskTags.tagForContextEntity(entity))
-            .body(new Callable<Collection<Entity>>() {
-                @Override
-                public Collection<Entity> call() throws Exception {
-                    Collection<Entity> context = new ArrayList<>();
-                    for (Object tag : Tasks.current().getTags()) {
-                        if (tag instanceof WrappedEntity) {
-                            WrappedEntity wrapped = (WrappedEntity)tag;
-                            if (BrooklynTaskTags.CONTEXT_ENTITY.equals(wrapped.wrappingType)) {
-                                context.add(wrapped.entity);
-                            }
-                        }
+            .body(new AssertContextRunnable(ImmutableList.of(app))).build();
+        app.getExecutionContext().submit(task).getUnchecked();
+    }
+
+    @Test
+    public void testSingleExecutionContextEntityWithTaskAndExternalFlags() {
+        // Should cause an exception to be thrown in future releases. For now will log a warning.
+        // Until then make sure the task is tagged only with the context of the executor.
+        final TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        Task<Void> task = Tasks.<Void>builder()
+            .body(new AssertContextRunnable(ImmutableList.of(app))).build();
+        ImmutableMap<String,?> flags = ImmutableMap.of(
+                "tags", ImmutableList.of(BrooklynTaskTags.tagForContextEntity(entity)));
+        app.getExecutionContext().submit(flags, task).getUnchecked();
+    }
+
+    @Test
+    public void testSingleExecutionContextEntityWithCallable() {
+        // Should cause an exception to be thrown in future releases. For now will log a warning.
+        // Until then make sure the task is tagged only with the context of the executor.
+        final TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        Callable<Void> task = new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                new AssertContextRunnable(ImmutableList.of(app)).run();
+                return null;
+            }
+        };
+
+        ImmutableMap<String,?> flags = ImmutableMap.of(
+                "tags", ImmutableList.of(BrooklynTaskTags.tagForContextEntity(entity)));
+        app.getExecutionContext().submit(flags, task).getUnchecked();
+    }
+
+    @Test
+    public void testSingleExecutionContextEntityWithRunnable() {
+        // Should cause an exception to be thrown in future releases. For now will log a warning.
+        // Until then make sure the task is tagged only with the context of the executor.
+        final TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        Runnable task = new AssertContextRunnable(ImmutableList.of(app));
+        ImmutableMap<String,?> flags = ImmutableMap.of(
+                "tags", ImmutableList.of(BrooklynTaskTags.tagForContextEntity(entity)));
+        app.getExecutionContext().submit(flags, task).getUnchecked();
+    }
+
+    private static class AssertContextRunnable implements Runnable {
+        private Collection<?> expectedContext;
+
+        public AssertContextRunnable(Collection<?> expectedContext) {
+            this.expectedContext = expectedContext;
+        }
+
+        @Override
+        public void run() {
+            Collection<Entity> context = new ArrayList<>();
+            for (Object tag : Tasks.current().getTags()) {
+                if (tag instanceof WrappedEntity) {
+                    WrappedEntity wrapped = (WrappedEntity)tag;
+                    if (BrooklynTaskTags.CONTEXT_ENTITY.equals(wrapped.wrappingType)) {
+                        context.add(wrapped.entity);
                     }
-                    return context;
                 }
-            }).build();
-        Task<Collection<Entity>> result = app.getExecutionContext().submit(task);
-        assertEquals(result.getUnchecked(), ImmutableList.of(entity));
+            }
+            assertEquals(context, expectedContext, "Found " + context + ", expected " + expectedContext);
+        }
+        
     }
 
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricher.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricher.java
@@ -110,7 +110,6 @@ public class SystemServiceEnricher extends AbstractEnricher implements Enricher 
                 .description("Update system service")
                 .add(installerTask)
                 .add(udpateTask)
-                .tag(BrooklynTaskTags.tagForContextEntity(entity))
                 .tag(BrooklynTaskTags.NON_TRANSIENT_TASK_TAG)
                 .build();
 


### PR DESCRIPTION
When executing a task which is already tagged with a context entity in the execution context of another task, the task ends up with two context entities in its tags. It's indeterministic which one will be available through BrooklynTaskTags.getContextEntity. 

The context entity should be set by internal code at a single place. Remove all places where we are setting the context additionally and add a warning at runtime if detected. To be changed to an exception after a release or two, currently a warning in the logs.

Merge together with https://github.com/apache/brooklyn-library/pull/71.
