### PR TITLE
Change default `machineCreateAttempts` to 3

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationConfig.java
@@ -261,7 +261,7 @@ public interface JcloudsLocationConfig extends CloudLocationConfig {
             .PORT_FORWARDING_MANAGER;
 
     public static final ConfigKey<Integer> MACHINE_CREATE_ATTEMPTS = ConfigKeys.newIntegerConfigKey(
-            "machineCreateAttempts", "Number of times to retry if jclouds fails to create a VM", 1);
+            "machineCreateAttempts", "Number of times to retry if jclouds fails to create a VM", 3);
 
     public static final ConfigKey<Integer> MAX_CONCURRENT_MACHINE_CREATIONS = ConfigKeys.newIntegerConfigKey(
             "maxConcurrentMachineCreations", "Maximum number of concurrent machine-creations", Integer.MAX_VALUE);


### PR DESCRIPTION
In testing I've found that increasing the `machineCreateAttempts` to 3 makes the provisioning of machines more robust. I think it should be made default.