### PR TITLE
Use subnet IP on machine locations that dont implement HasSubnetHostname

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/Machines.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/Machines.java
@@ -49,8 +49,13 @@ public class Machines {
             hostname = ((HasSubnetHostname) where).getSubnetHostname();
         }
         if (hostname == null && where instanceof MachineLocation) {
-            InetAddress addr = ((MachineLocation) where).getAddress();
-            if (addr != null) hostname = addr.getHostAddress();
+            Maybe<String> subnetIp = getSubnetIp(where);
+            if (subnetIp.isPresent()) {
+                hostname = subnetIp.get();
+            } else {
+                InetAddress addr = ((MachineLocation) where).getAddress();
+                if (addr != null) hostname = addr.getHostAddress();
+            }
         }
         log.debug("computed subnet hostname {} for {}", hostname, where);
         // TODO if Maybe.absent(message) appears, could/should use that

--- a/core/src/test/java/org/apache/brooklyn/core/location/MachinesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/MachinesTest.java
@@ -87,24 +87,29 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
         assertEquals(Machines.findUniqueMachineLocation(ImmutableList.of(l1, l2), SshMachineLocation.class).get(), l1);
         assertFalse(Machines.findUniqueMachineLocation(ImmutableList.of(l2), LocalhostMachine.class).isPresent());
     }
-    
+
     @Test
     public void testFindSubnetIpFromAttribute() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
                 .location(sshMachineSpec));
         entity.sensors().set(Attributes.SUBNET_ADDRESS, "myaddr");
-        
         assertEquals(Machines.findSubnetIp(entity).get(), "myaddr");
     }
-    
+
     @Test
     public void testFindSubnetIpFromLocation() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
                 .location(sshMachineSpec));
-        
         assertEquals(Machines.findSubnetIp(entity).get(), privateAddr);
     }
-    
+
+    @Test
+    public void testFindSubnetIpFromLocationWithoutPrivate() throws Exception {
+        TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
+                .location(sshMachineWithoutPrivateSpec));
+        assertEquals(Machines.findSubnetIp(entity).get(), publicAddr);
+    }
+
     @Test
     public void testFindSubnetHostnameFromAttribute() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
@@ -112,15 +117,21 @@ public class MachinesTest extends BrooklynAppUnitTestSupport {
         entity.sensors().set(Attributes.SUBNET_HOSTNAME, "myval");
         assertEquals(Machines.findSubnetHostname(entity).get(), "myval");
     }
-    
+
     @Test
     public void testFindSubnetHostnameFromLocation() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
                 .location(sshMachineSpec));
-        
+        assertEquals(Machines.findSubnetHostname(entity).get(), privateAddr);
+    }
+
+    @Test
+    public void testFindSubnetHostnameFromLocationWithoutPrivate() throws Exception {
+        TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)
+                .location(sshMachineWithoutPrivateSpec));
         assertEquals(Machines.findSubnetHostname(entity).get(), publicAddr);
     }
-    
+
     @Test
     public void testFindSubnetOrPrivateIpWithAddressAttributePrefersLocationPrivateIp() throws Exception {
         TestEntity entity = app.addChild(EntitySpec.create(TestEntity.class)


### PR DESCRIPTION
The `SshMachineLocation` interface does *NOT* implement `HasSubnetHostname` but it does include the method `getPrivateAddresses()` which means that when something creates a machine and sets the config key `SshMachineLocation.PRIVATE_ADDRESSES` with the private IP then the `machines.getSubnetHostname(Location)` helper method (called during entity startup) will happily set the `SUBNET_HOSTNAME` attribute to the public IP (via `location.getAddress().getHostAddress()`