### PR TITLE
BROOKLYN-394: increase jclouds retry/backoff time

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -72,6 +72,18 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
         properties.setProperty(Constants.PROPERTY_RELAX_HOSTNAME, Boolean.toString(true));
         properties.setProperty("jclouds.ssh.max-retries", conf.getStringKey("jclouds.ssh.max-retries") != null ? 
                 conf.getStringKey("jclouds.ssh.max-retries").toString() : "50");
+        
+        // See https://issues.apache.org/jira/browse/BROOKLYN-394
+        // For retries, the backoff times are:
+        //   Math.min(2^failureCount * retryDelayStart, retryDelayStart * 10) + random(10%)
+        // Therefore the backoff times will be: 500ms, 1s, 2s, 4s, 5s, 5s.
+        // The defaults (if not overridden here) are 50ms and 5 retires. This gives backoff
+        // times of 50ms, 100ms, 200ms, 400ms, 500ms (so a total backoff time of 1.25s), 
+        // which is not long when you're being rate-limited and there are multiple thread all 
+        // retrying their API calls.
+        properties.setProperty(Constants.PROPERTY_RETRY_DELAY_START, "500");
+        properties.setProperty(Constants.PROPERTY_MAX_RETRIES, "6");
+        
         // Enable aws-ec2 lazy image fetching, if given a specific imageId; otherwise customize for specific owners; or all as a last resort
         // See https://issues.apache.org/jira/browse/WHIRR-416
         if ("aws-ec2".equals(provider)) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRateLimitedRetryLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRateLimitedRetryLiveTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * Tests provisioning machines, where it causes a lot of activity (in an effort to be 
+ * rate-limited!). We expect the retry to do suitable exponential backoff that the retries
+ * eventually succeed, provisioning all the machines without error.
+ */
+public class JcloudsRateLimitedRetryLiveTest extends AbstractJcloudsLiveTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JcloudsRateLimitedRetryLiveTest.class);
+
+    public static final String LOCATION_SPEC = "jclouds:" + AWS_EC2_PROVIDER + ":" + AWS_EC2_USEAST_REGION_NAME;
+    
+    // Image: {id=us-east-1/ami-7d7bfc14, providerId=ami-7d7bfc14, name=RightImage_CentOS_6.3_x64_v5.8.8.5, location={scope=REGION, id=us-east-1, description=us-east-1, parent=aws-ec2, iso3166Codes=[US-VA]}, os={family=centos, arch=paravirtual, version=6.0, description=rightscale-us-east/RightImage_CentOS_6.3_x64_v5.8.8.5.manifest.xml, is64Bit=true}, description=rightscale-us-east/RightImage_CentOS_6.3_x64_v5.8.8.5.manifest.xml, version=5.8.8.5, status=AVAILABLE[available], loginUser=root, userMetadata={owner=411009282317, rootDeviceType=instance-store, virtualizationType=paravirtual, hypervisor=xen}}
+    public static final String AWS_EC2_CENTOS_IMAGE_ID = "us-east-1/ami-7d7bfc14";
+    
+    protected ListeningExecutorService executor;
+    
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+    }
+    
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            if (executor != null) executor.shutdownNow();
+        }
+    }
+    
+    @Test(groups = {"Live", "Acceptance"})
+    public void testCreateOne() throws Exception {
+        doMany(1);
+    }
+    
+    @Test(groups = {"Live", "Acceptance"})
+    public void testCreateMany() throws Exception {
+        doMany(20);
+    }
+    
+    protected void doMany(int num) throws Exception {
+        jcloudsLocation = (JcloudsLocation) managementContext.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
+
+        List<ListenableFuture<?>> futures = Lists.newArrayList();
+        for (int i = 0; i < num; i++) {
+            final int startingPort = 1024 + i;
+            ListenableFuture<?> future = executor.submit(new Runnable() {
+                public void run() {
+                    doOnce(jcloudsLocation, startingPort);
+                }});
+            futures.add(future);
+        }
+        
+        // Wait for all to to be done
+        Futures.successfulAsList(futures).get();
+        
+        // Fail if any of the the tasks failed
+        Futures.allAsList(futures).get();
+    }
+    
+    protected void doOnce(JcloudsLocation jcloudsLocation, int startingPort) {
+        // Use a non-trivial security group, to increase the amount of work done by AWS.
+        // Each VM's group has slightly different ports, to avoid any optimisations/sharing.
+        final List<Integer> inboundPorts = Lists.newArrayList();
+        inboundPorts.add(22);
+        for (int i = 0; i < 10; i++) {
+            inboundPorts.add(startingPort + (i*2));
+        }
+
+        JcloudsSshMachineLocation machine;
+        try {
+            // Don't want for ssh'able - we are testing the aws-ec2 API, rather than the subsequent
+            // machines that are provisioned.
+            machine = obtainMachine(MutableMap.<String,Object>builder()
+                    .put(JcloudsLocation.IMAGE_ID.getName(), AWS_EC2_CENTOS_IMAGE_ID)
+                    .put(JcloudsLocation.HARDWARE_ID.getName(), AWS_EC2_MEDIUM_HARDWARE_ID)
+                    .put(JcloudsLocation.INBOUND_PORTS.getName(), inboundPorts)
+                    .put(JcloudsLocation.WAIT_FOR_SSHABLE.getName(), false)
+                    .build());
+        } catch (Exception e) {
+            LOG.error("Problem obtaining machine", e);
+            throw Exceptions.propagate(e);
+        }
+        try {
+            releaseMachine(machine);
+        } catch (Exception e) {
+            LOG.error("Problem releasing machine", e);
+            throw Exceptions.propagate(e);
+        }
+    }
+}


