### PR TITLE
ConfigYaml test (for @SetFromFlag variants)

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigYamlTest.java
@@ -72,14 +72,24 @@ public class ConfigYamlTest extends AbstractYamlTest {
                 "  brooklyn.config:",
                 "    test.confName: myName",
                 "    test.confObject: myObj",
-                "    test.confDynamic: myDynamic");
+                "    confStringAlias: myString",
+                "    test.confDynamic: myDynamic",
+                "    myField: myFieldVal",
+                "    myField2Alias: myField2Val");
 
         final Entity app = createStartWaitAndLogApplication(yaml);
         TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
-     
-        assertEquals(entity.config().get(TestEntity.CONF_NAME), "myName"); // confName has @SetFromFlag
+
+        assertEquals(entity.config().get(TestEntity.CONF_NAME), "myName"); // confName has @SetFromFlag("confName"); using full name
         assertEquals(entity.config().get(TestEntity.CONF_OBJECT), "myObj"); // confObject does not have @SetFromFlag
+        assertEquals(entity.config().get(TestEntity.CONF_STRING), "myString"); // set using the @SetFromFlag alias
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("test.confDynamic")), "myDynamic"); // not defined on entity
+
+        // This isn't exactly desired behaviour, just a demonstration of what happens!
+        // The names used in YAML correspond to fields with @SetFromFlag. The values end up in the
+        // {@link EntitySpec#config} rather than {@link EntitySpec#flags}. The field is not set.
+        assertNull(entity.getMyField()); // field with @SetFromFlag
+        assertNull(entity.getMyField2()); // field with @SetFromFlag("myField2Alias"), set using alias
     }
 
     @Test
@@ -91,13 +101,17 @@ public class ConfigYamlTest extends AbstractYamlTest {
                 "- type: org.apache.brooklyn.core.test.entity.TestEntity",
                 "  test.confName: myName",
                 "  test.confObject: myObj",
-                "  test.confDynamic: myDynamic");
+                "  confStringAlias: myString",
+                "  test.confDynamic: myDynamic",
+                "  myField: myFieldVal",
+                "  myField2Alias: myField2Val");
 
         final Entity app = createStartWaitAndLogApplication(yaml);
         TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
      
-        assertEquals(entity.config().get(TestEntity.CONF_NAME), "myName"); // confName has @SetFromFlag
+        assertEquals(entity.config().get(TestEntity.CONF_NAME), "myName"); // confName has @SetFromFlag("confName"); using full name
         assertEquals(entity.config().get(TestEntity.CONF_OBJECT), "myObj"); // confObject does not have @SetFromFlag
+        assertEquals(entity.config().get(TestEntity.CONF_STRING), "myString"); // set using the @SetFromFlag alias
         
         // The "dynamic" config key (i.e. not defined on the entity's type) is not picked up to 
         // be set on the entity if it's not inside the "brooklyn.config" block. This isn't exactly
@@ -105,6 +119,12 @@ public class ConfigYamlTest extends AbstractYamlTest {
         // than to say it is definitely what we want! But like the comment at the start of the 
         // method says, this style is discouraged so we don't really care.
         assertNull(entity.config().get(ConfigKeys.newStringConfigKey("test.confDynamic"))); // not defined on entity
+        
+        // Again this isn't exactly desired behaviour, just a demonstration of what happens!
+        // The names used in YAML correspond to fields with @SetFromFlag. The values end up in the
+        // {@link EntitySpec#config} rather than {@link EntitySpec#flags}. The field is not set.
+        assertNull(entity.getMyField()); // field with @SetFromFlag
+        assertNull(entity.getMyField2()); // field with @SetFromFlag("myField2Alias"), set using alias
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
@@ -59,6 +59,9 @@ import com.google.common.reflect.TypeToken;
 @ImplementedBy(TestEntityImpl.class)
 public interface TestEntity extends Entity, Startable, EntityLocal, EntityInternal {
 
+    @SetFromFlag("confStringAlias")
+    public static final ConfigKey<String> CONF_STRING = ConfigKeys.newStringConfigKey("test.confString", "Configuration string", "defaultStringVal");
+
     @SetFromFlag("confName")
     public static final ConfigKey<String> CONF_NAME = ConfigKeys.newStringConfigKey("test.confName", "Configuration key, my name", "defaultval");
     public static final BasicConfigKey<Map> CONF_MAP_PLAIN = new BasicConfigKey<Map>(Map.class, "test.confMapPlain", "Configuration key that's a plain map", ImmutableMap.of());
@@ -120,4 +123,8 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     public Entity createAndManageChildFromConfig();
     
     public List<String> getCallHistory();
+    
+    public String getMyField();
+    
+    public String getMyField2();
 }

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.feed.ConfigToAttributes;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
@@ -47,12 +48,18 @@ import com.google.common.collect.Lists;
 public class TestEntityImpl extends AbstractEntity implements TestEntity {
     private static final Logger LOG = LoggerFactory.getLogger(TestEntityImpl.class);
 
+    @SetFromFlag
+    private String myField;
+    
+    @SetFromFlag("myField2Alias")
+    private String myField2;
+    
     protected int sequenceValue = 0;
     protected AtomicInteger counter = new AtomicInteger(0);
     protected Map<?,?> constructorProperties;
     protected Map<?,?> configureProperties;
     protected List<String> callHistory = Collections.synchronizedList(Lists.<String>newArrayList());
-    
+
     public TestEntityImpl() {
         super();
     }
@@ -95,6 +102,16 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
         if (LOG.isTraceEnabled()) LOG.trace("In sleepEffector for {}", this);
         callHistory.add("sleepEffector");
         Time.sleep(duration);
+    }
+
+    @Override
+    public String getMyField() {
+        return myField;
+    }
+    
+    @Override
+    public String getMyField2() {
+        return myField2;
     }
 
     @Override
@@ -192,5 +209,4 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
         @Override
         protected void initEnrichers() {}
     }
-    
 }


### PR DESCRIPTION
@neykov here are some additional tests to demonstrate the behaviour of `@SetFromFlag`, and config either at the top-level YAML or inside the `brooklyn.config:`.