### PR TITLE
[TRIVIAL] DslComponent: fix typo in comment

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -276,7 +276,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
                     }
                 }
                 
-                // Support being passes an explicit entity via the DSL
+                // Support being passed an explicit entity via the DSL
                 if (maybeComponentId.get() instanceof Entity) {
                     if (Iterables.contains(entitiesToSearch, maybeComponentId.get())) {
                         return Maybe.of((Entity)maybeComponentId.get());


### PR DESCRIPTION
Fixes a typo in a comment, spotted during review of https://github.com/apache/brooklyn-server/pull/417