### PR TITLE
Avoid NPE on getSubnetIp()

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -370,8 +370,9 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
         if (privateAddress.isPresent()) {
             return privateAddress.get();
         }
-        if (groovyTruth(node.getPublicAddresses())) {
-            return node.getPublicAddresses().iterator().next();
+        Set<String> publicAddresses = getPublicAddresses();
+        if (groovyTruth(publicAddresses)) {
+            return publicAddresses.iterator().next();
         }
         return null;
     }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.net.Networking;
-import org.jclouds.compute.ComputeServiceContext;
-import org.jclouds.compute.callables.RunScriptOnNode;
 import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
@@ -277,8 +275,9 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
         if (privateAddress.isPresent()) {
             return privateAddress.get();
         }
-        if (groovyTruth(node.getPublicAddresses())) {
-            return node.getPublicAddresses().iterator().next();
+        Set<String> publicAddresses = getPublicAddresses();
+        if (groovyTruth(publicAddresses)) {
+            return publicAddresses.iterator().next();
         }
         return null;
     }


### PR DESCRIPTION
Avoids direct access to `node` field, which may be `null`.