### PR TITLE
Resolve deferred values in containers (list, map) on config().getNonBlocking(...)

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -144,6 +144,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
                 .as(Object.class)
                 .defaultValue(marker)
                 .immediately(true)
+                .deep(true)
                 .context(getContext())
                 .swallowExceptions()
                 .get();

--- a/core/src/test/java/org/apache/brooklyn/core/config/ConfigTypeCoercionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/ConfigTypeCoercionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.config;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+
+public class ConfigTypeCoercionTest extends BrooklynAppUnitTestSupport {
+    private static ConfigKey<Object> SENSORS_UNTYPED = ConfigKeys.newConfigKey(Object.class, "sensors");
+    @SuppressWarnings("serial")
+    private static ConfigKey<List<? extends Sensor<?>>> SENSORS = ConfigKeys.newConfigKey(new TypeToken<List<? extends Sensor<?>>>() {}, "sensors");
+    
+    @Test
+    public void testSshConfigFromDefault() throws Exception {
+        // Simulate a deferred value
+        Task<Sensor<?>> sensorFuture = app.getExecutionContext().submit(new Callable<Sensor<?>>() {
+            @Override
+            public Sensor<?> call() throws Exception {
+                return TestApplication.MY_ATTRIBUTE;
+            }
+        });
+        app.config().set(SENSORS_UNTYPED, (Object)ImmutableList.of(sensorFuture));
+
+        Maybe<List<? extends Sensor<?>>> sensors = app.config().getNonBlocking(SENSORS);
+        assertTrue(sensors.isPresent(), "value expected");
+        Sensor<?> sensor = Iterables.getOnlyElement(sensors.get());
+        assertEquals(sensor, TestApplication.MY_ATTRIBUTE);
+    }
+
+}


### PR DESCRIPTION
Deferred values are not resolved in certain cases when in containers. The error I was getting was:
```
2017-01-27 16:44:23,958 DEBUG 118 o.a.b.c.b.s.d.BrooklynDslDeferredSupplier [ger-GCJlrQu1-259] Resolved DynamicClusterImpl{id=q9r9izpwme} from $brooklyn:sensor("kubernetes.url")
2017-01-27 16:44:23,958 DEBUG 118 o.a.b.c.b.s.d.BrooklynDslDeferredSupplier [ger-GCJlrQu1-625] Resolved Sensor: kubernetes.url (java.lang.Object) from $brooklyn:sensor("kubernetes.url")
2017-01-27 16:44:23,959 WARN  143 o.a.b.u.j.c.TypeCoercerExtensible [ger-GCJlrQu1-628] Failed to coerce collection from java.util.Collections$UnmodifiableRandomAccessList to java.util.Collection<? exten
ds org.apache.brooklyn.api.sensor.Sensor<?>>; returning uncoerced result to preserve (deprecated) backwards compatibility
java.lang.IllegalStateException: Could not coerce entry 0 in [sensor("kubernetes.url")] to java.util.Collection<? extends org.apache.brooklyn.api.sensor.Sensor<?>>: Cannot coerce type org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.DslSensorSupplier to org.apache.brooklyn.api.sensor.Sensor (sensor("kubernetes.url")): no adapter known
        at org.apache.brooklyn.util.guava.IllegalStateExceptionSupplier.get(IllegalStateExceptionSupplier.java:40)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.IllegalStateExceptionSupplier.get(IllegalStateExceptionSupplier.java:26)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.Maybe$Absent.getException(Maybe.java:337)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.Maybe.getException(Maybe.java:465)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceInternal(TypeCoercerExtensible.java:125)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerce(TypeCoercerExtensible.java:108)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.core.flags.TypeCoercions.tryCoerce(TypeCoercions.java:82)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal.getNonBlockingResolvingSimple(AbstractConfigurationSupportInternal.java:149)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal.getNonBlocking(AbstractConfigurationSupportInternal.java:83)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.config.ConfigConstraints.validateAll(ConfigConstraints.java:126)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.config.ConfigConstraints.getViolations(ConfigConstraints.java:115)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.config.ConfigConstraints.assertValid(ConfigConstraints.java:73)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.entity.AbstractEntity$BasicEnricherSupport.add(AbstractEntity.java:1691)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at org.apache.brooklyn.core.objs.proxy.InternalEntityFactory$1.run(InternalEntityFactory.java:350)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)[:1.7.0_80]
        at org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:522)[120:org.apache.brooklyn.core:0.11.0.20170126_1332]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262)[:1.7.0_80]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)[:1.7.0_80]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)[:1.7.0_80]
        at java.lang.Thread.run(Thread.java:745)[:1.7.0_80]
Caused by: org.apache.brooklyn.util.javalang.coerce.ClassCoercionException: Could not coerce entry 0 in [sensor("kubernetes.url")] to java.util.Collection<? extends org.apache.brooklyn.api.sensor.Sensor<?>>
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceCollection(TypeCoercerExtensible.java:298)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceInternal(TypeCoercerExtensible.java:122)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        ... 15 more
Caused by: org.apache.brooklyn.util.javalang.coerce.ClassCoercionException: Cannot coerce type org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.DslSensorSupplier to org.apache.brooklyn.api.sensor.Sensor (sensor("kubernetes.url")): no adapter known
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)[:1.7.0_80]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)[:1.7.0_80]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)[:1.7.0_80]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)[:1.7.0_80]
        at org.apache.brooklyn.util.javalang.Reflections.loadInstance(Reflections.java:347)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.Reflections.invokeConstructorFromArgs(Reflections.java:328)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.Reflections.invokeConstructorFromArgs(Reflections.java:289)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.Reflections.invokeConstructorFromArgs(Reflections.java:251)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.AnyExceptionSupplier.get(AnyExceptionSupplier.java:50)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.AnyExceptionSupplier.get(AnyExceptionSupplier.java:27)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.guava.Maybe$Absent.getException(Maybe.java:337)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        ... 17 more
Caused by: org.apache.brooklyn.util.javalang.coerce.ClassCoercionException: Cannot coerce type org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.DslSensorSupplier to org.apache.brooklyn.api.sensor.Sensor (sensor("kubernetes.url")): no adapter known
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceInternal(TypeCoercerExtensible.java:212)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerce(TypeCoercerExtensible.java:108)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        at org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceCollection(TypeCoercerExtensible.java:294)[143:org.apache.brooklyn.utils-common:0.11.0.20170126_1332]
        ... 16 more
```