### PR TITLE
Add findOpenSocketsOnNode to ReachableSocketFinder

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
@@ -95,11 +95,13 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Module;
 
-public class JcloudsUtil implements JcloudsLocationConfig {
+public class JcloudsUtil {
 
     // TODO Review what utility methods are needed, and what is now supported in jclouds 1.1
 
     private static final Logger LOG = LoggerFactory.getLogger(JcloudsUtil.class);
+
+    private JcloudsUtil() {}
 
     /**
      * @deprecated since 0.7; see {@link BashCommands}

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationReachabilityPredicateInstantiationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationReachabilityPredicateInstantiationTest.java
@@ -37,7 +37,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JcloudsLocationReachabilityPredicateInstantiationTest {
-    public static final HostAndPort ALLOWED_HOST_AND_PORT = HostAndPort.fromParts("localhost", 223);
+
+    protected static final AtomicInteger TEST_INIT_MAP_AND_EMPTY_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
+    protected static final AtomicInteger TEST_INIT_DEFAULT_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
+    private static final AtomicInteger TEST_INIT_MAP_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
+    private static final HostAndPort ALLOWED_HOST_AND_PORT = HostAndPort.fromParts("localhost", 223);
+
     private BailOutJcloudsLocation jcloudsLocation;
 
     private final NodeMetadata node = new NodeMetadataBuilder()
@@ -62,7 +67,6 @@ public class JcloudsLocationReachabilityPredicateInstantiationTest {
         Assert.assertTrue(hostsMatchedHolder.contains(ALLOWED_HOST_AND_PORT.getHostText()));
     }
 
-    protected static final AtomicInteger TEST_INIT_DEFAULT_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
     @Test
     public void testInitDefaultConstructor() throws Exception {
         Assert.assertEquals(TEST_INIT_DEFAULT_CONSTRUCTOR_COUNTER.get(), 0);
@@ -72,7 +76,6 @@ public class JcloudsLocationReachabilityPredicateInstantiationTest {
         Assert.assertEquals(TEST_INIT_DEFAULT_CONSTRUCTOR_COUNTER.get(), 1);
     }
 
-    protected static final AtomicInteger TEST_INIT_MAP_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
     @Test
     public void testInitMapConstructor() {
         Assert.assertEquals(TEST_INIT_MAP_CONSTRUCTOR_COUNTER.get(), 0);
@@ -94,7 +97,6 @@ public class JcloudsLocationReachabilityPredicateInstantiationTest {
         Assert.assertTrue(hostsMatchedHolder.contains(ALLOWED_HOST_AND_PORT.getHostText()));
     }
 
-    protected static final AtomicInteger TEST_INIT_MAP_AND_EMPTY_CONSTRUCTOR_COUNTER = new AtomicInteger(0);
     @Test
     public void testInitEmptyConstructor() {
         Assert.assertEquals(TEST_INIT_MAP_AND_EMPTY_CONSTRUCTOR_COUNTER.get(), 0);
@@ -117,7 +119,8 @@ public class JcloudsLocationReachabilityPredicateInstantiationTest {
     }
 
     static class NoSuitableConstructorPredicate implements Predicate<HostAndPort> {
-        public NoSuitableConstructorPredicate(NoSuitableConstructorPredicate a) {}
+        public NoSuitableConstructorPredicate(NoSuitableConstructorPredicate a) {
+        }
 
         @Override
         public boolean apply(@Nullable HostAndPort input) {
@@ -160,7 +163,7 @@ public class JcloudsLocationReachabilityPredicateInstantiationTest {
 
         @Override
         public boolean apply(@Nullable HostAndPort input) {
-            ((List<String>)flags.get("hostsMatchedHolder")).add(input.getHostText());
+            ((List<String>) flags.get("hostsMatchedHolder")).add(input.getHostText());
             return true;
         }
     }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/JcloudsReachableAddressStubbedTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.location.jclouds.networking;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
@@ -45,6 +46,7 @@ import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecParams;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
+import org.apache.brooklyn.util.time.Duration;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.NodeMetadata.Status;
 import org.jclouds.compute.domain.NodeMetadataBuilder;
@@ -109,10 +111,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
@@ -132,10 +134,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsWinRmMachineLocation machine = newWinrmMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertCalled();
         assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_HOST.getName()), reachableIp);
 
@@ -156,10 +158,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
@@ -180,10 +182,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
@@ -204,10 +206,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
 
@@ -221,7 +223,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
      * Therefore will also not search for reachable address (as that expects loginPort to be reachable).
      */
     @Test
-    public void testNoWaitFroSshable() throws Exception {
+    public void testNoWaitForSshable() throws Exception {
         List<String> publicAddresses = ImmutableList.of("1.1.1.1", "1.1.1.2", "1.1.1.3");
         List<String> privateAddresses = ImmutableList.of("2.1.1.1");
         reachableIp = null;
@@ -229,9 +231,9 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
                 .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, "false")
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .build());
-        
+
         addressChooser.assertNotCalled();
         assertTrue(RecordingSshTool.getExecCmds().isEmpty());
 
@@ -251,10 +253,10 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
                 .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, "false")
                 .build());
