### PR TITLE
Make the brooklyn server config discoverable by OSGi and downstream projects

### DIFF
--- a/karaf/config/pom.xml
+++ b/karaf/config/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>brooklyn-karaf</artifactId>
+        <groupId>org.apache.brooklyn</groupId>
+        <version>0.11.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>brooklyn-server-config</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifact</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/org.apache.brooklyn.classrename.cfg
+                                    </file>
+                                    <type>cfg</type>
+                                    <classifier>classrename</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/org.apache.brooklyn.core.catalog.bomscanner.cfg
+                                    </file>
+                                    <type>cfg</type>
+                                    <classifier>core.catalog.bomscanner</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>
+                                        ${project.basedir}/src/main/resources/org.apache.brooklyn.osgilauncher.cfg
+                                    </file>
+                                    <type>cfg</type>
+                                    <classifier>osgilauncher</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/karaf/config/src/main/resources/org.apache.brooklyn.classrename.cfg
+++ b/karaf/config/src/main/resources/org.apache.brooklyn.classrename.cfg
@@ -1,0 +1,21 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# This file can contains custom deserialization class mappings for the persistence state
+# Syntax should be <old-class>=<new-class>

--- a/karaf/config/src/main/resources/org.apache.brooklyn.core.catalog.bomscanner.cfg
+++ b/karaf/config/src/main/resources/org.apache.brooklyn.core.catalog.bomscanner.cfg
@@ -1,0 +1,27 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# CSV Whitelist of regular expressions to match bundle symbolic id if bundle is to be permitted to add
+# applications (templates) to the catalog
+whiteList=.*
+
+# CSV Blacklist of regular expressions to match bundle symbolic id to prevent selected whitelisted bundles
+# adding applications (templates) to the catalog
+blackList=
+

--- a/karaf/config/src/main/resources/org.apache.brooklyn.osgilauncher.cfg
+++ b/karaf/config/src/main/resources/org.apache.brooklyn.osgilauncher.cfg
@@ -1,0 +1,67 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# This file temporarily contains boot settings for brooklyn karaf launcher,
+# matching some of the command-line options of the previous brooklyn-cli launcher
+# (those used during the initialization sequence)
+#
+# Most of these will migrate to a permanent cfg file, once the components themselves get refactored
+# and the configuration options are agreed upon
+
+# Location of the global brooklyn.properties file
+#globalBrooklynPropertiesFile=~/.brooklyn/brooklyn.properties
+
+# Location of the local brooklyn.properties file, normally specified at the cli. Overrides properties from the global set.
+#localBrooklynPropertiesFile=
+
+# Location of the default catalog.bom
+default.catalog.location=${karaf.etc}/default.catalog.bom
+
+# Ignore catalog subsystem failures during startup (default is to continue, so errors can be viewed via the API)
+#ignoreCatalogErrors=true
+
+# Ignore persistence/HA subsystem failures during startup (default is to continue, so errors can be viewed via the API)
+#ignorePersistenceErrors=true
+
+# The high availability mode. Possible values are:
+# - DISABLED: management node works in isolation - will not cooperate with any other standby/master nodes in management plane;
+# - AUTO: will look for other management nodes, and will allocate itself as standby or master based on other nodes' states;
+# - MASTER: will startup as master - if there is already a master then fails immediately;
+# - STANDBY: will start up as lukewarm standby with no state - if there is not already a master then fails immediately,
+#   and if there is a master which subsequently fails, this node can promote itself;
+# - HOT_STANDBY: will start up as hot standby in read-only mode - if there is not already a master then fails immediately,
+#   and if there is a master which subseuqently fails, this node can promote itself;
+# - HOT_BACKUP: will start up as hot backup in read-only mode - no master is required, and this node will not become a master
+#highAvailabilityMode=DISABLED
+
+# The persistence mode. Possible values are:
+# - AUTO: will rebind to any existing state, or start up fresh if no state;
+# - DISABLED: will not read or persist any state;
+# - REBIND: will rebind to the existing state, or fail if no state available;
+# - CLEAN: will start up fresh (removing any existing state)
+#persistMode=AUTO
+
+# The directory to read/write persisted state (or container name if using an object store)
+#persistenceDir=
+
+# The location spec for an object store to read/write persisted state
+#persistenceLocation=
+
+# Periodic read-only rebind
+#persistPeriod=1s

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -320,4 +320,16 @@
         <bundle start-level="90">mvn:org.apache.brooklyn/brooklyn-karaf-init/${project.version}</bundle>
     </feature>
 
+    <feature name="brooklyn-server-config" version="${project.version}" description="Brooklyn server configuration files">
+        <configfile finalname="${karaf.etc}/${groupId}.classrename.cfg" override="false">
+            mvn:${project.groupId}/brooklyn-server-config/${project.version}/cfg/classrename
+        </configfile>
+        <configfile finalname="${karaf.etc}/${groupId}.core.catalog.bomscanner.cfg" override="false">
+            mvn:${project.groupId}/brooklyn-server-config/${project.version}/cfg/core.catalog.bomscanner
+        </configfile>
+        <configfile finalname="${karaf.etc}/${groupId}.osgilauncher.cfg" override="false">
+            mvn:${project.groupId}/brooklyn-server-config/${project.version}/cfg/osgilauncher
+        </configfile>
+    </feature>
+
 </features>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -58,6 +58,7 @@
     <module>httpcomponent-extension</module>
     <module>features</module>
     <module>commands</module>
+    <module>config</module>
   </modules>
   
   <dependencyManagement>


### PR DESCRIPTION
This is a follow up PR of https://github.com/apache/brooklyn-dist/pull/72

It moves the brooklyn server config back into `brooklyn-server` and create a feature that will be used in `brooklyn-dist` (https://github.com/apache/brooklyn-dist/pull/75)