### PR TITLE
Asserts: use DEFAULT_LONG_TIMEOUT in eventually()

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -74,17 +74,45 @@ import groovy.lang.Closure;
 public class Asserts {
 
     /** 
-     * Timeout for use when something should happen within several seconds,
-     * but there might be network calls or computation so {@link #DEFAULT_SHORT_TIMEOUT} is not applicable.
+     * Timeout for use when something should happen. This is the *default timeout* that should
+     * be used by tests (unless that test is asserting performance).
+     * 
+     * We willingly accept the hit of slow failing tests, in exchange for removing the 
+     * false-negative failures that have historically littered our jenkins builds 
+     * (which are presumably sometimes run on over-contended or low-spec machines).
+     * 
+     * If the long timeout is irritates during dev (e.g. when doing TDD, where failing tests are 
+     * an important step), then one can change this value locally or set using something like
+     * {@code -Dbrooklyn.test.defaultTimeout=1s}.
      */
-    public static final Duration DEFAULT_LONG_TIMEOUT = Duration.THIRTY_SECONDS;
-    
+    public static final Duration DEFAULT_LONG_TIMEOUT;
+
+    static {
+        String defaultTimeout = System.getProperty("brooklyn.test.defaultTimeout");
+        if (defaultTimeout == null){
+            DEFAULT_LONG_TIMEOUT = Duration.THIRTY_SECONDS;
+        } else {
+            DEFAULT_LONG_TIMEOUT = Duration.of(defaultTimeout);
+        }
+    }
+
     /** 
-     * Timeout for use when waiting for other threads to finish.
+     * Timeout for use when waiting for other threads to (normally) finish.
      * <p>
-     * Long enough for parallel execution to catch up, 
-     * even on overloaded mediocre test boxes most of the time,
-     * but short enough not to irritate you when your test is failing. */
+     * Long enough for parallel execution to (normally!) catch up, even on overloaded mediocre 
+     * test boxes most of the time, but short enough not to irritate too much when waiting
+     * this long.
+     * 
+     * Never use this for asserting that a condition is satisfied within a given length of time.
+     * Instead use {@link #DEFAULT_LONG_TIMEOUT} to avoid the false-negatives that have 
+     * historically littered our jenkins builds.
+     * 
+     * Use this constant for asserting that something does *not* happen. If it was going to happen,
+     * then it's reasonable to expect it would normally have happened within this time. For 
+     * example, if we are asserting that no more events are received after unsubscribing, then
+     * this would be an appropriate timeout to use (perhaps by using 
+     * {@link #succeedsContinually(Runnable)}, which defaults to this timeout).
+     */
     public static final Duration DEFAULT_SHORT_TIMEOUT = Duration.ONE_SECOND;
     
     /** @deprecated since 0.9.0 use {@link #DEFAULT_LONG_TIMEOUT} */ @Deprecated
@@ -780,12 +808,12 @@ public class Asserts {
      * 
      * @param supplier supplies the value to test, such as {@link Suppliers#ofInstance(Object)} for a constant 
      * @param predicate the {@link Predicate} to apply to each value given by the supplier
-     * @param timeout how long to wait, default {@link #DEFAULT_SHORT_TIMEOUT}
+     * @param timeout how long to wait, default {@link #DEFAULT_LONG_TIMEOUT}
      * @param period how often to check, default quite often so you won't notice but letting the CPU do work
      * @param errMsg an error message to display if not satisfied, in addition to the last-tested supplied value and the predicate
      */
     public static <T> void eventually(Supplier<? extends T> supplier, Predicate<T> predicate, Duration timeout, Duration period, String errMsg) {
-        if (timeout==null) timeout = DEFAULT_SHORT_TIMEOUT;
+        if (timeout==null) timeout = DEFAULT_LONG_TIMEOUT;
         if (period==null) period = DEFAULT_SHORT_PERIOD;
         CountdownTimer timeleft = timeout.countdownTimer();
         
@@ -850,21 +878,21 @@ public class Asserts {
     }
     
     /**
-     * @see #succeedsContinually(Map, Callable)
+     * @see #succeedsEventually(Map, Callable)
      */
     public static void succeedsEventually(Runnable r) {
         succeedsEventually(ImmutableMap.<String,Object>of(), r);
     }
 
     /**
-     * @see #succeedsContinually(Map, Callable)
+     * @see #succeedsEventually(Map, Callable)
      */
     public static void succeedsEventually(Map<String,?> flags, Runnable r) {
         succeedsEventually(flags, toCallable(r));
     }
     
     /**
-     * @see #succeedsContinually(Map, Callable)
+     * @see #succeedsEventually(Map, Callable)
      */
     public static <T> T succeedsEventually(Callable<T> c) {
         return succeedsEventually(ImmutableMap.<String,Object>of(), c);
@@ -887,6 +915,7 @@ public class Asserts {
     // TODO flags are ugly; remove this in favour of something strongly typed,
     // e.g. extending Repeater and taking the extra semantics.
     // TODO remove the #succeedsEventually in favour of #eventually (and same for continually)
+    //      Aled says why? I've found succeedsEventually to be a concise & clear way to write tests.
     /**
      * Convenience method for cases where we need to test until something is true.
      *
@@ -990,7 +1019,7 @@ public class Asserts {
 
     // TODO unify with "continually"; see also eventually, some of those options might be useful
     public static <T> T succeedsContinually(Map<?,?> flags, Callable<T> job) {
-        Duration duration = toDuration(flags.get("timeout"), Duration.ONE_SECOND);
+        Duration duration = toDuration(flags.get("timeout"), DEFAULT_SHORT_TIMEOUT);
         Duration period = toDuration(flags.get("period"), Duration.millis(10));
         long periodMs = period.toMilliseconds();
         long startTime = System.currentTimeMillis();

--- a/utils/common/src/test/java/org/apache/brooklyn/test/AssertsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/test/AssertsTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.Asserts.ShouldHaveFailedPreviouslyAssertionError;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -41,11 +40,14 @@ public class AssertsTest {
         }
     };
     
-    // TODO this is confusing -- i'd expect it to fail since it always returns false;
-    // see notes at start of Asserts and in succeedsEventually method
+    // Note this behaviour is different from what a Groovy programmer might expect. The meaning of
+    // "succeeds" is that the method completes without throwing an exception, rather than it 
+    // returning groovy-truth. See notes in {@link Asserts#succeedsEventually(Map, Callable)}.
+    // If you want to assert about the return value, consider using {@link Asserts#eventually(Supplier, Predicate)}.
     @Test
     public void testSucceedsEventually() {
-        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.millis(50)), Callables.returning(false));
+        Boolean result = Asserts.succeedsEventually(MutableMap.of("timeout", Duration.millis(50)), Callables.returning(false));
+        Assert.assertEquals(result, (Boolean)false);
     }
     
     @Test
@@ -69,7 +71,7 @@ public class AssertsTest {
                     }
                 }},
                 Duration.of(10, TimeUnit.MILLISECONDS));
-            Assert.fail("Should have thrown AssertionError on timeout");
+            Asserts.shouldHaveFailedPreviously("Should have thrown AssertionError on timeout");
         } catch (TimeoutException e) {
             // success
         }
@@ -88,7 +90,7 @@ public class AssertsTest {
                     throw new IllegalStateException("Simulating failure");
                 }},
                 Duration.THIRTY_SECONDS);
-            Assert.fail("Should have thrown AssertionError on timeout");
+            Asserts.shouldHaveFailedPreviously("Should have thrown AssertionError on timeout");
         } catch (ExecutionException e) {
             IllegalStateException ise = Exceptions.getFirstThrowableOfType(e, IllegalStateException.class);
             if (ise == null || !ise.toString().contains("Simulating failure")) throw e;


### PR DESCRIPTION
And update javadoc to say why. Also makes the timeout configurable
via `-Dbrooklyn.test.defaultTimeout=1s`.