### PR TITLE
Test change to coercion of default config values

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.Task;
-import org.apache.brooklyn.camp.brooklyn.AbstractJcloudsStubYamlTest.ByonComputeServiceStaticRef;
 import org.apache.brooklyn.camp.spi.Assembly;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -40,6 +40,7 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests.Build
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.stream.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,7 +113,14 @@ public abstract class AbstractYamlTest {
     }
 
     protected String loadYaml(String yamlFileName, String ...extraLines) throws Exception {
-        String input = new ResourceUtils(this).getResourceAsString(yamlFileName).trim();
+        ResourceUtils ru = new ResourceUtils(this);
+        if (!ru.doesUrlExist(yamlFileName)) {
+            if (ru.doesUrlExist(Urls.mergePaths(getClass().getPackage().getName().replace('.', '/'), yamlFileName))) {
+                // look in package-specific folder if not found at root
+                yamlFileName = Urls.mergePaths(getClass().getPackage().getName().replace('.', '/'), yamlFileName);
+            }
+        }
+        String input = ru.getResourceAsString(yamlFileName).trim();
         StringBuilder builder = new StringBuilder(input);
         for (String l: extraLines)
             builder.append("\n").append(l);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -335,7 +335,7 @@ public class ConfigParametersYamlTest extends AbstractYamlTest {
                 "    sshToolClass: "+RecordingSshTool.class.getName(),
                 "services:",
                 "- type: sub-entity");
-        Entity app = createStartWaitAndLogApplication(yaml);
+        createStartWaitAndLogApplication(yaml);
         
         ExecCmd cmd = ExecCmdAsserts.findExecContaining(RecordingSshTool.getExecCmds(), "myLaunchCmd");
         assertEquals(cmd.env.get("KEY_IN_SUPER"), "myDefaultVal", "cmd="+cmd);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigTypeCoercionYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigTypeCoercionYamlTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
+import org.apache.brooklyn.util.text.StringPredicates;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ConfigTypeCoercionYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(ConfigTypeCoercionYamlTest.class);
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        RecordingSshTool.clear();
+    }
+    
+    @Test
+    public void testSshConfigFromDefault() throws Exception {
+        RecordingSshTool.setCustomResponse(".*myCommand.*", new RecordingSshTool.CustomResponse(0, "myResponse", null));
+        
+        String bp = loadYaml("config-type-coercion-test.yaml",
+            "location:",
+            "  localhost:",
+            "    sshToolClass: "+RecordingSshTool.class.getName());
+        // remove all lines referring to "exact" -- that's useful for expository and running in UI
+        // but it will fail (timeout) if the port isn't available so not good in tests
+        bp = Strings.removeLines(bp, StringPredicates.containsLiteralIgnoreCase("exact"));
+        
+        Entity app = createAndStartApplication(bp);
+        waitForApplicationTasks(app);
+
+        Map<?, ?> props = RecordingSshTool.getLastExecCmd().env;
+        
+        Assert.assertEquals(props.get("RANGE_PORT_SENSOR"), "20003");
+        Asserts.assertStringContains((String)props.get("RANGE_PORT_CONFIG"), "{\"start\"", "20003");
+        
+        Assert.assertEquals(props.get("INT_PORT_CONFIG"), "20001");
+        Assert.assertEquals(props.get("INT_PORT_DEFAULT_CONFIG"), "30001");
+        
+        Assert.assertEquals(props.get("RANGE_PORT_DEFAULT_SENSOR"), "30003");
+        // NB: change in Oct 2016, default values are now coerced just like explicit value
+        // (previous to Oct 2016 this would have returned just "30003+", no json)
+        Asserts.assertStringContains((String)props.get("RANGE_PORT_DEFAULT_CONFIG"), "{\"start\"", "30003");
+    }
+    
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityNameYamlTest.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 
 @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
