### PR TITLE
Allow oauth.endpoint in location

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/LocationConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/LocationConfigKeys.java
@@ -50,6 +50,8 @@ public class LocationConfigKeys {
     public static final ConfigKey<String> CLOUD_REGION_ID = ConfigKeys.newStringConfigKey("region");
     public static final ConfigKey<String> CLOUD_AVAILABILITY_ZONE_ID = ConfigKeys.newStringConfigKey("availabilityZone");
 
+    public static final ConfigKey<String> OAUTH_ENDPOINT = ConfigKeys.newStringConfigKey("oauth.endpoint");
+
     @SuppressWarnings("serial")
     public static final ConfigKey<Set<String>> ISO_3166 = ConfigKeys.newConfigKey(new TypeToken<Set<String>>() {}, "iso3166", "ISO-3166 or ISO-3166-2 location codes"); 
 

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -39,7 +39,8 @@ public interface CloudLocationConfig {
     public static final ConfigKey<String> CLOUD_ENDPOINT = LocationConfigKeys.CLOUD_ENDPOINT;
     public static final ConfigKey<String> CLOUD_REGION_ID = LocationConfigKeys.CLOUD_REGION_ID;
     public static final ConfigKey<String> CLOUD_AVAILABILITY_ZONE_ID = LocationConfigKeys.CLOUD_AVAILABILITY_ZONE_ID;
-        
+
+    public static final ConfigKey<String> OAUTH_ENDPOINT = LocationConfigKeys.OAUTH_ENDPOINT;
 
     @SetFromFlag("extensions")
     public static final MapConfigKey<String> EXTENSION = LocationConfigKeys.EXTENSIONS;

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -74,7 +74,9 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
         properties.setProperty(Constants.PROPERTY_RELAX_HOSTNAME, Boolean.toString(true));
         properties.setProperty("jclouds.ssh.max-retries", conf.getStringKey("jclouds.ssh.max-retries") != null ? 
                 conf.getStringKey("jclouds.ssh.max-retries").toString() : "50");
-        
+
+        if (conf.get(OAUTH_ENDPOINT) != null) properties.setProperty(OAUTH_ENDPOINT.getName(),conf.get(OAUTH_ENDPOINT));
+
         // See https://issues.apache.org/jira/browse/BROOKLYN-394
         // For retries, the backoff times are:
         //   Math.min(2^failureCount * retryDelayStart, retryDelayStart * 10) + random(10%)


### PR DESCRIPTION
`oauth.endpoint` is required by Azure ARM but isn't passed through to the jcloudsProperties.