### PR TITLE
BROOKLYN-404: fix ConcurrentModificationException in BrooklynProperties

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigUtils.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.core.config.WrappedConfigKey;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.StringPredicates;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,20 +82,18 @@ public class ConfigUtils {
     
     public static BrooklynProperties filterFor(BrooklynProperties properties, Predicate<? super String> filter) {
         BrooklynProperties result = BrooklynProperties.Factory.newEmpty();
-        for (String k: (Collection<String>)properties.keySet()) {
-            if (filter.apply(k)) {
-                result.put(k, properties.get(k));
-            }
+        Set<ConfigKey<?>> keys = properties.findKeys(ConfigPredicates.nameSatisfies(filter));
+        for (ConfigKey<?> key : keys) {
+            result.put(key, properties.getConfig(key));
         }
         return result;
     }
     
     public static BrooklynProperties filterForPrefix(BrooklynProperties properties, String prefix) {
         BrooklynProperties result = BrooklynProperties.Factory.newEmpty();
-        for (String k: (Collection<String>)properties.keySet()) {
-            if (k.startsWith(prefix)) {
-                result.put(k, properties.get(k));
-            }
+        Set<ConfigKey<?>> keys = properties.findKeys(ConfigPredicates.nameSatisfies(StringPredicates.startsWith(prefix)));
+        for (ConfigKey<?> key : keys) {
+            result.put(key, properties.getConfig(key));
         }
         return result;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
@@ -50,7 +50,7 @@ import com.google.common.base.Supplier;
  * thereafter.
  */
 @SuppressWarnings("rawtypes")
-public interface BrooklynProperties extends Map, StringConfigMap {
+public interface BrooklynProperties extends StringConfigMap {
 
     public static class Factory {
         private static final Logger LOG = LoggerFactory.getLogger(BrooklynProperties.Factory.class);
@@ -104,7 +104,7 @@ public interface BrooklynProperties extends Map, StringConfigMap {
              * Creates a Builder that when built, will return the BrooklynProperties passed to this constructor
              */
             private Builder(BrooklynProperties originalProperties) {
-                this.originalProperties = new BrooklynPropertiesImpl().addFromMap(originalProperties);
+                this.originalProperties = new BrooklynPropertiesImpl().addFromMap(originalProperties.asMapWithStringKeys());
             }
             
             /**
@@ -157,7 +157,7 @@ public interface BrooklynProperties extends Map, StringConfigMap {
             
             public BrooklynProperties build() {
                 if (originalProperties != null) 
-                    return new BrooklynPropertiesImpl().addFromMap(originalProperties);
+                    return new BrooklynPropertiesImpl().addFromMap(originalProperties.asMapWithStringKeys());
                 
                 BrooklynProperties properties = new BrooklynPropertiesImpl();
 
@@ -181,6 +181,7 @@ public interface BrooklynProperties extends Map, StringConfigMap {
             }
 
             @Override
+            @SuppressWarnings("deprecation")
             public String toString() {
                 return Objects.toStringHelper(this)
                         .omitNullValues()
@@ -280,11 +281,9 @@ public interface BrooklynProperties extends Map, StringConfigMap {
     public String getFirst(Map flags, String ...keys);
 
     /** like normal map.put, except config keys are dereferenced on the way in */
-    @Override
     public Object put(Object key, Object value);
 
-    /** like normal map.putAll, except config keys are dereferenced on the way in */
-    @Override
+    /** like normal {@link java.util.Map#putAll(Map)}, except config keys are dereferenced on the way in */
     public void putAll(Map vals);
     
     public <T> Object put(HasConfigKey<T> key, T value);
@@ -293,6 +292,21 @@ public interface BrooklynProperties extends Map, StringConfigMap {
     
     public <T> boolean putIfAbsent(ConfigKey<T> key, T value);
     
+    @Beta
+    public boolean containsKey(String key);
+
+    @Beta
+    public boolean containsKey(ConfigKey<?> key);
+
+    @Beta
+    public boolean remove(String key);
+
+    @Beta
+    public boolean remove(ConfigKey<?> key);
+
+    @Beta
+    public Object getConfig(String key);
+
     @Override
     public <T> T getConfig(ConfigKey<T> key);
 
@@ -323,6 +337,9 @@ public interface BrooklynProperties extends Map, StringConfigMap {
 
     @Override
     public BrooklynProperties submap(Predicate<ConfigKey<?>> filter);
+
+    @Beta
+    public BrooklynProperties submapByName(Predicate<? super String> filter);
 
     @Override
     public Map<String, Object> asMapWithStringKeys();

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationDefinition.java
@@ -33,11 +33,11 @@ public class BasicLocationDefinition implements LocationDefinition {
     private final String spec;
     private final Map<String,Object> config;
 
-    public BasicLocationDefinition(String name, String spec, Map<String,? extends Object> config) {
+    public BasicLocationDefinition(String name, String spec, Map<String, ?> config) {
         this(Identifiers.makeRandomId(8), name, spec, config);
     }
     
-    public BasicLocationDefinition(String id, String name, String spec, Map<String,? extends Object> config) {      
+    public BasicLocationDefinition(String id, String name, String spec, Map<String, ?> config) {      
         this.id = Preconditions.checkNotNull(id);
         this.name = name;
         this.spec = Preconditions.checkNotNull(spec);

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicLocationRegistry.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.config.ConfigUtils;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.mgmt.internal.LocalLocationManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -282,8 +283,8 @@ public class BasicLocationRegistry implements LocationRegistry {
                     String spec = (String) namedLocationProps.asMapWithStringKeys().get(k);
                     // make up an ID
                     String id = Identifiers.makeRandomId(8);
-                    Map<String, Object> config = ConfigUtils.filterForPrefixAndStrip(namedLocationProps.asMapWithStringKeys(), k+".");
-                    definedLocations.put(id, new BasicLocationDefinition(id, name, spec, config));
+                    BrooklynProperties config = ConfigUtils.filterForPrefixAndStrip(namedLocationProps.asMapWithStringKeys(), k+".");
+                    definedLocations.put(id, new BasicLocationDefinition(id, name, spec, config.asMapWithStringKeys()));
                     count++;
                 }
             }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Reflections;
@@ -99,10 +100,13 @@ public class BasicExternalConfigSupplierRegistry implements ExternalConfigSuppli
 
             String name = strippedKey;
             String providerClassname = (String) externalProviderProperties.get(key);
-            Map<String, Object> config = ConfigUtils.filterForPrefixAndStrip(externalProviderProperties, key + ".");
+            BrooklynProperties config = ConfigUtils.filterForPrefixAndStrip(externalProviderProperties, key + ".");
 
             try {
                 Maybe<ExternalConfigSupplier> configSupplier = Reflections.invokeConstructorFromArgs(classloader, ExternalConfigSupplier.class, providerClassname, mgmt, name, config);
+                if (!configSupplier.isPresent()) {
+                    configSupplier = Reflections.invokeConstructorFromArgs(classloader, ExternalConfigSupplier.class, providerClassname, mgmt, name, config.asMapWithStringKeys());
+                }
                 if (!configSupplier.isPresent()) {
                     configSupplier = Reflections.invokeConstructorFromArgs(classloader, ExternalConfigSupplier.class, providerClassname, mgmt, name);
                 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
@@ -103,6 +104,32 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
     }
     
     @Override
+    public boolean containsKey(String key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsKey(ConfigKey<?> key) {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean remove(String key) {
+        return delegate.remove(key);
+    }
+    
+    @Override
+    public boolean remove(ConfigKey<?> key) {
+        return delegate.remove(key);
+    }
+    
+    @Override
+    public Object getConfig(String key) {
+        Object raw = delegate.getConfig(key);
+        return resolve(ConfigKeys.newConfigKey(Object.class, key), raw);
+    }
+
+    @Override
     public <T> T getConfig(ConfigKey<T> key) {
         T raw = delegate.getConfig(key);
         return resolve(key, raw);
@@ -144,7 +171,7 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
 
     @Override
     public Map<ConfigKey<?>,Object> getAllConfigLocalRaw() {
-        Map<ConfigKey<?>, Object> raw = delegate.getAllConfig();
+        Map<ConfigKey<?>, Object> raw = delegate.getAllConfigLocalRaw();
         Map<ConfigKey<?>, Object> result = Maps.newLinkedHashMap();
         for (Map.Entry<ConfigKey<?>, Object> entry : raw.entrySet()) {
             result.put(entry.getKey(), transform(entry.getKey(), entry.getValue()));
@@ -159,7 +186,7 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
 
     @Override
     public Map<String, Object> asMapWithStringKeys() {
-        Map<ConfigKey<?>, Object> raw = delegate.getAllConfig();
+        Map<ConfigKey<?>, Object> raw = delegate.getAllConfigLocalRaw();
         Map<String, Object> result = Maps.newLinkedHashMap();
         for (Map.Entry<ConfigKey<?>, Object> entry : raw.entrySet()) {
             result.put(entry.getKey().getName(), transform(entry.getKey(), entry.getValue()));
@@ -202,6 +229,13 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
         BrooklynProperties submap = delegate.submap(filter);
         return new DeferredBrooklynProperties(submap, mgmt);
     }
+    
+    @Override
+    public BrooklynProperties submapByName(Predicate<? super String> filter) {
+        BrooklynProperties submap = delegate.submapByName(filter);
+        return new DeferredBrooklynProperties(submap, mgmt);
+    }
+
     @Override
     public Set<ConfigKey<?>> findKeys(Predicate<? super ConfigKey<?>> filter) {
         return delegate.findKeys(filter);
@@ -307,7 +341,7 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
     
     
     //////////////////////////////////////////////////////////////////////////////////
-    // Methods below from java.util.LinkedHashMap, which BrooklynProperties extends //
+    // Methods below from ConfigMap, which BrooklynProperties extends               //
     //////////////////////////////////////////////////////////////////////////////////
     
     @Override
@@ -320,49 +354,11 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
         return delegate.isEmpty();
     }
 
-    @Override
-    public boolean containsKey(Object key) {
-        return delegate.containsKey(key);
-    }
 
-    @Override
-    public boolean containsValue(Object value) {
-        return delegate.containsValue(value);
-    }
-
-    @Override
-    public Object get(Object key) {
-        return delegate.get(key);
-    }
-
-    @Override
-    public Object remove(Object key) {
-        return delegate.remove(key);
-    }
-
-    @Override
-    public void clear() {
-        delegate.clear();
-    }
-
-    @Override
-    @SuppressWarnings("rawtypes")
-    public Set keySet() {
-        return delegate.keySet();
-    }
-
-    @Override
-    @SuppressWarnings("rawtypes")
-    public Collection values() {
-        return delegate.values();
-    }
+    //////////////////////////////////////////////////////////////////////////////////
+    // Methods below from Object                                                    //
+    //////////////////////////////////////////////////////////////////////////////////
     
-    @Override
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public Set<Map.Entry> entrySet() {
-        return delegate.entrySet();
-    }
-
     @Override
     public boolean equals(Object o) {
         return delegate.equals(o);

--- a/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesBuilderTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesBuilderTest.java
@@ -58,7 +58,7 @@ public class BrooklynPropertiesBuilderTest {
                 .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
                 .build();
         
-        assertEquals(props.get("brooklyn.mykey"), "myval");
+        assertEquals(props.getConfig("brooklyn.mykey"), "myval");
     }
     
     @Test
@@ -76,8 +76,8 @@ public class BrooklynPropertiesBuilderTest {
                 .localPropertiesFile(localPropertiesFile.getAbsolutePath())
                 .build();
         
-        assertEquals(props.get("brooklyn.mykey"), "myvaloverriding");
-        assertEquals(props.get("brooklyn.mykey2"), "myvalglobal2");
-        assertEquals(props.get("brooklyn.mykeyLocal"), "myvallocal2");
+        assertEquals(props.getConfig("brooklyn.mykey"), "myvaloverriding");
+        assertEquals(props.getConfig("brooklyn.mykey2"), "myvalglobal2");
+        assertEquals(props.getConfig("brooklyn.mykeyLocal"), "myvallocal2");
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/BrooklynPropertiesTest.java
@@ -155,9 +155,9 @@ public class BrooklynPropertiesTest {
         assertEquals(p2.getFirst("akey"), null);
         
         BrooklynProperties p3a = props.submap(ConfigPredicates.startingWith("a."));
-        assertEquals(p3a, p2);
+        assertPropertiesEquals(p3a, p2);
         BrooklynProperties p3b = props.submap(ConfigPredicates.matchingRegex("a\\..*"));
-        assertEquals(p3b, p2);
+        assertPropertiesEquals(p3b, p2);
         
         BrooklynProperties p4 = props.submap(ConfigPredicates.matchingRegex("a.*"));
         assertEquals(p4.getAllConfig().keySet().size(), 3, "wrong size submap: "+p4);
@@ -182,21 +182,24 @@ public class BrooklynPropertiesTest {
         
         props.put(aString, "aval2");
         assertEquals(props.getConfig(aString), "aval2");
-        assertEquals(props.get("a.key"), "aval2");
+        assertEquals(props.getConfig("a.key"), "aval2");
 
         props.put(nNum, "345");
         assertEquals(props.getConfig(nNum), (Integer)345);
-        assertEquals(props.get("n.key"), "345");
+        assertEquals(props.getConfig("n.key"), "345");
 
         assertEquals(props.getConfig(aBsent), null);
         assertEquals(props.getConfig(aBsent, 123), (Integer)123);
         assertEquals(props.getConfig(aDfault), (Integer)123);
         
         props.put(aMisstyped, "x1");
-        assertEquals(props.get("am.isstyped"), "x1");
+        assertEquals(props.getConfig("am.isstyped"), "x1");
         boolean workedWhenShouldntHave = false;
         try { props.getConfig(aMisstyped); workedWhenShouldntHave = true; } catch (Exception e) {}
         if (workedWhenShouldntHave) fail("should have failed getting "+aMisstyped+" because can't coerce");
     }
 
+    protected void assertPropertiesEquals(BrooklynProperties actual, BrooklynProperties expected) {
+        assertEquals(actual.asMapWithStringKeys(), expected.asMapWithStringKeys());
+    }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
@@ -97,11 +97,11 @@ public class LocalManagementContextTest {
         BrooklynProperties properties = BrooklynProperties.Factory.newEmpty();
         properties.put("myname", "myval");
         context = LocalManagementContextForTests.builder(true).useProperties(properties).build();
-        assertEquals(context.getBrooklynProperties().get("myname"), "myval");
+        assertEquals(context.getBrooklynProperties().getConfig("myname"), "myval");
         properties.put("myname", "newval");
-        assertEquals(properties.get("myname"), "newval");
+        assertEquals(properties.getConfig("myname"), "newval");
         // TODO: Should changes in the 'properties' collection be reflected in context.getBrooklynProperties()?
-        assertNotEquals(context.getBrooklynProperties().get("myname"), "newval");
+        assertNotEquals(context.getBrooklynProperties().getConfig("myname"), "newval");
     }
     
     @Test

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -318,7 +318,7 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
             if (port!=null) webServer.setPort(port);
             if (useHttps!=null) webServer.setHttpsEnabled(useHttps);
             webServer.setShutdownHandler(shutdownHandler);
-            webServer.putAttributes(brooklynProperties);
+            webServer.putAttributes(brooklynProperties.asMapWithStringKeys());
             webServer.skipSecurity(skipSecurity);
             for (WebAppContextProvider webapp : webApps) {
                 webServer.addWar(webapp);

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindToCloudObjectStoreTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindToCloudObjectStoreTest.java
@@ -67,7 +67,7 @@ public class BrooklynLauncherRebindToCloudObjectStoreTest extends BrooklynLaunch
     @Override
     protected LocalManagementContextForTests newManagementContextForTests(BrooklynProperties props) {
         BrooklynProperties p2 = BrooklynProperties.Factory.newDefault();
-        if (props!=null) p2.putAll(props);
+        if (props!=null) p2.putAll(props.getAllConfigLocalRaw());
         return new LocalManagementContextForTests(p2);
     }
 

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -169,10 +169,10 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
      */
     public static BailOutJcloudsLocation newBailOutJcloudsLocationForLiveTest(LocalManagementContext mgmt, Map<ConfigKey<?>, ?> config) {
         BrooklynProperties brooklynProperties = mgmt.getBrooklynProperties();
-        String identity = (String) brooklynProperties.get("brooklyn.location.jclouds.aws-ec2.identity");
-        if (identity == null) identity = (String) brooklynProperties.get("brooklyn.jclouds.aws-ec2.identity");
-        String credential = (String) brooklynProperties.get("brooklyn.location.jclouds.aws-ec2.credential");
-        if (credential == null) credential = (String) brooklynProperties.get("brooklyn.jclouds.aws-ec2.credential");
+        String identity = (String) brooklynProperties.getConfig("brooklyn.location.jclouds.aws-ec2.identity");
+        if (identity == null) identity = (String) brooklynProperties.getConfig("brooklyn.jclouds.aws-ec2.identity");
+        String credential = (String) brooklynProperties.getConfig("brooklyn.location.jclouds.aws-ec2.credential");
+        if (credential == null) credential = (String) brooklynProperties.getConfig("brooklyn.jclouds.aws-ec2.credential");
 
         Map<ConfigKey<?>, ?> allConfig = MutableMap.<ConfigKey<?>, Object>builder()
                 .put(CLOUD_PROVIDER, AbstractJcloudsLiveTest.AWS_EC2_PROVIDER)

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsLocationTest.java
@@ -521,7 +521,6 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
         Assert.assertEquals(geo.longitude, -20d, 0.00001);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testInheritsGeoFromLocationMetadataProperties() throws Exception {
         // in location-metadata.properties:
@@ -534,8 +533,9 @@ public class JcloudsLocationTest implements JcloudsLocationConfig {
             .configure(ACCESS_IDENTITY, "bogus")
             .configure(ACCESS_CREDENTIAL, "bogus")
             .configure(MACHINE_CREATE_ATTEMPTS, 1);
-        FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class)
-            .configure(new JcloudsPropertiesFromBrooklynProperties().getJcloudsProperties("softlayer", "wdc01", null, managementContext.getBrooklynProperties()))
+        Map<String, Object> brooklynProperties = managementContext.getBrooklynProperties().asMapWithStringKeys();
+		FakeLocalhostWithParentJcloudsLocation ll = managementContext.getLocationManager().createLocation(LocationSpec.create(FakeLocalhostWithParentJcloudsLocation.class)
+            .configure(new JcloudsPropertiesFromBrooklynProperties().getJcloudsProperties("softlayer", "wdc01", null, brooklynProperties))
             .configure(allConfig.getAllConfig()));
         MachineLocation l = ll.obtain();
         log.info("loc:" +l);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/LocalBrooklynNodeImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/LocalBrooklynNodeImpl.java
@@ -32,11 +32,11 @@ public class LocalBrooklynNodeImpl extends BrooklynNodeImpl implements LocalBroo
         // Override management username and password from brooklyn.properties
         // TODO Why use BrooklynProperties, rather than StringConfigMap returned by mgmt.getConfig()?
         BrooklynProperties properties = ((ManagementContextInternal)getManagementContext()).getBrooklynProperties();
-        String user = (String) properties.get(String.format(LOCAL_BROOKLYN_NODE_KEY, "user"));
-        String password = (String) properties.get(String.format(LOCAL_BROOKLYN_NODE_KEY, "password"));
+        String user = (String) properties.getConfig(String.format(LOCAL_BROOKLYN_NODE_KEY, "user"));
+        String password = (String) properties.getConfig(String.format(LOCAL_BROOKLYN_NODE_KEY, "password"));
         if (Strings.isBlank(password)) {
             if (Strings.isBlank(user)) user = "admin";
-            password = (String) properties.get(String.format(BROOKLYN_WEBCONSOLE_PASSWORD_KEY, user));
+            password = (String) properties.getConfig(String.format(BROOKLYN_WEBCONSOLE_PASSWORD_KEY, user));
         }
         if (Strings.isNonBlank(user) && Strings.isNonBlank(password)) {
             config().set(MANAGEMENT_USER, user);


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/BROOKLYN-404, the fix is to change `BrooklynProperties` so it no longer exposes the map interface. This means we can much more easily control its mutators and its accessors to avoid such `ConcurrentModificationException`s.

This PR does *not* do anything about @neykov's additional suggestion in jira: "Taking a step back I think we should either let users update the properties in a non-hackish way (that is include the mutators in the interface which getConfig() returns) or introduce an alternative "scratch" space to serve the same purpose."

Currently, if someone wants to modify the `BrooklynProperties`, it needs to be cast to `BrooklynProperties` (whereas `managementContext.getConfig()` returns `StringConfigMap`, which is a super-interface of `BrooklynProperties`).