### PR TITLE
Add jcloudsProviderRenames.properties

### DIFF
--- a/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/jcloudsProviderRenames.properties
+++ b/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/jcloudsProviderRenames.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+openstack-mitaka-nova     : openstack-nova
+openstack-devtest-compute : openstack-nova


### PR DESCRIPTION
This adds the `jcloudsProviderRenames.properties` file missing from #508