### PR TITLE
Use CSRF headers

### DIFF
--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -50,6 +50,7 @@ import org.apache.brooklyn.launcher.config.CustomResourceLocator;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.rest.RestApiSetup;
+import org.apache.brooklyn.rest.filter.CsrfTokenFilter;
 import org.apache.brooklyn.rest.filter.EntitlementContextFilter;
 import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.filter.LoggingFilter;
@@ -460,7 +461,8 @@ public class BrooklynWebServer {
                 new RequestTaggingRsFilter(),
                 new NoCacheFilter(),
                 new HaHotCheckResourceFilter(),
-                new EntitlementContextFilter());
+                new EntitlementContextFilter(),
+                new CsrfTokenFilter());
         RestApiSetup.installServletFilters(context,
                 RequestTaggingFilter.class,
                 LoggingFilter.class);

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -109,7 +109,8 @@ public interface ServerApi {
 
     @GET
     @Path("/up/extended")
-    @ApiOperation(value = "Returns extended server-up information, a map including up (/up), shuttingDown (/shuttingDown), healthy (/healthy), and ha (/ha/states) (qv)")
+    @ApiOperation(value = "Returns extended server-up information, a map including up (/up), shuttingDown (/shuttingDown), healthy (/healthy), and ha (/ha/states) (qv)"
+        + "; also forces a session, so a useful general-purpose call for a UI client to do when starting")
     public Map<String,Object> getUpExtended();
 
     @GET
@@ -198,7 +199,8 @@ public interface ServerApi {
 
     @GET
     @Path("/user")
-    @ApiOperation(value = "Return user information for this Brooklyn instance", 
+    @ApiOperation(value = "Return user information for this Brooklyn instance"
+                + "; also forces a session, so a useful general-purpose call for a UI client to do when starting", 
             response = String.class,
             responseContainer = "List")
     public String getUser(); 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.brooklyn.rest.domain.ApiError;
+import org.apache.brooklyn.util.text.Identifiers;
+
+/**
+ * If client specifies {@link #REQUEST_CSRF_TOKEN_HEADER}
+ * (as any of the values {@link #REQUEST_CSRF_TOKEN_HEADER_LOGIN}, {@link #REQUEST_CSRF_TOKEN_HEADER_NEW}, {@link #REQUEST_CSRF_TOKEN_HEADER_TRUE})
+ * then the server will return a {@link #REQUIRED_CSRF_TOKEN_HEADER} header containing a token.
+ * <p>
+ * The server will require that header with the given token on subsequent POST requests
+ * (and other actions -- excluding GET which is always permitted;
+ * future enhancement may allow client to control whether GET is allowed or not).
+ */
+@Provider
+@Priority(400)
+public class CsrfTokenFilter implements ContainerRequestFilter, ContainerResponseFilter {
+    
+    public static final String REQUIRED_CSRF_TOKEN_ATTR = CsrfTokenFilter.class.getName()+"."+"REQUIRED_CSRF_TOKEN";
+    
+    public static final String REQUIRED_CSRF_TOKEN_HEADER = CsrfTokenFilter.class.getName()+"."+"X-CsrfToken";
+    public static final String REQUEST_CSRF_TOKEN_HEADER = CsrfTokenFilter.class.getName()+"."+"X-CsrfToken-Request";
+    /** means to return the token */
+    public static final String REQUEST_CSRF_TOKEN_HEADER_TRUE = "true";
+    /** means to create a new token */
+    public static final String REQUEST_CSRF_TOKEN_HEADER_NEW = "new";
+    /** means to create and return a token on login only (ie if one doesn't exist for the session) */
+    public static final String REQUEST_CSRF_TOKEN_HEADER_LOGIN = "login";
+    
+    @Context
+    private HttpServletRequest request;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        Object requiredToken = request.getSession().getAttribute(REQUIRED_CSRF_TOKEN_ATTR);
+        if (requiredToken!=null) {
+            String suppliedToken = request.getHeader(REQUIRED_CSRF_TOKEN_HEADER);
+            if (suppliedToken==null) {
+                if (HttpMethod.GET.equals(requestContext.getMethod())) {
+                    // GETs are permitted with no token (but an invalid token will be caught)
+                    return;
+                }
+
+                fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+                        .message(REQUIRED_CSRF_TOKEN_HEADER+" header required containing token previously supplied")
+                        .build());
+            } else if (suppliedToken.equals(requiredToken)) {
+                // approved
+            } else {
+                fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+                    .message(REQUIRED_CSRF_TOKEN_HEADER+" header did not match current token")
+                    .build());
+            }
+        }
+    }
+
+    private void fail(ContainerRequestContext requestContext, ApiError apiError) {
+        requestContext.abortWith(apiError.asJsonResponse());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        String requestHeader = request.getHeader(REQUEST_CSRF_TOKEN_HEADER);
+        if (requestHeader==null) return;
+        String oldToken = (String) request.getSession().getAttribute(REQUIRED_CSRF_TOKEN_ATTR);
+        String tokenToReturn = null;
+        boolean createToken = false;
+        
+        if (REQUEST_CSRF_TOKEN_HEADER_LOGIN.equals(requestHeader)) {
+            if (oldToken==null) createToken = true;
+            else return;
+        } else if (REQUEST_CSRF_TOKEN_HEADER_TRUE.equals(requestHeader)) {
+            tokenToReturn = oldToken;
+            if (tokenToReturn==null) createToken = true;
+        } else if (REQUEST_CSRF_TOKEN_HEADER_NEW.equals(requestHeader)) {
+            createToken = true;
+        }
+    
+        if (createToken) {
+            tokenToReturn = Identifiers.makeRandomId(16);
+            request.getSession().setAttribute(REQUIRED_CSRF_TOKEN_ATTR, tokenToReturn);
+        }
+        
+        if (tokenToReturn==null) {
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+                .message(REQUEST_CSRF_TOKEN_HEADER+" contained invalid value; expected: "+
+                    REQUEST_CSRF_TOKEN_HEADER_TRUE+" | "+
+                    REQUEST_CSRF_TOKEN_HEADER_LOGIN+" | "+
+                    REQUEST_CSRF_TOKEN_HEADER_NEW)
+                .build());
+        } else {
+            responseContext.getHeaders().add(REQUIRED_CSRF_TOKEN_HEADER, tokenToReturn);
+        }
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
@@ -19,69 +19,191 @@
 package org.apache.brooklyn.rest.filter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.HttpMethod;
+import javax.servlet.http.HttpSession;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.rest.api.ServerApi;
 import org.apache.brooklyn.rest.domain.ApiError;
 import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.collections.EnumerationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 /**
- * If client specifies {@link #REQUEST_CSRF_TOKEN_HEADER}
- * (as any of the values {@link #REQUEST_CSRF_TOKEN_HEADER_LOGIN}, {@link #REQUEST_CSRF_TOKEN_HEADER_NEW}, {@link #REQUEST_CSRF_TOKEN_HEADER_TRUE})
- * then the server will return a {@link #REQUIRED_CSRF_TOKEN_HEADER} header containing a token.
+ * Causes the server to return a "Csrf-Token" cookie in certain circumstances,
+ * and thereafter to require clients to send that token as an "X-Csrf-Token" header on certain requests.
  * <p>
- * The server will require that header with the given token on subsequent POST requests
- * (and other actions -- excluding GET which is always permitted;
- * future enhancement may allow client to control whether GET is allowed or not).
+ * To enable REST requests to work from the <code>br</code> CLI and regular <code>curl</code> without CSRF,
+ * this CSRF protection only applies when a session is in effect.
+ * Sessions are only established by some REST requests:
+ * {@link ServerApi#getUpExtended()} is a good choice (/v1/server/up/extended).
+ * It can also be forced by using the {@link #CSRF_TOKEN_REQUIRED_HEADER} header on any REST request.
+ * Browser-based UI clients should use one of the above methods early in operation.
+ * <p>
+ * The standard model is that the token is required for all <i>write</i> (ie non-GET) requests being made
+ * with a valid session cookie (ie the request is part of an ongoing session).
+ * In such cases, the client must send the X-Csrf-Token as a header.
+ * This prevents a third-party site from effecting a mutating cross-site request via the browser. 
+ * <p>
+ * For transitional reasons, the default behaviour in the current implementation is to warn (not fail)
+ * if no token is supplied in the above case. This will likely be changed to enforce the standard model 
+ * in a subsequent version, but it avoids breaking backwards compatibility for any existing session-based clients.
+ * <p>
+ * Clients can force different required behaviour (e.g. "fail") by including the
+ * {@link #CSRF_TOKEN_REQUIRED_HEADER} with one of the values in {@link CsrfTokenRequiredForRequests},
+ * viz. to require the header on ALL requests, or on NONE, instead of just on WRITE requests (the default).
+ * If such a mode is explicitly specified it is enforced (instead of just displaying the transitional warning),
+ * so while transitioning to enforce CSRF this header should be supplied.
+ * The Brooklyn UI does this.
+ * <p>
+ * This uses *two* names, <code>Csrf-Token</code> and <code>Xsrf-Token</code>.
+ * The former seems the usual convention, but Angular apps use the latter.
+ * This strategy should mean that Angular apps should get CSRF protection with no special configuration.
+ * <p>
+ * The cookies are sent by the client on every request, by virtue of being cookies,
+ * although this is not necessary (and rather wasteful). A client may optimise by deleting the cookies 
+ * and caching the information in another form. 
+ * The cookie names do not have any salt/uid, so in dev on localhost you may get conflicts, e.g. between
+ * multiple Brooklyn instances or other apps that use the same token names.
+ * (In contrast the session ID token, usually JSESSIONID, has a BROOKLYN<uid> field at runtime to prevent
+ * such collisions.)
+ * <p>
+ * Additional CSRF strategies might be worth considering, in addition to the one described above:
+ * <ul>
+ * <li> Compare "Referer / Origin" against "Host" / "X-Forwarded-Host" (or app knowing its location)
+ *      (disallowing if different is probably a good idea)
+ * <li> Look for "X-Requested-With: XMLHttpRequest" on POST, esp if there is cookie and/or user agent is a browser
+ *      (but angular drops this one)
+ * </ul>
+ * More info at:  https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet .
+ * (These have not been implemented because the cookie pattern is sufficient, and one of the strongest.)
+ * 
  */
 @Provider
 @Priority(400)
 public class CsrfTokenFilter implements ContainerRequestFilter, ContainerResponseFilter {
     
-    public static final String REQUIRED_CSRF_TOKEN_ATTR = CsrfTokenFilter.class.getName()+"."+"REQUIRED_CSRF_TOKEN";
+    private static final Logger log = LoggerFactory.getLogger(CsrfTokenFilter.class);
+
+    private static final String CSRF_TOKEN_VALUE_BASE = "Csrf-Token";
+    public static final String CSRF_TOKEN_VALUE_COOKIE = CSRF_TOKEN_VALUE_BASE.toUpperCase();
+    public static final String CSRF_TOKEN_VALUE_HEADER = HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_BASE);
+    // also send this so angular works as expected
+    public static final String CSRF_TOKEN_VALUE_BASE_ANGULAR_NAME = "Xsrf-Token";
+    public static final String CSRF_TOKEN_VALUE_COOKIE_ANGULAR_NAME = CSRF_TOKEN_VALUE_BASE_ANGULAR_NAME.toUpperCase();
+    public static final String CSRF_TOKEN_VALUE_HEADER_ANGULAR_NAME = HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_BASE_ANGULAR_NAME);
     
