### PR TITLE
JcloudsLocation is not releasing its customizers (BROOKLYN-427)

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -89,7 +90,7 @@ public class JcloudsCustomizerInstantiationYamlDslTest extends AbstractJcloudsSt
         }
     }
     
-    @Test(groups = "Broken")
+    @Test
     public void testCustomizers() throws Exception {
         String yaml = Joiner.on("\n").join(
                 "location: " + LOCATION_CATALOG_ID,
@@ -132,10 +133,12 @@ public class JcloudsCustomizerInstantiationYamlDslTest extends AbstractJcloudsSt
     }
 
     private void assertCallsMade(String ...values) {
-        List<String> expected = ImmutableList.copyOf(values);
+        List<String> expected = MutableList.of();
+        expected.addAll(Arrays.asList(values));
         for (RecordingLocationCustomizer.CallParams parm : RecordingLocationCustomizer.calls) {
-            assertTrue(expected.contains(parm.method));
+            assertTrue(expected.remove(parm.method));
         }
+        assertEquals(expected.size(), 0);
     }
 
     public static class RecordingLocationCustomizer extends BasicJcloudsLocationCustomizer {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -72,6 +72,7 @@ import org.apache.brooklyn.core.location.cloud.AbstractCloudMachineProvisioningL
 import org.apache.brooklyn.core.location.cloud.AvailabilityZoneExtension;
 import org.apache.brooklyn.core.location.cloud.names.AbstractCloudMachineNamer;
 import org.apache.brooklyn.core.location.cloud.names.CloudMachineNamer;
+import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.mgmt.internal.LocalLocationManager;
 import org.apache.brooklyn.core.mgmt.persist.LocationWithObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
@@ -1057,6 +1058,13 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     + " "+machineLocation+" connection usable in "+Duration.of(usableTimestamp).subtract(provisionTimestamp).toStringRounded()+";"
                     + " and os customized in "+Duration.of(customizedTimestamp).subtract(usableTimestamp).toStringRounded()+" - "+Joiner.on(", ").join(customisationForLogging)+")";
             LOG.info(logMessage);
+
+            if (customizers.size() > 0) {
+                machineLocation.config().set(JCLOUDS_LOCATION_CUSTOMIZERS, customizers);
+            }
+            if (machineCustomizers.size() > 0) {
+                machineLocation.config().set(MACHINE_LOCATION_CUSTOMIZERS, machineCustomizers);
+            }
 
             return machineLocation;
 
@@ -2221,7 +2229,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         Exception tothrow = null;
 
-        ConfigBag setup = config().getBag();
+        ConfigBag setup = ((LocationInternal)machine).config().getBag();
         Collection<JcloudsLocationCustomizer> customizers = getCustomizers(setup);
         Collection<MachineLocationCustomizer> machineCustomizers = getMachineCustomizers(setup);
         


### PR DESCRIPTION
preRelease and postRelease of JcloudsLocationCustomizers are not being 
called as expected during the release of a Jclouds machine location.
The problem is that the "setup" used in JcloudsLocation.obtainOnce includes a copy of the flags passed from MachineLifecycleEffectorTasks#stopAnyProvisionedMachines,
which includes the customizers. However, the "setup" used in the "release"
method of JcloudsLocation is taken from the JcloudsLocation itself, which
is the provisioning (i.e. parent) location, which doesn't have those 
customizers in it.
It would actually make more sense to get the location customizers from
the machine location, as a given parent could have mutiple machines
with different customizers.

The changes here include an addition to the
`JcloudsCustomizerInstantiationYamlDslTest#testCustomizers`
to demonstrate the problem, and a fix that adds the config to 
the machine location.

