### PR TITLE
(WIP) execAsync parameter for SshMachineLocation#execCommand

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Callable;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.location.MachineDetails;
+import org.apache.brooklyn.api.location.NoMachinesAvailableException;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
@@ -48,6 +49,7 @@ import org.apache.brooklyn.util.core.internal.ssh.sshj.SshjTool;
 import org.apache.brooklyn.util.core.internal.ssh.sshj.SshjTool.SshjToolBuilder;
 import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.net.Urls;
@@ -78,8 +80,11 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
     
     @Override
     protected SshMachineLocation newHost() {
-        return mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", Networking.getLocalHost()));
+        try {
+            return ((LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().getLocationManaged("localhost")).obtain();
+        } catch (NoMachinesAvailableException e) {
+            throw Exceptions.propagate(e);
+        }
     }
 
     // Overridden just to make it integration (because `newHost()` returns a real ssh'ing host)
@@ -207,6 +212,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
     // For issue #230
     @Test(groups = "Integration")
     public void testOverridingPropertyOnExec() throws Exception {
+        // TODO check what that test does and its correctness
         SshMachineLocation host = new SshMachineLocation(MutableMap.of("address", Networking.getLocalHost(), "sshPrivateKeyData", "wrongdata"));
         
         OutputStream outStream = new ByteArrayOutputStream();
@@ -257,7 +263,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
         // For explanation of (some of) the magic behind this command, see http://stackoverflow.com/a/229606/68898
         final String command = "if [[ \"$0\" == \"/var/tmp/\"* ]]; then true; else false; fi";
 
-        LocalhostMachineProvisioningLocation lhp = mgmt.getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.class));
+        LocalhostMachineProvisioningLocation lhp = (LocalhostMachineProvisioningLocation)mgmt.getLocationRegistry().getLocationManaged("localhost");
         SshMachineLocation sm = lhp.obtain();
 
         Map<String, Object> props = ImmutableMap.<String, Object>builder()
@@ -276,9 +282,9 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
                 .put(SshMachineLocation.SCRIPT_DIR.getName(), "/var/tmp")
                 .build();
 
-        LocalhostMachineProvisioningLocation lhp = 
-            mgmt.getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.class)
-                .configure(locationConfig));
+        LocalhostMachineProvisioningLocation lhp =
+                ((LocalhostMachineProvisioningLocation)mgmt.getLocationRegistry().getLocationManaged("localhost"))
+                .configure(locationConfig);
         SshMachineLocation sm = lhp.obtain();
 
         int rc = sm.execScript("Test script directory execution", ImmutableList.of(command));
@@ -294,8 +300,8 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
                 .build();
 
         LocalhostMachineProvisioningLocation lhp = 
-            mgmt.getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.class)
-                .configure(locationConfig));
+                ((LocalhostMachineProvisioningLocation)mgmt.getLocationRegistry().getLocationManaged("localhost"))
+                .configure(locationConfig);
         SshMachineLocation sm = lhp.obtain();
 
         int rc = sm.execScript("Test script directory execution", ImmutableList.of(command));

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshjExecAsyncInSshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshjExecAsyncInSshMachineLocationIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.ssh;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.location.NoMachinesAvailableException;
+import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
+import org.apache.brooklyn.util.core.internal.ssh.sshj.SshjTool;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.brooklyn.util.core.internal.ssh.ShellTool.PROP_EXEC_ASYNC;
+import static org.apache.brooklyn.util.core.internal.ssh.SshTool.BROOKLYN_CONFIG_KEY_PREFIX;
+
+@Test(groups = "WIP")
+public class SshjExecAsyncInSshMachineLocationIntegrationTest extends SshMachineLocationIntegrationTest {
+    public static class RecordingSshjTool extends SshjTool {
+        public static final AtomicInteger execCount = new AtomicInteger(0);
+
+        public RecordingSshjTool(Map<String, ?> map) {
+            super(map);
+        }
+
+        @Override
+        protected int execScriptAsyncAndPoll(final Map<String,?> props, final List<String> commands, final Map<String,?> env) {
+            try {
+                return super.execScriptAsyncAndPoll(props, commands, env);
+            } finally {
+                execCount.incrementAndGet();
+            }
+        }
+    }
+    @Override
+    protected SshMachineLocation newHost() {
+        LocalhostMachineProvisioningLocation localhostMachineProvisioningLocation = (LocalhostMachineProvisioningLocation) mgmt.getLocationRegistry().getLocationManaged("localhost");
+        localhostMachineProvisioningLocation.config().putAll(ImmutableMap.of(BROOKLYN_CONFIG_KEY_PREFIX + PROP_EXEC_ASYNC.getName(), true));
+        localhostMachineProvisioningLocation.config().set(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshjTool.class.getName());
+        try {
+            return localhostMachineProvisioningLocation.obtain();
+        } catch (NoMachinesAvailableException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    // TODO fix failing test
+    @Test(groups = "Integration")
+    @Override
+    public void testSshExecScript() throws Exception {
+        super.testSshExecScript();
+        Assert.assertEquals(RecordingSshjTool.execCount.get(), 1);
+    }
+
+    @Test(groups = "Integration")
+    @Override
+    public void testGetMachineDetails() throws Exception {
+        super.testGetMachineDetails();
+        Assert.assertEquals(RecordingSshjTool.execCount.get(), 1);
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        super.tearDown();
+        RecordingSshjTool.execCount.set(0);
+    }
+}


### PR DESCRIPTION
This enables ssh machine location to always use that flag for execCommand and execScript
```
location:
  jclouds:vcloud-director:
    brooklyn.ssh.config.execAsync: true
services:
- type: catalog-item
```