-    public static final String REQUIRED_CSRF_TOKEN_HEADER = CsrfTokenFilter.class.getName()+"."+"X-CsrfToken";
-    public static final String REQUEST_CSRF_TOKEN_HEADER = CsrfTokenFilter.class.getName()+"."+"X-CsrfToken-Request";
-    /** means to return the token */
-    public static final String REQUEST_CSRF_TOKEN_HEADER_TRUE = "true";
-    /** means to create a new token */
-    public static final String REQUEST_CSRF_TOKEN_HEADER_NEW = "new";
-    /** means to create and return a token on login only (ie if one doesn't exist for the session) */
-    public static final String REQUEST_CSRF_TOKEN_HEADER_LOGIN = "login";
+    public static final String CSRF_TOKEN_VALUE_ATTR = CsrfTokenFilter.class.getName()+"."+CSRF_TOKEN_VALUE_COOKIE;
     
+    public static String HEADER_OF_COOKIE(String cookieName) {
+        return "X-"+cookieName;
+    }
+    
+    public static final String CSRF_TOKEN_REQUIRED_HEADER = "X-Csrf-Token-Required-For-Requests";
+    public static final String CSRF_TOKEN_REQUIRED_ATTR = CsrfTokenFilter.class.getName()+"."+CSRF_TOKEN_REQUIRED_HEADER;
+    public static enum CsrfTokenRequiredForRequests { ALL, WRITE, NONE, }
+    public static CsrfTokenRequiredForRequests DEFAULT_REQUIRED_FOR_REQUESTS = CsrfTokenRequiredForRequests.WRITE;
+
     @Context
     private HttpServletRequest request;
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        Object requiredToken = request.getSession().getAttribute(REQUIRED_CSRF_TOKEN_ATTR);
-        if (requiredToken!=null) {
-            String suppliedToken = request.getHeader(REQUIRED_CSRF_TOKEN_HEADER);
-            if (suppliedToken==null) {
-                if (HttpMethod.GET.equals(requestContext.getMethod())) {
-                    // GETs are permitted with no token (but an invalid token will be caught)
-                    return;
-                }
+        // if header supplied, check it is valid
+        String requiredWhenS = request.getHeader(CSRF_TOKEN_REQUIRED_HEADER);
+        if (Strings.isNonBlank(requiredWhenS) && getRequiredForRequests(requiredWhenS, null)==null) {
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.BAD_REQUEST)
+                .message(HEADER_OF_COOKIE(CSRF_TOKEN_REQUIRED_HEADER)+" header if supplied must be one of "
+                    + Arrays.asList(CsrfTokenRequiredForRequests.values()))
+                .build());
+            return;
+    }
+        
+        if (!request.isRequestedSessionIdValid()) {
+            // no session; just return
+            return;
+        }
+        
+        @SuppressWarnings("unchecked")
+        List<String> suppliedTokensDefault = (List<String>) EnumerationUtils.toList(request.getHeaders(CSRF_TOKEN_VALUE_HEADER));
+        @SuppressWarnings("unchecked")
+        List<String> suppliedTokensAngular = (List<String>) EnumerationUtils.toList(request.getHeaders(CSRF_TOKEN_VALUE_HEADER_ANGULAR_NAME));
+        List<String> suppliedTokens = Lists.newArrayList(suppliedTokensDefault);
+        suppliedTokens.addAll(suppliedTokensAngular);
 