### PR DESCRIPTION
Question: Is 500ms and 6 retries a sensible level? It feels to me like a large backoff is good for API calls to a cloud. I can see this might slow things down in some situations (e.g. when it was a transient connectivity problem), but that still seems unlikely to happen often. In all the important cases I can think of, a larger backoff + retry time seems desirable.

When running the `testCreateMany` to provision 20 VMs concurrently in AWS, I managed to cause rate-limiting when calling `RunInstances`, getting back `503 Service Unavailable` for 6 of the 20 VMs:

```
grep -E "JavaUrlHttpCommandExecutorService.*Receiving.* 503 Service Unavailable" brooklyn.debug.log 
2016-11-20 21:41:07,014 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-7]: Receiving response 305126632: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:07,027 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-17]: Receiving response -202425525: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:07,181 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-20]: Receiving response 1461817670: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:07,902 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-7]: Receiving response -412329992: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:07,951 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-17]: Receiving response -2106831550: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:08,094 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-20]: Receiving response -1404718861: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:08,189 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response -1425449702: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:09,141 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response -1388229651: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:09,575 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-11]: Receiving response 1776862310: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:11,419 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-15]: Receiving response 1334001839: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:11,695 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response 1602574625: HTTP/1.1 503 Service Unavailable
```

Here's the output for one of them:
```
016-11-20 21:41:07,774 DEBUG o.j.r.i.InvokeHttpMethod [pool-3-thread-13]: >> invoking RunInstances
2016-11-20 21:41:08,189 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response -1425449702: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:08,191 DEBUG o.j.a.h.AWSServerErrorRetryHandler [pool-3-thread-13]: Retry 1/6: delaying for 541 ms: server error: [method=org.jclouds.aws.ec2.features.AWSInstanceApi.public abstract org.jclouds.ec2.domain.Reservation org.jclouds.aws.ec2.features.AWSInstanceApi.runInstancesInRegion(java.lang.String,java.lang.String,java.lang.String,int,int,org.jclouds.ec2.options.RunInstancesOptions[])[us-east-1, null, ami-7d7bfc14, 1, 1, [Lorg.jclouds.ec2.options.RunInstancesOptions;@17ed1f23], request=POST https://ec2.us-east-1.amazonaws.com/ HTTP/1.1]
2016-11-20 21:41:09,141 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response -1388229651: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:09,143 DEBUG o.j.a.h.AWSServerErrorRetryHandler [pool-3-thread-13]: Retry 2/6: delaying for 2143 ms: server error: [method=org.jclouds.aws.ec2.features.AWSInstanceApi.public abstract org.jclouds.ec2.domain.Reservation org.jclouds.aws.ec2.features.AWSInstanceApi.runInstancesInRegion(java.lang.String,java.lang.String,java.lang.String,int,int,org.jclouds.ec2.options.RunInstancesOptions[])[us-east-1, null, ami-7d7bfc14, 1, 1, [Lorg.jclouds.ec2.options.RunInstancesOptions;@17ed1f23], request=POST https://ec2.us-east-1.amazonaws.com/ HTTP/1.1]
2016-11-20 21:41:11,695 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response 1602574625: HTTP/1.1 503 Service Unavailable
2016-11-20 21:41:11,697 DEBUG o.j.a.h.AWSServerErrorRetryHandler [pool-3-thread-13]: Retry 3/6: delaying for 4681 ms: server error: [method=org.jclouds.aws.ec2.features.AWSInstanceApi.public abstract org.jclouds.ec2.domain.Reservation org.jclouds.aws.ec2.features.AWSInstanceApi.runInstancesInRegion(java.lang.String,java.lang.String,java.lang.String,int,int,org.jclouds.ec2.options.RunInstancesOptions[])[us-east-1, null, ami-7d7bfc14, 1, 1, [Lorg.jclouds.ec2.options.RunInstancesOptions;@17ed1f23], request=POST https://ec2.us-east-1.amazonaws.com/ HTTP/1.1]
2016-11-20 21:41:17,536 DEBUG o.j.h.i.JavaUrlHttpCommandExecutorService [pool-3-thread-13]: Receiving response 1803030217: HTTP/1.1 200 OK
```

Note that it didn't succeed until we'd backed off multiple times for some of the `RunInstances` calls, with it taking a 4.7 second backoff above before it worked on the 4th attempt. I therefore suspect it was actually making things *worse* when we retried after 50ms, 100ms, 200ms, 400ms and 800ms (e.g. causing concurrent calls from other threads to be a lot more likely to fail, and not succeeding in any of the 5 retries).