### PR TITLE
Fix https tests

### DIFF
--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCallImpl.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestHttpCallImpl.java
@@ -93,7 +93,7 @@ public class TestHttpCallImpl extends TargetableTestComponentImpl implements Tes
                     public String get() {
                         try {
                             final HttpRequestBase httpMethod = createHttpMethod(method, url, headers, body);
-                            return HttpTool.execAndConsume(HttpTool.httpClientBuilder().trustAll(trustAll).build(), httpMethod).getContentAsString();
+                            return HttpTool.execAndConsume(HttpTool.httpClientBuilder().uri(url).trustAll(trustAll).build(), httpMethod).getContentAsString();
                         } catch (Exception e) {
                             LOG.info("HTTP call to [{}] failed due to [{}]", url, e.getMessage());
                             throw Exceptions.propagate(e);
@@ -109,7 +109,7 @@ public class TestHttpCallImpl extends TargetableTestComponentImpl implements Tes
                     public Integer get() {
                         try {
                             final HttpRequestBase httpMethod = createHttpMethod(method, url, headers, body);
-                            final Maybe<HttpResponse> response = HttpTool.execAndConsume(HttpTool.httpClientBuilder().trustAll(trustAll).build(), httpMethod).getResponse();
+                            final Maybe<HttpResponse> response = HttpTool.execAndConsume(HttpTool.httpClientBuilder().uri(url).trustAll(trustAll).build(), httpMethod).getResponse();
                             if (response.isPresentAndNonNull()) {
                                 return response.get().getStatusLine().getStatusCode();
                             } else {


### PR DESCRIPTION
This fixes HTTPS YAML tests. Previously the `trustAll(trustAll)` was not working due to no URL being specified during the build method which caused it to be ignored [here](https://github.com/apache/brooklyn-server/blob/master/utils/common/src/main/java/org/apache/brooklyn/util/http/HttpTool.java#L361).