### PR TITLE
SshCommandEffector + shell.env

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/sensor/PortAttributeSensorAndConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/PortAttributeSensorAndConfigKey.java
@@ -134,7 +134,7 @@ public class PortAttributeSensorAndConfigKey extends AttributeSensorAndConfigKey
                 LOG.warn("{}: ports not applicable, or not yet applicable, because has multiple locations {}; ignoring ", new Object[] { entity, locations, getName() });
             }
         } else {
-            LOG.warn("{}: ports not applicable, or not yet applicable, bacause has no locations; ignoring {}", entity, getName());
+            LOG.warn("{}: ports not applicable, or not yet applicable, because has no locations; ignoring {}", entity, getName());
         }
         return null;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.sensor.ssh;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,7 +139,7 @@ public final class SshCommandSensor<T> extends AddSensor<T> {
     }
 
     @Beta
-    public static String makeCommandExecutingInDirectory(String command, String executionDir, EntityLocal entity) {
+    public static String makeCommandExecutingInDirectory(String command, String executionDir, Entity entity) {
         String finalCommand = command;
         String execDir = executionDir;
         if (Strings.isBlank(execDir)) {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -198,7 +198,7 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
             "cluster.entity", "The cluster an entity is a member of");
 
     AttributeSensor<Boolean> CLUSTER_ONE_AND_ALL_MEMBERS_UP = Sensors.newBooleanSensor(
-            "cluster.one_and_all.members.up", "True cluster is running, there is on member, and all members are service.isUp");
+            "cluster.one_and_all.members.up", "True if the cluster is running, there is one member, and all members are service.isUp");
 
     /**
      * Changes the cluster size by the given number.

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -246,7 +246,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
     @Test(groups = "Integration")
     public void testCopyStreamTo() throws Exception {
         String contents = "abc";
-        File dest = new File(Os.tmp(), "sssMachineLocationTest_dest.tmp");
+        File dest = new File(Os.tmp(), "sshMachineLocationTest_dest.tmp");
         try {
             host.copyTo(Streams.newInputStreamWithContents(contents), dest.getAbsolutePath());
             assertEquals("abc", Files.readFirstLine(dest, Charsets.UTF_8));
@@ -257,7 +257,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
 
     @Test(groups = "Integration")
     public void testInstallUrlTo() throws Exception {
-        File dest = new File(Os.tmp(), "sssMachineLocationTest_dir/");
+        File dest = new File(Os.tmp(), "sshMachineLocationTest_dir/");
         dest.mkdir();
         try {
             int result = host.installTo("https://raw.github.com/brooklyncentral/brooklyn/master/README.md", Urls.mergePaths(dest.getAbsolutePath(), "README.md"));
@@ -271,7 +271,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
     
     @Test(groups = "Integration")
     public void testInstallClasspathCopyTo() throws Exception {
-        File dest = new File(Os.tmp(), "sssMachineLocationTest_dir/");
+        File dest = new File(Os.tmp(), "sshMachineLocationTest_dir/");
         dest.mkdir();
         try {
             int result = host.installTo("classpath://brooklyn/config/sample.properties", Urls.mergePaths(dest.getAbsolutePath(), "sample.properties"));

--- a/core/src/test/java/org/apache/brooklyn/util/core/xstream/XmlSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/xstream/XmlSerializerTest.java
@@ -59,7 +59,7 @@ public class XmlSerializerTest {
     protected void assertSerializeAndDeserialize(Object val) throws Exception {
         String xml = serializer.toString(val);
         Object result = serializer.fromString(xml);
-        LOG.info("val="+val+"'; xml="+xml+"; result="+result);
+        LOG.debug("val="+val+"'; xml="+xml+"; result="+result);
         assertEquals(result, val);
     }
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -3460,7 +3460,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         }
         if (sshHostAndPort.isPresent() || inferredHostAndPort != null) {
             if (isWindows(node, setup)) {
-                LOG.warn("Cannpy query aws-ec2 Windows instance "+node.getId()+"@"+node.getLocation()+" over ssh for its hostname; falling back to jclouds metadata for address");
+                LOG.warn("Error querying aws-ec2 Windows instance "+node.getId()+"@"+node.getLocation()+" over ssh for its hostname; falling back to jclouds metadata for address");
             } else {
                 HostAndPort hostAndPortToUse = sshHostAndPort.isPresent() ? sshHostAndPort.get() : inferredHostAndPort;
                 try {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -208,11 +208,6 @@
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-guava</artifactId>
-                <version>${fasterxml.jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-joda</artifactId>
                 <version>${fasterxml.jackson.version}</version>
             </dependency>

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
@@ -96,10 +96,20 @@ public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
         runTest(ImmutableMap.of("imageId", "us-east-1/ami-5e12dc36", "loginUser", "admin", "hardwareId", SMALL_HARDWARE_ID));
     }
 
-    @Test(groups = {"Live"})
+    /**
+     * @deprecated since 0.10.0 use {@link #test_Debian_7()} instead.
+     */
+    @Test(groups = {"Live"}, enabled=false)
+    @Deprecated
     public void test_Debian_7_2() throws Exception {
-        // release codename "wheezy"
-        runTest(ImmutableMap.of("imageId", "us-east-1/ami-5586a43c", "loginUser", "admin", "hardwareId", SMALL_HARDWARE_ID));
+        test_Debian_7();
+    }
+
+    @Test(groups = {"Live"})
+    public void test_Debian_7() throws Exception {
+        // See images at https://wiki.debian.org/Cloud/AmazonEC2Image/Wheezy.
+        // release codename "wheezy", version 7.8.aws.1.
+        runTest(ImmutableMap.of("imageId", "us-east-1/ami-baeda9d2", "loginUser", "admin", "hardwareId", SMALL_HARDWARE_ID));
     }
 
     @Test(groups = {"Live"})


### PR DESCRIPTION
SshCommandEffector resolves shell.env against the target entity rather than always resolving it against the entity the effector is attached to. This also fixes the resolution of the execution directory.