### PR TITLE
[BROOKLYN-401] Fix failing GC tasks test

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -525,6 +525,8 @@ public class BrooklynGarbageCollector {
         if (taskTagsInCategoryOverCapacity.isEmpty())
             return 0;
         
+        // TODO Skip tasks that will be evicted anyway (transient, expired)
+        // https://issues.apache.org/jira/browse/BROOKLYN-401
         Collection<Task<?>> tasks = executionManager.allTasksLive();
         List<Task<?>> tasksToConsiderDeleting = MutableList.of();
         try {


### PR DESCRIPTION
Background tasks get in the way, messing with the logic of what to evict next.

Note that this only changes the expectations in the tests, doesn't improve the GC as suggested in BROOKLYN-401.