### PR TITLE
Tests - stop persistence before rebind

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsRebindStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsRebindStubYamlTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.camp.brooklyn;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.camp.brooklyn.AbstractJcloudsStubYamlTest.ByonComputeServiceStaticRef;
@@ -91,11 +92,11 @@ public abstract class AbstractJcloudsRebindStubYamlTest extends JcloudsRebindStu
     }
 
     @Override
-    protected LocalManagementContext createNewManagementContext(final File mementoDir, final HighAvailabilityMode haMode) {
+    protected LocalManagementContext createNewManagementContext(final File mementoDir, final HighAvailabilityMode haMode, final Map<?, ?> additionalProperties) {
         newLauncher = new BrooklynCampPlatformLauncherNoServer() {
             @Override
             protected LocalManagementContext newMgmtContext() {
-                return AbstractJcloudsRebindStubYamlTest.super.createNewManagementContext(mementoDir, haMode);
+                return AbstractJcloudsRebindStubYamlTest.super.createNewManagementContext(mementoDir, haMode, additionalProperties);
             }
         };
         newLauncher.launch();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -106,7 +106,7 @@ public class DslAndRebindYamlTest extends AbstractYamlTest {
     }
 
     protected Application rebind(Application app) throws Exception {
-        RebindTestUtils.waitForPersisted(app);
+        RebindTestUtils.stopPersistence(app);
         Application result = RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
         mgmtContexts.add(result.getManagementContext());
         return result;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JavaWebAppWithDslYamlRebindIntegrationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JavaWebAppWithDslYamlRebindIntegrationTest.java
@@ -82,7 +82,7 @@ public class JavaWebAppWithDslYamlRebindIntegrationTest extends AbstractYamlTest
     }
 
     public Application rebind(Application app) throws Exception {
-        RebindTestUtils.waitForPersisted(app);
+        RebindTestUtils.stopPersistence(app);
         // optionally for good measure can also check this:
 //        RebindTestUtils.checkCurrentMementoSerializable(app);
         Application result = RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/RebindOsgiTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/RebindOsgiTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertNull;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -91,8 +92,8 @@ public class RebindOsgiTest extends AbstractYamlRebindTest {
     }
     
     @Override
-    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode) {
-        LocalManagementContext result = super.createNewManagementContext(mementoDir, haMode);
+    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode, Map<?, ?> additionalProperties) {
+        LocalManagementContext result = super.createNewManagementContext(mementoDir, haMode, additionalProperties);
         for (String bundleUrl : bundleUrlsToInstallOnRebind) {
             try {
                 installBundle(result, bundleUrl);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogEntityTest.java
@@ -125,7 +125,7 @@ public class RebindCatalogEntityTest extends RebindTestFixture<StartableApplicat
     //      because that won't have right catalog classpath.
     //      How to reuse that code cleanly?
     protected StartableApplication rebindWithAppClass() throws Exception {
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         LocalManagementContext newManagementContext = RebindTestUtils.newPersistingManagementContextUnstarted(mementoDir, classLoader);
 
         UrlClassLoader ucl = new UrlClassLoader(url);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogItemTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogItemTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType;
@@ -93,7 +94,7 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
     }
 
     @Override
-    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode) {
+    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode, Map<?, ?> additionalProperties) {
         BrooklynProperties properties = BrooklynProperties.Factory.newDefault();
         properties.put(BrooklynServerConfig.BROOKLYN_CATALOG_URL, "classpath://brooklyn/entity/rebind/rebind-catalog-item-test-catalog.xml");
         return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogWhenCatalogPersistenceDisabledTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogWhenCatalogPersistenceDisabledTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.mgmt.rebind;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
+import java.util.Map;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -58,25 +59,10 @@ public class RebindCatalogWhenCatalogPersistenceDisabledTest extends RebindTestF
     }
 
     @Override
-    protected LocalManagementContext createOrigManagementContext() {
-        BrooklynProperties properties = BrooklynProperties.Factory.newDefault();
+    protected BrooklynProperties createBrooklynProperties() {
+        BrooklynProperties properties = super.createBrooklynProperties();
         properties.put(BrooklynServerConfig.BROOKLYN_CATALOG_URL, TEST_CATALOG);
-        return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
-                .properties(properties)
-                .persistPeriodMillis(getPersistPeriodMillis())
-                .forLive(useLiveManagementContext())
-                .buildStarted();
-    }
-
-    @Override
-    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode) {
-        BrooklynProperties properties = BrooklynProperties.Factory.newDefault();
-        properties.put(BrooklynServerConfig.BROOKLYN_CATALOG_URL, TEST_CATALOG);
-        return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
-                .properties(properties)
-                .forLive(useLiveManagementContext())
-                .haMode(haMode)
-                .buildUnstarted();
+        return properties;
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityDynamicTypeInfoTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityDynamicTypeInfoTest.java
@@ -75,7 +75,7 @@ public class RebindEntityDynamicTypeInfoTest extends RebindTestFixtureWithApp {
         // dynamic effector
         origApp.getMutableEntityType().addEffector(SayHiBody.EFFECTOR);
         
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         File mementoFile = new File(new File(mementoDir, "entities"), origApp.getId());
         String memento = Streams.readFullyAndClose(new FileReader(mementoFile));

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -370,7 +370,7 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         MyLatchingEntityImpl.latching = true;
         
         // Serialize and rebind, but don't yet manage the app
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         RebindTestUtils.checkCurrentMementoSerializable(origApp);
         newManagementContext = RebindTestUtils.newPersistingManagementContextUnstarted(mementoDir, classLoader);
         Thread thread = new Thread() {
@@ -421,7 +421,7 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         MyLatchingEntityImpl.latching = true;
 
         // Serialize and rebind, but don't yet manage the app
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         RebindTestUtils.checkCurrentMementoSerializable(origApp);
         newManagementContext = new LocalManagementContext();
         Thread thread = new Thread() {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindLocationTest.java
@@ -177,7 +177,7 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
         MyLocation.myStaticFieldNotSetFromFlag = "myval";
         origApp.start(ImmutableList.of(origLoc));
 
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         MyLocation.myStaticFieldNotSetFromFlag = "mynewval";
         newApp = (TestApplication) RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
         MyLocation newLoc = (MyLocation) Iterables.get(newApp.getLocations(), 0);
@@ -192,7 +192,7 @@ public class RebindLocationTest extends RebindTestFixtureWithApp {
         MyLocation origLoc = new MyLocation(MutableMap.of("myStaticFieldSetFromFlag", "myval"));
         origApp.start(ImmutableList.of(origLoc));
 
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         MyLocation.myStaticFieldSetFromFlag = "mynewval"; // not auto-checkpointed
         newApp = (TestApplication) RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
         MyLocation newLoc = (MyLocation) Iterables.get(newApp.getLocations(), 0);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindOptions.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindOptions.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.core.mgmt.rebind;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -46,6 +47,7 @@ public class RebindOptions {
     public PersistenceObjectStore objectStore;
     public HighAvailabilityMode haMode;
     public Function<Collection<Application>, Application> applicationChooserOnRebind;
+    public Map<?, ?> additionalProperties;
     
     public static RebindOptions create() {
         return new RebindOptions();
@@ -64,6 +66,7 @@ public class RebindOptions {
         result.objectStore(options.objectStore);
         result.haMode(options.haMode);
         result.applicationChooserOnRebind(options.applicationChooserOnRebind);
+        result.additionalProperties(options.additionalProperties);
         return result;
     }
     public RebindOptions checkSerializable(boolean val) {
@@ -110,9 +113,12 @@ public class RebindOptions {
         this.haMode = val;
         return this;
     }
-    
     public RebindOptions applicationChooserOnRebind(Function<Collection<Application>, Application> val) {
         this.applicationChooserOnRebind = val;
+        return this;
+    }
+    public RebindOptions additionalProperties(Map<?, ?> additionalProperties) {
+        this.additionalProperties = additionalProperties;
         return this;
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindPolicyTest.java
@@ -137,7 +137,7 @@ public class RebindPolicyTest extends RebindTestFixtureWithApp {
 
         Entities.unmanage(entity);
         Locations.unmanage(loc);
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         BrooklynMementoManifest manifest = loadMementoManifest();
         assertFalse(manifest.getEntityIdToManifest().containsKey(entity.getId()));
@@ -156,7 +156,7 @@ public class RebindPolicyTest extends RebindTestFixtureWithApp {
 
         entity.policies().remove(policy);
         entity.enrichers().remove(enricher);
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         BrooklynMementoManifest manifest = loadMementoManifest();
         assertFalse(manifest.getPolicyIdToType().containsKey(policy.getId()));

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -121,21 +122,25 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
     
     /** As {@link #createNewManagementContext(File)} using the default memento dir */
     protected LocalManagementContext createNewManagementContext() {
-        return createNewManagementContext(mementoDir);
+        return createNewManagementContext(mementoDir, null);
     }
     
     /** @return An unstarted management context using the specified mementoDir (or default if null) */
-    protected LocalManagementContext createNewManagementContext(File mementoDir) {
-        return createNewManagementContext(mementoDir, getHaMode());
+    protected LocalManagementContext createNewManagementContext(File mementoDir, Map<?, ?> additionalProperties) {
+        return createNewManagementContext(mementoDir, getHaMode(), additionalProperties);
     }
-    
-    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode) {
+
+    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode, Map<?, ?> additionalProperties) {
         if (mementoDir==null) mementoDir = this.mementoDir;
+        BrooklynProperties brooklynProperties = createBrooklynProperties();
+        if (additionalProperties != null) {
+            brooklynProperties.addFrom(additionalProperties);
+        }
         return RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
                 .forLive(useLiveManagementContext())
                 .haMode(haMode)
                 .emptyCatalog(useEmptyCatalog())
-                .properties(createBrooklynProperties())
+                .properties(brooklynProperties)
                 .enableOsgi(useOsgi())
                 .buildUnstarted();
     }
@@ -287,7 +292,7 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
         if (options.classLoader == null) options.classLoader(classLoader);
         if (options.mementoDir == null) options.mementoDir(mementoDir);
         if (options.origManagementContext == null) options.origManagementContext(origManagementContext);
-        if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir));
+        if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir, options.additionalProperties));
         
         RebindTestUtils.waitForPersisted(origApp);
         
@@ -318,9 +323,9 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
         if (options.classLoader == null) options.classLoader(classLoader);
         if (options.mementoDir == null) options.mementoDir(mementoDir);
         if (options.origManagementContext == null) options.origManagementContext(origManagementContext);
-        if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir, options.haMode));
+        if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir, options.haMode, options.additionalProperties));
         
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         newManagementContext = options.newManagementContext;
         newApp = (T) RebindTestUtils.rebind(options);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
@@ -294,7 +294,7 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
         if (options.origManagementContext == null) options.origManagementContext(origManagementContext);
         if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir, options.additionalProperties));
         
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         newManagementContext = options.newManagementContext;
         newApp = (T) RebindTestUtils.rebind(options);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
 import org.apache.brooklyn.api.mgmt.rebind.RebindExceptionHandler;
+import org.apache.brooklyn.api.mgmt.rebind.RebindManager;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMemento;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoPersister;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoRawData;
@@ -465,6 +466,16 @@ public class RebindTestUtils {
 
     public static void waitForPersisted(ManagementContext managementContext) throws InterruptedException, TimeoutException {
         managementContext.getRebindManager().waitForPendingComplete(TIMEOUT, true);
+    }
+
+    public static void stopPersistence(Application origApp) throws InterruptedException, TimeoutException {
+        stopPersistence(origApp.getManagementContext());
+    }
+
+    public static void stopPersistence(ManagementContext managementContext) throws InterruptedException, TimeoutException {
+        RebindManager rebindManager = managementContext.getRebindManager();
+        rebindManager.waitForPendingComplete(TIMEOUT, true);
+        rebindManager.stop();
     }
 
     public static void checkCurrentMementoSerializable(Application app) throws Exception {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
@@ -63,7 +63,6 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
-@SuppressWarnings("serial")
 public class CompoundTransformerTest extends RebindTestFixtureWithApp {
 
     private static final Logger LOG = LoggerFactory.getLogger(CompoundTransformerTest.class);
@@ -430,6 +429,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
     protected TestApplication transformAndRebind(CompoundTransformer transformer) throws Exception {
         RebindTestUtils.waitForPersisted(origApp);
         BrooklynMementoRawData newRawData = transform(origManagementContext, transformer);
+        RebindTestUtils.stopPersistence(origApp);
         newMementoDir = persist(newRawData);
         return rebind(newMementoDir);
     }
@@ -492,6 +492,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
     
     // Example method, similar to EntityPredicates where we want to move the annonymous inner class
     // to be a named inner class
+    @SuppressWarnings("serial")
     public static <T> Predicate<Entity> idEqualTo(final T paramVal) {
         return new SerializablePredicate<Entity>() {
             @Override
@@ -501,6 +502,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
         };
     }
 
+    @SuppressWarnings("serial")
     private static class RenamedIdEqualToPredicate implements SerializablePredicate<Entity> {
         private String val;
         

--- a/core/src/test/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocationRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocationRebindTest.java
@@ -113,7 +113,7 @@ public class FixedListMachineProvisioningLocationRebindTest {
     }
 
     private TestApplication rebind() throws Exception {
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         return (TestApplication) RebindTestUtils.rebind(mementoDir, getClass().getClassLoader());
     }
     

--- a/core/src/test/java/org/apache/brooklyn/location/multi/MultiLocationRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/multi/MultiLocationRebindTest.java
@@ -113,7 +113,7 @@ public class MultiLocationRebindTest {
     }
     
     private TestApplication rebind(boolean checkSerializable) throws Exception {
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         if (checkSerializable) {
             RebindTestUtils.checkCurrentMementoSerializable(origApp);
         }

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
@@ -205,7 +205,7 @@ public abstract class AbstractBlueprintTest {
         if (options.newManagementContext == null) options.newManagementContext(newMgmt);
         
         for (Application origApp : origApps) {
-            RebindTestUtils.waitForPersisted(origApp);
+            RebindTestUtils.stopPersistence(origApp);
         }
         
         mgmt = options.newManagementContext;

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolverStubbedRebindTest.java
@@ -188,7 +188,7 @@ public class JcloudsByonLocationResolverStubbedRebindTest extends AbstractJcloud
         if (options.origManagementContext == null) options.origManagementContext(origManagementContext);
         if (options.newManagementContext == null) options.newManagementContext(createNewManagementContext(options.mementoDir));
         
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         
         newManagementContext = options.newManagementContext;
         newApp = RebindTestUtils.rebind(options);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/RebindJcloudsLocationLiveTest.java
@@ -27,8 +27,6 @@ import java.io.File;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.OsDetails;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
@@ -175,7 +173,7 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
         // Force it to be persisted again. Expect to pesist without the NodeMetadata and Template.
         app2.getManagementContext().getRebindManager().getChangeListener().onChanged(loc2);
         app2.getManagementContext().getRebindManager().getChangeListener().onChanged(machine2);
-        RebindTestUtils.waitForPersisted(app2);
+        RebindTestUtils.stopPersistence(app2);
         
         String newMachineXml = new String(java.nio.file.Files.readAllBytes(persistedMachineFile.toPath()));
         assertFalse(newMachineXml.contains("AWSEC2TemplateOptions"), newMachineXml);
@@ -241,7 +239,7 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
         // Force it to be persisted again. Expect to pesist without the NodeMetadata and Template.
         app2.getManagementContext().getRebindManager().getChangeListener().onChanged(loc2);
         app2.getManagementContext().getRebindManager().getChangeListener().onChanged(machine2);
-        RebindTestUtils.waitForPersisted(app2);
+        RebindTestUtils.stopPersistence(app2);
         
         String newMachineXml = new String(java.nio.file.Files.readAllBytes(persistedMachineFile.toPath()));
         assertFalse(newMachineXml.contains("NodeMetadataImpl"), newMachineXml);
@@ -327,7 +325,7 @@ public class RebindJcloudsLocationLiveTest extends AbstractJcloudsLiveTest {
     }
     
     private TestApplication rebind(RebindOptions options) throws Exception {
-        RebindTestUtils.waitForPersisted(origApp);
+        RebindTestUtils.stopPersistence(origApp);
         return (TestApplication) RebindTestUtils.rebind(options);
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/ClockerDynamicLocationPatternRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/ClockerDynamicLocationPatternRebindTest.java
@@ -57,8 +57,8 @@ public class ClockerDynamicLocationPatternRebindTest extends RebindTestFixtureWi
     }
     
     @Override
-    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode) {
-        LocalManagementContext result = super.createNewManagementContext(mementoDir, haMode);
+    protected LocalManagementContext createNewManagementContext(File mementoDir, HighAvailabilityMode haMode, Map<?, ?> additionalProperties) {
+        LocalManagementContext result = super.createNewManagementContext(mementoDir, haMode, additionalProperties);
         StubResolver stubResolver = new StubResolver();
         ((BasicLocationRegistry)result.getLocationRegistry()).registerResolver(stubResolver);
         return result;


### PR DESCRIPTION
This is an attempt to fix the frequent test failures on Apache Jenkins Windows slaves. The tests would fail with `The process cannot access the file because it is being used by another process` while rebinding against the on-disk persisted state.

While I wasn't able to reproduce this I believe it's due to the tests not stopping persistence on the old management context. It probably tries to write to the persisted state while the new management context rebinds, leading to file locking errors. The fix is to stop persistence in the old management context before rebind. Note that the old management context is still kept alive, only persistence is stopped, so we can work with the old entities.

A couple of example failures:
  * https://builds.apache.org/view/Brooklyn/job/brooklyn-master-windows/85/consoleFull
  * https://builds.apache.org/view/Brooklyn/job/brooklyn-master-windows/84/consoleFull

```
2016-11-01 13:34:16,299 INFO  TESTNG FAILED: "Surefire test" - org.apache.brooklyn.entity.software.base.SoftwareProcessEntityHttpFeedRebindTest.testRebind() finished in 723 ms
org.apache.brooklyn.util.exceptions.PropagatedRuntimeException: Failure rebinding; 2 errors including: problem loading memento: memento vykkmus4ho read error: Problem reading String contents of file C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho: FileNotFoundException: C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho (The process cannot access the file because it is being used by another process)
	at org.apache.brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:129)
	at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.rebind(RebindManagerImpl.java:513)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils.rebindAll(RebindTestUtils.java:454)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils.rebind(RebindTestUtils.java:331)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestFixture.rebind(RebindTestFixture.java:295)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp.rebind(RebindTestFixtureWithApp.java:49)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp.rebind(RebindTestFixtureWithApp.java:32)
	at org.apache.brooklyn.core.mgmt.rebind.RebindTestFixture.rebind(RebindTestFixture.java:231)
	at org.apache.brooklyn.entity.software.base.SoftwareProcessEntityHttpFeedRebindTest.runRebindWithHttpFeed(SoftwareProcessEntityHttpFeedRebindTest.java:136)
	at org.apache.brooklyn.entity.software.base.SoftwareProcessEntityHttpFeedRebindTest.testRebind(SoftwareProcessEntityHttpFeedRebindTest.java:104)
Caused by: java.util.concurrent.ExecutionException: org.apache.brooklyn.util.exceptions.CompoundRuntimeException: Failure rebinding; 2 errors including: problem loading memento: memento vykkmus4ho read error: Problem reading String contents of file C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho: FileNotFoundException: C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho (The process cannot access the file because it is being used by another process)
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:188)
	at com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:63)
	at org.apache.brooklyn.util.core.task.BasicTask.get(BasicTask.java:361)
	at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.rebind(RebindManagerImpl.java:511)
	... 36 more
Caused by: org.apache.brooklyn.util.exceptions.CompoundRuntimeException: Failure rebinding; 2 errors including: problem loading memento: memento vykkmus4ho read error: Problem reading String contents of file C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho: FileNotFoundException: C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho (The process cannot access the file because it is being used by another process)
	at org.apache.brooklyn.util.exceptions.Exceptions.create(Exceptions.java:439)
	at org.apache.brooklyn.core.mgmt.rebind.RebindExceptionHandlerImpl.onDoneImpl(RebindExceptionHandlerImpl.java:497)
	at org.apache.brooklyn.core.mgmt.rebind.RebindExceptionHandlerImpl.onDone(RebindExceptionHandlerImpl.java:413)
	at org.apache.brooklyn.core.mgmt.rebind.RebindIteration.run(RebindIteration.java:268)
	at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.rebindImpl(RebindManagerImpl.java:558)
	at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl$3.call(RebindManagerImpl.java:508)
	at org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl$3.call(RebindManagerImpl.java:506)
	at org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:522)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalStateException: problem loading memento: memento vykkmus4ho read error
	at org.apache.brooklyn.core.mgmt.rebind.RebindExceptionHandlerImpl.onLoadMementoFailed(RebindExceptionHandlerImpl.java:178)
	at org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore$2.visit(BrooklynMementoPersisterToObjectStore.java:294)
	at org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore$1VisitorWrapper.run(BrooklynMementoPersisterToObjectStore.java:452)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	... 4 more
Caused by: org.apache.brooklyn.util.exceptions.PropagatedRuntimeException: Problem reading String contents of file C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho: FileNotFoundException: C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho (The process cannot access the file because it is being used by another process)
	at org.apache.brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:165)
	at org.apache.brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:140)
	at org.apache.brooklyn.core.mgmt.persist.FileBasedStoreObjectAccessor.get(FileBasedStoreObjectAccessor.java:58)
	at org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore.read(BrooklynMementoPersisterToObjectStore.java:641)
	at org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore.access$000(BrooklynMementoPersisterToObjectStore.java:83)
	at org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore$2.visit(BrooklynMementoPersisterToObjectStore.java:291)
	... 6 more
Caused by: java.io.FileNotFoundException: C:\Users\jenkins\AppData\Local\Temp\1\SoftwareProcessEntityHttpFeedRebindTest-z8Ub\locations\vykkmus4ho (The process cannot access the file because it is being used by another process)
	at java.io.FileInputStream.open(Native Method)
	at java.io.FileInputStream.<init>(FileInputStream.java:146)
	at com.google.common.io.Files$FileByteSource.openStream(Files.java:126)
	at com.google.common.io.Files$FileByteSource.openStream(Files.java:116)
	at com.google.common.io.ByteSource$AsCharSource.openStream(ByteSource.java:434)
	at com.google.common.io.CharSource.read(CharSource.java:161)
	at org.apache.brooklyn.core.mgmt.persist.FileBasedStoreObjectAccessor.get(FileBasedStoreObjectAccessor.java:56)
	... 9 more
```