### PR TITLE
BasicJcloudsLocationCustomizer is an EntityInitializer

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -23,7 +23,6 @@ import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
 import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
 
-import com.google.common.annotations.Beta;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigInheritance;
@@ -37,6 +36,7 @@ import org.apache.brooklyn.util.core.internal.ssh.ShellTool;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.time.Duration;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
@@ -236,5 +236,14 @@ public class BrooklynConfigKeys {
     public static final ConfigKey<String> SSH_CONFIG_SCRIPT_HEADER = newConfigKeyWithPrefix(BROOKLYN_SSH_CONFIG_KEY_PREFIX, ShellTool.PROP_SCRIPT_HEADER);
     public static final ConfigKey<String> SSH_CONFIG_DIRECT_HEADER = newConfigKeyWithPrefix(BROOKLYN_SSH_CONFIG_KEY_PREFIX, ShellTool.PROP_DIRECT_HEADER);
     public static final ConfigKey<Boolean> SSH_CONFIG_NO_DELETE_SCRIPT = newConfigKeyWithPrefix(BROOKLYN_SSH_CONFIG_KEY_PREFIX, ShellTool.PROP_NO_DELETE_SCRIPT);
+
+    public static final MapConfigKey<Object> PROVISIONING_PROPERTIES = new MapConfigKey.Builder<Object>(Object.class, "provisioning.properties")
+            .description("Custom properties to be passed in when provisioning a new machine")
+            .defaultValue(ImmutableMap.<String, Object>of())
+            .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
+            .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
+            .build();
+
+    private BrooklynConfigKeys() {}
 
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -22,7 +22,6 @@ package org.apache.brooklyn.location.jclouds;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.location.LocationSpec;
@@ -49,9 +48,6 @@ import com.google.common.reflect.TypeToken;
 
 public class BailOutJcloudsLocation extends JcloudsLocation {
 
-    public static final String ERROR_MESSAGE = "early termination for test";
-    public static final RuntimeException BAIL_OUT_FOR_TESTING = new RuntimeException(ERROR_MESSAGE);
-    
     // Don't care which image; not actually provisioning
     private static final String US_EAST_IMAGE_ID = "us-east-1/ami-7d7bfc14";
 
@@ -82,7 +78,7 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
         if (Boolean.TRUE.equals(getConfig(BUILD_TEMPLATE))) {
             template = super.buildTemplate(computeService, config, customizers);
         }
-        throw new RuntimeException(BAIL_OUT_FOR_TESTING);
+        throw new BailOutException("early termination for test");
     }
 
     public Template getTemplate() {
@@ -190,6 +186,12 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
                 .build();
 
         return newBailOutJcloudsLocation(mgmt, allConfig);
+    }
+
+    public static class BailOutException extends RuntimeException {
+        public BailOutException(String message) {
+            super(message);
+        }
     }
 
 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizerTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+public class BasicJcloudsLocationCustomizerTest extends BrooklynAppUnitTestSupport {
+
+    private BasicJcloudsLocationCustomizer testCustomizer;
+
+    @BeforeMethod
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        testCustomizer = new BasicJcloudsLocationCustomizer();
+    }
+
+    @Test
+    public void testCustomiserIncluded() {
+        TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .addInitializer(testCustomizer));
+        assertCustomizers(entity, 1);
+    }
+
+    @Test
+    public void testCustomizersMerged() {
+        TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                .addInitializer(testCustomizer)
+                .configure(
+                        BrooklynConfigKeys.PROVISIONING_PROPERTIES.subKey(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()),
+                        ImmutableList.of(new BasicJcloudsLocationCustomizer())));
+        assertCustomizers(entity, 2);
+    }
+
+    @Test
+    public void testInitialiserAppliedToMembersOfCluster() {
+        final EntitySpec<TestEntity> memberSpec = EntitySpec.create(TestEntity.class)
+                .addInitializer(testCustomizer);
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.INITIAL_SIZE, 3)
+                .configure(DynamicCluster.MEMBER_SPEC, memberSpec));
+        app.start(ImmutableList.of(app.newSimulatedLocation()));
+        for (Entity member : cluster.getMembers()) {
+            assertCustomizers(member, 1);
+        }
+    }
+
+    @Test
+    public void testApplyToEntity() {
+        TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        assertNoCustomizers(entity);
+        testCustomizer.apply(entity);
+        assertCustomizers(entity, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertCustomizers(Entity entity, int numberCustomizers) {
+        Object object = entity.config().get(BrooklynConfigKeys.PROVISIONING_PROPERTIES.subKey(
+                JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()));
+        assertNotNull(object, "expected value for customizers in " + entity.config().get(BrooklynConfigKeys.PROVISIONING_PROPERTIES));
+        assertTrue(object instanceof Collection, "expected collection, got " + object.getClass());
+        Collection<JcloudsLocationCustomizer> customizers = (Collection<JcloudsLocationCustomizer>) object;
+        assertEquals(customizers.size(), numberCustomizers,
+                "expected " + numberCustomizers + " customizer" + Strings.s(numberCustomizers) + " in " + Iterables.toString(customizers));
+        assertTrue(customizers.contains(testCustomizer), "expected to find testCustomizer in " + Iterables.toString(customizers));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertNoCustomizers(Entity entity) {
+        Object object = entity.config().get(BrooklynConfigKeys.PROVISIONING_PROPERTIES.subKey(
+                JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS.getName()));
+        if (object != null) {
+            assertTrue(object instanceof Collection, "expected collection, got " + object.getClass());
+            Collection<JcloudsLocationCustomizer> customizers = (Collection<JcloudsLocationCustomizer>) object;
+            assertEquals(customizers.size(), 0, "expected no entries in " + Iterables.toString(customizers));
+        }
+    }
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -264,12 +264,7 @@ public interface SoftwareProcess extends Entity, Startable {
             .build();
 
     @SetFromFlag("provisioningProperties")
-    MapConfigKey<Object> PROVISIONING_PROPERTIES = new MapConfigKey.Builder<Object>(Object.class, "provisioning.properties")
-            .description("Custom properties to be passed in when provisioning a new machine")
-            .defaultValue(ImmutableMap.<String, Object>of())
-            .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
-            .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
-            .build();
+    MapConfigKey<Object> PROVISIONING_PROPERTIES = BrooklynConfigKeys.PROVISIONING_PROPERTIES;
 
     @SetFromFlag("maxRebindSensorsDelay")
     ConfigKey<Duration> MAXIMUM_REBIND_SENSOR_CONNECT_DELAY = ConfigKeys.newConfigKey(Duration.class,

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasksTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasksTest.java
@@ -45,7 +45,6 @@ import org.apache.brooklyn.location.jclouds.BailOutJcloudsLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.task.TaskInternal;
 import org.apache.brooklyn.util.core.task.ValueResolver;
-import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 import org.testng.annotations.DataProvider;
@@ -109,13 +108,9 @@ public class MachineLifecycleEffectorTasksTest {
         try {
             ((EntityLocal) triggerEntity).sensors().set(ready, true);
             task.get(Duration.THIRTY_SECONDS);
-        } catch (Throwable t) {
-            Exceptions.propagateIfFatal(t);
-            if ((t.toString().contains(BailOutJcloudsLocation.ERROR_MESSAGE))) {
-                // expected - BailOut location throws - just swallow
-            } else {
-                Exceptions.propagate(t);
-            }
+            Asserts.shouldHaveFailedPreviously("BailOutJcloudsLocation should have thrown");
+        } catch (BailOutJcloudsLocation.BailOutException t) {
+            // expected
         } finally {
             Entities.destroyAll(app.getManagementContext());
         }


### PR DESCRIPTION
Repeats https://github.com/apache/brooklyn-server/pull/168 but puts the location customizers into the entity's provisioning properties rather than setting it on the entity directly. It required moving `SoftwareProcess.PROVISIONING_PROPERTIES` to `BrooklynConfigKeys` so that it could be referenced from `brooklyn-locations-jclouds`.