### PR TITLE
Fix JMX Karaf import

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -229,7 +229,7 @@
 
     <feature name="brooklyn-software-base"  version="${project.version}"  description="Brooklyn Software Base">
         <bundle>mvn:org.apache.brooklyn/brooklyn-software-base/${project.version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$DynamicImport-Package=javax.management.openmbean</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$Import-Package=javax.management.openmbean,*</bundle>
         <feature>brooklyn-software-winrm</feature>
         <feature>brooklyn-policy</feature>
     </feature>
@@ -237,7 +237,7 @@
     <feature name="brooklyn-jmxmp-agent" version="${project.version}" description="Brooklyn Secure JMXMP Agent">
         <bundle>mvn:org.apache.brooklyn/brooklyn-jmxmp-agent/${project.version}</bundle>
         <feature>brooklyn-core</feature>
-        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$DynamicImport-Package=javax.management.openmbean</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$Import-Package=javax.management.openmbean,*</bundle>
     </feature>
 
     <feature name="brooklyn-jmxrmi-agent" version="${project.version}" description="Brooklyn JMX RMI Agent">

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -229,7 +229,7 @@
 
     <feature name="brooklyn-software-base"  version="${project.version}"  description="Brooklyn Software Base">
         <bundle>mvn:org.apache.brooklyn/brooklyn-software-base/${project.version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$DynamicImport-Package=javax.management.openmbean</bundle>
         <feature>brooklyn-software-winrm</feature>
         <feature>brooklyn-policy</feature>
     </feature>
@@ -237,7 +237,7 @@
     <feature name="brooklyn-jmxmp-agent" version="${project.version}" description="Brooklyn Secure JMXMP Agent">
         <bundle>mvn:org.apache.brooklyn/brooklyn-jmxmp-agent/${project.version}</bundle>
         <feature>brooklyn-core</feature>
-        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}</bundle>
+        <bundle dependency="true">wrap:mvn:org.glassfish.external/opendmk_jmxremote_optional_jar/${opendmk_jmxremote_optional_jar.version}$DynamicImport-Package=javax.management.openmbean</bundle>
     </feature>
 
     <feature name="brooklyn-jmxrmi-agent" version="${project.version}" description="Brooklyn JMX RMI Agent">


### PR DESCRIPTION
JMX in a Tomcat deployment was failing in Karaf with the exception `java.lang.RuntimeException: java.io.IOException: java.lang.ClassNotFoundException: javax.management.openmbean.CompositeDataSupport`. This was because of a missing dependency from the wrap of `org.glassfish.external/opendmk_jmxremote_optional_jar`. 

Unfortunately adding an `$Import-Package=javax.management.openmbean` here would exclude the other files included from the jar so `$DynamicImport-Package` is used.