### PR TITLE
Fix app.stop so doesn’t go on-fire briefly

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
@@ -200,9 +200,9 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
     public void stop() {
         logApplicationLifecycle("Stopping");
 
+        setExpectedStateAndRecordLifecycleEvent(Lifecycle.STOPPING);
         ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(this, Attributes.SERVICE_STATE_ACTUAL, "Application stopping");
         sensors().set(SERVICE_UP, false);
-        setExpectedStateAndRecordLifecycleEvent(Lifecycle.STOPPING);
         try {
             doStop();
         } catch (Exception e) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -126,7 +125,7 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
                 .configure(SoftwareProcess.STOP_LATCH, DependentConfiguration.attributeWhenReady(app, stopper)));
         
         final Task<Void> startTask = Entities.invokeEffector(app, app, MyService.START, ImmutableMap.of("locations", ImmutableList.of(loc)));
-        ((EntityLocal)triggerEntity).sensors().set(Attributes.SERVICE_UP, true);
+        triggerEntity.sensors().set(Attributes.SERVICE_UP, true);
         startTask.get(Duration.THIRTY_SECONDS);
 
         final Task<Void> stopTask = Entities.invokeEffector(app, app, MyService.STOP);
@@ -151,7 +150,7 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
         assertDriverEventsEquals(entity, preLatchEvents);
 
         assertFalse(task.isDone());
-        ((EntityLocal)triggerEntity).sensors().set(Attributes.SERVICE_UP, true);
+        triggerEntity.sensors().set(Attributes.SERVICE_UP, true);
         task.get(Duration.THIRTY_SECONDS);
         assertDriverEventsEquals(entity, ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources", "launch"));
     }


### PR DESCRIPTION
Previously in app.stop, we set the serviceUp=false before setting
expectedState=stopping. This meant there was a race where we could
briefly infer the actual state as on_fire.

This caused failure of `SoftwareProcessEntityLatchTest.testStopLatchBlocks`:
the attributeWhenReady latch would abort because it received an
event saying that the app was on_fire, so the stop_latch completely
immediately.

The fix is simple: in app.stop, set the expectedSate=stopping before
setting serviceUp=false.

@neykov @geomacy you'll both be interested in this.