### PR TITLE
Allow all certs in TestHttpCall

### DIFF
--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCall.java
@@ -51,6 +51,8 @@ public interface TestHttpCall extends BaseTest {
             .defaultValue(HttpMethod.GET)
             .build();
 
+    ConfigKey<Boolean> TRUST_ALL = ConfigKeys.newBooleanConfigKey("trustAll","Trust all certificates used to sign this request",true);
+
     ConfigKey<Map<String, String>> TARGET_HEADERS = ConfigKeys.builder(new TypeToken<Map<String, String>>() {})
             .name("headers")
             .description("Headers to add to the request")


### PR DESCRIPTION
This enables self signed and other certificates to be used within `TestHttpCall`. Tested on AWS with the [brooklyncentral/brooklyn-tomcat-7-server](https://github.com/brooklyncentral/brooklyn-tomcat-7-server) tests.