### PR TITLE
LocalEntityManager: make fields private

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
@@ -163,6 +163,9 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
     @Override
     EnricherSupportInternal enrichers();
 
+    @Override
+    GroupSupportInternal groups();
+
     @Beta
     public interface EntitySubscriptionSupportInternal extends BrooklynObjectInternal.SubscriptionSupportInternal {
         public SubscriptionContext getSubscriptionContext();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -91,25 +91,25 @@ public class LocalEntityManager implements EntityManagerInternal {
     private final InternalPolicyFactory policyFactory;
     
     /** Entities that have been created, but have not yet begun to be managed */
-    protected final Map<String,Entity> preRegisteredEntitiesById = Collections.synchronizedMap(new WeakHashMap<String, Entity>());
+    private final Map<String,Entity> preRegisteredEntitiesById = Collections.synchronizedMap(new WeakHashMap<String, Entity>());
 
     /** Entities that are in the process of being managed, but where management is not yet complete */
-    protected final Map<String,Entity> preManagedEntitiesById = Collections.synchronizedMap(new WeakHashMap<String, Entity>());
+    private final Map<String,Entity> preManagedEntitiesById = Collections.synchronizedMap(new WeakHashMap<String, Entity>());
     
     /** Proxies of the managed entities */
-    protected final ConcurrentMap<String,Entity> entityProxiesById = Maps.newConcurrentMap();
+    private final ConcurrentMap<String,Entity> entityProxiesById = Maps.newConcurrentMap();
     
     /** Real managed entities */
-    protected final Map<String,Entity> entitiesById = Maps.newLinkedHashMap();
+    private final Map<String,Entity> entitiesById = Maps.newLinkedHashMap();
     
     /** Management mode for each entity */
-    protected final Map<String,ManagementTransitionMode> entityModesById = Collections.synchronizedMap(Maps.<String,ManagementTransitionMode>newLinkedHashMap());
+    private final Map<String,ManagementTransitionMode> entityModesById = Collections.synchronizedMap(Maps.<String,ManagementTransitionMode>newLinkedHashMap());
 
     /** Proxies of the managed entities */
-    protected final ObservableList entities = new ObservableList();
+    private final ObservableList entities = new ObservableList();
     
     /** Proxies of the managed entities that are applications */
-    protected final Set<Application> applications = Sets.newConcurrentHashSet();
+    private final Set<Application> applications = Sets.newConcurrentHashSet();
 
     private final BrooklynStorage storage;
     private final Map<String,String> entityTypes;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -742,7 +742,7 @@ public class LocalEntityManager implements EntityManagerInternal {
             if (e instanceof Group) {
                 Collection<Entity> members = ((Group)e).getMembers();
                 for (Entity member : members) {
-                    if (!Entities.isNoLongerManaged(member)) member.removeGroup((Group)e);
+                    if (!Entities.isNoLongerManaged(member)) ((EntityInternal)member).groups().remove((Group)e);
                 }
             }
         } else {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.entity.stock.DelegateEntity;
@@ -143,7 +144,7 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
                 }
             }
 
-            member.addGroup((Group)getProxyIfAvailable());
+            ((EntityInternal)member).groups().add((Group)getProxyIfAvailable());
             boolean changed = addMemberInternal(member);
             if (changed) {
                 log.debug("Group {} got new member {}", this, member);
@@ -216,7 +217,7 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
             Exception errorRemoving = null;
             // suppress errors if member is being unmanaged in parallel
             try {
-                member.removeGroup((Group)getProxyIfAvailable());
+                ((EntityInternal)member).groups().remove((Group)getProxyIfAvailable());
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);
                 errorRemoving = e;

--- a/core/src/test/java/org/apache/brooklyn/entity/group/GroupTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/GroupTest.java
@@ -104,7 +104,7 @@ public class GroupTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testAddingUnmanagedGroupDoesNotFailBadly() throws Exception {
         Entities.unmanage(group);
-        entity1.addGroup(group);
+        entity1.groups().add(group);
         Entities.unmanage(entity1);
     }
     


### PR DESCRIPTION
As discussed with @geomacy in https://github.com/apache/brooklyn-server/pull/453#discussion_r89106124 ...

Making these fields non-private is asking for trouble - it makes it
harder to reason about what the class does and whether it’s safe,
particularly around thread safety etc.
    
It is also exposing more implementation detail than is required, making
refactoring harder in the future.
    
If there is a compelling reason to provide access to the fields,
we can consider adding accessor(s).