### PR TITLE
Remove net.java.dev.jna dependency exclusion

### DIFF
--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -122,26 +122,6 @@
         <dependency>
             <groupId>${jclouds.groupId}.driver</groupId>
             <artifactId>jclouds-sshj</artifactId>
-            <exclusions>
-                <!-- provided versions are LGPL-only -->
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>jna</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.java.dev.jna</groupId>
-                    <artifactId>platform</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- dual-licensed under LGPL and ASL 2 -->
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
         </dependency>
 
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -480,16 +480,6 @@
                 <version>${maxmind.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>${jna.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.java.dev.jna</groupId>
-                <artifactId>jna-platform</artifactId>
-                <version>${jna.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jline</groupId>
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
         <jax-rs-api.version>2.0.1</jax-rs-api.version>
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
-        <jna.version>4.0.0</jna.version>
         <winrm4j.version>0.4.0</winrm4j.version>
         <karaf.version>4.0.4</karaf.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>


### PR DESCRIPTION
jclouds now correctly imports the dual-licensed version of jna, 
so we can rely on that rather than excluding it ourselves.

See https://github.com/jclouds/jclouds/commit/b3882cbfed873a5975d4918d1fb8b836b544c421. This is definitely in jclouds 1.9.2. (and 1.9.3 as well): see https://github.com/jclouds/jclouds/blob/rel/jclouds-1.9.2/drivers/sshj/pom.xml#L110.

With this change, looking at `mvn dependency:tree -Dverbose` includes the output below, and shows that the only "jna" dependencies are version 4.1.0.

```
[INFO] |     +- com.jcraft:jsch.agentproxy.usocket-jna:jar:0.0.8:compile
[INFO] |     |  +- net.java.dev.jna:jna:jar:4.1.0:compile
[INFO] |     |  \- net.java.dev.jna:jna-platform:jar:4.1.0:compile
[INFO] |     |     \- (net.java.dev.jna:jna:jar:4.1.0:compile - omitted for duplicate)
```

It also confirms that `jna` and `jna-platform` don't pull in any other transitive dependencies, so the upgrade from 4.0.0 to 4.1.0 shouldn't cause any problems (it just brings us in line with the versions that were actually tested in the jclouds releases!).