### PR TITLE
Upgrade karaf-maven-plugin to avoid double User-Agent bug

### DIFF
--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
-                <version>${karaf.version}</version>
+                <version>${karaf.plugin.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
         <maxmind-db.version>1.2.1</maxmind-db.version>
         <winrm4j.version>0.4.0</winrm4j.version>
         <karaf.version>4.0.4</karaf.version>
+        <!--
+            Fixes double User-Agent issue leading to split Nexus repo.
+            Caused by karaf-maven-plugin depending on wagon-http 2.8 having the bug.
+         -->
+        <karaf.plugin.version>4.0.6</karaf.plugin.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>


### PR DESCRIPTION
Deploying the project as is leads to the creation of two staging repos. With modules using the `karaf-maven-plugin` in one and the rest in the other bucket.

This is caused by a bug in `wagon-http-2.8` already fixed in maven 3.3.3. `karaf-maven-plugin` has a dependency on `wagon-http-2.8` so it pulls in the version even in versions of maven that use later (and fixed) releases.

Nexus will create a unique repo based on a number of factors - the IP of the user and the User-Agent being included. If one of those changes during deployment it will lead to a new staging repo being created.

Changes already applied on 0.10.0 branch.

Merge together with https://github.com/apache/brooklyn-library/pull/81 and https://github.com/apache/brooklyn-dist/pull/66.