### PR TITLE
Silence the info log

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingProvider.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/DeserializingProvider.java
@@ -67,7 +67,7 @@ public class DeserializingProvider {
                     builder.putAll(loader.load());
                 }
                 cache = builder.build();
-                LOG.info("Config cache loaded, size {}", cache.size());
+                LOG.debug("Config cache loaded, size {}", cache.size());
             }
             return cache;
         }

--- a/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
+++ b/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
@@ -20,7 +20,7 @@
 <included>
     
     <!-- sshj very noisy, profligate with errors, put to file only, at warn level -->
-    <logger name="com.hierynomus" level="WARN" additivity="false">
+    <logger name="net.schmizz" level="WARN" additivity="false">
         <appender-ref ref="FILE" />
     </logger>
 


### PR DESCRIPTION
* SSHJ logging goes to debug log only
* Users don't need to see config cache size