### PR TITLE
Use servicemix bundle for okio

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -255,8 +255,9 @@
             https://github.com/square/okhttp/issues/2243
             https://github.com/square/okhttp/pull/2246
         -->
-        <bundle dependency="true">wrap:mvn:com.squareup.okhttp/okhttp/2.2.0</bundle>
-        <bundle dependency="true">wrap:mvn:com.squareup.okio/okio/1.2.0</bundle>
+        <!-- TODO use ServiceMix bundle for okhttp when dependency on okio is fixed there -->
+        <bundle dependency="true">wrap:mvn:com.squareup.okhttp/okhttp/2.2.0$Import-Package=org.apache.http.*;resolution:=optional,android.util.*;resolution:=optional,okio;version="[1.2.0, 1.3.0)",*</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.2.0_1</bundle>
         <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-okhttp/${jclouds.version}</bundle>
 
         <bundle dependency="true">mvn:org.apache.jclouds.driver/jclouds-sshj/${jclouds.version}</bundle>


### PR DESCRIPTION
 - servicemix `okio` version 1.2.0_1
 - still wrap: `okhttp` 2.2.0 but with explicit dependency on `okio` 1.2.x bundle