### PR TITLE
Small JcloudsLocation refactor

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -141,7 +141,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
             this.reconfigurable = val; return self();
         }
         /**
-         * @deprecated since 0.10.0; use {@link #runtime2Inheritance(ConfigInheritance)}
+         * @deprecated since 0.10.0; use {@link #runtimeInheritance(ConfigInheritance)}
          */ 
         @Deprecated
         public B parentInheritance(ConfigInheritance val) {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
@@ -95,11 +95,15 @@ public interface Attributes {
             UserAndHostAndPort.class, 
             "host.winrmAddress", 
             "user@host:port for WinRM'ing (or null if inappropriate)");
-    AttributeSensor<String> SUBNET_HOSTNAME = Sensors.newStringSensor( "host.subnet.hostname", "Host name as known internally in " +
-            "the subnet where it is running (if different to host.name)");
-    AttributeSensor<String> SUBNET_ADDRESS = Sensors.newStringSensor( "host.subnet.address", "Host address as known internally in " +
-            "the subnet where it is running (if different to host.name)");
+    AttributeSensor<String> SUBNET_HOSTNAME = Sensors.newStringSensor(
+            "host.subnet.hostname",
+            "Host name as known internally in the subnet where it is running (if different to host.name)");
+    AttributeSensor<String> SUBNET_ADDRESS = Sensors.newStringSensor(
+            "host.subnet.address",
+            "Host address as known internally in the subnet where it is running (if different to host.name)");
 
+    /** @deprecated since 0.11.0 without replacement */
+    @Deprecated
     AttributeSensor<String> HOST_AND_PORT = Sensors.newStringSensor( "hostandport", "host:port" );
 
     /*
@@ -134,10 +138,6 @@ public interface Attributes {
     AttributeSensor<Lifecycle.Transition> SERVICE_STATE_EXPECTED = Sensors.newSensor(Lifecycle.Transition.class,
             "service.state.expected", "Last controlled change to service state, indicating what the expected state should be");
     
-    /** @deprecated since 0.7.0 use {@link #SERVICE_STATE_ACTUAL} or {@link #SERVICE_STATE_EXPECTED} as appropriate. */
-    @Deprecated
-    AttributeSensor<Lifecycle> SERVICE_STATE = SERVICE_STATE_ACTUAL;
-
     /*
      * Other metadata (optional)
      */

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -79,7 +79,7 @@ public interface CloudLocationConfig {
 
     public static final ConfigKey<String> POLL_FOR_FIRST_REACHABLE_ADDRESS = ConfigKeys.newStringConfigKey("pollForFirstReachableAddress", 
             "Whether and how long to wait for reaching the VM's ip:port; "
-            + "if 'false', will default to the node's first public IP (or privae if no public IPs); "
+            + "if 'false', will default to the node's first public IP (or private if no public IPs); "
             + "if 'true' uses default duration; otherwise accepts a time string e.g. '5m' (the default) or a number of milliseconds", "5m");
 
     @SuppressWarnings("serial")

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -700,7 +700,7 @@ public class DependentConfiguration {
     public static class ProtoBuilder {
         /**
          * Will wait for the attribute on the given entity, with default behaviour:
-         * If that entity reports {@link Lifecycle#ON_FIRE} for its {@link Attributes#SERVICE_STATE} then it will abort;
+         * If that entity reports {@link Lifecycle#ON_FIRE} for its {@link Attributes#SERVICE_STATE_ACTUAL} then it will abort;
          * If that entity is stopping or destroyed (see {@link Builder#timeoutIfStoppingOrDestroyed(Duration)}),
          * then it will timeout after 1 minute.
          */

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -165,7 +165,6 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
      * brooklyn.location.named.myLocation.sshToolClass = com.acme.brooklyn.MyCustomSshTool
      * brooklyn.location.named.myLocation.sshToolClass.myparam = myvalue
      * }
-     * }
      * </pre>
      * <p>
      */
@@ -516,16 +515,6 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
         cleanupTask = null;
         sshPoolCacheOrNull = null;
     }
-
-    // should not be necessary, and causes objects to be kept around a lot longer than desired
-//    @Override
-//    protected void finalize() throws Throwable {
-//        try {
-//            close();
-//        } finally {
-//            super.finalize();
-//        }
-//    }
 
     @Override
     public InetAddress getAddress() {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
@@ -120,8 +120,6 @@ public class BasicJcloudsLocationCustomizer extends BasicConfigurableObject impl
      * @return the calling entity
      */
     protected Entity getCallerContext(JcloudsMachineLocation machine) {
-        SudoTtyFixingCustomizer s;
-
         Object context = config().get(LocationConfigKeys.CALLER_CONTEXT);
         if (context == null) {
             context = machine.config().get(LocationConfigKeys.CALLER_CONTEXT);
@@ -129,7 +127,6 @@ public class BasicJcloudsLocationCustomizer extends BasicConfigurableObject impl
         if (!(context instanceof Entity)) {
             throw new IllegalStateException("Invalid location context: " + context);
         }
-        Entity entity = (Entity) context;
-        return entity;
+        return (Entity) context;
     }
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/CreateUserStatements.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/CreateUserStatements.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds;
+
+import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
+
+import java.security.KeyPair;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.core.location.LocationConfigUtils;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.crypto.SecureKeys;
+import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.domain.Image;
+import org.jclouds.compute.functions.Sha512Crypt;
+import org.jclouds.domain.LoginCredentials;
+import org.jclouds.scriptbuilder.domain.LiteralStatement;
+import org.jclouds.scriptbuilder.domain.Statement;
+import org.jclouds.scriptbuilder.statements.login.AdminAccess;
+import org.jclouds.scriptbuilder.statements.login.ReplaceShadowPasswordEntry;
+import org.jclouds.scriptbuilder.statements.ssh.AuthorizeRSAPublicKeys;
+import org.jclouds.scriptbuilder.statements.ssh.SshStatements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+public class CreateUserStatements {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateUserStatements.class);
+
+    private final LoginCredentials createdUserCredentials;
+    private final List<Statement> statements;
+
+    CreateUserStatements(LoginCredentials creds, List<Statement> statements) {
+        this.createdUserCredentials = creds;
+        this.statements = statements;
+    }
+
+    public LoginCredentials credentials() {
+        return createdUserCredentials;
+    }
+
+    public List<Statement> statements() {
+        return statements;
+    }
+
+    /**
+     * Returns the commands required to create the user, to be used for connecting (e.g. over ssh)
+     * to the machine; also returns the expected login credentials.
+     * <p>
+     * The returned login credentials may be null if we haven't done any user-setup and no specific
+     * user was supplied (i.e. if {@code dontCreateUser} was true and {@code user} was null or blank).
+     * In which case, the caller should use the jclouds node's login credentials.
+     * <p>
+     * There are quite a few configuration options. Depending on their values, the user-creation
+     * behaves differently:
+     * <ul>
+     * <li>{@code dontCreateUser} says not to run any user-setup commands at all. If {@code user} is
+     * non-empty (including with the default value), then that user will subsequently be used,
+     * otherwise the (inferred) {@code loginUser} will be used.
+     * <li>{@code loginUser} refers to the existing user that jclouds should use when setting up the VM.
+     * Normally this will be inferred from the image (i.e. doesn't need to be explicitly set), but sometimes
+     * the image gets it wrong so this can be a handy override.
+     * <li>{@code user} is the username for brooklyn to subsequently use when ssh'ing to the machine.
+     * If not explicitly set, its value will default to the username of the user running brooklyn.
+     * <ul>
+     * <li>If the {@code user} value is null or empty, then the (inferred) {@code loginUser} will
+     * subsequently be used, setting up the password/authorizedKeys for that loginUser.
+     * <li>If the {@code user} is "root", then setup the password/authorizedKeys for root.
+     * <li>If the {@code user} equals the (inferred) {@code loginUser}, then don't try to create this
+     * user but instead just setup the password/authorizedKeys for the user.
+     * <li>Otherwise create the given user, setting up the password/authorizedKeys (unless
+     * {@code dontCreateUser} is set, obviously).
+     * </ul>
+     * <li>{@code publicKeyData} is the key to authorize (i.e. add to .ssh/authorized_keys),
+     * if not null or blank. Note the default is to use {@code ~/.ssh/id_rsa.pub} or {@code ~/.ssh/id_dsa.pub}
+     * if either of those files exist for the user running brooklyn.
+     * Related is {@code publicKeyFile}, which is used to populate publicKeyData.
+     * <li>{@code password} is the password to set for the user. If null or blank, then a random password
+     * will be auto-generated and set.
+     * <li>{@code privateKeyData} is the key to use when subsequent ssh'ing, if not null or blank.
+     * Note the default is to use {@code ~/.ssh/id_rsa} or {@code ~/.ssh/id_dsa}.
+     * The subsequent preferences for ssh'ing are:
+     * <ul>
+     * <li>Use the {@code privateKeyData} if not null or blank (including if using default)
+     * <li>Use the {@code password} (or the auto-generated password if that is blank).
+     * </ul>
+     * <li>{@code grantUserSudo} determines whether or not the created user may run the sudo command.</li>
+     * </ul>
+     *
+     * @param image  The image being used to create the VM
+     * @param config Configuration for creating the VM
+     * @return The commands required to create the user, along with the expected login credentials for that user,
+     * or null if we are just going to use those from jclouds.
+     */
+    public static CreateUserStatements get(JcloudsLocation location, @Nullable Image image, ConfigBag config) {
+        //NB: private key is not installed remotely, just used to get/validate the public key
+        Preconditions.checkNotNull(location, "location argument required");
+        String user = Preconditions.checkNotNull(location.getUser(config), "user required");
+        final boolean isWindows = location.isWindows(image, config);
+        final String explicitLoginUser = config.get(JcloudsLocation.LOGIN_USER);
+        final String loginUser = groovyTruth(explicitLoginUser)
+                ? explicitLoginUser
+                : (image != null && image.getDefaultCredentials() != null)
+                        ? image.getDefaultCredentials().identity
+                        : null;
+        final boolean dontCreateUser = config.get(JcloudsLocation.DONT_CREATE_USER);
+        final boolean grantUserSudo = config.get(JcloudsLocation.GRANT_USER_SUDO);
+        final LocationConfigUtils.OsCredential credential = LocationConfigUtils.getOsCredential(config);
+        credential.checkNoErrors().logAnyWarnings();
+        final String passwordToSet =
+                Strings.isNonBlank(credential.getPassword()) ? credential.getPassword() : Identifiers.makeRandomId(12);
+        final List<Statement> statements = Lists.newArrayList();
+        LoginCredentials createdUserCreds = null;
+
+        if (dontCreateUser) {
+            // dontCreateUser:
+            // if caller has not specified a user, we'll just continue to use the loginUser;
+            // if caller *has*, we set up our credentials assuming that user and credentials already exist
+
+            if (Strings.isBlank(user)) {
+                // createdUserCreds returned from this method will be null;
+                // we will use the creds returned by jclouds on the node
+                LOG.info("Not setting up user {} (subsequently using loginUser {})", user, loginUser);
+                config.put(JcloudsLocation.USER, loginUser);
+
+            } else {
+                LOG.info("Not creating user {}, and not installing its password or authorizing keys (assuming it exists)", user);
+
+                if (credential.isUsingPassword()) {
+                    createdUserCreds = LoginCredentials.builder().user(user).password(credential.getPassword()).build();
+                    if (Boolean.FALSE.equals(config.get(JcloudsLocation.DISABLE_ROOT_AND_PASSWORD_SSH))) {
+                        statements.add(SshStatements.sshdConfig(ImmutableMap.of("PasswordAuthentication", "yes")));
+                    }
+                } else if (credential.hasKey()) {
+                    createdUserCreds = LoginCredentials.builder().user(user).privateKey(credential.getPrivateKeyData()).build();
+                }
+            }
+
+        } else if (isWindows) {
+            // TODO Generate statements to create the user.
+            // createdUserCreds returned from this method will be null;
+            // we will use the creds returned by jclouds on the node
+            LOG.warn("Not creating or configuring user on Windows VM, despite " + JcloudsLocation.DONT_CREATE_USER.getName() + " set to false");
+
+            // TODO extractVmCredentials() will use user:publicKeyData defaults, if we don't override this.
+            // For linux, how would we configure Brooklyn to use the node.getCredentials() - i.e. the version
+            // that the cloud automatically generated?
+            if (config.get(JcloudsLocation.USER) != null) config.put(JcloudsLocation.USER, "");
+            if (config.get(JcloudsLocation.PASSWORD) != null) config.put(JcloudsLocation.PASSWORD, "");
+            if (config.get(JcloudsLocation.PRIVATE_KEY_DATA) != null) config.put(JcloudsLocation.PRIVATE_KEY_DATA, "");
+            if (config.get(JcloudsLocation.PRIVATE_KEY_FILE) != null) config.put(JcloudsLocation.PRIVATE_KEY_FILE, "");
+            if (config.get(JcloudsLocation.PUBLIC_KEY_DATA) != null) config.put(JcloudsLocation.PUBLIC_KEY_DATA, "");
+            if (config.get(JcloudsLocation.PUBLIC_KEY_FILE) != null) config.put(JcloudsLocation.PUBLIC_KEY_FILE, "");
+
+        } else if (Strings.isBlank(user) || user.equals(loginUser) || user.equals(JcloudsLocation.ROOT_USERNAME)) {
+            boolean useKey = Strings.isNonBlank(credential.getPublicKeyData());
+
+            // For subsequent ssh'ing, we'll be using the loginUser
+            if (Strings.isBlank(user)) {
+                user = loginUser;
+                config.put(JcloudsLocation.USER, user);
+            }
+
+            // Using the pre-existing loginUser; setup the publicKey/password so can login as expected
+
+            // *Always* change the password (unless dontCreateUser was specified)
+            statements.add(new ReplaceShadowPasswordEntry(Sha512Crypt.function(), user, passwordToSet));
+            createdUserCreds = LoginCredentials.builder().user(user).password(passwordToSet).build();
+
+            if (useKey) {
+                // NB: further keys are added from config *after* user creation
+                statements.add(new AuthorizeRSAPublicKeys("~" + user + "/.ssh", ImmutableList.of(credential.getPublicKeyData()), null));
+                if (Strings.isNonBlank(credential.getPrivateKeyData())) {
+                    createdUserCreds = LoginCredentials.builder().user(user).privateKey(credential.getPrivateKeyData()).build();
+                }
+            }
+
+            if (!useKey || Boolean.FALSE.equals(config.get(JcloudsLocation.DISABLE_ROOT_AND_PASSWORD_SSH))) {
+                // ensure password is permitted for ssh
+                statements.add(SshStatements.sshdConfig(ImmutableMap.of("PasswordAuthentication", "yes")));
+                if (user.equals(JcloudsLocation.ROOT_USERNAME)) {
+                    statements.add(SshStatements.sshdConfig(ImmutableMap.of("PermitRootLogin", "yes")));
+                }
+            }
+
+        } else {
+            String pubKey = credential.getPublicKeyData();
+            String privKey = credential.getPrivateKeyData();
+
+            if (credential.isEmpty()) {
+                /*
+                 * TODO have an explicit `create_new_key_per_machine` config key.
+                 * error if privateKeyData is set in this case.
+                 * publicKeyData automatically added to EXTRA_SSH_KEY_URLS_TO_AUTH.
+                 *
+                 * if this config key is not set, use a key `brooklyn_id_rsa` and `.pub` in `MGMT_BASE_DIR`,
+                 * with permission 0600, creating it if necessary, and logging the fact that this was created.
+                 */
+                // TODO JcloudsLocation used to log this once only: loggedSshKeysHint.compareAndSet(false, true).
+                if (!config.containsKey(JcloudsLocation.PRIVATE_KEY_FILE)) {
+                    LOG.info("Default SSH keys not found or not usable; will create new keys for each machine. " +
+                                    "Create ~/.ssh/id_rsa or set {} / {} / {} as appropriate for this location " +
+                                    "if you wish to be able to log in without Brooklyn.",
+                            new Object[]{JcloudsLocation.PRIVATE_KEY_FILE.getName(), JcloudsLocation.PRIVATE_KEY_PASSPHRASE.getName(), JcloudsLocation.PASSWORD.getName()});
+                }
+                KeyPair newKeyPair = SecureKeys.newKeyPair();
+                pubKey = SecureKeys.toPub(newKeyPair);
+                privKey = SecureKeys.toPem(newKeyPair);
+                LOG.debug("Brooklyn key being created for " + user + " at new machine " + location + " is:\n" + privKey);
+            }
+
+            // Create the user
+            // note AdminAccess requires _all_ fields set, due to http://code.google.com/p/jclouds/issues/detail?id=1095
+            AdminAccess.Builder adminBuilder = AdminAccess.builder()
+                    .adminUsername(user)
+                    .grantSudoToAdminUser(grantUserSudo);
+            adminBuilder.cryptFunction(Sha512Crypt.function());
+
+            boolean useKey = Strings.isNonBlank(pubKey);
+            adminBuilder.cryptFunction(Sha512Crypt.function());
+
+            // always set this password; if not supplied, it will be a random string
+            adminBuilder.adminPassword(passwordToSet);
+            // log the password also, in case we need it
+            LOG.debug("Password '{}' being created for user '{}' at the machine we are about to provision in {}; {}",
+                    new Object[]{passwordToSet, user, location, useKey ? "however a key will be used to access it" : "this will be the only way to log in"});
+
+            if (grantUserSudo && config.get(JcloudsLocationConfig.DISABLE_ROOT_AND_PASSWORD_SSH)) {
+                // the default - set root password which we forget, because we have sudo acct
+                // (and lock out root and passwords from ssh)
+                adminBuilder.resetLoginPassword(true);
+                adminBuilder.loginPassword(Identifiers.makeRandomId(12));
+            } else {
+                adminBuilder.resetLoginPassword(false);
+                adminBuilder.loginPassword(Identifiers.makeRandomId(12) + "-ignored");
+            }
+
+            if (useKey) {
+                adminBuilder.authorizeAdminPublicKey(true).adminPublicKey(pubKey);
+            } else {
+                adminBuilder.authorizeAdminPublicKey(false).adminPublicKey(Identifiers.makeRandomId(12) + "-ignored");
+            }
+
+            // jclouds wants us to give it the private key, otherwise it might refuse to authorize the public key
+            // (in AdminAccess.build, if adminUsername != null && adminPassword != null);
+            // we don't want to give it the private key, but we *do* want the public key authorized;
+            // this code seems to trigger that.
+            // (we build the creds below)
+            adminBuilder.installAdminPrivateKey(false).adminPrivateKey(Identifiers.makeRandomId(12) + "-ignored");
+
+            // lock SSH means no root login and no passwordless login
+            // if we're using a password or we don't have sudo, then don't do this!
+            adminBuilder.lockSsh(useKey && grantUserSudo && config.get(JcloudsLocationConfig.DISABLE_ROOT_AND_PASSWORD_SSH));
+
+            statements.add(adminBuilder.build());
+
+            if (useKey) {
+                createdUserCreds = LoginCredentials.builder().user(user).privateKey(privKey).build();
+            } else if (passwordToSet != null) {
+                createdUserCreds = LoginCredentials.builder().user(user).password(passwordToSet).build();
+            }
+
+            if (!useKey || Boolean.FALSE.equals(config.get(JcloudsLocation.DISABLE_ROOT_AND_PASSWORD_SSH))) {
+                // ensure password is permitted for ssh
+                statements.add(SshStatements.sshdConfig(ImmutableMap.of("PasswordAuthentication", "yes")));
+            }
+        }
+
+        String customTemplateOptionsScript = config.get(JcloudsLocation.CUSTOM_TEMPLATE_OPTIONS_SCRIPT_CONTENTS);
+        if (Strings.isNonBlank(customTemplateOptionsScript)) {
+            statements.add(new LiteralStatement(customTemplateOptionsScript));
+        }
+
+        LOG.debug("Machine we are about to create in {} will be customized with: {}", location, statements);
+
+        return new CreateUserStatements(createdUserCreds, statements);
+    }
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2234,64 +2234,6 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         return new RebindToMachinePredicate(config);
     }
 
-    /**
-     * Determines whether a machine may be rebinded to by comparing the given id, hostname and region
-     * against the node's id, hostname, provider id and public addresses.
-     */
-    private static class RebindToMachinePredicate implements Predicate<ComputeMetadata> {
-
-        final String rawId;
-        final String rawHostname;
-        final String rawRegion;
-
-        public RebindToMachinePredicate(ConfigBag config) {
-            rawId = (String) config.getStringKey("id");
-            rawHostname = (String) config.getStringKey("hostname");
-            rawRegion = (String) config.getStringKey("region");
-        }
-
-        @Override
-        public boolean apply(ComputeMetadata input) {
-            // ID exact match
-            if (rawId != null) {
-                // Second is AWS format
-                if (rawId.equals(input.getId()) || rawRegion != null && (rawRegion + "/" + rawId).equals(input.getId())) {
-                    return true;
-                }
-            }
-
-            // else do node metadata lookup
-            if (input instanceof NodeMetadata) {
-                NodeMetadata node = NodeMetadata.class.cast(input);
-                if (rawHostname != null && rawHostname.equalsIgnoreCase(node.getHostname()))
-                    return true;
-                if (rawHostname != null && node.getPublicAddresses().contains(rawHostname))
-                    return true;
-                if (rawId != null && rawId.equalsIgnoreCase(node.getHostname()))
-                    return true;
-                if (rawId != null && node.getPublicAddresses().contains(rawId))
-                    return true;
-                // don't do private IPs because they might be repeated
-                if (rawId != null && rawId.equalsIgnoreCase(node.getProviderId()))
-                    return true;
-                if (rawHostname != null && rawHostname.equalsIgnoreCase(node.getProviderId()))
-                    return true;
-            }
-
-            return false;
-        }
-
-        @Override
-        public String toString() {
-            return Objects.toStringHelper(this)
-                    .omitNullValues()
-                    .add("id", rawId)
-                    .add("hostname", rawHostname)
-                    .add("region", rawRegion)
-                    .toString();
-        }
-    }
-
     protected JcloudsSshMachineLocation registerJcloudsSshMachineLocation(
             ComputeService computeService, NodeMetadata node, Optional<Template> template,
             LoginCredentials credentials, HostAndPort managementHostAndPort, ConfigBag setup) throws IOException {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -257,8 +257,7 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
     public static final ConfigKey<JcloudsPortForwarderExtension> PORT_FORWARDER = ConfigKeys.newConfigKey(
             JcloudsPortForwarderExtension.class, "portforwarding.forwarder", "The port-forwarder to use");
     
-    public static final ConfigKey<PortForwardManager> PORT_FORWARDING_MANAGER = BrooklynAccessUtils
-            .PORT_FORWARDING_MANAGER;
+    public static final ConfigKey<PortForwardManager> PORT_FORWARDING_MANAGER = BrooklynAccessUtils.PORT_FORWARDING_MANAGER;
 
     public static final ConfigKey<Integer> MACHINE_CREATE_ATTEMPTS = ConfigKeys.newIntegerConfigKey(
             "machineCreateAttempts", "Number of times to retry if jclouds fails to create a VM", 2);
@@ -293,20 +292,15 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
     public static final ConfigKey<Map<String,Object>> TEMPLATE_OPTIONS = ConfigKeys.newConfigKey(
             new TypeToken<Map<String, Object>>() {}, "templateOptions", "Additional jclouds template options");
 
-    /*
-         The purpose of this config is to aid deployment of blueprints to clouds where it is difficult to get nodes to
-         communicate via private IPs. This config allows a user to overwrite private IPs as public IPs, thus ensuring
-         that any blueprints they wish to deploy which may use private IPs still work in these clouds.
+    /**
+     * The purpose of this config is to aid deployment of blueprints to clouds where it is difficult to get nodes to
+     * communicate via private IPs. This config allows a user to overwrite private IPs as public IPs, thus ensuring
+     * that any blueprints they wish to deploy which may use private IPs still work in these clouds.
      */
     @Beta
     public static final ConfigKey<Boolean> USE_MACHINE_PUBLIC_ADDRESS_AS_PRIVATE_ADDRESS = ConfigKeys.newBooleanConfigKey(
             "useMachinePublicAddressAsPrivateAddress",
             "When true we will use the public IP/Hostname of a JClouds Location as the private IP/Hostname",
             false);
-
-    // TODO
-    
-//  "noDefaultSshKeys" - hints that local ssh keys should not be read as defaults
-    // this would be useful when we need to indicate a password
 
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -420,9 +420,10 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
     protected Optional<String> getPrivateAddress() {
         for (String p : getPrivateAddresses()) {
             // disallow local only addresses
-            if (Networking.isLocalOnly(p)) continue;
-            // other things may be public or private, but either way, return it
-            return Optional.of(p);
+            if (!Networking.isLocalOnly(p)) {
+                // other things may be public or private, but either way, return it
+                return Optional.of(p);
+            }
         }
         return Optional.absent();
     }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/RebindToMachinePredicate.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/RebindToMachinePredicate.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.domain.ComputeMetadata;
+import org.jclouds.compute.domain.NodeMetadata;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
+
+/**
+ * Determines whether a machine may be rebinded to by comparing the given id, hostname and region
+ * against the node's id, hostname, provider id and public addresses.
+ */
+class RebindToMachinePredicate implements Predicate<ComputeMetadata> {
+
+    final String rawId;
+    final String rawHostname;
+    final String rawRegion;
+
+    public RebindToMachinePredicate(ConfigBag config) {
+        rawId = (String) config.getStringKey("id");
+        rawHostname = (String) config.getStringKey("hostname");
+        rawRegion = (String) config.getStringKey("region");
+    }
+
+    @Override
+    public boolean apply(ComputeMetadata input) {
+        // ID exact match
+        if (rawId != null) {
+            // Second is AWS format
+            if (rawId.equals(input.getId()) || rawRegion != null && (rawRegion + "/" + rawId).equals(input.getId())) {
+                return true;
+            }
+        }
+
+        // else do node metadata lookup
+        if (input instanceof NodeMetadata) {
+            NodeMetadata node = NodeMetadata.class.cast(input);
+            if (rawHostname != null && rawHostname.equalsIgnoreCase(node.getHostname()))
+                return true;
+            if (rawHostname != null && node.getPublicAddresses().contains(rawHostname))
+                return true;
+            if (rawId != null && rawId.equalsIgnoreCase(node.getHostname()))
+                return true;
+            if (rawId != null && node.getPublicAddresses().contains(rawId))
+                return true;
+            // don't do private IPs because they might be repeated
+            if (rawId != null && rawId.equalsIgnoreCase(node.getProviderId()))
+                return true;
+            if (rawHostname != null && rawHostname.equalsIgnoreCase(node.getProviderId()))
+                return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .omitNullValues()
+                .add("id", rawId)
+                .add("hostname", rawHostname)
+                .add("region", rawRegion)
+                .toString();
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoAssignFloatingIpOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoAssignFloatingIpOption.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AutoAssignFloatingIpOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(AutoAssignFloatingIpOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof NovaTemplateOptions) {
+            ((NovaTemplateOptions) t).autoAssignFloatingIp((Boolean) v);
+        } else if (t instanceof CloudStackTemplateOptions) {
+            ((CloudStackTemplateOptions) t).setupStaticNat((Boolean) v);
+        } else {
+            LOG.info("ignoring auto-assign-floating-ip({}) in VM creation because not supported for cloud/type ({})", v, t);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoCreateFloatingIpsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoCreateFloatingIpsOption.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AutoCreateFloatingIpsOption implements TemplateOptionCustomizer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoCreateFloatingIpsOption.class);
+    
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        LOG.warn("Using deprecated " + JcloudsLocationConfig.AUTO_CREATE_FLOATING_IPS + "; use " + JcloudsLocationConfig.AUTO_ASSIGN_FLOATING_IP + " instead");
+        if (t instanceof NovaTemplateOptions) {
+            ((NovaTemplateOptions) t).autoAssignFloatingIp((Boolean) v);
+        } else {
+            LOG.info("ignoring auto-generate-floating-ips({}) in VM creation because not supported for cloud/type ({})", v, t);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoGenerateKeypairsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/AutoGenerateKeypairsOption.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AutoGenerateKeypairsOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(AutoGenerateKeypairsOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof NovaTemplateOptions) {
+            ((NovaTemplateOptions) t).generateKeyPair((Boolean) v);
+        } else if (t instanceof CloudStackTemplateOptions) {
+            ((CloudStackTemplateOptions) t).generateKeyPair((Boolean) v);
+        } else {
+            LOG.info("ignoring auto-generate-keypairs({}) in VM creation because not supported for cloud/type ({})", v, t);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/DomainNameOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/DomainNameOption.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DomainNameOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(DomainNameOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof SoftLayerTemplateOptions) {
+            ((SoftLayerTemplateOptions) t).domainName(TypeCoercions.coerce(v, String.class));
+        } else {
+            LOG.info("ignoring domain-name({}) in VM creation because not supported for cloud/type ({})", v, t);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/ExtraPublicKeyDataToAuthOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/ExtraPublicKeyDataToAuthOption.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ExtraPublicKeyDataToAuthOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtraPublicKeyDataToAuthOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        // this is unreliable:
+        // * seems now (Aug 2016) to be run *before* the TO.runScript which creates the user,
+        // so is installed for the initial login user not the created user
+        // * not supported in GCE (it uses it as the login public key, see email to jclouds list, 29 Aug 2015)
+        // so only works if you also overrideLoginPrivateKey
+        // --
+        // for this reason we also inspect these ourselves
+        // along with EXTRA_PUBLIC_KEY_URLS_TO_AUTH
+        // and install after creation;
+        // --
+        // we also do it here for legacy reasons though i (alex) can't think of any situations it's needed
+        // --
+        // also we warn on exceptions in case someone is dumping comments or something else
+        try {
+            t.authorizePublicKey(v.toString());
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            LOG.warn("Error trying jclouds authorizePublicKey; will run later: " + e, e);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/InboundPortsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/InboundPortsOption.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.core.location.PortRanges;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.commons.lang3.ArrayUtils;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Iterables;
+
+class InboundPortsOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(InboundPortsOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        int[] inboundPorts = toIntPortArray(v);
+        if (LOG.isDebugEnabled())
+            LOG.debug("opening inbound ports {} for cloud/type {}", Arrays.toString(inboundPorts), t.getClass());
+        t.inboundPorts(inboundPorts);
+    }
+
+    private int[] toIntPortArray(Object v) {
+        PortRange portRange = PortRanges.fromIterable(Collections.singletonList(v));
+        return ArrayUtils.toPrimitive(Iterables.toArray(portRange, Integer.class));
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/KeyPairOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/KeyPairOption.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.ec2.compute.options.EC2TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class KeyPairOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(KeyPairOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof EC2TemplateOptions) {
+            ((EC2TemplateOptions) t).keyPair(v.toString());
+        } else if (t instanceof NovaTemplateOptions) {
+            ((NovaTemplateOptions) t).keyPairName(v.toString());
+        } else if (t instanceof CloudStackTemplateOptions) {
+            ((CloudStackTemplateOptions) t).keyPair(v.toString());
+        } else {
+            LOG.info("ignoring keyPair({}) in VM creation because not supported for cloud/type ({})", v, t);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserOption.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+
+class LoginUserOption implements TemplateOptionCustomizer {
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (v != null) {
+            t.overrideLoginUser(v.toString());
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPasswordOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPasswordOption.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+
+class LoginUserPasswordOption implements TemplateOptionCustomizer {
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (v != null) {
+            t.overrideLoginPassword(v.toString());
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPrivateKeyDataOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPrivateKeyDataOption.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+
+class LoginUserPrivateKeyDataOption implements TemplateOptionCustomizer {
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (v != null) {
+            t.overrideLoginPrivateKey(v.toString());
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPrivateKeyFileOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/LoginUserPrivateKeyFileOption.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.os.Os;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+class LoginUserPrivateKeyFileOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(LoginUserPrivateKeyFileOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (v != null) {
+            String privateKeyFileName = v.toString();
+            String privateKey;
+            try {
+                privateKey = Files.toString(new File(Os.tidyPath(privateKeyFileName)), Charsets.UTF_8);
+            } catch (IOException e) {
+                LOG.error(privateKeyFileName + "not found", e);
+                throw Exceptions.propagate(e);
+            }
+            t.overrideLoginPrivateKey(privateKey);
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/NetworkNameOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/NetworkNameOption.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
+import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class NetworkNameOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(NetworkNameOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof AWSEC2TemplateOptions) {
+            // subnet ID is the sensible interpretation of network name in EC2
+            ((AWSEC2TemplateOptions) t).subnetId((String) v);
+
+        } else {
+            if (isGoogleComputeTemplateOptions(t)) {
+                // no warning needed
+                // we think this is the only jclouds endpoint which supports this option
+
+            } else if (t instanceof SoftLayerTemplateOptions) {
+                LOG.warn("networkName is not be supported in SoftLayer; use `templateOptions` with `primaryNetworkComponentNetworkVlanId` or `primaryNetworkBackendComponentNetworkVlanId`");
+            } else if (!(t instanceof CloudStackTemplateOptions) && !(t instanceof NovaTemplateOptions)) {
+                LOG.warn("networkName is experimental in many jclouds endpoints may not be supported in this cloud");
+                // NB, from @andreaturli
+//                                Cloudstack uses custom securityGroupIds and networkIds not the generic networks
+//                                Openstack Nova uses securityGroupNames which is marked as @deprecated (suggests to use groups which is maybe even more confusing)
+//                                Azure supports the custom networkSecurityGroupName
+            }
+
+            t.networks((String) v);
+        }
+    }
+
+    /**
+     * Avoid having a dependency on googlecompute because it doesn't have an OSGi bundle yet.
+     * Fixed in jclouds 2.0.0-SNAPSHOT
+     */
+    private static boolean isGoogleComputeTemplateOptions(TemplateOptions t) {
+        return t.getClass().getName().equals("org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions");
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/RunAsRootOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/RunAsRootOption.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+
+class RunAsRootOption implements TemplateOptionCustomizer {
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        t.runAsRoot((Boolean)v);
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/SecurityGroupOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/SecurityGroupOption.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.ec2.compute.options.EC2TemplateOptions;
+import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SecurityGroupOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityGroupOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof EC2TemplateOptions) {
+            String[] securityGroups = toStringArray(v);
+            ((EC2TemplateOptions) t).securityGroups(securityGroups);
+        } else if (t instanceof NovaTemplateOptions) {
+            String[] securityGroups = toStringArray(v);
+            t.securityGroups(securityGroups);
+        } else if (t instanceof SoftLayerTemplateOptions) {
+            String[] securityGroups = toStringArray(v);
+            t.securityGroups(securityGroups);
+        } else if (isGoogleComputeTemplateOptions(t)) {
+            String[] securityGroups = toStringArray(v);
+            t.securityGroups(securityGroups);
+        } else {
+            LOG.info("ignoring securityGroups({}) in VM creation because not supported for cloud/type ({})", v, t.getClass());
+        }
+    }
+
+    private String[] toStringArray(Object v) {
+        return Strings.toStringList(v).toArray(new String[0]);
+    }
+
+    /**
+     * Avoid having a dependency on googlecompute because it doesn't have an OSGi bundle yet.
+     * Fixed in jclouds 2.0.0-SNAPSHOT
+     */
+    private static boolean isGoogleComputeTemplateOptions(TemplateOptions t) {
+        return t.getClass().getName().equals("org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions");
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/StringTagsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/StringTagsOption.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.util.List;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class StringTagsOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(StringTagsOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        List<String> tags = Strings.toStringList(v);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("setting VM tags {} for {}", tags, t);
+        }
+        t.tags(tags);
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateBuilderCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateBuilderCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.domain.TemplateBuilder;
+
+public interface TemplateBuilderCustomizer {
+
+    void apply(TemplateBuilder tb, ConfigBag props, Object v);
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateBuilderCustomizers.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateBuilderCustomizers.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.javalang.Enums;
+import org.apache.brooklyn.util.text.ByteSizeStrings;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.domain.OsFamily;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.domain.TemplateBuilderSpec;
+
+public class TemplateBuilderCustomizers {
+
+    private TemplateBuilderCustomizers() {
+    }
+
+    public static TemplateBuilderCustomizer hardwareId() {
+        return new HardwareIdTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer imageDescription() {
+        return new ImageDescriptionRegexTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer imageId() {
+        return new ImageIdTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer imageNameRegex() {
+        return new ImageNameRegexTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer minCores() {
+        return new MinCoresTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer minDisk() {
+        return new MinDiskTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer minRam() {
+        return new MinRamTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer noOp() {
+        return new NoOpTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer os64Bit() {
+        return new Os64BitTemplateBuidler();
+    }
+
+    public static TemplateBuilderCustomizer osFamily() {
+        return new OsFamilyTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer osVersionRegex() {
+        return new OsVersionRegexTemplateBuilder();
+    }
+
+    public static TemplateBuilderCustomizer templateSpec() {
+        return new TemplateSpecTemplateBuilder();
+    }
+
+    private static class MinRamTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.minRam((int) (ByteSizeStrings.parse(Strings.toString(v), "mb") / 1000 / 1000));
+        }
+    }
+
+    private static class MinCoresTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.minCores(TypeCoercions.coerce(v, Double.class));
+        }
+    }
+
+    private static class MinDiskTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.minDisk((int) (ByteSizeStrings.parse(Strings.toString(v), "gb") / 1000 / 1000 / 1000));
+        }
+    }
+
+    private static class HardwareIdTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.hardwareId(v.toString());
+        }
+    }
+
+    private static class ImageIdTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.imageId(v.toString());
+        }
+    }
+
+    private static class ImageDescriptionRegexTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.imageDescriptionMatches(v.toString());
+        }
+    }
+
+    private static class ImageNameRegexTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.imageNameMatches(v.toString());
+        }
+    }
+
+    private static class OsFamilyTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            Maybe<OsFamily> osFamily = Enums.valueOfIgnoreCase(OsFamily.class, v.toString());
+            if (osFamily.isAbsent()) {
+                throw new IllegalArgumentException("Invalid " + JcloudsLocationConfig.OS_FAMILY + " value " + v);
+            }
+            tb.osFamily(osFamily.get());
+        }
+    }
+
+    private static class OsVersionRegexTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.osVersionMatches(v.toString());
+        }
+    }
+
+    private static class TemplateSpecTemplateBuilder implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            tb.from(TemplateBuilderSpec.parse(v.toString()));
+        }
+    }
+
+    private static class Os64BitTemplateBuidler implements TemplateBuilderCustomizer {
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+            Boolean os64Bit = TypeCoercions.coerce(v, Boolean.class);
+            if (os64Bit != null) {
+                tb.os64Bit(os64Bit);
+            }
+        }
+    }
+
+    private static class NoOpTemplateBuilder implements TemplateBuilderCustomizer {
+        @Override
+        public void apply(TemplateBuilder tb, ConfigBag props, Object v) {
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.jclouds.compute.options.TemplateOptions;
+
+public interface TemplateOptionCustomizer {
+
+    void apply(TemplateOptions tb, ConfigBag props, Object v);
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionCustomizers.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionCustomizers.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+// Has "2" in its name so JcloudsLocation can use it without having to use a fully qualified reference.
+public class TemplateOptionCustomizers {
+
+    private TemplateOptionCustomizers() {}
+
+    public static TemplateOptionCustomizer autoAssignFloatingIp() {
+        return new AutoAssignFloatingIpOption();
+    }
+
+    public static TemplateOptionCustomizer autoCreateFloatingIps() {
+        return new AutoCreateFloatingIpsOption();
+    }
+
+    public static TemplateOptionCustomizer autoGenerateKeypairs() {
+        return new AutoGenerateKeypairsOption();
+    }
+
+    public static TemplateOptionCustomizer domainName() {
+        return new DomainNameOption();
+    }
+
+    public static TemplateOptionCustomizer extraPublicKeyDataToAuth() {
+        return new ExtraPublicKeyDataToAuthOption();
+    }
+
+    public static TemplateOptionCustomizer inboundPorts() {
+        return new InboundPortsOption();
+    }
+
+    public static TemplateOptionCustomizer keyPair() {
+        return new KeyPairOption();
+    }
+
+    public static TemplateOptionCustomizer loginUser() {
+        return new LoginUserOption();
+    }
+
+    public static TemplateOptionCustomizer loginUserPassword() {
+        return new LoginUserPasswordOption();
+    }
+
+    public static TemplateOptionCustomizer loginUserPrivateKeyData() {
+        return new LoginUserPrivateKeyDataOption();
+    }
+
+    public static TemplateOptionCustomizer loginUserPrivateKeyFile() {
+        return new LoginUserPrivateKeyFileOption();
+    }
+
+    public static TemplateOptionCustomizer networkName() {
+        return new NetworkNameOption();
+    }
+
+    public static TemplateOptionCustomizer runAsRoot() {
+        return new RunAsRootOption();
+    }
+
+    public static TemplateOptionCustomizer securityGroups() {
+        return new SecurityGroupOption();
+    }
+
+    public static TemplateOptionCustomizer stringTags() {
+        return new StringTagsOption();
+    }
+
+    public static TemplateOptionCustomizer templateOptions() {
+        return new TemplateOptionsOption();
+    }
+
+    public static TemplateOptionCustomizer userDataUuencoded() {
+        return new UserDataUuencodedOption();
+    }
+
+    public static TemplateOptionCustomizer userMetadataMap() {
+        return new UserMetadataMapOption();
+    }
+
+    public static TemplateOptionCustomizer userMetadataString() {
+        return new UserMetadataStringOption();
+    }
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.util.Map;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.MethodCoercions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class TemplateOptionsOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(TemplateOptionsOption.class);
+
+    @Override
+    public void apply(TemplateOptions options, ConfigBag config, Object v) {
+        if (v == null) return;
+        @SuppressWarnings("unchecked") Map<String, Object> optionsMap = (Map<String, Object>) v;
+        if (optionsMap.isEmpty()) return;
+
+        Class<? extends TemplateOptions> clazz = options.getClass();
+        for (final Map.Entry<String, Object> option : optionsMap.entrySet()) {
+            if (option.getValue() != null) {
+                Maybe<?> result = MethodCoercions.tryFindAndInvokeBestMatchingMethod(options, option.getKey(), option.getValue());
+                if (result.isAbsent()) {
+                    LOG.warn("Ignoring request to set template option {} because this is not supported by {}", new Object[]{option.getKey(), clazz.getCanonicalName()});
+                }
+            } else {
+                // jclouds really doesn't like you to pass nulls; don't do it! For us,
+                // null is the only way to remove an inherited value when the templateOptions
+                // map is being merged.
+                LOG.debug("Ignoring request to set template option {} because value is null", new Object[]{option.getKey(), clazz.getCanonicalName()});
+            }
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserDataUuencodedOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserDataUuencodedOption.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.ec2.compute.options.EC2TemplateOptions;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UserDataUuencodedOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(UserDataUuencodedOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof EC2TemplateOptions) {
+            byte[] bytes = toByteArray(v);
+            ((EC2TemplateOptions) t).userData(bytes);
+        } else if (t instanceof SoftLayerTemplateOptions) {
+            ((SoftLayerTemplateOptions) t).userData(Strings.toString(v));
+        } else {
+            LOG.info("ignoring userData({}) in VM creation because not supported for cloud/type ({})", v, t.getClass());
+        }
+    }
+
+    private byte[] toByteArray(Object v) {
+        if (v instanceof byte[]) {
+            return (byte[]) v;
+        } else if (v instanceof CharSequence) {
+            return v.toString().getBytes();
+        } else {
+            throw new IllegalArgumentException("Invalid type for byte[]: " + v + " of type " + v.getClass());
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserMetadataMapOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserMetadataMapOption.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.util.Map;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.KeyValueParser;
+import org.jclouds.compute.options.TemplateOptions;
+
+import com.google.common.collect.Maps;
+
+class UserMetadataMapOption implements TemplateOptionCustomizer {
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (v != null) {
+            t.userMetadata(toMapStringString(v));
+        }
+    }
+    private Map<String,String> toMapStringString(Object v) {
+        if (v instanceof Map<?,?>) {
+            Map<String,String> result = Maps.newLinkedHashMap();
+            for (Map.Entry<?,?> entry : ((Map<?,?>)v).entrySet()) {
+                String key = entry.getKey().toString();
+                String value = entry.getValue().toString();
+                result.put(key, value);
+            }
+            return result;
+        } else if (v instanceof CharSequence) {
+            return KeyValueParser.parseMap(v.toString());
+        } else {
+            throw new IllegalArgumentException("Invalid type for Map<String,String>: " + v +
+                    (v != null ? " of type "+v.getClass() : ""));
+        }
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserMetadataStringOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/UserMetadataStringOption.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.location.jclouds.templates.customize;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.ec2.compute.options.EC2TemplateOptions;
+import org.jclouds.softlayer.compute.options.SoftLayerTemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UserMetadataStringOption implements TemplateOptionCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(UserMetadataStringOption.class);
+
+    public void apply(TemplateOptions t, ConfigBag props, Object v) {
+        if (t instanceof EC2TemplateOptions) {
+            // See AWS docs: http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/UsingConfig_WinAMI.html#user-data-execution
+            if (v == null) return;
+            String data = v.toString();
+            if (!(data.startsWith("<script>") || data.startsWith("<powershell>"))) {
+                data = "<script> " + data + " </script>";
+            }
+            ((EC2TemplateOptions) t).userData(data.getBytes());
+        } else if (t instanceof SoftLayerTemplateOptions) {
+            ((SoftLayerTemplateOptions) t).userData(Strings.toString(v));
+        } else {
+            // Try reflection: userData(String), or guestCustomizationScript(String);
+            // the latter is used by vCloud Director.
+            Class<? extends TemplateOptions> clazz = t.getClass();
+            Method userDataMethod = null;
+            try {
+                userDataMethod = clazz.getMethod("userData", String.class);
+            } catch (SecurityException e) {
+                LOG.info("Problem reflectively inspecting methods of " + t.getClass() + " for setting userData", e);
+            } catch (NoSuchMethodException e) {
+                try {
+                    // For vCloud Director
+                    userDataMethod = clazz.getMethod("guestCustomizationScript", String.class);
+                } catch (NoSuchMethodException e2) {
+                    // expected on various other clouds
+                }
+            }
+            if (userDataMethod != null) {
+                try {
+                    userDataMethod.invoke(t, Strings.toString(v));
+                } catch (InvocationTargetException e) {
+                    LOG.info("Problem invoking " + userDataMethod.getName() + " of " + t.getClass() + ", for setting userData (rethrowing)", e);
+                    throw Exceptions.propagate(e);
+                } catch (IllegalAccessException e) {
+                    LOG.debug("Unable to reflectively invoke " + userDataMethod.getName() + " of " + t.getClass() + ", for setting userData (rethrowing)", e);
+                    throw Exceptions.propagate(e);
+                }
+            } else {
+                LOG.info("ignoring userDataString({}) in VM creation because not supported for cloud/type ({})", v, t.getClass());
+            }
+        }
+    }
+}

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTemplateOptionsCustomisersLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTemplateOptionsCustomisersLiveTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.location.jclouds.templates.customize.TemplateOptionCustomizer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
 import org.jclouds.compute.options.TemplateOptions;
@@ -98,7 +99,7 @@ public class JcloudsLocationTemplateOptionsCustomisersLiveTest extends AbstractJ
         checkState(locationConfig.containsKey(keyToTest),
                 "location config does not contain the key " + keyToTest.getName());
 
-        JcloudsLocation.CustomizeTemplateOptions code = JcloudsLocation.SUPPORTED_TEMPLATE_OPTIONS_PROPERTIES.get(keyToTest);
+        TemplateOptionCustomizer code = JcloudsLocation.SUPPORTED_TEMPLATE_OPTIONS_PROPERTIES.get(keyToTest);
         code.apply(templateOptions, locationConfig, locationConfig.get(keyToTest));
     }
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.location.LocationSpec;
@@ -41,7 +40,6 @@ import org.apache.brooklyn.core.location.cloud.names.CustomMachineNamer;
 import org.apache.brooklyn.core.location.geo.HostGeoInfo;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import org.apache.brooklyn.location.jclouds.JcloudsLocation.UserCreation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -580,8 +578,8 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
                         .put(JcloudsLocationConfig.USER, "bob").put(JcloudsLocationConfig.LOGIN_USER_PASSWORD, "b0b")
                         .putAll(config).build());
 
-        UserCreation creation = jl.createUserStatements(null, jl.config().getBag());
-        return new StatementList(creation.statements).render(OsFamily.UNIX);
+        CreateUserStatements creation = CreateUserStatements.get(jl, null, jl.config().getBag());
+        return new StatementList(creation.statements()).render(OsFamily.UNIX);
     }
     
     @Test

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -491,6 +491,8 @@ public abstract class MachineLifecycleEffectorTasks {
                 SshMachineLocation sshMachine = (SshMachineLocation) machine;
                 UserAndHostAndPort sshAddress = UserAndHostAndPort.fromParts(
                         sshMachine.getUser(), sshMachine.getAddress().getHostName(), sshMachine.getPort());
+                // FIXME: Who or what is SSH_ADDRESS intended for? It's not necessarily the address that
+                // the SshMachineLocation is using for ssh connections (because it accepts SSH_HOST as an override).
                 entity().sensors().set(Attributes.SSH_ADDRESS, sshAddress);
             }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -115,7 +115,7 @@ import com.google.common.reflect.TypeToken;
  *  <li> {@link #preStopCustom()}
  *  <li> {@link #postStopCustom()}
  * </ul>
- * Note methods at this level typically look after the {@link Attributes#SERVICE_STATE} sensor.
+ * Note methods at this level typically look after the {@link Attributes#SERVICE_STATE_ACTUAL} sensor.
  *
  * @since 0.6.0
  */
@@ -489,7 +489,8 @@ public abstract class MachineLifecycleEffectorTasks {
             entity().sensors().set(Attributes.ADDRESS, machine.getAddress().getHostAddress());
             if (machine instanceof SshMachineLocation) {
                 SshMachineLocation sshMachine = (SshMachineLocation) machine;
-                UserAndHostAndPort sshAddress = UserAndHostAndPort.fromParts(sshMachine.getUser(), sshMachine.getAddress().getHostName(), sshMachine.getPort());
+                UserAndHostAndPort sshAddress = UserAndHostAndPort.fromParts(
+                        sshMachine.getUser(), sshMachine.getAddress().getHostName(), sshMachine.getPort());
                 entity().sensors().set(Attributes.SSH_ADDRESS, sshAddress);
             }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
-
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.util.collections.MutableList;
@@ -44,7 +43,9 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 
 public class Strings {
@@ -824,6 +825,33 @@ public class Strings {
         if (list==null) return null;
         List<String> result = MutableList.of();
         for (Object v: list) result.add(toStringWithValueForNull(v, valueIfNull));
+        return result;
+    }
+
+    /**
+     * Tries to convert v to a list of strings.
+     * <p>
+     * If v is <code>null</code> then the method returns an empty immutable list.
+     * If v is {@link Iterable} or an <code>Object[]</code> then toString is called on its elements.
+     * If v is a {@link String} then a singleton list containing v is returned.
+     * Otherwise the method throws an {@link IllegalArgumentException}.
+     */
+    public static List<String> toStringList(Object v) {
+        if (v == null) return ImmutableList.of();
+        List<String> result = Lists.newArrayList();
+        if (v instanceof Iterable) {
+            for (Object o : (Iterable<?>) v) {
+                result.add(o.toString());
+            }
+        } else if (v instanceof Object[]) {
+            for (int i = 0; i < ((Object[]) v).length; i++) {
+                result.add(((Object[]) v)[i].toString());
+            }
+        } else if (v instanceof String) {
+            result.add((String) v);
+        } else {
+            throw new IllegalArgumentException("Invalid type for List<String>: " + v + " of type " + v.getClass());
+        }
         return result;
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
@@ -202,8 +202,17 @@ public class Duration implements Comparable<Duration>, Serializable {
             }
         };
 
-    /** tries to convert given object to a Duration, parsing strings, treating numbers as millis, etc;
-     * throws IAE if not convertible */
+    /**
+     * Converts the given object to a Duration by attempting the following in order:
+     * <ol>
+     *     <li>return null if the object is null</li>
+     *     <li>{@link #parse(String) parse} the object as a string</li>
+     *     <li>treat numbers as milliseconds</li>
+     *     <li>obtain the elapsed time of a {@link Stopwatch}</li>
+     *     <li>invoke the object's <code>toMilliseconds</code> method, if one exists.</li>
+     * </ol>
+     * If none of these cases work the method throws an {@link IllegalArgumentException}.
+     */
     public static Duration of(Object o) {
         if (o == null) return null;
         if (o instanceof Duration) return (Duration)o;


### PR DESCRIPTION
I took the opportunity to move a number of the supporting classes in `JcloudsLocation` to their own top-level classes. I particular I touched `RebindToMachinePredicate`, the logic for creating users, and all of the `CustomizeTemplateOptions` and `CustomizeTemplateBuilders`.

It's a fairly large PR but I haven't introduced much that's new or changed any existing functionality. Most of it is ASF license headers. 

Suggest reviewing it with whitespace changes disabled (append `?w=1` to GitHub's URL).