### PR TITLE
Allow a user to add or override deserialize configuration in karaf

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/ClasspathConfigLoader.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/ClasspathConfigLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.persist;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.stream.Streams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+/**
+ * Loads the class-renames from the configuration file on the classpath.
+ *
+ * @see {@link #DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH}
+ */
+public class ClasspathConfigLoader implements ConfigLoader {
+    private static final Logger LOG = LoggerFactory.getLogger(ClasspathConfigLoader.class);
+    private static final String DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH = "classpath://org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties";
+
+
+    @Override
+    public Map<String, String> load() {
+        try {
+            InputStream resource = new ResourceUtils(DeserializingClassRenamesProvider.class).getResourceFromUrl(DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH);
+
+            try {
+                Properties props = new Properties();
+                props.load(resource);
+
+                Map<String, String> result = Maps.newLinkedHashMap();
+                for (Enumeration<?> iter = props.propertyNames(); iter.hasMoreElements(); ) {
+                    String key = (String) iter.nextElement();
+                    String value = props.getProperty(key);
+                    result.put(key, value);
+                }
+                return result;
+            } catch (IOException e) {
+                throw Exceptions.propagate(e);
+            } finally {
+                Streams.closeQuietly(resource);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to load class-renames from " + DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH + " (continuing)", e);
+            return ImmutableMap.<String, String>of();
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/ConfigLoader.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/ConfigLoader.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.persist;
+
+import java.util.Map;
+
+public interface ConfigLoader {
+    public Map<String, String> load();
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingClassRenamesProvider.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingClassRenamesProvider.java
@@ -18,67 +18,74 @@
  */
 package org.apache.brooklyn.core.mgmt.persist;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
-import org.apache.brooklyn.util.core.ResourceUtils;
-import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.Reflections;
-import org.apache.brooklyn.util.stream.Streams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 
+/*
+ * This provider keeps a cache of the class-renames, which is lazily populated (see {@link #cache}.
+ * Calling {@link #reset()} will set this cache to null, causing it to be reloaded next time
+ * it is requested.
+ *
+ * Loading the cache involves iterating over the {@link #loaders}, returning the union of
+ * the results from {@link Loader#load()}.
+ *
+ * Initially, the only loader is the basic {@link ClasspathConfigLoader}.
+ *
+ * However, when running in karaf the {@link OsgiConfigLoader} will be instantiated and added.
+ * See karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+ */
 @Beta
 public class DeserializingClassRenamesProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(DeserializingClassRenamesProvider.class);
 
-    public static final String DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH = "classpath://org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties";
+    private static final List<ConfigLoader> loaders = Lists.newCopyOnWriteArrayList();
+    static {
+        loaders.add(new ClasspathConfigLoader());
+    }
     
     private static volatile Map<String, String> cache;
-    
-    @Beta
-    public static Map<String, String> loadDeserializingClassRenames() {
-        // Double-checked locking - got to use volatile or some such!
-        if (cache == null) {
-            synchronized (DeserializingClassRenamesProvider.class) {
-                if (cache == null) {
-                    cache = loadDeserializingClassRenamesCache();
-                }
-            }
-        }
-        return cache;
-    }
-    
-    private static Map<String, String> loadDeserializingClassRenamesCache() {
-        InputStream resource = new ResourceUtils(DeserializingClassRenamesProvider.class).getResourceFromUrl(DESERIALIZING_CLASS_RENAMES_PROPERTIES_PATH);
-        if (resource != null) {
-            try {
-                Properties props = new Properties();
-                props.load(resource);
-                
-                Map<String, String> result = Maps.newLinkedHashMap();
-                for (Enumeration<?> iter = props.propertyNames(); iter.hasMoreElements();) {
-                    String key = (String) iter.nextElement();
-                    String value = props.getProperty(key);
-                    result.put(key, value);
-                }
-                return result;
-            } catch (IOException e) {
-                throw Exceptions.propagate(e);
-            } finally {
-                Streams.closeQuietly(resource);
-            }
-        } else {
-            return ImmutableMap.<String, String>of();
-        }
+
+    public static List<ConfigLoader> getLoaders() {
+        return loaders;
     }
 
     @Beta
+    public static Map<String, String> loadDeserializingClassRenames() {
+        synchronized (DeserializingClassRenamesProvider.class) {
+            if (cache == null) {
+                MutableMap.Builder<String, String> builder = MutableMap.<String, String>builder();
+                for (ConfigLoader loader : loaders) {
+                    builder.putAll(loader.load());
+                }
+                cache = builder.build();
+                LOG.info("Class-renames cache loaded, size {}", cache.size());
+            }
+            return cache;
+        }
+    }
+
+    /**
+     * Handles inner classes, where the outer class has been renamed. For example:
+     * 
+     * {@code findMappedName("com.example.MyFoo$MySub")} will return {@code com.example.renamed.MyFoo$MySub}, if
+     * the renamed contains {@code com.example.MyFoo: com.example.renamed.MyFoo}.
+     */
+    @Beta
     public static String findMappedName(String name) {
-        return Reflections.findMappedNameAndLog(loadDeserializingClassRenames(), name);
+        return Reflections.findMappedNameAndLog(DeserializingClassRenamesProvider.loadDeserializingClassRenames(), name);
+    }
+
+    public static void reset() {
+        synchronized (DeserializingClassRenamesProvider.class) {
+            cache = null;
+        }
     }
 }

--- a/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiConfigLoader.java
+++ b/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiConfigLoader.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.launcher.osgi;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.core.mgmt.persist.ConfigLoader;
+import org.apache.brooklyn.core.mgmt.persist.DeserializingClassRenamesProvider;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.osgi.framework.Constants;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Loads the class-renames from the OSGi configuration file: {@code org.apache.brooklyn.classrename.cfg}.
+ *
+ * Only public for OSGi instantiation - treat as an internal class, which may change in
+ * future releases.
+ *
+ * See http://stackoverflow.com/questions/18844987/creating-a-blueprint-bean-from-an-inner-class:
+ * we unfortunately need to include {@code !org.apache.brooklyn.core.mgmt.persist.DeserializingClassRenamesProvider}
+ * in the Import-Package, as the mvn plugin gets confused due to the use of this inner class
+ * within the blueprint.xml.
+ *
+ * @see {@link #KARAF_DESERIALIZING_CLASS_RENAMES_PROPERTIES}
+ */
+public class OsgiConfigLoader implements ConfigLoader {
+    private static final Logger LOG = LoggerFactory.getLogger(OsgiConfigLoader.class);
+    private static final List<String> EXCLUDED_KEYS = ImmutableList.of("service.pid", "felix.fileinstall.filename");
+    private static final String KARAF_DESERIALIZING_CLASS_RENAMES_PROPERTIES = "org.apache.brooklyn.classrename";
+
+    private ConfigurationAdmin configAdmin;
+
+    public OsgiConfigLoader() {
+        LOG.trace("OsgiConfigLoader instance created");
+    }
+
+    // For injection as OSGi bean
+    public void setConfigAdmin(ConfigurationAdmin configAdmin) {
+        this.configAdmin = configAdmin;
+    }
+
+    // Called by OSGi
+    public void init() {
+        LOG.trace("DeserializingClassRenamesProvider.OsgiConfigLoader.init: registering loader");
+        DeserializingClassRenamesProvider.getLoaders().add(this);
+        DeserializingClassRenamesProvider.reset();
+    }
+
+    // Called by OSGi
+    public void destroy() {
+        LOG.trace("DeserializingClassRenamesProvider.OsgiConfigLoader.destroy: unregistering loader");
+        boolean removed = DeserializingClassRenamesProvider.getLoaders().remove(this);
+        if (removed) {
+            DeserializingClassRenamesProvider.reset();
+        }
+    }
+
+    // Called by OSGi when configuration changes
+    public void updateProperties(Map properties) {
+        LOG.debug("DeserializingClassRenamesProvider.OsgiConfigLoader.updateProperties: clearing cache, so class-renames will be reloaded");
+        DeserializingClassRenamesProvider.reset();
+    }
+
+    @Override
+    public Map<String, String> load() {
+        if (configAdmin == null) {
+            LOG.warn("No OSGi configuration-admin available - cannot load {}.cfg", KARAF_DESERIALIZING_CLASS_RENAMES_PROPERTIES);
+            return ImmutableMap.of();
+        }
+
+        String filter = '(' + Constants.SERVICE_PID + '=' + KARAF_DESERIALIZING_CLASS_RENAMES_PROPERTIES + ')';
+        Configuration[] configs;
+
+        try {
+            configs = configAdmin.listConfigurations(filter);
+        } catch (InvalidSyntaxException | IOException e) {
+            LOG.info("Cannot list OSGi configurations");
+            throw Exceptions.propagate(e);
+        }
+
+        final MutableMap<String, String> map = MutableMap.of();
+        if (configs != null) {
+            for (Configuration config : configs) {
+                LOG.debug("Reading OSGi configuration from {}; bundleLocation={}", config.getPid(), config.getBundleLocation());
+                map.putAll(dictToMap(config.getProperties()));
+            }
+        } else {
+            LOG.info("No OSGi configuration found for {}.cfg", KARAF_DESERIALIZING_CLASS_RENAMES_PROPERTIES);
+        }
+
+        return map;
+    }
+
+    private Map<String, String> dictToMap(Dictionary<String, Object> props) {
+        Map<String, String> mapProps = MutableMap.of();
+        Enumeration<String> keyEnum = props.keys();
+        while (keyEnum.hasMoreElements()) {
+            String key = keyEnum.nextElement();
+            if (!EXCLUDED_KEYS.contains(key)) {
+                mapProps.put(key, (String) props.get(key));
+            }
+        }
+        return mapProps;
+    }
+}

--- a/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/karaf/init/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -47,10 +47,23 @@ limitations under the License.
         </cm:default-properties>
     </cm:property-placeholder>
 
+    <bean id="deserializingClassRenamesProvider"
+          class="org.apache.brooklyn.launcher.osgi.OsgiConfigLoader"
+          init-method="init"
+          destroy-method="destroy">
+
+        <property name="configAdmin" ref="configAdmin" />
+
+        <cm:managed-properties persistent-id="org.apache.brooklyn.classrename"
+                               update-method="updateProperties"
+                               update-strategy="component-managed" />
+    </bean>
+
     <bean id="launcher"
           class="org.apache.brooklyn.launcher.osgi.OsgiLauncher"
           init-method="init"
-          destroy-method="destroy">
+          destroy-method="destroy"
+          depends-on="deserializingClassRenamesProvider">
 
         <property name="brooklynVersion" ref="brooklynVersion" />
 


### PR DESCRIPTION
This will make the code search for another file `etc/org.apache.brooklyn.persistence.class.rename.properties` during the deserialization and load the properties accordingly.

The file `etc/org.apache.brooklyn.persistence.class.rename.properties` does not exist by default but can be created manually. The aim is for any blueprint author to setup rewrite rules for the persistence state, if some classnames from its own blueprints change. Of course, the default rules provided by Brooklyn are always loaded  