### PR TITLE
BROOKLYN-426: avoid propagating NoClassDefFoundError

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/LoaderDispatcher.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/LoaderDispatcher.java
@@ -44,6 +44,10 @@ public interface LoaderDispatcher<T> {
                 return Maybe.<Class<?>>of(SystemFrameworkLoader.get().loadClassFromBundle(className, bundle));
             } catch (ClassNotFoundException e) {
                 return Maybe.absent("Failed to load class " + className + " from bundle " + bundle, e);
+            } catch (NoClassDefFoundError e) {
+                // Can happen if a bundle misbehaves (e.g. it doesn't include Import-Package for 
+                // all the packages it really needs.
+                return Maybe.absent("Failed to load class " + className + " from bundle " + bundle, e);
             }
         }
 
@@ -53,6 +57,10 @@ public interface LoaderDispatcher<T> {
                 return Maybe.<Class<?>>of(loader.loadClass(className));
             } catch (IllegalStateException e) {
                 propagateIfCauseNotClassNotFound(e);
+                return Maybe.absent("Failed to load class " + className + " from loader " + loader, e);
+            } catch (NoClassDefFoundError e) {
+                // Can happen if a bundle misbehaves (e.g. it doesn't include Import-Package for 
+                // all the packages it really needs.
                 return Maybe.absent("Failed to load class " + className + " from loader " + loader, e);
             }
         }
@@ -67,6 +75,10 @@ public interface LoaderDispatcher<T> {
                 propagateIfCauseNotClassNotFound(e);
                 return Maybe.absent("Failed to load class " + className + " from class loader " + classLoader, e);
             } catch (ClassNotFoundException e) {
+                return Maybe.absent("Failed to load class " + className + " from class loader " + classLoader, e);
+            } catch (NoClassDefFoundError e) {
+                // Can happen if a bundle misbehaves (e.g. it doesn't include Import-Package for 
+                // all the packages it really needs.
                 return Maybe.absent("Failed to load class " + className + " from class loader " + classLoader, e);
             }
         }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BROOKLYN-426 for details.

Tested this with a badly behaving bundle, and confirmed that we were able to list the catalog contents when this fix is used.