-                fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
-                        .message(REQUIRED_CSRF_TOKEN_HEADER+" header required containing token previously supplied")
-                        .build());
-            } else if (suppliedToken.equals(requiredToken)) {
-                // approved
+        Object requiredToken = request.getSession().getAttribute(CSRF_TOKEN_VALUE_ATTR);
+        CsrfTokenRequiredForRequests whenRequired = (CsrfTokenRequiredForRequests) request.getSession().getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
+
+        boolean isRequired;
+        
+        if (whenRequired==null) {
+            if (suppliedTokens.isEmpty()) {
+                log.warn("No CSRF token expected or supplied but a cookie-session is active: client should be updated"
+                    + " (in future CSRF tokens or instructions may be required for session-based clients)"
+                    + " - " + Entitlements.getEntitlementContext());
+                whenRequired = CsrfTokenRequiredForRequests.NONE;
             } else {
-                fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
-                    .message(REQUIRED_CSRF_TOKEN_HEADER+" header did not match current token")
-                    .build());
+                // default
+                whenRequired = DEFAULT_REQUIRED_FOR_REQUESTS;
             }
+            // remember it to suppress warnings subsequently
+            request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, whenRequired);
+        }
+        
+        switch (whenRequired) {
+        case NONE:
+            isRequired = false;
+            break;
+        case WRITE:
+            isRequired = !org.eclipse.jetty.http.HttpMethod.GET.toString().equals(requestContext.getMethod());
+            break;
+        case ALL:
+            isRequired = true;
+            break;
+        default:
+            log.warn("Unexpected "+CSRF_TOKEN_REQUIRED_ATTR+" value "+whenRequired);
+            isRequired = true;
+        }
+        
+        if (Iterables.any(suppliedTokens, Predicates.equalTo(requiredToken))) {
+            // matching token supplied, or not being used 
+            return;
+        }
+        
+        if (!isRequired) {
+            // csrf not required, but it doesn't match
+            if (requiredToken!=null) {
+                log.trace("CSRF optional token mismatch: client did not send valid token, but it isn't required so proceeding");
+            }
+            return;
+        }
+
+        if (suppliedTokens.isEmpty()) {
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+                    .message(HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_COOKIE)+" header is required, containing token previously returned from server in cookie")
+                    .build());
+        } else {
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+                .message(HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_COOKIE)+" header did not match expected CSRF token")
+                .build());
         }
     }
 
