### PR TITLE
Limit parallelism of start/stop steps on SoftwareProcess

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -142,29 +141,12 @@ public class DslDeferredFunctionCall extends BrooklynDslDeferredSupplier<Object>
     }
 
     protected Maybe<?> resolve(Object object, boolean immediate) {
-        if (object instanceof DslFunctionSource || object == null) {
-            return Maybe.of(object);
-        }
-
-        Maybe<?> resultMaybe = Tasks.resolving(object, Object.class)
-                .context(entity().getExecutionContext())
-                .deep(true)
-                .immediately(immediate)
-                .recursive(false)
-                .getMaybe();
-
-        if (resultMaybe.isPresent()) {
-            // No nice way to figure out whether the object is deferred. Try to resolve it
-            // until it matches the input value as a poor man's replacement.
-            Object result = resultMaybe.get();
-            if (result == object) {
-                return resultMaybe;
-            } else {
-                return resolve(result, immediate);
-            }
-        } else {
-            return resultMaybe;
-        }
+        return Tasks.resolving(object, Object.class)
+            .context(entity().getExecutionContext())
+            .deep(true)
+            .immediately(immediate)
+            .iterator()
+            .nextOrLast(DslFunctionSource.class);
     }
 
     private static void checkCallAllowed(Method m) {

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor;
+
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Can be used as:
+ * <pre>
+ * {@code
+ * brooklyn.initializers:
+ * - type: org.apache.brooklyn.core.sensor.MaxConcurrencySensor
+ *   brooklyn.config:
+ *     name: start-latch-value
+ *     latch.concurrency.max: 10
+ * }
+ *
+ * and is the short hand for:
+ *
+ * <pre>
+ * {@code
+ * brooklyn.initializers:
+ * - type: org.apache.brooklyn.core.sensor.StaticSensor
+ *   brooklyn.config:
+ *     name: start-latch-value
+ *     static.value:
+ *       $brooklyn.object:
+ *         type: org.apache.brooklyn.core.sensor.ReleaseableLatch$Factory
+ *         factoryMethod.name: newMaxConcurrencyLatch
+ *         factoryMethod.args: [10]
+ * }
+ * </pre>
+ */
+public class MaxConcurrencySensor extends AddSensor<ReleaseableLatch> {
+    private static final Logger log = LoggerFactory.getLogger(MaxConcurrencySensor.class);
+
+    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newConfigKeyWithDefault(AddSensor.SENSOR_TYPE, ReleaseableLatch.class.getName());
+    public static final ConfigKey<Integer> MAX_CONCURRENCY = ConfigKeys.newIntegerConfigKey(
+            "latch.concurrency.max",
+            "The maximum number of threads that can execute the step for the latch this sensors is used at, in parallel.",
+            Integer.MAX_VALUE);
+    private Object maxConcurrency;
+
+    public MaxConcurrencySensor(ConfigBag params) {
+        super(params);
+        maxConcurrency = params.getStringKey(MAX_CONCURRENCY.getName());
+    }
+
+    @Override
+    public void apply(@SuppressWarnings("deprecation") final org.apache.brooklyn.api.entity.EntityLocal entity) {
+        super.apply(entity);
+        final Task<ReleaseableLatch> resolveValueTask = DependentConfiguration.maxConcurrency(maxConcurrency);
+
+        class SetValue implements Runnable {
+            @Override
+            public void run() {
+                ReleaseableLatch releaseableLatch = resolveValueTask.getUnchecked();
+                log.debug(this+" setting sensor "+sensor+" to "+releaseableLatch+" on "+entity);
+                entity.sensors().set(sensor, releaseableLatch);
+            }
+        }
+        Task<ReleaseableLatch> setValueTask = Tasks.<ReleaseableLatch>builder().displayName("Setting " + sensor + " on " + entity).body(new SetValue()).build();
+
+        Entities.submit(entity, Tasks.sequential("Resolving and setting " + sensor + " on " + entity, resolveValueTask, setValueTask));
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ReleaseableLatch.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ReleaseableLatch.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor;
+
+import java.util.concurrent.Semaphore;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.ImmediateSupplier;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+
+// DeferredSupplier used as a marker interface to prevent coercion. When resolved it must evaluate to {@code Boolean.TRUE}.
+public interface ReleaseableLatch extends DeferredSupplier<Boolean>, ImmediateSupplier<Boolean> {
+    /**
+     * Increment usage count for the {@code caller} entity
+     */
+    void acquire(Entity caller);
+
+    /**
+     * Decrement usage count for the {@code caller} entity
+     */
+    void release(Entity caller);
+
+    static abstract class AbstractReleaseableLatch implements ReleaseableLatch {
+        // Instances coerce to TRUE as they are non-null.
+        @Override public Boolean get() {return Boolean.TRUE;}
+        @Override public Maybe<Boolean> getImmediately() {return Maybe.of(Boolean.TRUE);}
+    }
+
+    ReleaseableLatch NOP = new Factory.NopLatch();
+
+    static class Factory {
+        private static class NopLatch extends AbstractReleaseableLatch {
+            @Override public void acquire(Entity caller) {}
+            @Override public void release(Entity caller) {}
+        }
+
+        private static class MaxConcurrencyLatch extends AbstractReleaseableLatch {
+            private int permits;
+            private transient final Semaphore sem;
+
+            public MaxConcurrencyLatch(int permits) {
+                this.permits = permits;
+                this.sem = new Semaphore(permits);
+            }
+
+            @Override
+            public void acquire(Entity caller) {
+                try {
+                    sem.acquire();
+                } catch (InterruptedException e) {
+                    throw Exceptions.propagate(e);
+                }
+            }
+
+            @Override
+            public void release(Entity caller) {
+                sem.release();
+            }
+
+            // On rebind reset thread count
+            private Object readResolve() {
+                return newMaxConcurrencyLatch(permits);
+            }
+
+            @Override
+            public String toString() {
+                return getClass().getSimpleName() + "[permits=" + sem.availablePermits() + "/" + permits + "]";
+            }
+        }
+
+        public static ReleaseableLatch newMaxConcurrencyLatch(int maxThreadsNum) {
+            return new MaxConcurrencyLatch(maxThreadsNum);
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ReleaseableLatch.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ReleaseableLatch.java
@@ -26,15 +26,18 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 
 import com.google.common.base.Function;
 
-// DeferredSupplier used as a marker interface to prevent coercion. When resolved it must evaluate to {@code Boolean.TRUE}.
 public interface ReleaseableLatch {
     /**
-     * Increment usage count for the {@code caller} entity
+     * Increment usage count for the {@code caller} entity. Implementations may ignore {@code caller}.
+     * 
+     * @param caller The entity latching on the object
      */
     void acquire(Entity caller);
 
     /**
-     * Decrement usage count for the {@code caller} entity
+     * Decrement usage count for the {@code caller} entity. Implementations may ignore {@code caller}.
+     *
+     * @param caller The entity latching on the object
      */
     void release(Entity caller);
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolverIterator.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolverIterator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.task;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+
+/**
+ * Resolve one step at a time, returning intermediate results or absent if there's a resolve error.
+ * Each step is a single one-level evaluation of the previous value.
+ * Use this if you are interested in intermediate suppliers wrapping the end result. Use ValueResolver if you need the deeper-most value.
+ */
+public class ValueResolverIterator<T> implements Iterator<Maybe<Object>> {
+    private static final Maybe<Object> NEXT_VALUE = Maybe.absent();
+    private ValueResolver<T> resolver;
+    private Maybe<Object> prev;
+
+    // * Present when resolving is successful
+    // * Absent when resolving failed
+    // * null when last value reached; can't resolve further either due to error or value is non-resolvable
+    private Maybe<Object> next;
+
+    public ValueResolverIterator(ValueResolver<T> resolver) {
+        this.resolver = resolver;
+        this.prev = Maybe.of(resolver.getOriginalValue());
+        this.next = prev;
+    }
+
+    /**
+     * @return the current element in the iterator. If {@link Maybe#absent()} there was a resolve error.
+     */
+    public Maybe<Object> peek() {
+        return prev;
+    }
+
+    /**
+     * Returns {@code true} if the current value is resolvable.
+     */
+    @Override
+    public boolean hasNext() {
+        fetchNext();
+        return next != null;
+    }
+
+    /**
+     * Resolves the value recursively, returning the immediately resolved value.
+     * If there's a resolve failure a {@link Maybe#absent()} is returned containing
+     * the failure description as the last element.
+     */
+    @Override
+    public Maybe<Object> next() {
+        if (!hasNext()) {
+            if (prev.isPresent()) {
+                throw new NoSuchElementException("The value " + prev.get() + " is non-resolvable");
+            } else {
+                throw new NoSuchElementException("Last resolve failed: " + prev);
+            }
+        }
+        prev = next;
+        next = NEXT_VALUE;
+        return prev;
+    }
+
+    private void fetchNext() {
+        if (next == NEXT_VALUE) {
+            if (prev.isPresent()) {
+                Object prevValue = prev.get();
+                if (prevValue != null) {
+                    ValueResolver<Object> nextResolver = createIterativeResolver(prevValue);
+                    try {
+                        next = nextResolver.getMaybe();
+                    } catch (Exception e) {
+                        Exceptions.propagateIfFatal(e);
+                        next = Maybe.absent("Failed resolving " + prev + " with resolver " + resolver, e);
+                    }
+                    if (next.isPresent() && next.get() == prev.get()) {
+                        // Resolved value same as previous value, last element reached
+                        next = null;
+                    }
+                } else {
+                    // Can't resolve null further
+                    // Same as previous case, just cuts on on the resolver calls
+                    next = null;
+                }
+            } else {
+                // Resolve error, can't continue
+                next = null;
+            }
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new IllegalStateException("Operation not supported");
+    }
+
+    private ValueResolver<Object> createIterativeResolver(Object value) {
+        return resolver.cloneReplacingValueAndType(value, Object.class)
+            .recursive(false);
+    }
+
+    /**
+     * @return the first resolved value satisfying the {@code stopCondition}.
+     * If none is found return the last element.
+     */
+    public Maybe<Object> nextOrLast(Predicate<Object> stopCondition) {
+        if (!hasNext()) {
+            return prev;
+        }
+        Maybe<Object> item;
+        do {
+            item = next();
+            if (item.isAbsent() || stopCondition.apply(item.get())) {
+                return item;
+            }
+        } while (hasNext());
+        return item;
+    }
+
+    /**
+     * @return the first resolved value instance of {@code type}.
+     * If none is found return the last element.
+     */
+    public Maybe<Object> nextOrLast(Class<?> type) {
+        return nextOrLast(Predicates.instanceOf(type));
+    }
+
+    /**
+     * @return the first resolved value instance of {@code type}.
+     * If not found returns {@link Maybe#absent()} either due to
+     * the end reached or a resolve error. To check if there was a
+     * resolve error call {@code peek().isAbsent()}.
+     */
+    public <S> Maybe<S> next(Class<S> type) {
+        while (hasNext()) {
+            Maybe<Object> item = next();
+            if (item.isAbsent() || type.isInstance(item.get())) {
+                @SuppressWarnings("unchecked")
+                Maybe<S> typedItem = (Maybe<S>) item;
+                return typedItem;
+            }
+        }
+        return Maybe.absent("Did not find items of type " + type + " in " + resolver);
+    }
+
+    /**
+     * @return the last element of the iterator reached either because
+     * resolving no longer possible or there was a resolve error.
+     */
+    @SuppressWarnings("unchecked")
+    public Maybe<T> last() {
+        Maybe<Object> last = peek();
+        while (hasNext()) {
+            last = next();
+            if (last.isAbsent()) {
+                return (Maybe<T>) last;
+            }
+        }
+        return coerceValue(last, resolver.getType());
+    }
+
+    private Maybe<T> coerceValue(Maybe<Object> valueMaybe, Class<T> type) {
+        if (valueMaybe.isPresent()) {
+            T coercedValue = TypeCoercions.coerce(valueMaybe.get(), type);
+            return Maybe.of(coercedValue);
+        } else {
+            @SuppressWarnings("unchecked")
+            Maybe<T> uncheckedValue = (Maybe<T>) valueMaybe;
+            return uncheckedValue;
+        }
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensorTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 
 public class MaxConcurrencySensorTest extends BrooklynAppUnitTestSupport {
     private static final AttributeSensor<Integer> MAX_PERMITS = Sensors.newIntegerSensor("max.permits");
-    private static final AttributeSensor<ReleaseableLatch> SENSOR = Sensors.newSensor(ReleaseableLatch.class, "myname");
 
     @Test
     public void testAddsStaticSensorOfTypeString() {
@@ -43,7 +42,7 @@ public class MaxConcurrencySensorTest extends BrooklynAppUnitTestSupport {
         int actualPermits = 10;
         app.sensors().set(MAX_PERMITS, actualPermits);
 
-        EntityAsserts.assertAttributeEventuallyNonNull(entity, SENSOR);
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, (AttributeSensor<?>)entity.getEntityType().getSensor("myname"));
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/MaxConcurrencySensorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MaxConcurrencySensorTest extends BrooklynAppUnitTestSupport {
+    private static final AttributeSensor<Integer> MAX_PERMITS = Sensors.newIntegerSensor("max.permits");
+    private static final AttributeSensor<ReleaseableLatch> SENSOR = Sensors.newSensor(ReleaseableLatch.class, "myname");
+
+    @Test
+    public void testAddsStaticSensorOfTypeString() {
+        BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
+                .addInitializer(new MaxConcurrencySensor(ConfigBag.newInstance(ImmutableMap.of(
+                        MaxConcurrencySensor.SENSOR_NAME, "myname",
+                        MaxConcurrencySensor.MAX_CONCURRENCY, DependentConfiguration.formatString("%d",
+                                DependentConfiguration.attributeWhenReady(app, MAX_PERMITS)))))));
+
+        int actualPermits = 10;
+        app.sensors().set(MAX_PERMITS, actualPermits);
+
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, SENSOR);
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/ReleaseableLatchRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/ReleaseableLatchRebindTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor;
+
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.Test;
+
+public class ReleaseableLatchRebindTest extends RebindTestFixtureWithApp {
+
+    @Test(timeOut = Asserts.THIRTY_SECONDS_TIMEOUT_MS)
+    public void testRebindResetsPermits() throws Exception {
+        final AttributeSensor<ReleaseableLatch> latchSensor = Sensors.newSensor(ReleaseableLatch.class, "latch");
+        final ReleaseableLatch latchSemaphore = ReleaseableLatch.Factory.newMaxConcurrencyLatch(1);
+        origApp.sensors().set(latchSensor, latchSemaphore);
+        latchSemaphore.acquire(origApp);
+ 
+        rebind();
+
+        ReleaseableLatch newSemaphore = newApp.sensors().get(latchSensor);
+        // makes sure permits are reset and we can acquire the semaphore again
+        newSemaphore.acquire(origApp);
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
@@ -23,6 +23,7 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.test.Asserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -51,7 +52,7 @@ public class BrooklynMgmtUnitTestSupport {
         }
     }
 
-    @AfterMethod(alwaysRun=true)
+    @AfterMethod(alwaysRun=true, timeOut=Asserts.THIRTY_SECONDS_TIMEOUT_MS)
     public void tearDown() throws Exception {
         try {
             destroyManagementContextSafely(mgmt);

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverIteratorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverIteratorTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.task;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.NoSuchElementException;
+
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.core.task.ValueResolverTest.FailingImmediateAndDeferredSupplier;
+import org.apache.brooklyn.util.core.task.ValueResolverTest.WrappingImmediateAndDeferredSupplier;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicates;
+
+public class ValueResolverIteratorTest extends BrooklynAppUnitTestSupport {
+    enum ResolveType {
+        IMMEDIATE(true),
+        BLOCKING(false);
+
+        private boolean immediate;
+
+        ResolveType(boolean immediate) {
+            this.immediate = immediate;
+        }
+
+        public boolean isImmediate() {
+            return immediate;
+        }
+    }
+
+    @DataProvider
+    public Object[][] resolveTypes() {
+        return new Object[][] {{ResolveType.IMMEDIATE}, {ResolveType.BLOCKING}};
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testIteratorFailing(ResolveType resolveType) {
+        FailingImmediateAndDeferredSupplier failingExpected = new FailingImmediateAndDeferredSupplier();
+        WrappingImmediateAndDeferredSupplier wrapperExpected = new WrappingImmediateAndDeferredSupplier(failingExpected);
+        ValueResolver<Object> resolver = Tasks.resolving(wrapperExpected)
+                .as(Object.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Object> iter = resolver.iterator();
+        assertTrue(iter.hasNext(), "expected wrapper");
+        Maybe<Object> wrapperActual = iter.next();
+        assertEquals(wrapperActual.get(), wrapperExpected);
+        assertEquals(wrapperActual, iter.peek());
+        assertTrue(iter.hasNext());
+        Maybe<Object> failingActual = iter.next();
+        assertEquals(failingActual.get(), failingExpected);
+        assertEquals(failingActual, iter.peek());
+        assertTrue(iter.hasNext());
+        Maybe<Object> absent = iter.next();
+        assertTrue(absent.isAbsent());
+
+        assertFalse(iter.hasNext(), "expected absent due to resolve failure");
+        try {
+            iter.next();
+            Asserts.shouldHaveFailedPreviously("no more elements in iterator");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
+
+        Maybe<Object> last = iter.nextOrLast(Predicates.alwaysTrue());
+        assertTrue(last.isAbsent(), "expected absent because previous resolve failed");
+        assertEquals(last, iter.peek());
+
+        try {
+            iter.remove();
+            Asserts.shouldHaveFailedPreviously("can't remove elements");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testIterator(ResolveType resolveType) {
+        Integer o3ExpectedLast = Integer.valueOf(10);
+        String o3Expected = o3ExpectedLast.toString(); //test coercion
+        WrappingImmediateAndDeferredSupplier o2Expected = new WrappingImmediateAndDeferredSupplier(o3Expected);
+        WrappingImmediateAndDeferredSupplier o1Expected = new WrappingImmediateAndDeferredSupplier(o2Expected);
+        ValueResolver<Integer> resolver = Tasks.resolving(o1Expected)
+                .as(Integer.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Integer> iter = resolver.iterator();
+        assertTrue(iter.hasNext(), "expected o1");
+        Maybe<Object> o1Actual = iter.next();
+        assertEquals(o1Actual.get(), o1Expected);
+        assertEquals(o1Actual, iter.peek());
+        assertTrue(iter.hasNext());
+        Maybe<Object> o2Actual = iter.next();
+        assertEquals(o2Actual.get(), o2Expected);
+        assertEquals(o2Actual, iter.peek());
+        assertTrue(iter.hasNext());
+        Maybe<Object> o3Actual = iter.next();
+        assertEquals(o3Actual.get(), o3Expected);
+        assertEquals(o3Actual, iter.peek());
+
+        assertFalse(iter.hasNext(), "expected no more elements");
+        try {
+            iter.next();
+            Asserts.shouldHaveFailedPreviously("no more elements in iterator");
+        } catch (NoSuchElementException e) {
+            // expected
+        }
+
+        Maybe<Object> lastUntyped = iter.nextOrLast(Predicates.alwaysTrue());
+        assertTrue(lastUntyped.isPresent(), "expected present - all resolves successful");
+        // Note these are NOT equal because peek doesn't coerce
+        assertEquals(lastUntyped, iter.peek());
+        assertEquals(lastUntyped.get(), o3Expected);
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testNull(ResolveType resolveType) {
+        ValueResolver<Void> resolver = Tasks.resolving(null)
+            .as(Void.class)
+            .context(app)
+            .immediately(resolveType.isImmediate());
+        assertNull(resolver.get());
+        ValueResolverIterator<Void> iter = resolver.iterator();
+        assertTrue(iter.hasNext());
+        assertNull(iter.next().get());
+        assertFalse(iter.hasNext());
+
+        Maybe<Object> voidOrLast = resolver.iterator().nextOrLast(Void.class);
+        assertNull(voidOrLast.get());
+
+        Maybe<Void> voidItem = resolver.iterator().next(Void.class);
+        assertTrue(voidItem.isAbsent());
+
+        Maybe<Void> lastItem = resolver.iterator().last();
+        assertNull(lastItem.get());
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testNextOrLastFound(ResolveType resolveType) {
+        FailingImmediateAndDeferredSupplier failingExpected = new FailingImmediateAndDeferredSupplier();
+        WrappingImmediateAndDeferredSupplier wrapperExpected = new WrappingImmediateAndDeferredSupplier(failingExpected);
+        ValueResolver<Object> resolver = Tasks.resolving(wrapperExpected)
+                .as(Object.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Object> iter = resolver.iterator();
+        Maybe<Object> actual = iter.nextOrLast(FailingImmediateAndDeferredSupplier.class);
+        assertTrue(actual.isPresent());
+        assertNotEquals(actual, iter.last());
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testNextOrLastNotFound(ResolveType resolveType) {
+        FailingImmediateAndDeferredSupplier failingExpected = new FailingImmediateAndDeferredSupplier();
+        WrappingImmediateAndDeferredSupplier wrapperExpected = new WrappingImmediateAndDeferredSupplier(failingExpected);
+        ValueResolver<Object> resolver = Tasks.resolving(wrapperExpected)
+                .as(Object.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Object> iter = resolver.iterator();
+        Maybe<Object> actual = iter.nextOrLast(Void.class);
+        assertFalse(actual.isPresent());
+        assertEquals(actual, iter.last());
+    }
+    
+    @Test(dataProvider="resolveTypes")
+    public void testNextTypeFound(ResolveType resolveType) {
+        FailingImmediateAndDeferredSupplier failingExpected = new FailingImmediateAndDeferredSupplier();
+        WrappingImmediateAndDeferredSupplier wrapperExpected = new WrappingImmediateAndDeferredSupplier(failingExpected);
+        ValueResolver<Object> resolver = Tasks.resolving(wrapperExpected)
+                .as(Object.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Object> iter = resolver.iterator();
+        Maybe<FailingImmediateAndDeferredSupplier> actual = iter.next(FailingImmediateAndDeferredSupplier.class);
+        assertTrue(actual.isPresent());
+        assertNotEquals(actual, iter.last());
+    }
+
+    @Test(dataProvider="resolveTypes")
+    public void testNextTypeNotFound(ResolveType resolveType) {
+        FailingImmediateAndDeferredSupplier failingExpected = new FailingImmediateAndDeferredSupplier();
+        WrappingImmediateAndDeferredSupplier wrapperExpected = new WrappingImmediateAndDeferredSupplier(failingExpected);
+        ValueResolver<Object> resolver = Tasks.resolving(wrapperExpected)
+                .as(Object.class)
+                .context(app)
+                .immediately(resolveType.isImmediate());
+        ValueResolverIterator<Object> iter = resolver.iterator();
+        Maybe<Void> actual = iter.next(Void.class);
+        assertFalse(actual.isPresent());
+        assertEquals(actual, iter.last());
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
@@ -249,7 +249,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
         }
     }
     
-    private static class WrappingImmediateAndDeferredSupplier implements ImmediateSupplier<Object>, DeferredSupplier<Object> {
+    static class WrappingImmediateAndDeferredSupplier implements ImmediateSupplier<Object>, DeferredSupplier<Object> {
         private Object value;
 
         public WrappingImmediateAndDeferredSupplier(Object value) {
@@ -268,7 +268,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
         
     }
 
-    private static class FailingImmediateAndDeferredSupplier implements ImmediateSupplier<Object>, DeferredSupplier<Object> {
+    static class FailingImmediateAndDeferredSupplier implements ImmediateSupplier<Object>, DeferredSupplier<Object> {
 
         @Override
         public Object get() {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefLifecycleEffectorTasks.java
@@ -28,15 +28,12 @@ import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.location.Machines;
-import org.apache.brooklyn.core.sensor.ReleaseableLatch;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.util.collections.Jsonya;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.Jsonya.Navigator;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskTags;
@@ -48,6 +45,8 @@ import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
@@ -59,7 +58,7 @@ import com.google.common.collect.ImmutableList;
  * <p>
  * Instances of this should use the {@link ChefConfig} config attributes to configure startup,
  * and invoke {@link #usePidFile(String)} or {@link #useService(String)} to determine check-running and stop behaviour.
- * Alternatively this can be subclassed and {@link #postStartCustom(AtomicReference)} and {@link #stopProcessesAtMachine()} overridden.
+ * Alternatively this can be subclassed and {@link #postStartCustom()} and {@link #stopProcessesAtMachine()} overridden.
  * 
  * @since 0.6.0
  **/
@@ -239,7 +238,7 @@ public class ChefLifecycleEffectorTasks extends MachineLifecycleEffectorTasks im
     }
 
     @Override
-    protected void postStartCustom(AtomicReference<ReleaseableLatch> startLatchRef) {
+    protected void postStartCustom() {
         boolean result = false;
         result |= tryCheckStartPid();
         result |= tryCheckStartService();
@@ -248,7 +247,7 @@ public class ChefLifecycleEffectorTasks extends MachineLifecycleEffectorTasks im
             log.warn("No way to check whether "+entity()+" is running; assuming yes");
         }
         entity().sensors().set(SoftwareProcess.SERVICE_UP, true);
-        super.postStartCustom(startLatchRef);
+        super.postStartCustom();
     }
     
     protected boolean tryCheckStartPid() {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -38,14 +38,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.sensor.ReleaseableLatch;
+import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -132,8 +136,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 boolean skipInstall = locationInstalled.or(entityInstalled).or(false);
                 if (!skipInstall) {
                     DynamicTasks.queue("copy-pre-install-resources", new Runnable() { @Override public void run() {
-                        waitForConfigKey(BrooklynConfigKeys.PRE_INSTALL_RESOURCES_LATCH);
-                        copyPreInstallResources();
+                        try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.PRE_INSTALL_RESOURCES_LATCH)) {
+                            copyPreInstallResources();
+                        }
                     }});
 
                     DynamicTasks.queue("pre-install", new Runnable() { @Override public void run() {
@@ -145,18 +150,21 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                     }});
 
                     DynamicTasks.queue("setup", new Runnable() { @Override public void run() {
-                        waitForConfigKey(BrooklynConfigKeys.SETUP_LATCH);
-                        setup();
+                        try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.SETUP_LATCH)) {
+                            setup();
+                        }
                     }});
 
                     DynamicTasks.queue("copy-install-resources", new Runnable() { @Override public void run() {
-                        waitForConfigKey(BrooklynConfigKeys.INSTALL_RESOURCES_LATCH);
-                        copyInstallResources();
+                        try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.INSTALL_RESOURCES_LATCH)) {
+                            copyInstallResources();
+                        }
                     }});
 
                     DynamicTasks.queue("install (main)", new Runnable() { @Override public void run() {
-                        waitForConfigKey(BrooklynConfigKeys.INSTALL_LATCH);
-                        install();
+                        try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.INSTALL_LATCH)) {
+                            install();
+                        }
                     }});
 
                     DynamicTasks.queue("post-install-command", new Runnable() { @Override public void run() {
@@ -171,8 +179,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 }});
 
                 DynamicTasks.queue("customize (main)", new Runnable() { @Override public void run() {
-                    waitForConfigKey(BrooklynConfigKeys.CUSTOMIZE_LATCH);
-                    customize();
+                    try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.CUSTOMIZE_LATCH)) {
+                        customize();
+                    }
                 }});
 
                 DynamicTasks.queue("post-customize-command", new Runnable() { @Override public void run() {
@@ -181,9 +190,10 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
             }});
 
             DynamicTasks.queue("launch", new Runnable() { @Override public void run() {
-                DynamicTasks.queue("copy-runtime-resources", new Runnable() { @Override public void run() {
-                    waitForConfigKey(BrooklynConfigKeys.RUNTIME_RESOURCES_LATCH);
-                    copyRuntimeResources();
+                DynamicTasks.queue("copy-runtime-resources", new Runnable() { public void run() {
+                    try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.RUNTIME_RESOURCES_LATCH)) {
+                        copyRuntimeResources();
+                    }
                 }});
 
                 DynamicTasks.queue("pre-launch-command", new Runnable() { @Override public void run() {
@@ -191,8 +201,9 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
                 }});
 
                 DynamicTasks.queue("launch (main)", new Runnable() { @Override public void run() {
-                    waitForConfigKey(BrooklynConfigKeys.LAUNCH_LATCH);
-                    launch();
+                    try (CloseableLatch value = waitForLatch(BrooklynConfigKeys.LAUNCH_LATCH)) {
+                        launch();
+                    }
                 }});
 
                 DynamicTasks.queue("post-launch-command", new Runnable() { @Override public void run() {
@@ -204,6 +215,29 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         DynamicTasks.queue("post-launch", new Runnable() { @Override public void run() {
             postLaunch();
         }});
+    }
+
+    // Removes the checked Exception from the method signature
+    private static class CloseableLatch implements AutoCloseable {
+        private Entity caller;
+        private ReleaseableLatch releaseableLatch;
+
+        public CloseableLatch(Entity caller, ReleaseableLatch releaseableLatch) {
+            super();
+            this.caller = caller;
+            this.releaseableLatch = releaseableLatch;
+        }
+
+        @Override
+        public void close() {
+            DynamicTasks.waitForLast();
+            releaseableLatch.release(caller);
+        }
+    }
+
+    private CloseableLatch waitForLatch(ConfigKey<Boolean> configKey) {
+        ReleaseableLatch releaseableLatch = MachineLifecycleEffectorTasks.waitForLatch((EntityInternal)entity, configKey);
+        return new CloseableLatch(entity, releaseableLatch);
     }
 
     @Override
@@ -622,11 +656,6 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
 
     public String processTemplateContents(String templateContents, Map<String,? extends Object> extraSubstitutions) {
         return TemplateProcessor.processTemplateContents(templateContents, this, extraSubstitutions);
-    }
-
-    protected void waitForConfigKey(ConfigKey<?> configKey) {
-        Object val = entity.config().get(configKey);
-        if (val != null) log.debug("{} finished waiting for {} (value {}); continuing...", new Object[] {this, configKey, val});
     }
 
     public String getArchiveNameFormat() {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -48,8 +47,8 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
-import org.apache.brooklyn.core.sensor.ReleaseableLatch;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
+import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks.CloseableLatch;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -217,26 +216,8 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         }});
     }
 
-    // Removes the checked Exception from the method signature
-    private static class CloseableLatch implements AutoCloseable {
-        private Entity caller;
-        private ReleaseableLatch releaseableLatch;
-
-        public CloseableLatch(Entity caller, ReleaseableLatch releaseableLatch) {
-            this.caller = caller;
-            this.releaseableLatch = releaseableLatch;
-        }
-
-        @Override
-        public void close() {
-            DynamicTasks.drain(null, false);
-            releaseableLatch.release(caller);
-        }
-    }
-
     private CloseableLatch waitForLatch(ConfigKey<Boolean> configKey) {
-        ReleaseableLatch releaseableLatch = MachineLifecycleEffectorTasks.waitForLatch((EntityInternal)entity, configKey);
-        return new CloseableLatch(entity, releaseableLatch);
+        return MachineLifecycleEffectorTasks.waitForCloseableLatch((EntityInternal)entity, configKey);
     }
 
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -223,14 +223,13 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
         private ReleaseableLatch releaseableLatch;
 
         public CloseableLatch(Entity caller, ReleaseableLatch releaseableLatch) {
-            super();
             this.caller = caller;
             this.releaseableLatch = releaseableLatch;
         }
 
         @Override
         public void close() {
-            DynamicTasks.waitForLast();
+            DynamicTasks.drain(null, false);
             releaseableLatch.release(caller);
         }
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -88,7 +88,7 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
             try {
                 // There's no preStartCustom call in the restart effector to get the latch value
                 // so nothing to release here - pass the nop value.
-                postStartCustom(new AtomicReference<>(ReleaseableLatch.NOP));
+                postStartCustom();
                 postRestartCustom();
             } finally {
                 ServiceStateLogic.setExpectedState(entity(), Lifecycle.RUNNING);
@@ -174,7 +174,7 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
 
     @Override
-    protected void postStartCustom(AtomicReference<ReleaseableLatch> startLatchRef) {
+    protected void postStartCustom() {
         entity().postDriverStart();
         if (entity().connectedSensors) {
             // many impls aren't idempotent - though they should be!
@@ -185,7 +185,7 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
         }
         entity().waitForServiceUp();
         entity().postStart();
-        super.postStartCustom(startLatchRef);
+        super.postStartCustom();
     }
     
     @Override
@@ -261,10 +261,9 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
     
     @Override
-    protected void postStopCustom(AtomicReference<ReleaseableLatch> stopLatchRef) {
-        super.postStopCustom(stopLatchRef);
-        
+    protected void postStopCustom() {
         entity().postStop();
+        super.postStopCustom();
     }
 
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessDriverLifecycleEffectorTasks.java
@@ -122,13 +122,13 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
      
     @Override
-    protected void preStartCustom(MachineLocation machine, AtomicReference<ReleaseableLatch> startLatchRef) {
+    protected void preStartCustom(MachineLocation machine) {
         entity().initDriver(machine);
 
         // Note: must only apply config-sensors after adding to locations and creating driver; 
         // otherwise can't do things like acquire free port from location
         // or allowing driver to set up ports; but must be careful in init not to block on these!
-        super.preStartCustom(machine, startLatchRef);
+        super.preStartCustom(machine);
         
         entity().preStart();
     }
@@ -189,8 +189,8 @@ public class SoftwareProcessDriverLifecycleEffectorTasks extends MachineLifecycl
     }
     
     @Override
-    protected void preStopConfirmCustom(AtomicReference<ReleaseableLatch> stopLatchRef) {
-        super.preStopConfirmCustom(stopLatchRef);
+    protected void preStopConfirmCustom() {
+        super.preStopConfirmCustom();
         
         entity().preStopConfirmCustom();
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasks.java
@@ -1152,6 +1152,7 @@ public abstract class MachineLifecycleEffectorTasks {
             return ReleaseableLatch.NOP;
         } else {
             ValueResolverIterator<Boolean> iter = resolveLatchIterator(entity, rawValue.get(), configKey);
+            // The iterator is used to prevent coercion; the value should always be the last one, but iter.last() will return a coerced Boolean
             Maybe<ReleaseableLatch> releasableLatchMaybe = iter.next(ReleaseableLatch.class);
             if (releasableLatchMaybe.isPresent()) {
                 ReleaseableLatch latch = releasableLatchMaybe.get();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
@@ -56,7 +56,6 @@ import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskInternal;
-import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
@@ -286,14 +285,6 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
         public CountingLatch(ReleaseableLatch delegate, int maxConcurrency) {
             this.delegate = delegate;
             this.maxConcurrency = maxConcurrency;
-        }
-
-        public Boolean get() {
-            return delegate.get();
-        }
-
-        public Maybe<Boolean> getImmediately() {
-            return delegate.getImmediately();
         }
 
         public void acquire(Entity caller) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
@@ -128,9 +128,7 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
             public Void apply(MyService entity) {
                 String taskName = (latch == SoftwareProcess.STOP_LATCH) ? "stop" : "start";
                 assertEffectorBlockingDetailsEventually(entity, taskName, "Acquiring " + latch + " " + latchSemaphore);
-                if (latch != SoftwareProcess.START_LATCH) {
-                    assertDriverEventsEquals(entity, preLatchEvents);
-                }
+                assertDriverEventsEquals(entity, preLatchEvents);
                 latchSemaphore.release(entity);
                 return null;
             }
@@ -153,9 +151,7 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
         }
 
         assertEffectorBlockingDetailsEventually(entity, task.getDisplayName(), "Waiting for config " + latch.getName());
-        if (latch != SoftwareProcess.START_LATCH) {
-            assertDriverEventsEquals(entity, preLatchEvents);
-        }
+        assertDriverEventsEquals(entity, preLatchEvents);
         assertFalse(task.isDone());
 
         app.sensors().set(latchSensor, latchValue);
@@ -246,8 +242,13 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
     }
 
     private void assertDriverEventsEquals(MyService entity, List<String> expectedEvents) {
-        List<String> events = ((SimulatedDriver)entity.getDriver()).events;
-        assertEquals(events, expectedEvents, "events="+events);
+        SimulatedDriver driver = (SimulatedDriver)entity.getDriver();
+        if (driver != null) {
+            List<String> events = driver.events;
+            assertEquals(events, expectedEvents, "events="+events);
+        } else {
+            assertEquals(expectedEvents.size(), 0);
+        }
     }
 
     private void assertEffectorBlockingDetailsEventually(final Entity entity, final String effectorName, final String blockingDetailsSnippet) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
@@ -128,7 +128,9 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
             public Void apply(MyService entity) {
                 String taskName = (latch == SoftwareProcess.STOP_LATCH) ? "stop" : "start";
                 assertEffectorBlockingDetailsEventually(entity, taskName, "Acquiring " + latch + " " + latchSemaphore);
-                assertDriverEventsEquals(entity, preLatchEvents);
+                if (latch != SoftwareProcess.START_LATCH) {
+                    assertDriverEventsEquals(entity, preLatchEvents);
+                }
                 latchSemaphore.release(entity);
                 return null;
             }
@@ -151,7 +153,9 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
         }
 
         assertEffectorBlockingDetailsEventually(entity, task.getDisplayName(), "Waiting for config " + latch.getName());
-        assertDriverEventsEquals(entity, preLatchEvents);
+        if (latch != SoftwareProcess.START_LATCH) {
+            assertDriverEventsEquals(entity, preLatchEvents);
+        }
         assertFalse(task.isDone());
 
         app.sensors().set(latchSensor, latchValue);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityLatchTest.java
@@ -21,10 +21,12 @@ package org.apache.brooklyn.entity.software.base;
 import static org.apache.brooklyn.core.mgmt.BrooklynTaskTags.getEffectorName;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -32,25 +34,31 @@ import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
+import org.apache.brooklyn.core.sensor.ReleaseableLatch;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.MyService;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.SimulatedDriver;
-import org.apache.brooklyn.entity.stock.BasicEntity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.task.TaskInternal;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -58,10 +66,14 @@ import com.google.common.collect.Lists;
 
 public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
 
+
     // NB: These tests don't actually require ssh to localhost -- only that 'localhost' resolves.
 
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(SoftwareProcessEntityLatchTest.class);
+
+    private static final ImmutableList<String> SOFTWARE_PROCESS_START_TASKS = ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources", "launch");
+    private static final ImmutableList<String> SOFTWARE_PROCESS_STOP_TASKS = ImmutableList.<String>builder().addAll(SOFTWARE_PROCESS_START_TASKS).add("stop").build();
 
     private SshMachineLocation machine;
     private FixedListMachineProvisioningLocation<SshMachineLocation> loc;
@@ -81,78 +93,99 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
         loc.addMachine(machine);
         return loc;
     }
-
-    @Test
-    public void testStartLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.START_LATCH, ImmutableList.<String>of());
+    
+    @DataProvider
+    public Object[][] latchAndTaskNamesProvider() {
+        return new Object[][] {
+            {SoftwareProcess.START_LATCH, ImmutableList.<String>of()},
+            {SoftwareProcess.SETUP_LATCH, ImmutableList.<String>of()},
+            {SoftwareProcess.INSTALL_RESOURCES_LATCH, ImmutableList.of("setup")},
+            {SoftwareProcess.INSTALL_LATCH, ImmutableList.of("setup", "copyInstallResources")},
+            {SoftwareProcess.CUSTOMIZE_LATCH, ImmutableList.of("setup", "copyInstallResources", "install")},
+            {SoftwareProcess.RUNTIME_RESOURCES_LATCH, ImmutableList.of("setup", "copyInstallResources", "install", "customize")},
+            {SoftwareProcess.LAUNCH_LATCH, ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources")},
+            {SoftwareProcess.STOP_LATCH, SOFTWARE_PROCESS_START_TASKS},
+        };
     }
 
-    @Test
-    public void testSetupLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.SETUP_LATCH, ImmutableList.<String>of());
+    @Test(dataProvider="latchAndTaskNamesProvider")
+    public void testBooleanLatchBlocks(final ConfigKey<Boolean> latch, List<String> preLatchEvents) throws Exception {
+        doTestLatchBlocks(latch, preLatchEvents, Boolean.TRUE, Functions.<Void>constant(null));
     }
 
-    @Test
-    public void testIntallResourcesLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.INSTALL_RESOURCES_LATCH, ImmutableList.of("setup"));
+    @Test(dataProvider="latchAndTaskNamesProvider")
+    public void testReleaseableLatchBlocks(final ConfigKey<Boolean> latch, final List<String> preLatchEvents) throws Exception {
+        final ReleaseableLatch latchSemaphore = ReleaseableLatch.Factory.newMaxConcurrencyLatch(0);
+        doTestLatchBlocks(latch, preLatchEvents, latchSemaphore, new Function<MyService, Void>() {
+            @Override
+            public Void apply(MyService entity) {
+                String taskName = (latch == SoftwareProcess.STOP_LATCH) ? "stop" : "start";
+                assertEffectorBlockingDetailsEventually(entity, taskName, "Acquiring " + latch + " " + latchSemaphore);
+                assertDriverEventsEquals(entity, preLatchEvents);
+                latchSemaphore.release(entity);
+                return null;
+            }
+        });
+
     }
 
-    @Test
-    public void testInstallLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.INSTALL_LATCH, ImmutableList.of("setup", "copyInstallResources"));
-    }
-
-    @Test
-    public void testCustomizeLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.CUSTOMIZE_LATCH, ImmutableList.of("setup", "copyInstallResources", "install"));
-    }
-
-    @Test
-    public void testRuntimeResourcesLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.RUNTIME_RESOURCES_LATCH, ImmutableList.of("setup", "copyInstallResources", "install", "customize"));
-    }
-
-    @Test
-    public void testLaunchLatchBlocks() throws Exception {
-        runTestLatchBlocks(SoftwareProcess.LAUNCH_LATCH, ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources"));
-    }
-
-    @Test
-    public void testStopLatchBlocks() throws Exception {
-        final AttributeSensor<Boolean> stopper = Sensors.newBooleanSensor("stop.now");
-        final BasicEntity triggerEntity = app.createAndManageChild(EntitySpec.create(BasicEntity.class));
+    public void doTestLatchBlocks(ConfigKey<Boolean> latch, List<String> preLatchEvents, Object latchValue, Function<? super MyService, Void> customAssertFn) throws Exception {
+        final AttributeSensor<Object> latchSensor = Sensors.newSensor(Object.class, "latch");
         final MyService entity = app.createAndManageChild(EntitySpec.create(MyService.class)
-                .configure(SoftwareProcess.STOP_LATCH, DependentConfiguration.attributeWhenReady(app, stopper)));
-        
+                .configure(ConfigKeys.newConfigKey(Object.class, latch.getName()), (Object)DependentConfiguration.attributeWhenReady(app, latchSensor)));
+
+        final Task<Void> task;
         final Task<Void> startTask = Entities.invokeEffector(app, app, MyService.START, ImmutableMap.of("locations", ImmutableList.of(loc)));
-        triggerEntity.sensors().set(Attributes.SERVICE_UP, true);
-        startTask.get(Duration.THIRTY_SECONDS);
+        if (latch != SoftwareProcess.STOP_LATCH) {
+            task = startTask;
+        } else {
+            startTask.get(Duration.THIRTY_SECONDS);
+            task = Entities.invokeEffector(app, app, MyService.STOP);
+        }
 
-        final Task<Void> stopTask = Entities.invokeEffector(app, app, MyService.STOP);
+        assertEffectorBlockingDetailsEventually(entity, task.getDisplayName(), "Waiting for config " + latch.getName());
+        assertDriverEventsEquals(entity, preLatchEvents);
+        assertFalse(task.isDone());
 
-        assertEffectorBlockingDetailsEventually(entity, MyService.STOP.getName(), "Waiting for config " + SoftwareProcess.STOP_LATCH.getName());
+        app.sensors().set(latchSensor, latchValue);
 
-        app.sensors().set(stopper, true);
-        stopTask.get(Asserts.DEFAULT_LONG_TIMEOUT);
+        customAssertFn.apply(entity);
 
-        assertDriverEventsEquals(entity, ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources", "launch", "stop"));
+        task.get(Duration.THIRTY_SECONDS);
+        assertDriverEventsEquals(entity, getLatchPostTasks(latch));
     }
 
+    @Test(dataProvider="latchAndTaskNamesProvider", timeOut=Asserts.THIRTY_SECONDS_TIMEOUT_MS)
+    public void testConcurrency(ConfigKey<Boolean> latch, List<String> _) throws Exception {
+        final int maxConcurrency = 2;
+        final ReleaseableLatch latchSemaphore = ReleaseableLatch.Factory.newMaxConcurrencyLatch(maxConcurrency);
+        final AttributeSensor<Object> latchSensor = Sensors.newSensor(Object.class, "latch");
+        final CountingLatch countingLatch = new CountingLatch(latchSemaphore, maxConcurrency);
+        @SuppressWarnings({"unused"})
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.INITIAL_SIZE, maxConcurrency*2)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(MyService.class)
+                        .configure(ConfigKeys.newConfigKey(Object.class, latch.getName()), (Object)DependentConfiguration.attributeWhenReady(app, latchSensor))));
+        app.sensors().set(latchSensor, countingLatch);
+        final Task<Void> startTask = Entities.invokeEffector(app, app, MyService.START, ImmutableMap.of("locations", ImmutableList.of(app.newLocalhostProvisioningLocation())));
+        startTask.get();
+        final Task<Void> stopTask = Entities.invokeEffector(app, app, MyService.STOP, ImmutableMap.<String, Object>of());
+        stopTask.get();
+        assertEquals(countingLatch.getCounter(), 0);
+        // Check we have actually used the latch
+        assertNotEquals(countingLatch.getMaxCounter(), 0, "Latch not acquired at all");
+        // In theory this is 0 < maxCnt <= maxConcurrency contract, but in practice
+        // we should always reach the maximum due to the sleeps below.
+        // Change if found to fail in the wild.
+        assertEquals(countingLatch.getMaxCounter(), maxConcurrency);
+    }
 
-    protected void runTestLatchBlocks(final ConfigKey<Boolean> latch, List<String> preLatchEvents) throws Exception {
-        final BasicEntity triggerEntity = app.createAndManageChild(EntitySpec.create(BasicEntity.class));
-        final MyService entity = app.createAndManageChild(EntitySpec.create(MyService.class)
-                .configure(latch, DependentConfiguration.attributeWhenReady(triggerEntity, Attributes.SERVICE_UP)));
-
-        final Task<Void> task = Entities.invokeEffector(app, app, MyService.START, ImmutableMap.of("locations", ImmutableList.of(loc)));
-
-        assertEffectorBlockingDetailsEventually(entity, MyService.START.getName(), "Waiting for config " + latch.getName());
-        assertDriverEventsEquals(entity, preLatchEvents);
-
-        assertFalse(task.isDone());
-        triggerEntity.sensors().set(Attributes.SERVICE_UP, true);
-        task.get(Duration.THIRTY_SECONDS);
-        assertDriverEventsEquals(entity, ImmutableList.of("setup", "copyInstallResources", "install", "customize", "copyRuntimeResources", "launch"));
+    protected List<String> getLatchPostTasks(final ConfigKey<?> latch) {
+        if (latch == SoftwareProcess.STOP_LATCH) {
+            return SOFTWARE_PROCESS_STOP_TASKS;
+        } else {
+            return SOFTWARE_PROCESS_START_TASKS;
+        }
     }
 
     private void assertDriverEventsEquals(MyService entity, List<String> expectedEvents) {
@@ -188,5 +221,54 @@ public class SoftwareProcessEntityLatchTest extends BrooklynAppUnitTestSupport {
             taskI = (TaskInternal<?>) taskI.getBlockingTask();
         }
         throw new IllegalStateException("No blocking details for "+task+" (walked task chain "+taskChain+")");
+    }
+
+    private static class CountingLatch implements ReleaseableLatch {
+        ReleaseableLatch delegate;
+        AtomicInteger cnt = new AtomicInteger();
+        AtomicInteger maxCnt = new AtomicInteger();
+        private int maxConcurrency;
+
+        public CountingLatch(ReleaseableLatch delegate, int maxConcurrency) {
+            this.delegate = delegate;
+            this.maxConcurrency = maxConcurrency;
+        }
+
+        public Boolean get() {
+            return delegate.get();
+        }
+
+        public Maybe<Boolean> getImmediately() {
+            return delegate.getImmediately();
+        }
+
+        public void acquire(Entity caller) {
+            delegate.acquire(caller);
+            assertCount(cnt.incrementAndGet());
+        }
+
+        public void release(Entity caller) {
+            cnt.decrementAndGet();
+            delegate.release(caller);
+        }
+
+        public int getMaxCounter() {
+            return maxCnt.get();
+        }
+        public int getCounter() {
+            return cnt.get();
+        }
+        private void assertCount(int newCnt) {
+            synchronized(maxCnt) {
+                maxCnt.set(Math.max(newCnt, maxCnt.get()));
+            }
+            assertTrue(newCnt <= maxConcurrency, "maxConcurrency limit failed at " + newCnt + " (max " + maxConcurrency + ")");
+            if (newCnt < maxConcurrency) {
+                Time.sleep(Duration.millis(100));
+            } else {
+                Time.sleep(Duration.millis(20));
+            }
+        }
+
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/DynamicToyMySqlEntityBuilder.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/DynamicToyMySqlEntityBuilder.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.entity.software.base.test.mysql;
 
 import java.io.File;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
@@ -30,11 +29,8 @@ import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
-import org.apache.brooklyn.core.sensor.ReleaseableLatch;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
 import org.apache.brooklyn.entity.stock.BasicStartable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation.LocalhostMachine;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -44,6 +40,8 @@ import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
 import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Predicates;
 import com.google.common.base.Splitter;
@@ -126,7 +124,7 @@ public class DynamicToyMySqlEntityBuilder {
                 return "submitted start";
             }
             @Override
-            protected void postStartCustom(AtomicReference<ReleaseableLatch> startLatchRef) {
+            protected void postStartCustom() {
                 // if it's still up after 5s assume we are good
                 Time.sleep(Duration.FIVE_SECONDS);
                 if (!DynamicTasks.queue(SshEffectorTasks.isPidFromFileRunning(dir(entity)+"/*/data/*.pid")).get()) {
@@ -152,7 +150,7 @@ public class DynamicToyMySqlEntityBuilder {
                 // Really should set this with a Feed that checks pid periodically.
                 // Should this instead be using SERVICE_NOT_UP_INDICATORS?
                 entity().sensors().set(Attributes.SERVICE_UP, true);
-                super.postStartCustom(startLatchRef);
+                super.postStartCustom();
             }
 
             @Override

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/DynamicToyMySqlEntityBuilder.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/mysql/DynamicToyMySqlEntityBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.entity.software.base.test.mysql;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
@@ -29,6 +30,7 @@ import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.sensor.ReleaseableLatch;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
 import org.apache.brooklyn.entity.stock.BasicStartable;
 import org.slf4j.Logger;
@@ -124,7 +126,7 @@ public class DynamicToyMySqlEntityBuilder {
                 return "submitted start";
             }
             @Override
-            protected void postStartCustom() {
+            protected void postStartCustom(AtomicReference<ReleaseableLatch> startLatchRef) {
                 // if it's still up after 5s assume we are good
                 Time.sleep(Duration.FIVE_SECONDS);
                 if (!DynamicTasks.queue(SshEffectorTasks.isPidFromFileRunning(dir(entity)+"/*/data/*.pid")).get()) {
@@ -150,6 +152,7 @@ public class DynamicToyMySqlEntityBuilder {
                 // Really should set this with a Feed that checks pid periodically.
                 // Should this instead be using SERVICE_NOT_UP_INDICATORS?
                 entity().sensors().set(Attributes.SERVICE_UP, true);
+                super.postStartCustom(startLatchRef);
             }
 
             @Override

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -73,6 +73,10 @@ import groovy.lang.Closure;
 @Beta
 public class Asserts {
 
+    // Used in annotations so needs to be a constant - can't be initialized similarly to DEFAULT_LONG_TIMEOUT
+    // TODO Can we force this by default on all unit tests, beforeMethod, afterMethod methods?
+    public static final long THIRTY_SECONDS_TIMEOUT_MS = 30000;
+
     /** 
      * Timeout for use when something should happen. This is the *default timeout* that should
      * be used by tests (unless that test is asserting performance).
@@ -90,7 +94,7 @@ public class Asserts {
     static {
         String defaultTimeout = System.getProperty("brooklyn.test.defaultTimeout");
         if (defaultTimeout == null){
-            DEFAULT_LONG_TIMEOUT = Duration.THIRTY_SECONDS;
+            DEFAULT_LONG_TIMEOUT = Duration.millis(THIRTY_SECONDS_TIMEOUT_MS);
         } else {
             DEFAULT_LONG_TIMEOUT = Duration.of(defaultTimeout);
         }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
@@ -157,6 +157,11 @@ public abstract class Maybe<T> implements Serializable, Supplier<T> {
         return ofDisallowingNull(value);
     }
     
+    /** Creates a new Maybe object out of the {@link Optional} argument */
+    public static <T> Maybe<T> fromOptional(Optional<T> value) {
+        return Maybe.fromNullable(value.orNull());
+    }
+    
     /** creates an instance wrapping a {@link SoftReference}, so it might go absent later on.
      * if null is supplied the result is a present null. */
     public static <T> Maybe<T> soft(@Nonnull T value) {


### PR DESCRIPTION
Setting a `ReleaseableLatch` as the latch of a `SoftwareProcess` allows for controlling the behaviour of the start/stop effector.
When `ReleaseableLatch.Factory.maxConcurrency(int)` is used as the value of the latch (either directly or by referncing a `MaxConcurrencySensor`) only the specified maximum number of threads will be able to execute the immediate step the latch is guarding.

It's very similar to `DynamicCluster.MAX_CONCURRENT_CHILD_COMMANDS` but allows for finer-grained control (though is specific to `SoftwareProcess`).


Merge together with https://github.com/apache/brooklyn-library/pull/87.