### PR TITLE
Drop availability zone suffixes when configuring AWS regions

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ResolvingConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ResolvingConfigBag.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -168,5 +169,12 @@ public class ResolvingConfigBag extends ConfigBag {
     @Override
     public Map<String, Object> getAllConfigRaw() {
         return getAllConfigMutable();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("size", size())
+                .toString();
     }
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -112,13 +112,23 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
                  * Filter.3.Name=image-type&Filter.3.Value.1=machine&
                  */
             }
-            
+
             // See https://issues.apache.org/jira/browse/BROOKLYN-399
             String region = conf.get(CLOUD_REGION_ID);
             if (Strings.isNonBlank(region)) {
+                /*
+                 * Drop availability zone suffixes. Without this deployments to regions like us-east-1b fail
+                 * because jclouds throws an IllegalStateException complaining that: location id us-east-1b
+                 * not found in: [{scope=PROVIDER, id=aws-ec2, description=https://ec2.us-east-1.amazonaws.com,
+                 * iso3166Codes=[US-VA, US-CA, US-OR, BR-SP, IE, DE-HE, SG, AU-NSW, JP-13]}]. The exception is
+                 * thrown by org.jclouds.compute.domain.internal.TemplateBuilderImpl#locationId(String).
+                 */
+                if (Character.isLetter(region.charAt(region.length() - 1))) {
+                    region = region.substring(0, region.length() - 1);
+                }
                 properties.setProperty(LocationConstants.PROPERTY_REGIONS, region);
             }
-            
+
             // occasionally can get com.google.common.util.concurrent.UncheckedExecutionException: java.lang.RuntimeException: 
             //     security group eu-central-1/jclouds#brooklyn-bxza-alex-eu-central-shoul-u2jy-nginx-ielm is not available after creating
             // the default timeout was 500ms so let's raise it in case that helps

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/zone/AwsAvailabilityZoneExtensionTest.java
@@ -68,17 +68,16 @@ public class AwsAvailabilityZoneExtensionTest {
     @Test(groups={"Live", "Sanity"})
     public void testFindsZones() throws Exception {
         List<Location> subLocations = zoneExtension.getSubLocations(Integer.MAX_VALUE);
-        List<String> zoneNames = getRegionsOf(subLocations);
-        assertTrue(subLocations.size() >= 3, "zones="+subLocations);
-        assertTrue(zoneNames.containsAll(ImmutableList.of(REGION_NAME+"a", REGION_NAME+"b", REGION_NAME+"c")), "zoneNames="+zoneNames);
+        assertTrue(subLocations.size() >= 3, "expected at least three zones in " + subLocations);
     }
     
     @Test(groups={"Live", "Sanity"})
     public void testFiltersZones() throws Exception {
         List<Location> subLocations = zoneExtension.getSubLocationsByName(Predicates.containsPattern(REGION_NAME+"[ab]"), Integer.MAX_VALUE);
         List<String> zoneNames = getRegionsOf(subLocations);
-        assertTrue(subLocations.size() == 2, "zones="+subLocations);
-        assertTrue(zoneNames.containsAll(ImmutableList.of(REGION_NAME+"a", REGION_NAME+"b")), "zoneNames="+zoneNames);
+        assertTrue(subLocations.size() == 2, "expected two zones in " + subLocations);
+        final ImmutableList<String> expected = ImmutableList.of(REGION_NAME + "a", REGION_NAME + "b");
+        assertTrue(zoneNames.containsAll(expected), "expected result to contain " + expected + ", found zoneNames=" + zoneNames);
     }
     
     // TODO choosing a specific availability zone looks dangerous!


### PR DESCRIPTION
This fixes the deployment of blueprints that give a specific availability zone as the region. For example:
```yaml
location:
  jclouds:aws-ec2:
    region: us-east-1b
services:
- type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
```
The problem was introduced in the fix for https://issues.apache.org/jira/browse/BROOKLYN-399 (see #458). Setting `LocationConstants.PROPERTY_REGIONS` to a region like `us-east-1b` causes jclouds to throw an `IllegalStateException` in `TemplateBuilder#locationId`.