### PR TITLE
Fix+test rename-jclouds-provider

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/DeserializingJcloudsRenamesProviderTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/DeserializingJcloudsRenamesProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.persist;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class DeserializingJcloudsRenamesProviderTest {
+
+    @Test
+    public void testRenameNoop() throws Exception {
+        assertEquals(rename("aws-ec2"), "aws-ec2");
+    }
+
+    @Test
+    public void testRenamesDefinedInClasspathFile() throws Exception {
+        assertEquals(rename("openstack-mitaka-nova"), "openstack-nova");
+        assertEquals(rename("openstack-devtest-compute"), "openstack-nova");
+    }
+    
+    protected String rename(String val) throws Exception {
+        return DeserializingJcloudsRenamesProvider.INSTANCE.applyJcloudsRenames(val);
+    }
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
+import org.apache.brooklyn.core.mgmt.persist.DeserializingJcloudsRenamesProvider;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Strings;
@@ -65,7 +66,9 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
 
     @Override
     public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) {
-        String provider = checkNotNull(conf.get(CLOUD_PROVIDER), "provider must not be null");
+        String rawProvider = checkNotNull(conf.get(CLOUD_PROVIDER), "provider must not be null");
+        String provider = DeserializingJcloudsRenamesProvider.INSTANCE.applyJcloudsRenames(rawProvider);
+
         String identity = checkNotNull(conf.get(CloudLocationConfig.ACCESS_IDENTITY), "identity must not be null");
         String credential = checkNotNull(conf.get(CloudLocationConfig.ACCESS_CREDENTIAL), "credential must not be null");
         

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.core.config.Sanitizer;
+import org.apache.brooklyn.core.mgmt.persist.DeserializingJcloudsRenamesProvider;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -270,7 +271,9 @@ public class JcloudsUtil implements JcloudsLocationConfig {
      *
      *  @since 0.7.0 */
     @Beta
-    public static BlobStoreContext newBlobstoreContext(String provider, @Nullable String endpoint, String identity, String credential) {
+    public static BlobStoreContext newBlobstoreContext(String rawProvider, @Nullable String endpoint, String identity, String credential) {
+        String provider = DeserializingJcloudsRenamesProvider.INSTANCE.applyJcloudsRenames(rawProvider);
+        
         Properties overrides = new Properties();
         // * Java 7,8 bug workaround - sockets closed by GC break the internal bookkeeping
         //   of HttpUrlConnection, leading to invalid handling of the "HTTP/1.1 100 Continue"

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRenamesRebindTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRenamesRebindTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests rebind (i.e. restarting Brooklyn server) when using the jclouds-provider renames.
+ */
+public class JcloudsRenamesRebindTest extends RebindTestFixtureWithApp {
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+        
+        // Don't let any defaults from brooklyn.properties (except credentials) interfere with test
+        AbstractJcloudsLiveTest.stripBrooklynProperties(origManagementContext.getBrooklynProperties());
+    }
+
+    @Test(expectedExceptions=NoSuchElementException.class)
+    public void testProviderDoesNotExist() throws Exception {
+        resolve("wrongprovider");
+    }
+    
+    @Test
+    public void testProviderNotRenamed() throws Exception {
+        JcloudsLocation loc = resolve("aws-ec2:us-east-1", ImmutableMap.of("identity", "dummy", "credential", "dummy"));
+        assertComputeServiceType(loc, "aws-ec2");
+        
+        rebind();
+        
+        JcloudsLocation newLoc = (JcloudsLocation) mgmt().getLocationManager().getLocation(loc.getId());
+        assertComputeServiceType(newLoc, "aws-ec2");
+    }
+
+    @Test
+    public void testProviderRenamed() throws Exception {
+        JcloudsLocation loc = resolve("openstack-mitaka-nova:http://hostdoesnotexist.com:5000", ImmutableMap.of("identity", "dummy", "credential", "dummy"));
+        assertComputeServiceType(loc, "openstack-nova");
+        
+        rebind();
+        
+        JcloudsLocation newLoc = (JcloudsLocation) mgmt().getLocationManager().getLocation(loc.getId());
+        assertComputeServiceType(newLoc, "openstack-nova");
+    }
+
+    private JcloudsLocation resolve(String spec) {
+        return resolve(spec, ImmutableMap.of());
+    }
+    
+    private JcloudsLocation resolve(String spec, Map<?,?> flags) {
+        return (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(spec, flags);
+    }
+    
+    private void assertComputeServiceType(JcloudsLocation loc, String expectedType) {
+        // TODO Would be nice to do this more explicitly, rather than relying on toString.
+        // But this is good enough.
+        ComputeService computeService = loc.getComputeService();
+        ComputeServiceContext context = computeService.getContext();
+        assertTrue(context.toString().contains("id="+expectedType), "computeService="+computeService+"; context="+computeService.getContext());
+    }
+    
+}


### PR DESCRIPTION
Without this fix, I get errors when rebinding to my existing persisted state that had used `openstack-mitaka-nova`. The error was:
```
2017-01-12 13:08:09,540 DEBUG 127 o.a.b.l.j.JcloudsSshMachineLocation [Timer-1] Problem getting image for SshMachineLocation[10.104.2.116:amp@10.104.2.116/10.104.2.116:22(id=bwjjhxas6l)], image id RegionOne/e16a7bca-7363-45b1-bd6a-0
2479d4cea77 (continuing)
java.util.NoSuchElementException: key [openstack-mitaka-nova] not in the list of providers or apis: {providers=[softlayer, go2cloud-jhb1, aws-s3, openhosting-east1, aws-ec2, serverlove-z1-man, elastichosts-sat-p, elastichosts-lon-b, gogrid, skalicloud-sdg-my, rackspace-cloudfiles-uk, azureblob, elastichosts-lon-p, rackspace-cloudfiles-us, rackspace-cloudservers-us, azurecompute-arm, rackspace-cloudservers-uk, azurecompute], apis=[rackspace-cloudfiles, openstack-nova, docker, ec2, rackspace-cloudidentity, byon, cloudstack, s3, atmos, openstack-swift, filesystem, stub, sts, elasticstack, transient, openstack-keystone]}
        at org.jclouds.ContextBuilder.newBuilder(ContextBuilder.java:175)[101:jclouds-core:2.0.0]
        at org.apache.brooklyn.location.jclouds.ComputeServiceRegistryImpl.findComputeService(ComputeServiceRegistryImpl.java:175)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsLocation.getComputeService(JcloudsLocation.java:509)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsLocation.getComputeService(JcloudsLocation.java:504)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsLocation.getComputeService(JcloudsLocation.java:498)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation.getComputeServiceOrNull(JcloudsSshMachineLocation.java:226)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation.getOptionalImage(JcloudsSshMachineLocation.java:255)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation.getOptionalOperatingSystem(JcloudsSshMachineLocation.java:562)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation.inferMachineDetails(JcloudsSshMachineLocation.java:580)[127:org.apache.brooklyn.locations-jclouds:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.ssh.SshMachineLocation.getMachineDetails(SshMachineLocation.java:1046)[120:org.apache.brooklyn.core:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.location.ssh.SshMachineLocation.getOsDetails(SshMachineLocation.java:1027)[120:org.apache.brooklyn.core:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.entity.machine.MachineEntityImpl.connectSensors(MachineEntityImpl.java:58)[132:org.apache.brooklyn.software-base:0.11.0.SNAPSHOT]
        at org.apache.brooklyn.entity.software.base.SoftwareProcessImpl$2.run(SoftwareProcessImpl.java:401)[132:org.apache.brooklyn.software-base:0.11.0.SNAPSHOT]
        at java.util.TimerThread.mainLoop(Timer.java:555)[:1.8.0_111]
        at java.util.TimerThread.run(Timer.java:505)[:1.8.0_111]
```