@@ -91,37 +213,69 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        String requestHeader = request.getHeader(REQUEST_CSRF_TOKEN_HEADER);
-        if (requestHeader==null) return;
-        String oldToken = (String) request.getSession().getAttribute(REQUIRED_CSRF_TOKEN_ATTR);
-        String tokenToReturn = null;
-        boolean createToken = false;
+        HttpSession session = request.getSession(false);
+        String token = (String) (session==null ? null : session.getAttribute(CSRF_TOKEN_VALUE_ATTR));
+        String requiredWhenS = request.getHeader(CSRF_TOKEN_REQUIRED_HEADER);
         
-        if (REQUEST_CSRF_TOKEN_HEADER_LOGIN.equals(requestHeader)) {
-            if (oldToken==null) createToken = true;
-            else return;
-        } else if (REQUEST_CSRF_TOKEN_HEADER_TRUE.equals(requestHeader)) {
-            tokenToReturn = oldToken;
-            if (tokenToReturn==null) createToken = true;
-        } else if (REQUEST_CSRF_TOKEN_HEADER_NEW.equals(requestHeader)) {
-            createToken = true;
-        }
-    
-        if (createToken) {
-            tokenToReturn = Identifiers.makeRandomId(16);
-            request.getSession().setAttribute(REQUIRED_CSRF_TOKEN_ATTR, tokenToReturn);
+        if (session==null) {
+            if (Strings.isBlank(requiredWhenS)) {
+                // no session and no requirement specified, bail out 
+                return;
+            }
+            // explicit requirement request forces a session  
+            session = request.getSession();
         }
         
-        if (tokenToReturn==null) {
-            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
-                .message(REQUEST_CSRF_TOKEN_HEADER+" contained invalid value; expected: "+
-                    REQUEST_CSRF_TOKEN_HEADER_TRUE+" | "+
-                    REQUEST_CSRF_TOKEN_HEADER_LOGIN+" | "+
-                    REQUEST_CSRF_TOKEN_HEADER_NEW)
-                .build());
+        CsrfTokenRequiredForRequests requiredWhen;
+        if (Strings.isNonBlank(requiredWhenS)) {
+            requiredWhen = getRequiredForRequests(requiredWhenS, DEFAULT_REQUIRED_FOR_REQUESTS);
+            request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
+            if (Strings.isNonBlank(token)) {
+                // already set csrf token, and the client got it
+                // (with the session token if they are in a session;
+                // or if client didn't get it it isn't in a session)
+                return;
+            }
         } else {
-            responseContext.getHeaders().add(REQUIRED_CSRF_TOKEN_HEADER, tokenToReturn);
+            if (Strings.isNonBlank(token)) {
+                // already set csrf token, and the client got it
+                // (with the session token if they are in a session;
+                // or if client didn't get it it isn't in a session)
+                return;
+            }
+            requiredWhen = (CsrfTokenRequiredForRequests) request.getSession().getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
+            if (requiredWhen==null) {
+                requiredWhen = DEFAULT_REQUIRED_FOR_REQUESTS;
+                request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
+            }
         }
+
+        if (requiredWhen==CsrfTokenRequiredForRequests.NONE) {
+            // not required; so don't set
+            return;
+        }
+
+        // create the token
+        token = Identifiers.makeRandomId(16);
+        request.getSession().setAttribute(CSRF_TOKEN_VALUE_ATTR, token);
+        
+        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE, token, "Clients should send this value in header "+CSRF_TOKEN_VALUE_HEADER+" for validation");
+        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE_ANGULAR_NAME, token, "Compatibility cookie for "+CSRF_TOKEN_VALUE_COOKIE+" following AngularJS conventions");
+    }
+
+    protected NewCookie addCookie(ContainerResponseContext responseContext, String cookieName, String token, String comment) {
+        NewCookie cookie = new NewCookie(cookieName, token, "/", null, comment, -1, false);
+        responseContext.getHeaders().add("Set-Cookie", cookie);
+        return cookie;
+    }
+
+    protected CsrfTokenRequiredForRequests getRequiredForRequests(String requiredWhenS, CsrfTokenRequiredForRequests defaultMode) {
+        CsrfTokenRequiredForRequests result = null;
+        if (requiredWhenS!=null) {
+            result = CsrfTokenRequiredForRequests.valueOf(requiredWhenS.toUpperCase());
+        }
+        if (result!=null) return result;
+        return defaultMode;
     }
 
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
@@ -24,7 +24,6 @@ import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ContextResolver;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
@@ -38,7 +38,6 @@ import org.apache.brooklyn.rest.transform.EntityTransformer;
 import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.Tasks;
