### PR TITLE
Get ready for compiling with JDK 1.8 / Java 1.8

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -486,8 +486,8 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             if (targetEntityMaybe.isAbsent()) return Maybe.absent("Target entity not available");
             EntityInternal targetEntity = (EntityInternal) targetEntityMaybe.get();
 
-            ConfigKey<?> key = targetEntity.getEntityType().getConfigKey(keyName);
-            Maybe<? extends Object> result = targetEntity.config().getNonBlocking(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
+            ConfigKey key = targetEntity.getEntityType().getConfigKey(keyName);
+            Maybe result = targetEntity.config().getNonBlocking(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
             return Maybe.<Object>cast(result);
         }
 
@@ -501,7 +501,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
                         @Override
                         public Object call() throws Exception {
                             Entity targetEntity = component.get();
-                            ConfigKey<?> key = targetEntity.getEntityType().getConfigKey(keyName);
+                            ConfigKey key = targetEntity.getEntityType().getConfigKey(keyName);
                             return targetEntity.getConfig(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
                         }})
                     .build();

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -486,8 +486,8 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
             if (targetEntityMaybe.isAbsent()) return Maybe.absent("Target entity not available");
             EntityInternal targetEntity = (EntityInternal) targetEntityMaybe.get();
 
-            ConfigKey key = targetEntity.getEntityType().getConfigKey(keyName);
-            Maybe result = targetEntity.config().getNonBlocking(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
+            ConfigKey<Object> key = (ConfigKey<Object>) targetEntity.getEntityType().getConfigKey(keyName);
+            Maybe<Object> result = targetEntity.config().getNonBlocking(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
             return Maybe.<Object>cast(result);
         }
 
@@ -501,7 +501,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> {
                         @Override
                         public Object call() throws Exception {
                             Entity targetEntity = component.get();
-                            ConfigKey key = targetEntity.getEntityType().getConfigKey(keyName);
+                            ConfigKey<Object> key = (ConfigKey<Object>) targetEntity.getEntityType().getConfigKey(keyName);
                             return targetEntity.getConfig(key != null ? key : ConfigKeys.newConfigKey(Object.class, keyName));
                         }})
                     .build();

--- a/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
@@ -225,7 +225,7 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     @Test
     public void testSetConfigKeyClear() throws Exception {
         entity.config().set(TestEntity.CONF_SET_THING.subKey(), "aval");
-        entity.config().set((ConfigKey)TestEntity.CONF_SET_THING, SetModifications.clearing());
+        entity.config().set((ConfigKey)TestEntity.CONF_SET_THING, (Object) SetModifications.clearing());
         // for now defaults to null, but empty list might be better? or whatever the default is?
         assertEquals(entity.getConfig(TestEntity.CONF_SET_THING), null);
     }
@@ -286,7 +286,7 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     @Test // ListConfigKey deprecated, as order no longer guaranteed
     public void testListConfigKeyClear() throws Exception {
         entity.config().set(TestEntity.CONF_LIST_THING.subKey(), "aval");
-        entity.config().set((ConfigKey)TestEntity.CONF_LIST_THING, ListModifications.clearing());
+        entity.config().set((ConfigKey)TestEntity.CONF_LIST_THING, (Object) ListModifications.clearing());
         // for now defaults to null, but empty list might be better? or whatever the default is?
         assertEquals(entity.getConfig(TestEntity.CONF_LIST_THING), null);
     }
@@ -342,7 +342,7 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     @Test
     public void testMapConfigClearMod() throws Exception {
         entity.config().set(TestEntity.CONF_MAP_THING.subKey("akey"), "aval");
-        entity.config().set((ConfigKey)TestEntity.CONF_MAP_THING, MapModifications.clearing());
+        entity.config().set((ConfigKey)TestEntity.CONF_MAP_THING, (Object) MapModifications.clearing());
         // for now defaults to null, but empty map might be better? or whatever the default is?
         assertEquals(entity.getConfig(TestEntity.CONF_MAP_THING), null);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
 
         <!-- Compilation -->
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
 
         <!-- Compilation -->
-        <java.version>1.8</java.version>
+        <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/EnumTypeCoercions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/EnumTypeCoercions.java
@@ -70,11 +70,11 @@ public class EnumTypeCoercions {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <T> Maybe<T> tryCoerceUntyped(String input, Class<T> targetType) {
+    public static Maybe tryCoerceUntyped(String input, Class targetType) {
         if (input==null) return null;
         if (targetType==null) return Maybe.absent("Null enum type");
         if (!targetType.isEnum()) return Maybe.absent("Type '"+targetType+"' is not an enum");
-        return tryCoerce(input, (Class)targetType);
+        return tryCoerce(input, targetType);
     }
     
     public static <E extends Enum<E>> Maybe<E> tryCoerce(String input, Class<E> targetType) {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/EnumTypeCoercions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/EnumTypeCoercions.java
@@ -43,7 +43,7 @@ public class EnumTypeCoercions {
      * <p>
      * Returns {@code defaultValue} if the string cannot be converted.
      *
-     * @see TypeCoercions#coerce(Object, Class)
+     * @see EnumTypeCoercions#tryCoerce(String, Class)
      * @see Enum#valueOf(Class, String)
      */
     public static <E extends Enum<E>> Function<String, E> stringToEnum(final Class<E> type, @Nullable final E defaultValue) {
@@ -74,7 +74,7 @@ public class EnumTypeCoercions {
         if (input==null) return null;
         if (targetType==null) return Maybe.absent("Null enum type");
         if (!targetType.isEnum()) return Maybe.absent("Type '"+targetType+"' is not an enum");
-        return tryCoerce(input, (Class<Enum>)targetType);
+        return tryCoerce(input, (Class)targetType);
     }
     
     public static <E extends Enum<E>> Maybe<E> tryCoerce(String input, Class<E> targetType) {


### PR DESCRIPTION
These changes are needed to compile Brooklyn with JDK 1.8, if/when we switch to Java 1.8.
At the same time they work with 1.7, which remains the selected `java.version` for compiling.

 - minor source changes (generics)