### PR TITLE
if AnyoneSecurityProvider is set explicitly then switch it out for Nop

### DIFF
--- a/launcher/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
+++ b/launcher/src/test/java/org/apache/brooklyn/rest/jsgui/BrooklynJavascriptGuiLauncher.java
@@ -20,16 +20,17 @@ package org.apache.brooklyn.rest.jsgui;
 
 import java.net.InetSocketAddress;
 
-import org.apache.brooklyn.rest.NopSecurityHandler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.webapp.WebAppContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.rest.BrooklynRestApiLauncher;
+import org.apache.brooklyn.rest.NopSecurityHandler;
+import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
 import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** launches Javascript GUI programmatically. and used for tests.
  * see {@link BrooklynRestApiLauncher} for more information.
@@ -65,7 +66,9 @@ public class BrooklynJavascriptGuiLauncher {
     
     /** due to the relative path search in {@link BrooklynRestApiLauncher} we can just call that method */ 
     public static Server startJavascriptAndRest() throws Exception {
-        return BrooklynRestApiLauncher.startRestResourcesViaServlet();
+        return BrooklynRestApiLauncher.launcherServlet()
+            .securityProvider(AnyoneSecurityProvider.class)
+            .start();
     }
 
     /** not much fun without a REST server. 

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynPropertiesSecurityFilterTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynPropertiesSecurityFilterTest.java
@@ -97,8 +97,7 @@ public class BrooklynPropertiesSecurityFilterTest extends BrooklynRestApiLaunche
     public void testInteractionOfSecurityFilterAndFormMapProvider() throws Exception {
         Stopwatch stopwatch = Stopwatch.createStarted();
         try {
-            Server server = useServerForTest(BrooklynRestApiLauncher.launcher()
-                    .securityProvider(AnyoneSecurityProvider.class)
+            Server server = useServerForTest(baseLauncher()
                     .forceUseOfDefaultCatalogWithJavaClassPath(true)
                     .withoutJsgui()
                     .start());

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -196,8 +196,10 @@ public class BrooklynRestApiLauncher {
 
         Maybe<Object> configSecurityProvider = mgmt.getConfig().getConfigLocalRaw(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME);
         boolean hasConfigSecurityProvider = configSecurityProvider.isPresent();
-        boolean hasOverrideSecurityProvider = (securityProvider != null && securityProvider != AnyoneSecurityProvider.class);
-        if (hasOverrideSecurityProvider || hasConfigSecurityProvider) {
+        boolean hasOverrideSecurityProvider = securityProvider != null;
+        boolean hasAnyoneOverrideSecurityProvide = (securityProvider == AnyoneSecurityProvider.class) ||
+            (!hasOverrideSecurityProvider && hasConfigSecurityProvider && AnyoneSecurityProvider.class.getName().equals(configSecurityProvider.get()));
+        if (!hasAnyoneOverrideSecurityProvide && (hasOverrideSecurityProvider || hasConfigSecurityProvider)) {
             ((WebAppContext)context).addOverrideDescriptor(getClass().getResource("/web-security.xml").toExternalForm());
             if (hasOverrideSecurityProvider) {
                 ((BrooklynProperties) mgmt.getConfig()).put(

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncher.java
@@ -342,16 +342,20 @@ public class BrooklynRestApiLauncher {
         log.info("Press Ctrl-C to quit.");
     }
 
+    public static BrooklynRestApiLauncher launcherServlet() {
+        return new BrooklynRestApiLauncher().mode(StartMode.SERVLET);
+    }
+    
     public static Server startRestResourcesViaServlet() throws Exception {
-        return new BrooklynRestApiLauncher()
-                .mode(StartMode.SERVLET)
-                .start();
+        return launcherServlet().start();
     }
 
+    public static BrooklynRestApiLauncher launcherWebXml() {
+        return new BrooklynRestApiLauncher().mode(StartMode.WEB_XML);
+    }
+    
     public static Server startRestResourcesViaWebXml() throws Exception {
-        return new BrooklynRestApiLauncher()
-                .mode(StartMode.WEB_XML)
-                .start();
+        return launcherWebXml().start();
     }
 
     /** look for the JS GUI webapp in common source places, returning path to it if found, or null.

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTest.java
@@ -24,7 +24,6 @@ import static org.apache.brooklyn.rest.BrooklynRestApiLauncher.StartMode.WEB_XML
 import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
-import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
@@ -45,10 +44,10 @@ public class BrooklynRestApiLauncherTest extends BrooklynRestApiLauncherTestFixt
         checkRestCatalogEntities(useServerForTest(baseLauncher().mode(WEB_XML).start()));
     }
 
-    private BrooklynRestApiLauncher baseLauncher() {
-        return BrooklynRestApiLauncher.launcher()
-                .securityProvider(AnyoneSecurityProvider.class)
-                .forceUseOfDefaultCatalogWithJavaClassPath(true);
+    @Override
+    protected BrooklynRestApiLauncher baseLauncher() {
+        return super.baseLauncher()
+            .forceUseOfDefaultCatalogWithJavaClassPath(true);
     }
     
     private static void checkRestCatalogEntities(Server server) throws Exception {

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTestFixture.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTestFixture.java
@@ -50,9 +50,8 @@ public abstract class BrooklynRestApiLauncherTestFixture {
     
     protected Server newServer() {
         try {
-            Server server = BrooklynRestApiLauncher.launcher()
+            Server server = baseLauncher()
                     .forceUseOfDefaultCatalogWithJavaClassPath(true)
-                    .securityProvider(AnyoneSecurityProvider.class)
                     .start();
             return server;
         } catch (Exception e) {
@@ -67,6 +66,11 @@ public abstract class BrooklynRestApiLauncherTestFixture {
             this.server = server;
         }
         return server;
+    }
+    
+    protected BrooklynRestApiLauncher baseLauncher() {
+        return BrooklynRestApiLauncher.launcher()
+                .securityProvider(AnyoneSecurityProvider.class);
     }
     
     /** @deprecated since 0.9.0 use {@link #getBaseUriHostAndPost(Server)} or {@link #getBaseUriRest(Server)} */

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
@@ -45,7 +45,7 @@ public class CsrfTokenFilterLauncherTest extends BrooklynRestApiLauncherTestFixt
 
     @Test
     public void testRequestToken() {
-        useServerForTest(BrooklynRestApiLauncher.launcher()
+        useServerForTest(baseLauncher()
             .withoutJsgui()
             .start());
 

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/HaMasterCheckFilterTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/HaMasterCheckFilterTest.java
@@ -159,9 +159,9 @@ public class HaMasterCheckFilterTest extends BrooklynRestApiLauncherTestFixture 
             readMgmt = createManagementContext(mementoDir, readMode);
         }
 
-        server = useServerForTest(BrooklynRestApiLauncher.launcher()
-                .managementContext(readMgmt)
+        server = useServerForTest(baseLauncher()
                 .securityProvider(AnyoneSecurityProvider.class)
+                .managementContext(readMgmt)
                 .forceUseOfDefaultCatalogWithJavaClassPath(true)
                 .withoutJsgui()
                 .disableHighAvailability(false)

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/AbstractRestApiEntitlementsTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/AbstractRestApiEntitlementsTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractRestApiEntitlementsTest extends BrooklynRestApiLau
                         .configure(TestEntity.CONF_NAME, "myname"));
         entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
         
-        useServerForTest(BrooklynRestApiLauncher.launcher()
+        useServerForTest(baseLauncher()
                 .managementContext(mgmt)
                 .forceUseOfDefaultCatalogWithJavaClassPath(true)
                 .start());

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceIntegrationTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceIntegrationTest.java
@@ -63,7 +63,7 @@ public class ServerResourceIntegrationTest extends BrooklynRestApiLauncherTestFi
         ManagementContext mgmt = new LocalManagementContext(brooklynProperties);
         
         try {
-            Server server = useServerForTest(BrooklynRestApiLauncher.launcher()
+            Server server = useServerForTest(baseLauncher()
                     .managementContext(mgmt)
                     .withoutJsgui()
                     .securityProvider(TestSecurityProvider.class)
@@ -103,7 +103,7 @@ public class ServerResourceIntegrationTest extends BrooklynRestApiLauncherTestFi
 
     @Test(groups = "Integration")
     public void testGetUser() throws Exception {
-        Server server = useServerForTest(BrooklynRestApiLauncher.launcher()
+        Server server = useServerForTest(baseLauncher()
                 .securityProvider(TestSecurityProvider.class)
                 .withoutJsgui()
                 .start());


### PR DESCRIPTION
improves logic of #434 -- https://github.com/apache/brooklyn-server/pull/434/commits/bfdf522c452df262b3b4bb55cd567ddf45b31fa7

that change caused some tests to fail if you had a security provider set in `brooklyn.properties` locally!  this ensures that an explicit `AnyoneSecurityProvider` is respected.