### PR TITLE
Fix Azure ARM VM names

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -74,8 +74,8 @@ public interface CloudLocationConfig {
     public static final ConfigKey<Integer> VM_NAME_MAX_LENGTH = ConfigKeys.newIntegerConfigKey(
         "vmNameMaxLength", "Maximum length of VM name", 60);
 
-    public static final ConfigKey<String> VM_NAME_DISALLOWED_PATTERN = ConfigKeys.newStringConfigKey(
-            "vmNameAllowedChars", "The character pattern to remove from a VM name", "[^a-zA-Z0-9\\-_]");
+    public static final ConfigKey<String> VM_NAME_ALLOWED_CHARACTERS = ConfigKeys.newStringConfigKey(
+            "vmNameAllowedChars", "The characters allowed in a VM name", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_");
 
     public static final ConfigKey<Integer> VM_NAME_SALT_LENGTH = ConfigKeys.newIntegerConfigKey(
         "vmNameSaltLength", "Number of characters to use for a random identifier inserted in hostname "

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.net.Networking;
+import org.apache.brooklyn.util.text.Identifiers;
 
 public interface CloudLocationConfig {
 
@@ -75,7 +76,7 @@ public interface CloudLocationConfig {
         "vmNameMaxLength", "Maximum length of VM name", 60);
 
     public static final ConfigKey<String> VM_NAME_ALLOWED_CHARACTERS = ConfigKeys.newStringConfigKey(
-            "vmNameAllowedChars", "The characters allowed in a VM name", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_");
+            "vmNameAllowedChars", "The characters allowed in a VM name", Identifiers.UPPER_CASE_ALPHA+Identifiers.LOWER_CASE_ALPHA+Identifiers.NUMERIC+"-_");
 
     public static final ConfigKey<Integer> VM_NAME_SALT_LENGTH = ConfigKeys.newIntegerConfigKey(
         "vmNameSaltLength", "Number of characters to use for a random identifier inserted in hostname "

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/CloudLocationConfig.java
@@ -74,6 +74,9 @@ public interface CloudLocationConfig {
     public static final ConfigKey<Integer> VM_NAME_MAX_LENGTH = ConfigKeys.newIntegerConfigKey(
         "vmNameMaxLength", "Maximum length of VM name", 60);
 
+    public static final ConfigKey<String> VM_NAME_DISALLOWED_PATTERN = ConfigKeys.newStringConfigKey(
+            "vmNameAllowedChars", "The character pattern to remove from a VM name", "[^a-zA-Z0-9\\-_]");
+
     public static final ConfigKey<Integer> VM_NAME_SALT_LENGTH = ConfigKeys.newIntegerConfigKey(
         "vmNameSaltLength", "Number of characters to use for a random identifier inserted in hostname "
             + "to uniquely identify machines", 4);

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
@@ -38,7 +38,7 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
         if (context instanceof Entity) entity = (Entity) context;
 
         StringShortener shortener = Strings.shortener();
-        shortener.setDisalowedCharacters(setup.get(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN));
+        shortener.setAllowedCharacters(setup.get(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS));
 
         shortener.separator("-");
         shortener.append("system", "brooklyn");

--- a/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/cloud/names/BasicCloudMachineNamer.java
@@ -36,8 +36,11 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
         Object context = setup.peek(CloudLocationConfig.CALLER_CONTEXT);
         Entity entity = null;
         if (context instanceof Entity) entity = (Entity) context;
-        
-        StringShortener shortener = Strings.shortener().separator("-");
+
+        StringShortener shortener = Strings.shortener();
+        shortener.setDisalowedCharacters(setup.get(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN));
+
+        shortener.separator("-");
         shortener.append("system", "brooklyn");
         
         /* timeStamp replaces the previously used randId. 
@@ -88,7 +91,7 @@ public class BasicCloudMachineNamer extends AbstractCloudMachineNamer {
                 .canRemove("user")
                 .canTruncate("appId", 2)
                 .canRemove("appId");
-        
+
         String s = shortener.getStringOfMaxLength(len);
         return sanitize(s).toLowerCase();
     }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.cloud.names.BasicCloudMachineNamer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
@@ -39,6 +40,18 @@ public class JcloudsMachineNamer extends BasicCloudMachineNamer {
         // TODO other cloud max length rules
 
         return null;
+    }
+
+    protected String generateNewIdOfLength(ConfigBag setup, int len) {
+
+        // if it's azurecompute-arm it needs a different VM_NAME_ALLOWED_PATTERN
+        String pattern = setup.get(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN);
+        if ((pattern == null || pattern == CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN.getDefaultValue()) &&
+                "azurecompute-arm".equals(setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER))) {
+        setup.put(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN, "[^a-zA-Z0-9]");
+        }
+
+        return super.generateNewIdOfLength(setup, len);
     }
 
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.location.jclouds;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.cloud.names.BasicCloudMachineNamer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Identifiers;
 
 public class JcloudsMachineNamer extends BasicCloudMachineNamer {
 
@@ -49,7 +50,7 @@ public class JcloudsMachineNamer extends BasicCloudMachineNamer {
         String pattern = setup.get(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS);
         if ((pattern == null || pattern == CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS.getDefaultValue()) &&
                 "azurecompute-arm".equals(setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER))) {
-        setup.put(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        setup.put(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS, Identifiers.UPPER_CASE_ALPHA+Identifiers.LOWER_CASE_ALPHA+Identifiers.NUMERIC);
         }
 
         return super.generateNewIdOfLength(setup, len);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
@@ -42,13 +42,14 @@ public class JcloudsMachineNamer extends BasicCloudMachineNamer {
         return null;
     }
 
+    @Override
     protected String generateNewIdOfLength(ConfigBag setup, int len) {
 
         // if it's azurecompute-arm it needs a different VM_NAME_ALLOWED_PATTERN
-        String pattern = setup.get(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN);
-        if ((pattern == null || pattern == CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN.getDefaultValue()) &&
+        String pattern = setup.get(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS);
+        if ((pattern == null || pattern == CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS.getDefaultValue()) &&
                 "azurecompute-arm".equals(setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER))) {
-        setup.put(CloudLocationConfig.VM_NAME_DISALLOWED_PATTERN, "[^a-zA-Z0-9]");
+        setup.put(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
         }
 
         return super.generateNewIdOfLength(setup, len);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/StringShortener.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/StringShortener.java
@@ -18,17 +18,14 @@
  */
 package org.apache.brooklyn.util.text;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /** utility which takes a bunch of segments and applies shortening rules to them */
 public class StringShortener {
 
     protected Map<String,String> wordsByIdInOrder = new LinkedHashMap<String,String>();
     protected String separator = null;
-    protected String disalowedCharacters;
+    protected Set<Character> allowedCharacters;
     
     protected interface ShorteningRule {
         /** returns the new list, with the relevant items in the list replaced */
@@ -57,18 +54,22 @@ public class StringShortener {
         }
     }
 
-    protected String removeDisalowedCharacters(String input){
-        if (disalowedCharacters != null) input = input.replaceAll(disalowedCharacters, "");
+    protected String removeDisallowedCharacters(String input){
+        if (allowedCharacters != null) {
+            StringBuilder output = new StringBuilder(input.length());
+            for (char c : input.toCharArray()){
+                if (allowedCharacters.contains(c)) output.append(c);
+                }
+            input = output.toString();
+            }
         return input;
     }
 
-
-    public String getDisalowedCharacters() {
-        return disalowedCharacters;
-    }
-
-    public StringShortener setDisalowedCharacters(String disalowedCharacters) {
-        this.disalowedCharacters = disalowedCharacters;
+    public StringShortener setAllowedCharacters(String disalowedCharacters) {
+        this.allowedCharacters = new HashSet<>();
+        for(char c : disalowedCharacters.toCharArray()) {
+            this.allowedCharacters.add(c);
+            }
         return this;
     }
     
@@ -94,12 +95,12 @@ public class StringShortener {
     
 
     public StringShortener separator(String separator) {
-        this.separator = removeDisalowedCharacters(separator);
+        this.separator = removeDisallowedCharacters(separator);
         return this;
     }
 
     public StringShortener append(String id, String text) {
-        text = removeDisalowedCharacters(text);
+        text = removeDisallowedCharacters(text);
         String old = wordsByIdInOrder.put(id, text);
         if (old!=null) {
             throw new IllegalStateException("Cannot append with id '"+id+"' when id already present");

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/StringShortener.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/StringShortener.java
@@ -28,6 +28,7 @@ public class StringShortener {
 
     protected Map<String,String> wordsByIdInOrder = new LinkedHashMap<String,String>();
     protected String separator = null;
+    protected String disalowedCharacters;
     
     protected interface ShorteningRule {
         /** returns the new list, with the relevant items in the list replaced */
@@ -55,6 +56,21 @@ public class StringShortener {
             return length;
         }
     }
+
+    protected String removeDisalowedCharacters(String input){
+        if (disalowedCharacters != null) input = input.replaceAll(disalowedCharacters, "");
+        return input;
+    }
+
+
+    public String getDisalowedCharacters() {
+        return disalowedCharacters;
+    }
+
+    public StringShortener setDisalowedCharacters(String disalowedCharacters) {
+        this.disalowedCharacters = disalowedCharacters;
+        return this;
+    }
     
     protected class RemovalRule implements ShorteningRule {
         public RemovalRule(String id) {
@@ -78,11 +94,12 @@ public class StringShortener {
     
 
     public StringShortener separator(String separator) {
-        this.separator = separator;
+        this.separator = removeDisalowedCharacters(separator);
         return this;
     }
 
     public StringShortener append(String id, String text) {
+        text = removeDisalowedCharacters(text);
         String old = wordsByIdInOrder.put(id, text);
         if (old!=null) {
             throw new IllegalStateException("Cannot append with id '"+id+"' when id already present");

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
@@ -46,7 +46,7 @@ public class StringShortenerTest {
     @Test
     public void testDisalowedCharactersShortener() {
         StringShortener ss = new StringShortener()
-                .setAllowedCharacters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+                .setAllowedCharacters(Identifiers.UPPER_CASE_ALPHA+Identifiers.LOWER_CASE_ALPHA+Identifiers.NUMERIC)
                 .separator("-")
                 .append("1", "he-llo")
                 .append("2", "_new")

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
@@ -46,7 +46,7 @@ public class StringShortenerTest {
     @Test
     public void testDisalowedCharactersShortener() {
         StringShortener ss = new StringShortener()
-                .setDisalowedCharacters("[^a-zA-Z0-9]")
+                .setAllowedCharacters("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
                 .separator("-")
                 .append("1", "he-llo")
                 .append("2", "_new")

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringShortenerTest.java
@@ -44,6 +44,26 @@ public class StringShortenerTest {
     }
 
     @Test
+    public void testDisalowedCharactersShortener() {
+        StringShortener ss = new StringShortener()
+                .setDisalowedCharacters("[^a-zA-Z0-9]")
+                .separator("-")
+                .append("1", "he-llo")
+                .append("2", "_new")
+                .append("3", "w.o.r.l.d")
+                .canRemove("2")
+                .canTruncate("1", 2)
+                .canTruncate("3", 2);
+
+        Assert.assertEquals(ss.getStringOfMaxLength(12), "helloworld");
+        Assert.assertEquals(ss.getStringOfMaxLength(9), "hellworld");
+        Assert.assertEquals(ss.getStringOfMaxLength(6), "heworl");
+        Assert.assertEquals(ss.getStringOfMaxLength(5), "hewor");
+        Assert.assertEquals(ss.getStringOfMaxLength(4), "hewo");
+        Assert.assertEquals(ss.getStringOfMaxLength(0), "");
+    }
+
+        @Test
     public void testEdgeCases() {
         StringShortener ss = new StringShortener();
         ss.separator(null);


### PR DESCRIPTION
Azure ARM only allows alphanumeric characters in it's naming. The default for Brooklyn is to use `-` characters to split up blocks of alphanumeric chars which breaks this. This adds an exception for `azurecompute-arm` in the same style as VM name length.

Tested with Tomcat 7 on Azure ARM, AWS and OpenStack