-import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/SensorResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/SensorResource.java
@@ -35,7 +35,6 @@ import org.apache.brooklyn.rest.domain.SensorSummary;
 import org.apache.brooklyn.rest.filter.HaHotStateRequired;
 import org.apache.brooklyn.rest.transform.SensorTransformer;
 import org.apache.brooklyn.rest.util.WebResourceUtils;
-import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -94,6 +95,9 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
     @Context
     private ContextResolver<ShutdownHandler> shutdownHandler;
 
+    @Context
+    private HttpServletRequest request;
+    
     @Override
     public void reloadBrooklynProperties() {
         if (Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_ALL_SERVER_INFO, null)) {
@@ -365,6 +369,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
     
     @Override
     public Map<String,Object> getUpExtended() {
+        request.getSession();
         return MutableMap.<String,Object>of(
             "up", isUp(),
             "shuttingDown", isShuttingDown(),
@@ -451,6 +456,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
 
     @Override
     public String getUser() {
+        request.getSession();
         EntitlementContext entitlementContext = Entitlements.getEntitlementContext();
         if (entitlementContext!=null && entitlementContext.user()!=null){
             return entitlementContext.user();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpSessionContext;
 
 import org.apache.brooklyn.util.text.Identifiers;
 
+/** mock session, used only for performing authentication */
 public class SecurityProviderHttpSession implements HttpSession {
     String id = Identifiers.makeRandomId(5);
     Map<String, Object> attributes = new ConcurrentHashMap<>();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/SecurityProviderHttpSession.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionContext;
 
 import org.apache.brooklyn.util.text.Identifiers;
 
@@ -63,8 +62,8 @@ public class SecurityProviderHttpSession implements HttpSession {
         return 0;
     }
 
-    @Override
-    public HttpSessionContext getSessionContext() {
+    @Deprecated //in interface
+    public javax.servlet.http.HttpSessionContext getSessionContext() {
         return null;
     }
 

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -101,6 +101,7 @@ limitations under the License.
                 TODO ShutdownHandlerProvider, sync with init work.
                 Needs to be custom OSGi implementation?
             -->
+            <bean class="org.apache.brooklyn.rest.filter.CsrfTokenFilter" />
             <bean class="org.apache.brooklyn.rest.filter.RequestTaggingRsFilter" />
             <bean class="org.apache.brooklyn.rest.filter.NoCacheFilter" />
             <bean class="org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter" />

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/CsrfTokenFilterTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/CsrfTokenFilterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.filter;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.http.HttpStatus;
+
+/** TODO test fails using BRRT because we have no session; see CsrfTokenFilterLauncherTest in different project,
+ * and comments in here; would prefer to have this test, so keep if we can enable sessions here */
+public class CsrfTokenFilterTest extends BrooklynRestResourceTest {
+
+    public static class SampleActionResource {
+        @GET
+        @Path("/test-get")
+        public String testGet() {
+            return "got";
+        }
+        @POST
+        @Path("/test-post")
+        public String testPost() {
+            return "posted";
+        }
+    }
+
+    @Override
+    protected void addBrooklynResources() {
+        addResource(new CsrfTokenFilter());
+        addResource(new SampleActionResource());
+    }
+    
+    @Override
+    protected void configureCXF(JAXRSServerFactoryBean sf) {
+        super.configureCXF(sf);
+        
+        /*
+        TODO how can we turn on sessions??
+        
+        // normal handler way 
+        val webapp = new ServletContextHandler(ServletContextHandler.SESSIONS)
+        SessionHandler sh = new SessionHandler();
+        webapp.setSessionHandler()
+
+        try {
+            // suggested bean way - but only for new servers 
+            sf.getBus().getExtension(JettyHTTPServerEngineFactory.class) 
+                .createJettyHTTPServerEngine(8000, "http") 
+                .setSessionSupport(true);
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
+        */
+    }
+
+//    @Test
+//    public void testRequestToken() {
+//        client().path("/logout").post(null);
+//        Response response = request("/logout").header(
+////        Response response = request("/test-get").header(
+//            CsrfTokenFilter.REQUEST_CSRF_TOKEN_HEADER, CsrfTokenFilter.REQUEST_CSRF_TOKEN_HEADER_TRUE).get();
+//        
+//        // comes back okay
+//        assertOkayResponse(response, "got");
+//        
+//        String token = response.getHeaderString(CsrfTokenFilter.REQUIRED_CSRF_TOKEN_HEADER);
+//        Assert.assertNotNull(token);
+//
+//        // can get subsequently
+//        response = request("/test-get").get();
+//        assertOkayResponse(response, "got");
+//    }
+
+    protected void assertOkayResponse(Response response, String expecting) {
+        assertEquals(response.getStatus(), HttpStatus.SC_OK);
+        String content = (String) response.readEntity(String.class);
+        assertEquals(content, expecting);
+    }
+
+    protected WebClient request(String path) {
+        return WebClient.create(getEndpointAddress(), clientProviders, "admin", "admin", null)
+            .path(path)
+            .accept(MediaType.APPLICATION_JSON_TYPE);
+    }
+
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestResourceTest.java
@@ -92,6 +92,7 @@ public abstract class BrooklynRestResourceTest extends BrooklynRestApiTest {
                 clientProviders = sf.getProviders();
             }
             configureCXF(sf);
+            
             sf.setAddress(getEndpointAddress());
             sf.setFeatures(ImmutableList.of(new org.apache.cxf.feature.LoggingFeature()));
             server = sf.create();

--- a/rest/rest-server/src/main/webapp/WEB-INF/web.xml
+++ b/rest/rest-server/src/main/webapp/WEB-INF/web.xml
@@ -75,6 +75,7 @@
                 org.apache.brooklyn.rest.filter.NoCacheFilter,
                 org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter,
                 org.apache.brooklyn.rest.filter.EntitlementContextFilter,
+                org.apache.brooklyn.rest.filter.CsrfTokenFilter,
                 org.apache.brooklyn.rest.util.ManagementContextProvider
                 <!-- org.apache.brooklyn.rest.util.ShutdownHandlerProvider -->
             </param-value>

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -60,7 +60,6 @@ import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.reflections.util.ClasspathHelper;
 import org.slf4j.Logger;

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
+import org.apache.brooklyn.rest.filter.CsrfTokenFilter;
 import org.apache.brooklyn.rest.filter.EntitlementContextFilter;
 import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.filter.LoggingFilter;
@@ -227,7 +228,8 @@ public class BrooklynRestApiLauncher {
                 new RequestTaggingRsFilter(),
                 new NoCacheFilter(),
                 new HaHotCheckResourceFilter(),
-                new EntitlementContextFilter());
+                new EntitlementContextFilter(),
+                new CsrfTokenFilter());
         RestApiSetup.installServletFilters(context, this.filters);
 
         context.setContextPath("/");

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
@@ -1,0 +1,107 @@
+package org.apache.brooklyn.rest;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import static org.testng.Assert.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.apache.brooklyn.rest.filter.CsrfTokenFilter;
+import org.apache.brooklyn.rest.filter.CsrfTokenFilterTest;
+import org.apache.brooklyn.util.http.HttpTool;
+import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpClient;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/** TODO would prefer to run without launcher, as in {@link CsrfTokenFilterTest}; see comments there
+ * (but tests more fleshed out here) */
+public class CsrfTokenFilterLauncherTest extends BrooklynRestApiLauncherTestFixture {
+
+    @Test
+    public void testRequestToken() {
+        useServerForTest(BrooklynRestApiLauncher.launcher()
+            .withoutJsgui()
+            .start());
+
+        HttpToolResponse response = HttpTool.httpGet(
+            client(), URI.create(getBaseUriRest() + "server/status"),
+            ImmutableMap.<String,String>of(
+                CsrfTokenFilter.REQUEST_CSRF_TOKEN_HEADER, CsrfTokenFilter.REQUEST_CSRF_TOKEN_HEADER_TRUE ));
+        
+        // comes back okay
+        assertOkayResponse(response, "MASTER");
+        
+        System.out.println(response.getHeaderLists());
+        List<String> tokens = response.getHeaderLists().get(CsrfTokenFilter.REQUIRED_CSRF_TOKEN_HEADER);
+        String token = Iterables.getOnlyElement(tokens);
+        Assert.assertNotNull(token);
+        
+        List<String> cookies = response.getHeaderLists().get(HttpHeaders.SET_COOKIE);
+        String cookie = Iterables.getOnlyElement(cookies);
+        Assert.assertNotNull(cookie);
+
+        // can post subsequently with token
+        response = HttpTool.httpPost(
+            client(), URI.create(getBaseUriRest() + "script/groovy"),
+            ImmutableMap.<String,String>of(
+                HttpHeaders.CONTENT_TYPE, "application/text",
+                HttpHeaders.COOKIE, cookie,
+                CsrfTokenFilter.REQUIRED_CSRF_TOKEN_HEADER, token ),
+            "return 0;".getBytes());
+        assertOkayResponse(response, "{\"result\":\"0\"}");
+
+        // but fails without token
+        response = HttpTool.httpPost(
+            client(), URI.create(getBaseUriRest() + "script/groovy"),
+            ImmutableMap.<String,String>of(
+                HttpHeaders.COOKIE, cookie,
+                HttpHeaders.CONTENT_TYPE, "application/text" ),
+            "return 0;".getBytes());
+        assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED);
+
+        // but you can get subsequently without token
+        response = HttpTool.httpGet(
+            client(), URI.create(getBaseUriRest() + "server/status"),
+            ImmutableMap.<String,String>of(
+                HttpHeaders.COOKIE, cookie ));
+
+        assertOkayResponse(response, "MASTER");
+    }
+
+    protected HttpClient client() {
+        return HttpTool.httpClientBuilder()
+            .uri(getBaseUriRest(server))
+            .build();
+    }
+
+    protected void assertOkayResponse(HttpToolResponse response, String expecting) {
+        assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
+        assertEquals(response.getContentAsString(), expecting);
+    }
+
+}


### PR DESCRIPTION
Adds a filter which returns and requires special cookies/headers to protect against forged cross-site requests.  Extensive documentation in `CsrfTokenFilter`.  @neykov or @m4rkmckenna or @geomacy you might be best placed to check this.

Also small tidy to logout process in https://github.com/apache/brooklyn-server/commit/e9aecbac1ccdebec1cb07f0f44c5c73f0137c64d -- would be useful if someone familiar with the thinking behind the existing process (switching to user) gives it a quick eyeball (probably @neykov or @bostko ?)