-        
+
         addressChooser.assertNotCalled();
 
         assertEquals(machine.getAddress().getHostAddress(), "1.1.1.1");
@@ -268,17 +270,17 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         List<String> privateAddresses = ImmutableList.of("2.1.1.1");
         reachableIp = "1.2.3.4";
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
-                
+
         PortForwardManager pfm = new PortForwardManagerImpl();
         RecordingJcloudsPortForwarderExtension portForwarder = new RecordingJcloudsPortForwarderExtension(pfm);
-        
+
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .put(JcloudsLocation.USE_PORT_FORWARDING, true)
                 .put(JcloudsLocation.PORT_FORWARDER, portForwarder)
                 .build());
-        
+
         addressChooser.assertNotCalled();
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_HOST.getName()), reachableIp);
         assertEquals(RecordingSshTool.getLastExecCmd().constructorProps.get(SshTool.PROP_PORT.getName()), 12345);
@@ -289,7 +291,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         assertEquals(machine.getHostname(), "1.1.1.1");
         assertEquals(machine.getSubnetIp(), "2.1.1.1");
     }
-    
+
     /**
      * Similar to {@link #testMachineUsesVanillaPublicAddress()}, except for a windows machine.
      */
@@ -299,17 +301,17 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         List<String> privateAddresses = ImmutableList.of("2.1.1.1");
         reachableIp = "1.2.3.4";
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
-                
+
         PortForwardManager pfm = new PortForwardManagerImpl();
         RecordingJcloudsPortForwarderExtension portForwarder = new RecordingJcloudsPortForwarderExtension(pfm);
-        
+
         JcloudsWinRmMachineLocation machine = newWinrmMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
-                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, Duration.millis(50).toString())
+                .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, Duration.millis(50).toString())
                 .put(JcloudsLocation.USE_PORT_FORWARDING, true)
                 .put(JcloudsLocation.PORT_FORWARDER, portForwarder)
                 .build());
-        
+
         addressChooser.assertNotCalled();
         assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_HOST.getName()), reachableIp);
         assertEquals(RecordingWinRmTool.getLastExec().constructorProps.get(WinRmTool.PROP_PORT.getName()), 12345);
@@ -319,7 +321,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         assertEquals(machine.getHostname(), "1.2.3.4"); // TODO Different impl from JcloudsSshMachineLocation!
         assertEquals(machine.getSubnetIp(), "2.1.1.1");
     }
-    
+
     @Test
     public void testMachineUsesFirstPublicAddress() throws Exception {
         List<String> publicAddresses = ImmutableList.of("1.1.1.1", "1.1.1.2");
@@ -328,7 +330,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         initNodeCreatorAndJcloudsLocation(newNodeCreator(publicAddresses, privateAddresses), ImmutableMap.of());
 
         JcloudsSshMachineLocation machine = newMachine(ImmutableMap.<ConfigKey<?>,Object>builder()
-                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Asserts.DEFAULT_LONG_TIMEOUT.toString())
+                .put(JcloudsLocationConfig.WAIT_FOR_SSHABLE, Duration.millis(50).toString())
                 .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS, false)
                 .build());
 
@@ -368,7 +370,7 @@ public class JcloudsReachableAddressStubbedTest extends AbstractJcloudsStubbedUn
         }
         
         public void assertCalled() {
-            assertTrue(calls.size() > 0, "no calls to "+this);
+            assertFalse(calls.isEmpty(), "no calls to "+this);
         }
         
         public void assertNotCalled() {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -539,6 +539,10 @@ public class Networking {
         }
     }
 
