### PR TITLE
Enable BasicExecutionManager logging for specific exceptions

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
@@ -536,7 +536,11 @@ public class BasicExecutionManager implements ExecutionManager {
                         // debug only here, because most submitters will handle failures
                         if (error instanceof InterruptedException || error instanceof RuntimeInterruptedException) {
                             log.debug("Detected interruption on task "+task+" (rethrowing)" +
-                                (Strings.isNonBlank(error.getMessage()) ? ": "+error.getMessage() : ""));
+                                    (Strings.isNonBlank(error.getMessage()) ? ": "+error.getMessage() : ""));
+                        } else if (error instanceof NullPointerException ||
+                                error instanceof IndexOutOfBoundsException ||
+                                error instanceof ClassCastException) {
+                            log.debug("Exception running task "+task+" (rethrowing): "+error, error);
                         } else {
                             log.debug("Exception running task "+task+" (rethrowing): "+error);
                         }


### PR DESCRIPTION
A NullPointerException in ServiceReplacer was being swallowed in BasicExecutionManager, this makes exemptions for logging specific types of Exceptions.
