### PR TITLE
SoftwareProcess integration tests: use INSTALL_UNIQUE_LABEL

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessIntegrationTest.java
@@ -51,7 +51,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
         super.setUp();
         localhost = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
         
-        runRecord = Files.createTempFile("testVanillaSoftwareProcess-runRecord", ".txt");
+        runRecord = Files.createTempFile("testVanillaSoftwareProcess-runRecord-"+Identifiers.makeRandomId(8), ".txt");
     }
 
     @Override
@@ -63,6 +63,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
     @Test(groups = "Integration")
     public void testAllCmds() throws Exception {
         app.createAndManageChild(EntitySpec.create(VanillaSoftwareProcess.class)
+                .configure(VanillaSoftwareProcess.INSTALL_UNIQUE_LABEL, Identifiers.makeRandomId(8))
                 .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo preInstallCommand >> "+runRecord.toAbsolutePath())
                 .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo installCommand >> "+runRecord.toAbsolutePath())
                 .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo postInstallCommand >> "+runRecord.toAbsolutePath())
@@ -98,6 +99,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
     @Test(groups = "Integration")
     public void testRestartCmds() throws Exception {
         VanillaSoftwareProcess entity = app.createAndManageChild(EntitySpec.create(VanillaSoftwareProcess.class)
+                .configure(VanillaSoftwareProcess.INSTALL_UNIQUE_LABEL, Identifiers.makeRandomId(8))
                 .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo preInstallCommand >> "+runRecord.toAbsolutePath())
                 .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo installCommand >> "+runRecord.toAbsolutePath())
                 .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo postInstallCommand >> "+runRecord.toAbsolutePath())
@@ -137,7 +139,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
 
     @Test(groups = "Integration")
     public void testDownloadOnlyCmd() throws Exception {
-        Path downloadArtifact = Files.createTempFile("testVanillaSoftwareProcess-downloadArtifact", ".txt");
+        Path downloadArtifact = Files.createTempFile("testVanillaSoftwareProcess-downloadArtifact-"+Identifiers.makeRandomId(8), ".txt");
         Files.write(downloadArtifact, "my download artifact".getBytes());
 
         try {
@@ -174,7 +176,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
     
     @Test(groups = "Integration")
     public void testDownloadAndInstallCmds() throws Exception {
-        Path downloadArtifact = Files.createTempFile("testVanillaSoftwareProcess-downloadArtifact", ".txt");
+        Path downloadArtifact = Files.createTempFile("testVanillaSoftwareProcess-downloadArtifact-"+Identifiers.makeRandomId(8), ".txt");
         Files.write(downloadArtifact, "my download artifact".getBytes());
 
         try {
@@ -246,7 +248,7 @@ public class VanillaSoftwareProcessIntegrationTest extends BrooklynAppLiveTestSu
     
     @Test(groups = "Integration", dependsOnMethods="testDownloadOnlyCmd")
     public void testDownloadUrlUsedInHashForInstallCompletion() throws Exception {
-        testDownloadOnlyCmd();;
+        testDownloadOnlyCmd();
     }
     
     @Test(groups = "Integration", dependsOnMethods="testInstallOnlyCmd")

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsIntegrationTest.java
@@ -18,14 +18,16 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Map;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class VanillaSoftwareProcessStreamsIntegrationTest extends AbstractSoftwareProcessStreamsTest {
     private Location localhost;
@@ -37,14 +39,16 @@ public class VanillaSoftwareProcessStreamsIntegrationTest extends AbstractSoftwa
         localhost = app.getManagementContext().getLocationRegistry().getLocationManaged("localhost");
     }
 
-    // Fails on subsequent runs because "BROOKLYN" marker already created in 
-    // install folder so install step not executed.
     // TODO Tests leave a lot of garbage in /tmp - should clean up after themselves.
-    @Test(groups = {"Integration", "Broken"})
+    @Test(groups = {"Integration"})
     @Override
     public void testGetsStreams() {
+        // Needs the installUniqueLabel so that, if run multiple times on same machine, there won't
+        // be a "BROOKLYN" marker already in the install dir (which would cause install to be 
+        // skipped).
         Map<String, String> cmds = getCommands();
         VanillaSoftwareProcess entity = app.createAndManageChild(EntitySpec.create(VanillaSoftwareProcess.class)
+                .configure(VanillaSoftwareProcess.INSTALL_UNIQUE_LABEL, Identifiers.makeRandomId(8))
                 .configure(VanillaSoftwareProcess.PRE_INSTALL_COMMAND, "echo " + cmds.get("pre-install-command"))
                 .configure(VanillaSoftwareProcess.INSTALL_COMMAND, "echo " + cmds.get("ssh: installing.*"))
                 .configure(VanillaSoftwareProcess.POST_INSTALL_COMMAND, "echo " + cmds.get("post-install-command"))


### PR DESCRIPTION
Fixes VanillaSoftwareProcessStreamsIntegrationTest.testGetsStreams,
for if run multiple times on the same machine.

@neykov can you take a quick look please?