### PR TITLE
BROOKLYN-383: fix json serialisation of tasks

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
@@ -180,6 +180,7 @@ public abstract class AbstractFeed extends AbstractEntityAdjunct implements Feed
         return activated;
     }
     
+    @Override
     public EntityLocal getEntity() {
         return entity;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -383,6 +383,10 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         }
     }
     
+    public Entity getEntity() {
+        return entity;
+    }
+    
     /** @deprecated since 0.7.0 only {@link AbstractEnricher} has emit convenience */
     protected <T> void emit(Sensor<T> sensor, Object val) {
         checkState(entity != null, "entity must first be set");

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
@@ -273,4 +273,23 @@ public class BidiSerialization {
             return mgmt.getExecutionManager().getTask((String) values.get("id"));
         }
     }
+    
+    /**
+     * Serializes a classloader to just tell us about its type; cannot deserialize it again though!
+     * 
+     * See https://issues.apache.org/jira/browse/BROOKLYN-304 - this new behaviour is better than the
+     * {@link OutOfMemoryError} we used to get.
+     */
+    public static class ClassLoaderSerialization extends AbstractWithManagementContextSerialization<ClassLoader> {
+        public ClassLoaderSerialization(ManagementContext mgmt) { 
+            super(ClassLoader.class, mgmt);
+        }
+        @Override
+        public void customWriteBody(ClassLoader value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        }
+        @Override
+        protected ClassLoader customReadBody(String type, Map<Object, Object> values, JsonParser jp, DeserializationContext ctxt) throws IOException {
+            return null;
+        }
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
@@ -24,7 +24,14 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
+import org.apache.brooklyn.api.policy.Policy;
+import org.apache.brooklyn.api.sensor.Enricher;
+import org.apache.brooklyn.api.sensor.Feed;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -33,6 +40,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.Optional;
 
 public class BidiSerialization {
 
@@ -101,8 +109,12 @@ public class BidiSerialization {
         }
 
         protected void writeBody(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeStringField("type", value.getClass().getCanonicalName());
+            jgen.writeStringField("type", customType(value));
             customWriteBody(value, jgen, provider);
+        }
+
+        protected String customType(T value) throws IOException {
+            return value.getClass().getCanonicalName();
         }
 
         public abstract void customWriteBody(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException;
@@ -125,7 +137,12 @@ public class BidiSerialization {
     public static class ManagementContextSerialization extends AbstractWithManagementContextSerialization<ManagementContext> {
         public ManagementContextSerialization(ManagementContext mgmt) { super(ManagementContext.class, mgmt); }
         @Override
-        public void customWriteBody(ManagementContext value, JsonGenerator jgen, SerializerProvider provider) throws IOException {}
+        protected String customType(ManagementContext value) throws IOException {
+            return type.getCanonicalName();
+        }
+        @Override
+        public void customWriteBody(ManagementContext value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        }
         @Override
         protected ManagementContext customReadBody(String type, Map<Object, Object> values, JsonParser jp, DeserializationContext ctxt) throws IOException {
             return mgmt;
@@ -137,9 +154,8 @@ public class BidiSerialization {
             super(type, mgmt);
         }
         @Override
-        protected void writeBody(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-            jgen.writeStringField("type", type.getCanonicalName());
-            customWriteBody(value, jgen, provider);
+        protected String customType(T value) throws IOException {
+            return type.getCanonicalName();
         }
         @Override
         public void customWriteBody(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
@@ -152,22 +168,109 @@ public class BidiSerialization {
         protected abstract T getInstanceFromId(String id);
     }
 
+    public abstract static class AbstractBrooklynAdjunctSerialization<T extends BrooklynObject & EntityAdjunct> extends AbstractWithManagementContextSerialization<T> {
+        public AbstractBrooklynAdjunctSerialization(Class<T> type, ManagementContext mgmt) { 
+            super(type, mgmt);
+        }
+        @Override
+        protected String customType(T value) throws IOException {
+            return type.getCanonicalName();
+        }
+        @Override
+        public void customWriteBody(T value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            Optional<String> entityId = getEntityId(value);
+            jgen.writeStringField("id", value.getId());
+            if (entityId.isPresent()) jgen.writeStringField("entityId", entityId.get());
+        }
+        @Override
+        protected T customReadBody(String type, Map<Object, Object> values, JsonParser jp, DeserializationContext ctxt) throws IOException {
+            Optional<String> entityId = Optional.fromNullable((String) values.get("entityId"));
+            Optional<Entity> entity = Optional.fromNullable(entityId.isPresent() ? null: mgmt.getEntityManager().getEntity(entityId.get()));
+            String id = (String) values.get("id");
+            return getInstanceFromId(entity, id);
+        }
+        protected Optional<String> getEntityId(T value) {
+            if (value instanceof AbstractEntityAdjunct) {
+                Entity entity = ((AbstractEntityAdjunct)value).getEntity();
+                return Optional.fromNullable(entity == null ? null : entity.getId());
+            }
+            return Optional.absent();
+        }
+        protected abstract T getInstanceFromId(Optional<Entity> entity, String id);
+    }
+
     public static class EntitySerialization extends AbstractBrooklynObjectSerialization<Entity> {
         public EntitySerialization(ManagementContext mgmt) { super(Entity.class, mgmt); }
         @Override protected Entity getInstanceFromId(String id) { return mgmt.getEntityManager().getEntity(id); }
     }
+    
     public static class LocationSerialization extends AbstractBrooklynObjectSerialization<Location> {
         public LocationSerialization(ManagementContext mgmt) { super(Location.class, mgmt); }
         @Override protected Location getInstanceFromId(String id) { return mgmt.getLocationManager().getLocation(id); }
     }
-    // TODO how to look up policies and enrichers? (not essential...)
-//    public static class PolicySerialization extends AbstractBrooklynObjectSerialization<Policy> {
-//        public EntitySerialization(ManagementContext mgmt) { super(Policy.class, mgmt); }
-//        @Override protected Policy getKind(String id) { return mgmt.getEntityManager().getEntity(id); }
-//    }
-//    public static class EnricherSerialization extends AbstractBrooklynObjectSerialization<Enricher> {
-//        public EntitySerialization(ManagementContext mgmt) { super(Entity.class, mgmt); }
-//        @Override protected Enricher getKind(String id) { return mgmt.getEntityManager().getEntity(id); }
-//    }
-
+    
+    public static class PolicySerialization extends AbstractBrooklynAdjunctSerialization<Policy> {
+        public PolicySerialization(ManagementContext mgmt) {
+            super(Policy.class, mgmt);
+        }
+        @Override protected Policy getInstanceFromId(Optional<Entity> entity, String id) {
+            if (id == null || !entity.isPresent()) return null;
+            for (Policy policy : entity.get().policies()) {
+                if (id.equals(policy.getId())) {
+                    return policy;
+                }
+            }
+            return null;
+        }
+    }
+    
+    public static class EnricherSerialization extends AbstractBrooklynAdjunctSerialization<Enricher> {
+        public EnricherSerialization(ManagementContext mgmt) {
+            super(Enricher.class, mgmt);
+        }
+        @Override protected Enricher getInstanceFromId(Optional<Entity> entity, String id) {
+            if (id == null || !entity.isPresent()) return null;
+            for (Enricher enricher : entity.get().enrichers()) {
+                if (id.equals(enricher.getId())) {
+                    return enricher;
+                }
+            }
+            return null;
+        }
+    }
+    
+    public static class FeedSerialization extends AbstractBrooklynAdjunctSerialization<Feed> {
+        public FeedSerialization(ManagementContext mgmt) {
+            super(Feed.class, mgmt);
+        }
+        @Override protected Feed getInstanceFromId(Optional<Entity> entity, String id) {
+            if (id == null || !entity.isPresent()) return null;
+            for (Feed feed : ((EntityInternal)entity).feeds().getFeeds()) {
+                if (id.equals(feed.getId())) {
+                    return feed;
+                }
+            }
+            return null;
+        }
+    }
+    
+    public static class TaskSerialization extends AbstractWithManagementContextSerialization<Task<?>> {
+        @SuppressWarnings("unchecked")
+        public TaskSerialization(ManagementContext mgmt) { 
+            super((Class<Task<?>>)(Class<?>)Task.class, mgmt);
+        }
+        @Override
+        protected String customType(Task<?> value) throws IOException {
+            return type.getCanonicalName();
+        }
+        @Override
+        public void customWriteBody(Task<?> value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            jgen.writeStringField("id", value.getId());
+            jgen.writeStringField("displayName", value.getDisplayName());
+        }
+        @Override
+        protected Task<?> customReadBody(String type, Map<Object, Object> values, JsonParser jp, DeserializationContext ctxt) throws IOException {
+            return mgmt.getExecutionManager().getTask((String) values.get("id"));
+        }
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
@@ -36,6 +36,10 @@ public class BrooklynObjectsJsonMapper {
         new BidiSerialization.ManagementContextSerialization(mgmt).install(mapperModule);
         new BidiSerialization.EntitySerialization(mgmt).install(mapperModule);
         new BidiSerialization.LocationSerialization(mgmt).install(mapperModule);
+        new BidiSerialization.PolicySerialization(mgmt).install(mapperModule);
+        new BidiSerialization.EnricherSerialization(mgmt).install(mapperModule);
+        new BidiSerialization.FeedSerialization(mgmt).install(mapperModule);
+        new BidiSerialization.TaskSerialization(mgmt).install(mapperModule);
 
         mapper.registerModule(new GuavaModule()).registerModule(mapperModule);
         return mapper;

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
@@ -40,6 +40,7 @@ public class BrooklynObjectsJsonMapper {
         new BidiSerialization.EnricherSerialization(mgmt).install(mapperModule);
         new BidiSerialization.FeedSerialization(mgmt).install(mapperModule);
         new BidiSerialization.TaskSerialization(mgmt).install(mapperModule);
+        new BidiSerialization.ClassLoaderSerialization(mgmt).install(mapperModule);
 
         mapper.registerModule(new GuavaModule()).registerModule(mapperModule);
         return mapper;

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoPersister.LookupContext;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
@@ -56,16 +57,19 @@ import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.mgmt.osgi.OsgiVersionMoreEntityTest;
+import org.apache.brooklyn.core.mgmt.rebind.RebindEntityTest.ReffingEntity;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.test.LogWatcher;
+import org.apache.brooklyn.test.LogWatcher.EventPredicates;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
-import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.osgi.Osgis;
+import org.apache.brooklyn.util.core.task.BasicTask;
 import org.apache.brooklyn.util.javalang.Reflections;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.net.UserAndHostAndPort;
@@ -80,16 +84,20 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Callables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class XmlMementoSerializerTest {
 
@@ -516,6 +524,32 @@ public class XmlMementoSerializerTest {
         } finally {
             Entities.destroyAll(managementContext);
         }
+    }
+
+    @Test
+    public void testTask() throws Exception {
+        final TestApplication app = TestApplication.Factory.newManagedInstanceForTests();
+        mgmt = app.getManagementContext();
+        Task<String> completedTask = app.getExecutionContext().submit(Callables.returning("myval"));
+        completedTask.get();
+        
+        String loggerName = UnwantedStateLoggingMapper.class.getName();
+        ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.WARN;
+        Predicate<ILoggingEvent> filter = EventPredicates.containsMessage("Task object serialization is not supported or recommended"); 
+        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
+        
+        String serializedForm;
+        watcher.start();
+        try {
+            serializedForm = serializer.toString(completedTask);
+            watcher.assertHasEvent();
+        } finally {
+            watcher.close();
+        }
+
+        assertEquals(serializedForm.trim(), "<"+BasicTask.class.getName()+">myval</"+BasicTask.class.getName()+">");
+        Object deserialized = serializer.fromString(serializedForm);
+        assertEquals(deserialized, null, "serializedForm="+serializedForm+"; deserialized="+deserialized);
     }
 
     public static class ReffingEntity {

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -81,6 +82,7 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     
     public static final MethodEffector<Void> MY_EFFECTOR = new MethodEffector<Void>(TestEntity.class, "myEffector");
     public static final MethodEffector<Object> IDENTITY_EFFECTOR = new MethodEffector<Object>(TestEntity.class, "identityEffector");
+    public static final MethodEffector<Void> SLEEP_EFFECTOR = new MethodEffector<Void>(TestEntity.class, "sleepEffector");
     
     public boolean isLegacyConstruction();
     
@@ -89,6 +91,9 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     
     @Effector(description="returns the arg passed in")
     public Object identityEffector(@EffectorParam(name="arg", description="val to return") Object arg);
+    
+    @Effector(description="sleeps for the given duration")
+    public void sleepEffector(@EffectorParam(name="duration") Duration duration);
     
     public AtomicInteger getCounter();
     

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
@@ -33,6 +33,8 @@ import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +89,13 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
         return checkNotNull(arg, "arg");
     }
     
+    @Override
+    public void sleepEffector(Duration duration) {
+        if (LOG.isTraceEnabled()) LOG.trace("In sleepEffector for {}", this);
+        callHistory.add("sleepEffector");
+        Time.sleep(duration);
+    }
+
     @Override
     public AtomicInteger getCounter() {
         return counter;

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceTest.java
@@ -20,16 +20,30 @@ package org.apache.brooklyn.rest.resources;
 
 import static org.testng.Assert.assertEquals;
 
+import java.io.InputStream;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.Enricher;
+import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.test.policy.TestEnricher;
+import org.apache.brooklyn.core.test.policy.TestPolicy;
+import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.rest.api.SensorApi;
 import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.EntitySpec;
@@ -37,19 +51,22 @@ import org.apache.brooklyn.rest.test.config.render.TestRendererHints;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.rest.testing.mocks.RestMockSimpleEntity;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.StringFunctions;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.apache.cxf.jaxrs.client.WebClient;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import java.io.InputStream;
-import javax.ws.rs.core.GenericType;
-import org.apache.cxf.jaxrs.client.WebClient;
+import com.google.common.util.concurrent.Callables;
 
 /**
  * Test the {@link SensorApi} implementation.
@@ -263,5 +280,98 @@ public class SensorResourceTest extends BrooklynRestResourceTest {
 
         } finally { addAmphibianSensor(entity); }
     }
+    
+    @Test
+    public void testGetSensorValueOfTypeManagementContext() throws Exception {
+        entity.sensors().set(Sensors.newSensor(ManagementContext.class, "myMgmt"), getManagementContext());
+        doGetSensorTest("myMgmt", Map.class, ImmutableMap.of("type", ManagementContext.class.getName()));
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeEntity() throws Exception {
+        // Note that non-raw will render it with just the entity's displayName
+        entity.sensors().set(Sensors.newSensor(Entity.class, "myEntity"), entity);
+        doGetSensorTest("myEntity", Map.class, ImmutableMap.of("type", Entity.class.getName(), "id", entity.getId()), true);
+        doGetSensorTest("myEntity", String.class, "\"simple-ent\"", false);
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeLocation() throws Exception {
+        Location loc = getManagementContext().getLocationRegistry().getLocationManaged("localhost");
+        entity.sensors().set(Sensors.newSensor(Location.class, "myLocation"), loc);
+        doGetSensorTest("myLocation", Map.class, ImmutableMap.of("type", Location.class.getName(), "id", loc.getId()));
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypePolicy() throws Exception {
+        Policy policy = entity.policies().add(org.apache.brooklyn.api.policy.PolicySpec.create(TestPolicy.class));
+        entity.sensors().set(Sensors.newSensor(Policy.class, "myPolicy"), policy);
+        doGetSensorTest("myPolicy", Map.class, ImmutableMap.of("type", Policy.class.getName(), "id", policy.getId(), "entityId", entity.getId()));
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeEnricher() throws Exception {
+        Enricher enricher = entity.enrichers().add(org.apache.brooklyn.api.sensor.EnricherSpec.create(TestEnricher.class));
+        entity.sensors().set(Sensors.newSensor(Enricher.class, "myEnricher"), enricher);
+        doGetSensorTest("myEnricher", Map.class, ImmutableMap.of("type", Enricher.class.getName(), "id", enricher.getId(), "entityId", entity.getId()));
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeFeed() throws Exception {
+        Feed feed = entity.feeds().add(FunctionFeed.builder().entity(entity).build());
+        entity.sensors().set(Sensors.newSensor(Feed.class, "myFeed"), feed);
+        doGetSensorTest("myFeed", Map.class, ImmutableMap.of("type", Feed.class.getName(), "id", feed.getId(), "entityId", entity.getId()));
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeCompletedTask() throws Exception {
+        Task<String> task = entity.getExecutionContext().submit(Callables.returning("myval"));
+        task.get();
+        entity.sensors().set(Sensors.newSensor(Task.class, "myTask"), task);
+        doGetSensorTest("myTask", String.class, "\"myval\"");
+    }
+    
+    @Test
+    public void testGetSensorValueOfTypeInprogressTask() throws Exception {
+        Task<Void> task = Tasks.<Void>builder().displayName("my-task-name").body(new SleepingCallable(Duration.THIRTY_SECONDS)).build();
+        entity.getExecutionContext().submit(task);
+        entity.sensors().set(Sensors.newSensor(Task.class, "myTask"), task);
+        doGetSensorTest("myTask", Map.class, ImmutableMap.of("type", Task.class.getName(), "id", task.getId(), "displayName", "my-task-name"));
+    }        
+    
+    @Test
+    public void testGetSensorValueOfTypeEffectorTask() throws Exception {
+        TestEntity testEntity = entity.addChild(org.apache.brooklyn.api.entity.EntitySpec.create(TestEntity.class));
+        Task<Void> task = testEntity.invoke(TestEntity.SLEEP_EFFECTOR, ImmutableMap.of("duration", Duration.THIRTY_SECONDS));
+        entity.sensors().set(Sensors.newSensor(Task.class, "myTask"), task);
+        doGetSensorTest("myTask", Map.class, ImmutableMap.of("type", Task.class.getName(), "id", task.getId(), "displayName", "sleepEffector"));
+    }
+    
+    protected <T> void doGetSensorTest(String sensorName, Class<T> expectedType, T expectedVal) throws Exception {
+        doGetSensorTest(sensorName, expectedType, expectedVal, true);
+        doGetSensorTest(sensorName, expectedType, expectedVal, false);
+    }
 
+    protected <T> void doGetSensorTest(String sensorName, Class<T> expectedType, T expectedVal, boolean raw) throws Exception {
+        Response response = client().path(SENSORS_ENDPOINT + "/" + sensorName)
+                .query("raw", raw)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .get();
+        
+        HttpAsserts.assertHealthyStatusCode(response.getStatus());
+        T value = response.readEntity(expectedType);
+        assertEquals(value, expectedVal);
+    }
+
+    public static class SleepingCallable implements Callable<Void> {
+        private final Duration duration;
+        
+        SleepingCallable(Duration duration) {
+            this.duration = duration;
+        }
+        public Void call() throws Exception {
+            Time.sleep(duration);
+            return null;
+        }
+    }
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricher.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/system_service/SystemServiceEnricher.java
@@ -133,9 +133,4 @@ public class SystemServiceEnricher extends AbstractEnricher implements Enricher 
     ExecutionContext getEntityExecutionContext() {
         return getManagementContext().getExecutionContext(entity);
     }
-
-    protected Entity getEntity() {
-        return entity;
-    }
-
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
@@ -60,7 +60,7 @@ public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
         assertSerialize(app, appExpected);
         assertSerialize(ImmutableList.of(app), "[" + appExpected + "]");
         assertSerialize(ImmutableMap.of("app", app), "{\"app\":" + appExpected + "}");
-        assertSerialize(mgmt, "{\"type\":\"org.apache.brooklyn.core.test.entity.LocalManagementContextForTests\"}");
+        assertSerialize(mgmt, "{\"type\":\"org.apache.brooklyn.api.mgmt.ManagementContext\"}");
         // TODO Fails with java.lang.OutOfMemoryError: GC overhead limit exceeded
         // https://issues.apache.org/jira/browse/BROOKLYN-304
         // assertSerialize(getClass().getClassLoader(), "???");

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
@@ -61,9 +61,9 @@ public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
         assertSerialize(ImmutableList.of(app), "[" + appExpected + "]");
         assertSerialize(ImmutableMap.of("app", app), "{\"app\":" + appExpected + "}");
         assertSerialize(mgmt, "{\"type\":\"org.apache.brooklyn.api.mgmt.ManagementContext\"}");
-        // TODO Fails with java.lang.OutOfMemoryError: GC overhead limit exceeded
         // https://issues.apache.org/jira/browse/BROOKLYN-304
-        // assertSerialize(getClass().getClassLoader(), "???");
+        assertSerialize(getClass().getClassLoader(), "{\"type\":\""+getClass().getClassLoader().getClass().getCanonicalName()+"\"}");
+        assertSerialize(getClass(), "class "+getClass().getName());
     }
 
     private void assertSerialize(Object actual, String expected) {

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -130,6 +130,10 @@ public class LogWatcher implements Closeable {
         }
     }
     
+    public void assertHasEvent() {
+        assertFalse(events.isEmpty());
+    }
+
     public void assertHasEventEventually() {
         Asserts.succeedsEventually(new Runnable() {
             public void run() {


### PR DESCRIPTION
* Also do the same for policies, enrichers and feeds.
* Adds AbstractEntityAdjunct.getEntity() to make that easier.
* Adds TestEntity.sleepEffector

And tests xml persistence of a task, while I'm at it.