### PR TITLE
Upgrade guava to v18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,12 @@
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->
-        <guava.version>16.0.1</guava.version>
-        <!-- This can be different, OSGi will pick it up -->
+        <guava.version>18.0</guava.version>
+        <!--
+            This can be different from above and should be used only by Swagger related code.
+            Note that some bundles used by Brooklyn will try to bind to the latest version available.
+            For example jclouds and jackson-datatype-guava both depend on guava [16,20).
+        -->
         <guava-swagger.version>18.0</guava-swagger.version>
         <xstream.version>1.4.8</xstream.version>
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>


### PR DESCRIPTION
Depends on #457. Fixes wiring problems with the new jclouds in Karaf.

`jclouds 1.9.3` depends on guava [16-20), so it will bind to the latest version it finds - which is 18. And Brooklyn is stuck on 16.0.1. Bumping Brooklyn to 18.0 moves everything to depend on the same version of guava thus solving the wiring problems.

Note that `guava-16.0.1` is still pulled in the Karaf distribution by [jclouds](https://github.com/jclouds/jclouds-karaf/blob/master/feature/src/main/resources/feature.xml#L30). But is not loaded at runtime.