@@ -159,11 +159,11 @@ public class EntityRefsYamlTest extends AbstractYamlTest {
         
         Entities.dumpInfo(app);
         
-        Entity entity1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity1"));
-        Entity entity1_1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity1.1"));
-        Entity entity2 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2"));
-        Entity entity2_1 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2.1"));
-        Entity entity2_2 = Iterables.find(Entities.descendants(app), EntityPredicates.displayNameEqualTo("entity2.2"));
+        Entity entity1 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity1"));
+        Entity entity1_1 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity1.1"));
+        Entity entity2 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity2"));
+        Entity entity2_1 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity2.1"));
+        Entity entity2_2 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity2.2"));
         
         assertEquals(entity1.getConfig(newConfigKey("conf1.sibling")), entity2);
         assertEquals(entity1.getConfig(newConfigKey("conf1.sibling2")), entity2);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigBrooklynPropertiesTest.java
@@ -129,10 +129,10 @@ public class ExternalConfigBrooklynPropertiesTest extends AbstractYamlTest {
         DeferredSupplier<?> val2 = (DeferredSupplier<?>) props.getConfigRaw(ConfigKeys.newStringConfigKey(property)).get();
         assertEquals(Tasks.resolveValue(val2, String.class, exec), expectedVal);
         
-        DeferredSupplier<?> val3 = (DeferredSupplier<?>) props.getConfigRaw(ConfigKeys.newStringConfigKey(property), false).get();
+        DeferredSupplier<?> val3 = (DeferredSupplier<?>) props.getConfigLocalRaw(ConfigKeys.newStringConfigKey(property)).get();
         assertEquals(Tasks.resolveValue(val3, String.class, exec), expectedVal);
 
-        DeferredSupplier<?> val4 = (DeferredSupplier<?>) props.getAllConfig().get(ConfigKeys.newStringConfigKey(property));
+        DeferredSupplier<?> val4 = (DeferredSupplier<?>) props.getAllConfigLocalRaw().get(ConfigKeys.newStringConfigKey(property));
         assertEquals(Tasks.resolveValue(val4, String.class, exec), expectedVal);
         
         String val5 = props.getFirst(property);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencedYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencedYamlTest.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.camp.brooklyn;
 import java.util.Collection;
 
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
-import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.entity.stock.BasicApplication;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WrapAppTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WrapAppTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.brooklyn.camp.brooklyn;
 
-import java.io.StringReader;
-
 import org.apache.brooklyn.core.entity.StartableApplication;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -32,7 +32,6 @@ import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
-import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlRebindTest.java
@@ -147,7 +147,7 @@ public class CatalogYamlRebindTest extends AbstractYamlRebindTest {
     }
 
     @Test(dataProvider = "dataProvider")
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({ "deprecation", "unused" })
     public void testRebindWithCatalogAndApp(RebindWithCatalogTestMode mode, boolean useOsgi) throws Exception {
         if (mode == RebindWithCatalogTestMode.REPLACE_CATALOG_WITH_NEWER_VERSION) {
             BrooklynFeatureEnablement.enable(BrooklynFeatureEnablement.FEATURE_AUTO_FIX_CATALOG_REF_ON_REBIND);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterParsingTest.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;

--- a/camp/camp-brooklyn/src/test/resources/org/apache/brooklyn/camp/brooklyn/config-type-coercion-test.yaml
+++ b/camp/camp-brooklyn/src/test/resources/org/apache/brooklyn/camp/brooklyn/config-type-coercion-test.yaml
@@ -1,0 +1,47 @@
+services:
+- type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
+  shell.env:
+    EXACT_PORT_CONFIG: $brooklyn:config("exact.port")
+    EXACT_PORT_SENSOR: $brooklyn:attributeWhenReady("exact.port")
+    RANGE_PORT_CONFIG: $brooklyn:config("range.port")
+    RANGE_PORT_SENSOR: $brooklyn:attributeWhenReady("range.port")
+    INT_PORT_CONFIG: $brooklyn:config("int.port")
+    EXACT_PORT_DEFAULT_CONFIG: $brooklyn:config("exact.default.port")
+    EXACT_PORT_DEFAULT_SENSOR: $brooklyn:attributeWhenReady("exact.default.port")
+    RANGE_PORT_DEFAULT_CONFIG: $brooklyn:config("range.default.port")
+    RANGE_PORT_DEFAULT_SENSOR: $brooklyn:attributeWhenReady("range.default.port")
+    INT_PORT_DEFAULT_CONFIG: $brooklyn:config("int.default.port")
+  install.command: true
+  checkRunning.command: true
+  launch.command: |
+    echo EXACT_PORT_CONFIG is $EXACT_PORT_CONFIG
+    echo EXACT_PORT_SENSOR is $EXACT_PORT_SENSOR
+    echo RANGE_PORT_CONFIG is $RANGE_PORT_CONFIG
+    echo RANGE_PORT_SENSOR is $RANGE_PORT_SENSOR
+    echo INT_PORT_CONFIG is $INT_PORT_CONFIG
+    echo EXACT_PORT_DEFAULT_CONFIG is $EXACT_PORT_DEFAULT_CONFIG
+    echo EXACT_PORT_DEFAULT_SENSOR is $EXACT_PORT_DEFAULT_SENSOR
+    echo RANGE_PORT_DEFAULT_CONFIG is $RANGE_PORT_DEFAULT_CONFIG
+    echo RANGE_PORT_DEFAULT_SENSOR is $RANGE_PORT_DEFAULT_SENSOR
+    echo INT_PORT_DEFAULT_CONFIG is $INT_PORT_DEFAULT_CONFIG
+  brooklyn.parameters:
+  - name: int.port
+    type: int
+  # ("exact" items are put on one line so we can filter them in tests)
+  - { name: exact.port, type: port }
+  - name: range.port
+    type: port
+  - name: int.default.port
+    type: int
+    default: 30001
+  - { name: exact.default.port, type: port, default: 30002 }
+  - name: range.default.port
+    type: port
+    default: 30003+
+  brooklyn.config:
+    int.port: 20001
+    exact.port: 20002
+    range.port: 20003+
+
+# if running manually, add this:
+# location: localhost

--- a/camp/camp-brooklyn/src/test/resources/org/apache/brooklyn/camp/brooklyn/config-type-coercion-test.yaml
+++ b/camp/camp-brooklyn/src/test/resources/org/apache/brooklyn/camp/brooklyn/config-type-coercion-test.yaml
@@ -1,3 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# used in ConfigTypeCoercionYamlTest.testSshConfigFromDefault
+# (that will remove lines containing the word `exact` to make it safer for testing)
+# this can be used as is in the UI, with location added, for manual testing/observation
+
 services:
 - type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
   shell.env:

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
@@ -41,8 +41,10 @@ import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 
 public class Strings {
@@ -217,7 +219,19 @@ public class Strings {
 
     /** convenience for joining lines together */
     public static String lines(String ...lines) {
-        return Joiner.on("\n").join(Arrays.asList(lines));
+        if (lines==null) return null;
+        return lines(Arrays.asList(lines));
+    }
+    
+    /** convenience for joining lines together */
+    public static String lines(Iterable<String> lines) {
+        if (lines==null) return null;
+        return Joiner.on("\n").join(lines);
+    }
+
+    public static String removeLines(String multiline, Predicate<CharSequence> patternToRemove) {
+        if (multiline==null) return null;
+        return lines(Iterables.filter(Arrays.asList(multiline.split("\n")), Predicates.not(patternToRemove)));
     }
 
     /** NON-REGEX - replaces all key->value entries from the replacement map in source (non-regex) */
@@ -948,4 +962,5 @@ public class Strings {
         }
         return result;
     }
+
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringsTest.java
@@ -343,6 +343,14 @@ public class StringsTest extends FixedLocaleTest {
         Assert.assertEquals(Strings.maxlenWithEllipsis("hello world", 9), "hello ...");
         Assert.assertEquals(Strings.maxlenWithEllipsis("hello world", 7, "--"), "hello--");
     }
+    
+    public void testLines() {
+        Assert.assertEquals(Strings.lines("a", "b"), "a\nb");
+    }
+    
+    public void testRemoveLines() {
+        Assert.assertEquals(Strings.removeLines(Strings.lines("a", "b"), StringPredicates.containsLiteralIgnoreCase("A")), "b");
+    }
 
     @Test
     public void testGetRemainderOfLineAfter() {


### PR DESCRIPTION
Several minor fixes/changes, plus one significant test in https://github.com/apache/brooklyn-server/commit/e9c1f4cbb67d1bd89d1e7d84f8730225047ea337 which highlights a change in behaviour since early Oct

Also see related PR adding this to release notes