+    public static Predicate<HostAndPort> isReachablePredicate() {
+        return new IsReachablePredicate();
+    }
+
     public static class IsReachablePredicate implements Predicate<HostAndPort> {
         @Override public boolean apply(HostAndPort input) {
             return Networking.isReachable(input);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/ReachableSocketFinder.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/ReachableSocketFinder.java
@@ -19,17 +19,17 @@ package org.apache.brooklyn.util.net;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -38,9 +38,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
@@ -55,12 +56,7 @@ public class ReachableSocketFinder {
     private final ListeningExecutorService userExecutor;
 
     public ReachableSocketFinder(ListeningExecutorService userExecutor) {
-        this(
-                new Predicate<HostAndPort>() {
-                    @Override public boolean apply(HostAndPort input) {
-                        return Networking.isReachable(input);
-                    }}, 
-                userExecutor);
+        this(Networking.isReachablePredicate(), userExecutor);
     }
 
     public ReachableSocketFinder(Predicate<? super HostAndPort> socketTester, ListeningExecutorService userExecutor) {
@@ -69,41 +65,23 @@ public class ReachableSocketFinder {
     }
 
     /**
-     * 
+     * Returns the first element of sockets that is reachable.
      * @param sockets The host-and-ports to test
      * @param timeout Max time to try to connect to the ip:port
      * 
      * @return The reachable ip:port
-     * @throws NoSuchElementException If no ports accessible within the given time
-     * @throws NullPointerException  If the sockets or duration is null
+     * @throws NoSuchElementException If no ports are accessible within the given time
+     * @throws NullPointerException  If sockets or timeout is null
      * @throws IllegalStateException  If the sockets to test is empty
      */
-    public HostAndPort findOpenSocketOnNode(final Collection<? extends HostAndPort> sockets, Duration timeout) {
+    public HostAndPort findOpenSocketOnNode(final Iterable<? extends HostAndPort> sockets, Duration timeout) {
         checkNotNull(sockets, "sockets");
-        checkState(sockets.size() > 0, "No hostAndPort sockets supplied");
-        
+        checkState(!Iterables.isEmpty(sockets), "No hostAndPort sockets supplied");
+        checkNotNull(timeout, "timeout");
         LOG.debug("blocking on any reachable socket in {} for {}", sockets, timeout);
-
-        final AtomicReference<HostAndPort> result = new AtomicReference<HostAndPort>();
-        boolean passed = Repeater.create("socket-reachable")
-                .limitTimeTo(timeout)
-                .backoffTo(Duration.FIVE_SECONDS)
-                .until(new Callable<Boolean>() {
-                        @Override
-                        public Boolean call() {
-                            Optional<HostAndPort> reachableSocket = tryReachable(sockets, Duration.FIVE_SECONDS);
-                            if (reachableSocket.isPresent()) {
-                                result.compareAndSet(null, reachableSocket.get());
-                                return true;
-                            }
-                            return false;
-                        }})
-                .run();
-
-        if (passed) {
-            LOG.debug("<< socket {} opened", result);
-            assert result.get() != null;
-            return result.get();
+        Iterator<HostAndPort> iter = findOpenSocketsOnNode(sockets, timeout).iterator();
+        if (iter.hasNext()) {
+            return iter.next();
         } else {
             LOG.warn("No sockets in {} reachable after {}", sockets, timeout);
             throw new NoSuchElementException("could not connect to any socket in " + sockets);
@@ -111,44 +89,89 @@ public class ReachableSocketFinder {
     }
 
     /**
-     * Checks if any any of the given HostAndPorts are reachable. It checks them all concurrently, and
-     * returns the first that is reachable (or Optional.absent).
+     * Returns an iterable of the elements in sockets that are reachable. The order of elements
+     * in the iterable corresponds to the order of the elements in the input, not the order in which their
+     * reachability was determined. Iterators are unmodifiable and are evaluated lazily.
+     *
+     * @param sockets The host-and-ports to test
+     * @param timeout Max time to try to connect to each ip:port
+     * @return An iterable containing all sockets that are reachable according to {@link #socketTester}.
+     * @throws NullPointerException  If sockets or timeout is null
+     * @throws IllegalStateException  If the sockets to test is empty
      */
-    private Optional<HostAndPort> tryReachable(Collection<? extends HostAndPort> sockets, Duration timeout) {
-        final AtomicReference<HostAndPort> reachableSocket = new AtomicReference<HostAndPort>();
-        final CountDownLatch latch = new CountDownLatch(1);
-        List<ListenableFuture<?>> futures = Lists.newArrayList();
+    public Iterable<HostAndPort> findOpenSocketsOnNode(final Iterable<? extends HostAndPort> sockets, Duration timeout) {
+        checkNotNull(sockets, "sockets");
+        checkState(!Iterables.isEmpty(sockets), "No hostAndPort sockets supplied");
+        checkNotNull(timeout, "timeout");
+        return Optional.presentInstances(tryReachable(sockets, timeout));
+    }
+
+    /**
+     * @return A lazily computed Iterable containing present values for the elements of sockets that are
+     * reachable according to {@link #socketTester} and absent values for those not. Checks are concurrent
+     * and the elements in the Iterable are ordered according to their position in sockets.
+     */
+    private Iterable<Optional<HostAndPort>> tryReachable(Iterable<? extends HostAndPort> sockets, final Duration timeout) {
+        final List<ListenableFuture<Optional<HostAndPort>>> futures = Lists.newArrayList();
+        final AtomicReference<Stopwatch> sinceFirstCompleted = new AtomicReference<>();
+
         for (final HostAndPort socket : sockets) {
-            futures.add(userExecutor.submit(new Runnable() {
+            futures.add(userExecutor.submit(new Callable<Optional<HostAndPort>>() {
+                @Override
+                public Optional<HostAndPort> call() {
+                    // Whether the socket was reachable (vs. the result of call, which is whether the repeater is done).
+                    final AtomicBoolean theResultWeCareAbout = new AtomicBoolean();
+                    Repeater.create("socket-reachable")
+                            .limitTimeTo(timeout)
+                            .backoffTo(Duration.FIVE_SECONDS)
+                            .until(new Callable<Boolean>() {
+                                @Override
+                                public Boolean call() throws TimeoutException {
+                                    boolean reachable = socketTester.apply(socket);
+                                    if (reachable) {
+                                        theResultWeCareAbout.set(true);
+                                        return true;
+                                    } else {
+                                        // Run another check if nobody else has completed yet or another task has
+                                        // completed but this one is still in its grace period.
+                                        Stopwatch timerSinceFirst = sinceFirstCompleted.get();
+                                        return timerSinceFirst != null && Duration.FIVE_SECONDS.subtract(Duration.of(timerSinceFirst)).isNegative();
+                                    }
+                                }
+                            })
+                            .run();
+                    if (theResultWeCareAbout.get()) {
+                        sinceFirstCompleted.compareAndSet(null, Stopwatch.createStarted());
+                    }
+                    return theResultWeCareAbout.get() ? Optional.of(socket) : Optional.<HostAndPort>absent();
+                }
+            }));
+        }
+
+        return new Iterable<Optional<HostAndPort>>() {
+            @Override
+            public Iterator<Optional<HostAndPort>> iterator() {
+                return new AbstractIterator<Optional<HostAndPort>>() {
+                    int count = 0;
+
                     @Override
-                    public void run() {
-                        try {
-                            if (socketTester.apply(socket)) {
-                                reachableSocket.compareAndSet(null, socket);
-                                latch.countDown();
+                    protected Optional<HostAndPort> computeNext() {
+                        if (count < futures.size()) {
+                            final Future<Optional<HostAndPort>> future = futures.get(count++);
+                            try {
+                                return future.get(timeout.toUnit(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+                            } catch (Exception e) {
+                                Exceptions.propagateIfInterrupt(e);
+                                LOG.trace("Suppressed exception checking reachability of socket", e);
                             }
-                        } catch (RuntimeInterruptedException e) {
-                            throw e;
-                        } catch (RuntimeException e) {
-                            LOG.warn("Error checking reachability of ip:port "+socket, e);
+                            future.cancel(true);
+                            return Optional.absent();
+                        } else {
+                            return endOfData();
                         }
-                    }}));
-        }
-        
-        ListenableFuture<List<Object>> compoundFuture = Futures.successfulAsList(futures);
-        Stopwatch stopwatch = Stopwatch.createStarted();
-        try {
-            while (reachableSocket.get() == null && !compoundFuture.isDone() && timeout.isLongerThan(stopwatch)) {
-                latch.await(50, TimeUnit.MILLISECONDS);
-            }            
-            return Optional.fromNullable(reachableSocket.get());
-            
-        } catch (InterruptedException e) {
-            throw Exceptions.propagate(e);
-        } finally {
-            for (Future<?> future : futures) {
-                future.cancel(true);
+                    }
+                };
             }
-        }
+        };
     }
 }


### PR DESCRIPTION
This changes the semantics of ReachableSocketFinder. Previously it would return as soon as any host+port was reached. Now it determines the status of each socket in order. The checks are concurrent but, for example, if the third of five sockets is reachable the status of the first and second will also be determined.

These changes are motivated by some other work on JcloudsLocation that I will open a pull request for shortly.