### PR TITLE
Remove uses of EntityLocal

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/Effectors.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/Effectors.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.effector.ParameterType;
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -129,7 +128,7 @@ public class Effectors {
         return invocation(entity, eff, parameters==null ? ImmutableMap.of() : parameters.getAllConfig());
     }
     
-    /** returns an unsubmitted task which invokes the given effector; use {@link Entities#invokeEffector(EntityLocal, Entity, Effector, Map)} for a submitted variant */
+    /** returns an unsubmitted task which invokes the given effector; use {@link Entities#invokeEffector(Entity, Entity, Effector, Map)} for a submitted variant */
     public static <T> TaskAdaptable<T> invocation(Entity entity, Effector<T> eff, @Nullable Map<?,?> parameters) {
         @SuppressWarnings("unchecked")
         Effector<T> eff2 = (Effector<T>) ((EntityInternal)entity).getEffector(eff.getName());

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1037,7 +1037,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
      * if the attribtue sensor is not-set or null
      * <p>
      * returns old value 
-     * @deprecated on interface since 0.5.0; use {@link ConfigToAttributes#apply(EntityLocal, AttributeSensorAndConfigKey)} */
+     * @deprecated on interface since 0.5.0; use {@link ConfigToAttributes#apply(Entity, AttributeSensorAndConfigKey)} */
     @Deprecated
     public <T> T setAttribute(AttributeSensorAndConfigKey<?,T> configuredSensor) {
         T v = getAttribute(configuredSensor);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAndAttribute.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAndAttribute.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.core.entity;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 
 import com.google.common.base.Objects;
@@ -68,7 +67,7 @@ public class EntityAndAttribute<T> implements Supplier<T> {
     }
 
     public void setValue(T val) {
-        ((EntityLocal)entity).sensors().set(attribute, val);
+        entity.sensors().set(attribute, val);
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityFunctions.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.objs.Identifiable;
@@ -127,7 +126,7 @@ public class EntityFunctions {
         // TODO PERSISTENCE WORKAROUND
         class UpdatingSensorMapEntryFunction implements Function<Entity, Void> {
             @Override public Void apply(Entity input) {
-                ServiceStateLogic.updateMapSensorEntry((EntityLocal)input, mapSensor, key, valueSupplier.get());
+                ServiceStateLogic.updateMapSensorEntry(input, mapSensor, key, valueSupplier.get());
                 return null;
             }
         }
@@ -318,7 +317,7 @@ public class EntityFunctions {
             this.valueSupplier = valueSupplier;
         }
         @Override public Void apply(Entity input) {
-            ServiceStateLogic.updateMapSensorEntry((EntityLocal)input, mapSensor, key, valueSupplier.get());
+            ServiceStateLogic.updateMapSensorEntry(input, mapSensor, key, valueSupplier.get());
             return null;
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
@@ -93,19 +93,19 @@ public class ServiceStateLogic {
     /** static only; not for instantiation */
     private ServiceStateLogic() {}
 
-    public static <TKey,TVal> TVal getMapSensorEntry(EntityLocal entity, AttributeSensor<Map<TKey,TVal>> sensor, TKey key) {
+    public static <TKey,TVal> TVal getMapSensorEntry(Entity entity, AttributeSensor<Map<TKey,TVal>> sensor, TKey key) {
         Map<TKey, TVal> map = entity.getAttribute(sensor);
         if (map==null) return null;
         return map.get(key);
     }
     
     @SuppressWarnings("unchecked")
-    public static <TKey,TVal> void clearMapSensorEntry(EntityLocal entity, AttributeSensor<Map<TKey,TVal>> sensor, TKey key) {
+    public static <TKey,TVal> void clearMapSensorEntry(Entity entity, AttributeSensor<Map<TKey,TVal>> sensor, TKey key) {
         updateMapSensorEntry(entity, sensor, key, (TVal)Entities.REMOVE);
     }
 
     /** update the given key in the given map sensor */
-    public static <TKey,TVal> void updateMapSensorEntry(EntityLocal entity, AttributeSensor<Map<TKey,TVal>> sensor, final TKey key, final TVal v) {
+    public static <TKey,TVal> void updateMapSensorEntry(Entity entity, AttributeSensor<Map<TKey,TVal>> sensor, final TKey key, final TVal v) {
         /*
          * Important to *not* modify the existing attribute value; must make a copy, modify that, and publish.
          * This is because a Propagator enricher will set this same value on another entity. There was very
@@ -220,28 +220,28 @@ public class ServiceStateLogic {
         
         /** puts the given value into the {@link Attributes#SERVICE_NOT_UP_INDICATORS} map as if the 
          * {@link UpdatingMap} enricher for the given key */
-        public static void updateNotUpIndicator(EntityLocal entity, String key, Object value) {
+        public static void updateNotUpIndicator(Entity entity, String key, Object value) {
             updateMapSensorEntry(entity, Attributes.SERVICE_NOT_UP_INDICATORS, key, value);
         }
         /** clears any entry for the given key in the {@link Attributes#SERVICE_NOT_UP_INDICATORS} map */
-        public static void clearNotUpIndicator(EntityLocal entity, String key) {
+        public static void clearNotUpIndicator(Entity entity, String key) {
             clearMapSensorEntry(entity, Attributes.SERVICE_NOT_UP_INDICATORS, key);
         }
-        /** as {@link #updateNotUpIndicator(EntityLocal, String, Object)} using the given sensor as the key */
-        public static void updateNotUpIndicator(EntityLocal entity, Sensor<?> sensor, Object value) {
+        /** as {@link #updateNotUpIndicator(Entity, String, Object)} using the given sensor as the key */
+        public static void updateNotUpIndicator(Entity entity, Sensor<?> sensor, Object value) {
             updateMapSensorEntry(entity, Attributes.SERVICE_NOT_UP_INDICATORS, sensor.getName(), value);
         }
-        /** as {@link #clearNotUpIndicator(EntityLocal, String)} using the given sensor as the key */
-        public static void clearNotUpIndicator(EntityLocal entity, Sensor<?> sensor) {
+        /** as {@link #clearNotUpIndicator(Entity, String)} using the given sensor as the key */
+        public static void clearNotUpIndicator(Entity entity, Sensor<?> sensor) {
             clearMapSensorEntry(entity, Attributes.SERVICE_NOT_UP_INDICATORS, sensor.getName());
         }
 
-        public static void updateNotUpIndicatorRequiringNonEmptyList(EntityLocal entity, AttributeSensor<? extends Collection<?>> collectionSensor) {
+        public static void updateNotUpIndicatorRequiringNonEmptyList(Entity entity, AttributeSensor<? extends Collection<?>> collectionSensor) {
             Collection<?> nodes = entity.getAttribute(collectionSensor);
             if (nodes==null || nodes.isEmpty()) ServiceNotUpLogic.updateNotUpIndicator(entity, collectionSensor, "Should have at least one entry");
             else ServiceNotUpLogic.clearNotUpIndicator(entity, collectionSensor);
         }
-        public static void updateNotUpIndicatorRequiringNonEmptyMap(EntityLocal entity, AttributeSensor<? extends Map<?,?>> mapSensor) {
+        public static void updateNotUpIndicatorRequiringNonEmptyMap(Entity entity, AttributeSensor<? extends Map<?,?>> mapSensor) {
             Map<?, ?> nodes = entity.getAttribute(mapSensor);
             if (nodes==null || nodes.isEmpty()) ServiceNotUpLogic.updateNotUpIndicator(entity, mapSensor, "Should have at least one entry");
             else ServiceNotUpLogic.clearNotUpIndicator(entity, mapSensor);
@@ -369,27 +369,27 @@ public class ServiceStateLogic {
         
         /** puts the given value into the {@link Attributes#SERVICE_PROBLEMS} map as if the 
          * {@link UpdatingMap} enricher for the given sensor reported this value */
-        public static void updateProblemsIndicator(EntityLocal entity, Sensor<?> sensor, Object value) {
+        public static void updateProblemsIndicator(Entity entity, Sensor<?> sensor, Object value) {
             updateMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, sensor.getName(), value);
         }
         /** clears any entry for the given sensor in the {@link Attributes#SERVICE_PROBLEMS} map */
-        public static void clearProblemsIndicator(EntityLocal entity, Sensor<?> sensor) {
+        public static void clearProblemsIndicator(Entity entity, Sensor<?> sensor) {
             clearMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, sensor.getName());
         }
-        /** as {@link #updateProblemsIndicator(EntityLocal, Sensor, Object)} */
-        public static void updateProblemsIndicator(EntityLocal entity, Effector<?> eff, Object value) {
+        /** as {@link #updateProblemsIndicator(Entity, Sensor, Object)} */
+        public static void updateProblemsIndicator(Entity entity, Effector<?> eff, Object value) {
             updateMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, eff.getName(), value);
         }
-        /** as {@link #clearProblemsIndicator(EntityLocal, Sensor)} */
-        public static void clearProblemsIndicator(EntityLocal entity, Effector<?> eff) {
+        /** as {@link #clearProblemsIndicator(Entity, Sensor)} */
+        public static void clearProblemsIndicator(Entity entity, Effector<?> eff) {
             clearMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, eff.getName());
         }
-        /** as {@link #updateProblemsIndicator(EntityLocal, Sensor, Object)} */
-        public static void updateProblemsIndicator(EntityLocal entity, String key, Object value) {
+        /** as {@link #updateProblemsIndicator(Entity, Sensor, Object)} */
+        public static void updateProblemsIndicator(Entity entity, String key, Object value) {
             updateMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, key, value);
         }
-        /** as {@link #clearProblemsIndicator(EntityLocal, Sensor)} */
-        public static void clearProblemsIndicator(EntityLocal entity, String key) {
+        /** as {@link #clearProblemsIndicator(Entity, Sensor)} */
+        public static void clearProblemsIndicator(Entity entity, String key) {
             clearMapSensorEntry(entity, Attributes.SERVICE_PROBLEMS, key);
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.core.effector.Effectors;
@@ -48,20 +47,20 @@ public class StartableMethods {
     private StartableMethods() {}
 
     /** Common implementation for start in parent nodes; just invokes start on all children of the entity */
-    public static void start(EntityLocal e, Collection<? extends Location> locations) {
+    public static void start(Entity e, Collection<? extends Location> locations) {
         log.debug("Starting entity "+e+" at "+locations);
         DynamicTasks.queueIfPossible(startingChildren(e, locations)).orSubmitAsync(e).getTask().getUnchecked();
     }
     
     /** Common implementation for stop in parent nodes; just invokes stop on all children of the entity */
-    public static void stop(EntityLocal e) {
+    public static void stop(Entity e) {
         log.debug("Stopping entity "+e);
         DynamicTasks.queueIfPossible(stoppingChildren(e)).orSubmitAsync(e).getTask().getUnchecked();
         if (log.isDebugEnabled()) log.debug("Stopped entity "+e);
     }
 
     /** Common implementation for restart in parent nodes; just invokes restart on all children of the entity */
-    public static void restart(EntityLocal e) {
+    public static void restart(Entity e) {
         log.debug("Restarting entity "+e);
         DynamicTasks.queueIfPossible(restartingChildren(e)).orSubmitAsync(e).getTask().getUnchecked();
         if (log.isDebugEnabled()) log.debug("Restarted entity "+e);

--- a/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.FeedMemento;
@@ -60,7 +61,7 @@ public abstract class AbstractFeed extends AbstractEntityAdjunct implements Feed
      * @deprecated since 0.7.0; use no-arg constructor; call {@link #setEntity(EntityLocal)}
      */
     @Deprecated
-    public AbstractFeed(EntityLocal entity) {
+    public AbstractFeed(Entity entity) {
         this(entity, false);
     }
     
@@ -68,8 +69,8 @@ public abstract class AbstractFeed extends AbstractEntityAdjunct implements Feed
      * @deprecated since 0.7.0; use no-arg constructor; call {@link #setEntity(EntityLocal)} and {@code setConfig(ONLY_IF_SERVICE_UP, onlyIfServiceUp)}
      */
     @Deprecated
-    public AbstractFeed(EntityLocal entity, boolean onlyIfServiceUp) {
-        this.entity = checkNotNull(entity, "entity");
+    public AbstractFeed(Entity entity, boolean onlyIfServiceUp) {
+        this.entity = checkNotNull((EntityInternal)entity, "entity");
         setConfig(ONLY_IF_SERVICE_UP, onlyIfServiceUp);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/feed/AttributePollHandler.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/AttributePollHandler.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.core.feed;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
@@ -49,7 +49,7 @@ public class AttributePollHandler<V> implements PollHandler<V> {
     public static final Logger log = LoggerFactory.getLogger(AttributePollHandler.class);
 
     private final FeedConfig<V,?,?> config;
-    private final EntityLocal entity;
+    private final Entity entity;
     @SuppressWarnings("rawtypes")
     private final AttributeSensor sensor;
     private final AbstractFeed feed;
@@ -68,7 +68,7 @@ public class AttributePollHandler<V> implements PollHandler<V> {
     private volatile boolean lastWasProblem = false;
 
     
-    public AttributePollHandler(FeedConfig<V,?,?> config, EntityLocal entity, AbstractFeed feed) {
+    public AttributePollHandler(FeedConfig<V,?,?> config, Entity entity, AbstractFeed feed) {
         this.config = checkNotNull(config, "config");
         this.entity = checkNotNull(entity, "entity");
         this.sensor = checkNotNull(config.getSensor(), "sensor");

--- a/core/src/main/java/org/apache/brooklyn/core/feed/ConfigToAttributes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/ConfigToAttributes.java
@@ -18,7 +18,7 @@
  */
 package org.apache.brooklyn.core.feed;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
@@ -29,7 +29,7 @@ import org.apache.brooklyn.core.sensor.TemplatedStringAttributeSensorAndConfigKe
 public class ConfigToAttributes {
 
     //normally just applied once, statically, not registered...
-    public static void apply(EntityLocal entity) {
+    public static void apply(Entity entity) {
         for (Sensor<?> it : entity.getEntityType().getSensors()) {
             if (it instanceof AttributeSensorAndConfigKey) {
                 apply(entity, (AttributeSensorAndConfigKey<?,?>)it);
@@ -41,7 +41,7 @@ public class ConfigToAttributes {
      * Convenience for ensuring an individual sensor is set from its config key
      * (e.g. sub-classes of DynamicWebAppCluster that don't want to set HTTP_PORT etc!)
      */
-    public static <T> T apply(EntityLocal entity, AttributeSensorAndConfigKey<?,T> key) {
+    public static <T> T apply(Entity entity, AttributeSensorAndConfigKey<?,T> key) {
         T v = entity.getAttribute(key);
         if (v!=null) return v;
         v = key.getAsSensorValue(entity);

--- a/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
@@ -50,7 +50,7 @@ import com.google.common.base.Objects;
 public class Poller<V> {
     public static final Logger log = LoggerFactory.getLogger(Poller.class);
 
-    private final EntityLocal entity;
+    private final Entity entity;
     private final boolean onlyIfServiceUp;
     private final Set<Callable<?>> oneOffJobs = new LinkedHashSet<Callable<?>>();
     private final Set<PollJob<V>> pollJobs = new LinkedHashSet<PollJob<V>>();
@@ -95,10 +95,10 @@ public class Poller<V> {
     
     /** @deprecated since 0.7.0, pass in whether should run onlyIfServiceUp */
     @Deprecated
-    public Poller(EntityLocal entity) {
+    public Poller(Entity entity) {
         this(entity, false);
     }
-    public Poller(EntityLocal entity, boolean onlyIfServiceUp) {
+    public Poller(Entity entity, boolean onlyIfServiceUp) {
         this.entity = entity;
         this.onlyIfServiceUp = onlyIfServiceUp;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
@@ -59,7 +59,7 @@ public final class AttributeMap {
     /**
      * Creates a new AttributeMap.
      *
-     * @param entity the EntityLocal this AttributeMap belongs to.
+     * @param entity the Entity this AttributeMap belongs to.
      * @throws NullPointerException if entity is null
      */
     public AttributeMap(AbstractEntity entity) {
@@ -71,7 +71,7 @@ public final class AttributeMap {
     /**
      * Creates a new AttributeMap.
      *
-     * @param entity  the EntityLocal this AttributeMap belongs to.
+     * @param entity  the Entity this AttributeMap belongs to.
      * @param storage the Map in which to store the values - should be concurrent or synchronized.
      * @throws NullPointerException if entity is null
      */

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeSensorAndConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeSensorAndConfigKey.java
@@ -41,7 +41,7 @@ import com.google.common.reflect.TypeToken;
 * The {@link ConfigKey} will have the same name and description as the sensor but not necessarily the same type.
 * Conversion to set the sensor value from the config key must be supplied in a subclass.
 * <p>
-* {@link ConfigToAttributes#apply(EntityLocal, AttributeSensorAndConfigKey)} is useful to set the attribute from the sensor.
+* {@link ConfigToAttributes#apply(Entity, AttributeSensorAndConfigKey)} is useful to set the attribute from the sensor.
 */
 public abstract class AttributeSensorAndConfigKey<ConfigType,SensorType> extends BasicAttributeSensor<SensorType> 
         implements ConfigKey.HasConfigKey<ConfigType> {
@@ -105,7 +105,7 @@ public abstract class AttributeSensorAndConfigKey<ConfigType,SensorType> extends
      * <b>(for this reason this method should generally not be invoked by callers except in tests and by the framework,
      * and similarly should not be overridden; implement {@link #convertConfigToSensor(Object, Entity)} instead for single-execution calls.
      * the framework calls this from {@link AbstractEntity#setAttribute(AttributeSensorAndConfigKey)} 
-     * typically via {@link ConfigToAttributes#apply(EntityLocal)} e.g. from SoftwareProcessImpl.preStart().)
+     * typically via {@link ConfigToAttributes#apply(Entity)} e.g. from SoftwareProcessImpl.preStart().)
      * </b> 
      */
     public SensorType getAsSensorValue(Entity e) {

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -90,7 +89,7 @@ import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 
 /** Conveniences for making tasks which run in entity {@link ExecutionContext}s, blocking on attributes from other entities, possibly transforming those;
- * these {@link Task} instances are typically passed in {@link EntityLocal#setConfig(ConfigKey, Object)}.
+ * these {@link Task} instances are typically passed in {@link Entity#setConfig(ConfigKey, Object)}.
  * <p>
  * If using a lot it may be useful to:
  * <pre>

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregatingEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregatingEnricher.java
@@ -90,7 +90,7 @@ public abstract class AbstractAggregatingEnricher<S,T> extends AbstractEnricher 
         synchronized (values) {
             S vo = values.get(producer);
             if (vo==null) {
-                S initialVal = ((EntityLocal)producer).getAttribute(source);
+                S initialVal = producer.getAttribute(source);
                 values.put(producer, initialVal != null ? initialVal : defaultValue);
                 //we might skip in onEvent in the short window while !values.containsKey(producer)
                 //but that's okay because the put which would have been done there is done here now

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
@@ -132,15 +131,15 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
             // FIXME do not set sensors on members; possibly we don't need FIRST at all, just look at the first in MEMBERS, and take care to guarantee order there
             Entity first = getAttribute(FIRST);
             if (first == null) {
-                ((EntityLocal) member).sensors().set(FIRST_MEMBER, true);
-                ((EntityLocal) member).sensors().set(FIRST, member);
+                member.sensors().set(FIRST_MEMBER, true);
+                member.sensors().set(FIRST, member);
                 sensors().set(FIRST, member);
             } else {
                 if (first.equals(member) || first.equals(member.getAttribute(FIRST))) {
                     // do nothing (rebinding)
                 } else {
-                    ((EntityLocal) member).sensors().set(FIRST_MEMBER, false);
-                    ((EntityLocal) member).sensors().set(FIRST, first);
+                    member.sensors().set(FIRST_MEMBER, false);
+                    member.sensors().set(FIRST, first);
                 }
             }
 

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabricImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabricImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -268,9 +267,9 @@ public class DynamicFabricImpl extends AbstractGroupImpl implements DynamicFabri
         
         if (locationName != null) {
             if (entity.getDisplayName()==null)
-                ((EntityLocal)entity).setDisplayName(entity.getEntityType().getSimpleName() +" ("+locationName+")");
+                entity.setDisplayName(entity.getEntityType().getSimpleName() +" ("+locationName+")");
             else if (!entity.getDisplayName().contains(locationName)) 
-                ((EntityLocal)entity).setDisplayName(entity.getDisplayName() +" ("+locationName+")");
+                entity.setDisplayName(entity.getDisplayName() +" ("+locationName+")");
         }
         if (entity.getParent()==null) entity.setParent(this);
         

--- a/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
@@ -25,9 +25,10 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.feed.AbstractFeed;
 import org.apache.brooklyn.core.feed.AttributePollHandler;
 import org.apache.brooklyn.core.feed.DelegatingPollHandler;
@@ -96,7 +97,7 @@ public class FunctionFeed extends AbstractFeed {
     }
     
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private boolean onlyIfServiceUp = false;
         private long period = 500;
         private TimeUnit periodUnits = TimeUnit.MILLISECONDS;
@@ -104,7 +105,7 @@ public class FunctionFeed extends AbstractFeed {
         private String uniqueTag;
         private volatile boolean built;
 
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = val;
             return this;
         }
@@ -135,7 +136,7 @@ public class FunctionFeed extends AbstractFeed {
         public FunctionFeed build() {
             built = true;
             FunctionFeed result = new FunctionFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityInternal)entity, "entity"));
             result.start();
             return result;
         }

--- a/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineLocation;
@@ -131,7 +132,7 @@ public class HttpFeed extends AbstractFeed {
     }
     
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private boolean onlyIfServiceUp = false;
         private Supplier<URI> baseUriProvider;
         private Duration period = Duration.millis(500);
@@ -145,7 +146,7 @@ public class HttpFeed extends AbstractFeed {
         private HttpExecutor httpExecutor;
         private volatile boolean built;
 
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = val;
             return this;
         }
@@ -230,7 +231,7 @@ public class HttpFeed extends AbstractFeed {
         public HttpFeed build() {
             built = true;
             HttpFeed result = new HttpFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             if (suspended) result.suspend();
             result.start();
             return result;

--- a/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.config.ConfigKey;
@@ -108,14 +109,14 @@ public class ShellFeed extends AbstractFeed {
     }
     
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private long period = 500;
         private TimeUnit periodUnits = TimeUnit.MILLISECONDS;
         private List<ShellPollConfig<?>> polls = Lists.newArrayList();
         private String uniqueTag;
         private volatile boolean built;
         
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = val;
             return this;
         }
@@ -138,7 +139,7 @@ public class ShellFeed extends AbstractFeed {
         public ShellFeed build() {
             built = true;
             ShellFeed result = new ShellFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             result.start();
             return result;
         }

--- a/core/src/main/java/org/apache/brooklyn/feed/ssh/SshFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/ssh/SshFeed.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -108,7 +109,7 @@ public class SshFeed extends AbstractFeed {
     }
     
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private boolean onlyIfServiceUp = false;
         private Supplier<SshMachineLocation> machine;
         private Duration period = Duration.of(500, TimeUnit.MILLISECONDS);
@@ -117,7 +118,7 @@ public class SshFeed extends AbstractFeed {
         private String uniqueTag;
         private volatile boolean built;
         
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = val;
             return this;
         }
@@ -162,7 +163,7 @@ public class SshFeed extends AbstractFeed {
         public SshFeed build() {
             built = true;
             SshFeed result = new SshFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             result.start();
             return result;
         }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/hello/LocalEntitiesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/hello/LocalEntitiesTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.EntityManager;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -227,7 +226,7 @@ public class LocalEntitiesTest extends BrooklynAppUnitTestSupport {
             assertEquals(null, sonsConfig[0]);
             for (Task tt : ((EntityInternal)dad).getExecutionContext().getTasks()) { log.info("task at dad:  {}, {}", tt, tt.getStatusDetail(false)); }
             for (Task tt : ((EntityInternal)son).getExecutionContext().getTasks()) { log.info("task at son:  {}, {}", tt, tt.getStatusDetail(false)); }
-            ((EntityLocal)dad).sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
+            dad.sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
             if (!s1.tryAcquire(2, TimeUnit.SECONDS)) fail("race mismatch, missing permits");
         }
         log.info("dad: "+dad.getAttribute(HelloEntity.FAVOURITE_NAME));
@@ -252,7 +251,7 @@ public class LocalEntitiesTest extends BrooklynAppUnitTestSupport {
                     }})));
         
         app.start(ImmutableList.of(loc));
-        ((EntityLocal)dad).sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
+        dad.sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
         assertEquals(son.getConfig(HelloEntity.MY_NAME), "Danny");
     }
     
@@ -270,7 +269,7 @@ public class LocalEntitiesTest extends BrooklynAppUnitTestSupport {
                     }})));
         
         app.start(ImmutableList.of(loc));
-        ((EntityLocal)dad).sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
+        dad.sensors().set(HelloEntity.FAVOURITE_NAME, "Dan");
         assertEquals(son.getConfig(HelloEntity.MY_NAME), "Danny");
     }
 

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
@@ -76,7 +75,7 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
 
     @Test
     public void testPicksCorrectNumSubLocations() throws Exception {
-        ((EntityLocal)cluster).config().set(DynamicCluster.NUM_AVAILABILITY_ZONES, 2);
+        cluster.config().set(DynamicCluster.NUM_AVAILABILITY_ZONES, 2);
         cluster.start(ImmutableList.of(loc));
         List<Location> subLocations = cluster.getAttribute(DynamicCluster.SUB_LOCATIONS);
         List<String> subLocationNames = getLocationNames(subLocations);
@@ -85,7 +84,7 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
     
     @Test
     public void testPicksCorrectNamedSubLocations() throws Exception {
-        ((EntityLocal)cluster).config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone2", "zone4"));
+        cluster.config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone2", "zone4"));
         cluster.start(ImmutableList.of(loc));
         List<Location> subLocations = cluster.getAttribute(DynamicCluster.SUB_LOCATIONS);
         List<String> subLocationNames = getLocationNames(subLocations);
@@ -94,7 +93,7 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
     
     @Test
     public void testSpreadsEntitiesAcrossZonesEvenly() throws Exception {
-        ((EntityLocal)cluster).config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
+        cluster.config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
         cluster.start(ImmutableList.of(loc));
         
         cluster.resize(4);
@@ -112,7 +111,7 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
     
     @Test
     public void testReplacesEntityInSameZone() throws Exception {
-        ((EntityLocal)cluster).config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
+        cluster.config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
         cluster.start(ImmutableList.of(loc));
         
         cluster.resize(4);
@@ -144,9 +143,9 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
             }
         };
         
-        ((EntityLocal)cluster).config().set(DynamicCluster.ZONE_FAILURE_DETECTOR, new ProportionalZoneFailureDetector(2, Duration.ONE_HOUR, 0.9, ticker));
-        ((EntityLocal)cluster).config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
-        ((EntityLocal)cluster).config().set(DynamicCluster.MEMBER_SPEC, EntitySpec.create(FailingEntity.class)
+        cluster.config().set(DynamicCluster.ZONE_FAILURE_DETECTOR, new ProportionalZoneFailureDetector(2, Duration.ONE_HOUR, 0.9, ticker));
+        cluster.config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
+        cluster.config().set(DynamicCluster.MEMBER_SPEC, EntitySpec.create(FailingEntity.class)
                 .configure(FailingEntity.FAIL_ON_START_CONDITION, failurePredicate));
         cluster.start(ImmutableList.of(loc));
         

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
@@ -178,6 +178,6 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
             }
         }
         
-        ((EntityLocal)entity).sensors().set(VM_USER_CREDENTIALS, creds);
+        entity.sensors().set(VM_USER_CREDENTIALS, creds);
     }
 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/followthesun/AbstractFollowTheSunPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/followthesun/AbstractFollowTheSunPolicyTest.java
@@ -26,7 +26,6 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.location.Location;
@@ -231,7 +230,7 @@ public class AbstractFollowTheSunPolicyTest {
     protected static MockItemEntity newItem(TestApplication app, MockContainerEntity container, String name, Map<? extends Entity, Double> workpattern) {
         MockItemEntity item = newItem(app, container, name);
         if (workpattern != null) {
-            ((EntityLocal)item).sensors().set(MockItemEntity.ITEM_USAGE_METRIC, (Map) workpattern);
+            item.sensors().set(MockItemEntity.ITEM_USAGE_METRIC, (Map) workpattern);
         }
         return item;
     }

--- a/policy/src/test/java/org/apache/brooklyn/policy/followthesun/FollowTheSunPolicySoakTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/followthesun/FollowTheSunPolicySoakTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.SimulatedLocation;
@@ -211,7 +210,7 @@ public class FollowTheSunPolicySoakTest extends AbstractFollowTheSunPolicyTest {
                     double jitteredWorkrate = Math.max(0, baseWorkrate + (random.nextDouble()*jitter*2 - jitter));
                     workrates.put(source, jitteredWorkrate);
                 }
-                ((EntityLocal)item).sensors().set(MockItemEntity.ITEM_USAGE_METRIC, workrates);
+                item.sensors().set(MockItemEntity.ITEM_USAGE_METRIC, workrates);
             }
 
             // Stop containers, and start others

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicyConcurrencyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicyConcurrencyTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.slf4j.Logger;
@@ -242,7 +241,7 @@ public class LoadBalancingPolicyConcurrencyTest extends AbstractLoadBalancingPol
                             return;
                         }
                         double jitteredWorkrate = workrate + (random.nextDouble()*jitter*2 - jitter);
-                        ((EntityLocal)item).sensors().set(TEST_METRIC, (int) Math.max(0, jitteredWorkrate));
+                        item.sensors().set(TEST_METRIC, (int) Math.max(0, jitteredWorkrate));
                     }
                 },
                 0, WORKRATE_UPDATE_PERIOD_MS, TimeUnit.MILLISECONDS);

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicySoakTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicySoakTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -159,7 +158,7 @@ public class LoadBalancingPolicySoakTest extends AbstractLoadBalancingPolicyTest
             
             for (int j = 0; j < numItems; j++) {
                 MockItemEntity item = items.get(j);
-                ((EntityLocal)item).sensors().set(MockItemEntity.TEST_METRIC, itemRates.get(j));
+                item.sensors().set(MockItemEntity.TEST_METRIC, itemRates.get(j));
             }
                 
             // Stop containers, and start others

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
@@ -178,15 +178,15 @@ public class EntityResource extends AbstractBrooklynRestResource implements Enti
 
     @Override
     public Response rename(String application, String entity, String newName) {
-        Entity entityLocal = brooklyn().getEntity(application, entity);
-        entityLocal.setDisplayName(newName);
+        Entity instance = brooklyn().getEntity(application, entity);
+        instance.setDisplayName(newName);
         return status(Response.Status.OK).build();
     }
 
     @Override
     public Response expunge(String application, String entity, boolean release) {
-        Entity entityLocal = brooklyn().getEntity(application, entity);
-        Task<?> task = brooklyn().expunge(entityLocal, release);
+        Entity instance = brooklyn().getEntity(application, entity);
+        Task<?> task = brooklyn().expunge(instance, release);
         TaskSummary summary = TaskTransformer.fromTask(ui.getBaseUriBuilder()).apply(task);
         return status(ACCEPTED).entity(summary).build();
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefAttributeFeed.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/chef/ChefAttributeFeed.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -111,7 +112,7 @@ public class ChefAttributeFeed extends AbstractFeed {
 
     @SuppressWarnings("rawtypes")
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private boolean onlyIfServiceUp = false;
         private String nodeName;
         private Set<ChefAttributePollConfig> polls = Sets.newLinkedHashSet();
@@ -119,7 +120,7 @@ public class ChefAttributeFeed extends AbstractFeed {
         private String uniqueTag;
         private volatile boolean built;
 
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = checkNotNull(val, "entity");
             return this;
         }
@@ -174,7 +175,7 @@ public class ChefAttributeFeed extends AbstractFeed {
         public ChefAttributeFeed build() {
             built = true;
             ChefAttributeFeed result = new ChefAttributeFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             result.start();
             return result;
         }
@@ -271,9 +272,9 @@ public class ChefAttributeFeed extends AbstractFeed {
     private static class CallInEntityExecutionContext<T> implements Callable<T> {
 
         private final Callable<T> job;
-        private EntityLocal entity;
+        private Entity entity;
 
-        private CallInEntityExecutionContext(EntityLocal entity, Callable<T> job) {
+        private CallInEntityExecutionContext(Entity entity, Callable<T> job) {
             this.job = job;
             this.entity = entity;
         }
@@ -292,10 +293,10 @@ public class ChefAttributeFeed extends AbstractFeed {
         private static final Iterable<String> PREFIXES = ImmutableList.of("", "automatic", "force_override", "override", "normal", "force_default", "default");
         private static final Splitter SPLITTER = Splitter.on('.');
 
-        private final EntityLocal entity;
+        private final Entity entity;
         private final Map<String, AttributeSensor<?>> chefAttributeSensors;
 
-        public SendChefAttributesToSensors(EntityLocal entity, Set<ChefAttributePollConfig<?>> polls) {
+        public SendChefAttributesToSensors(Entity entity, Set<ChefAttributePollConfig<?>> polls) {
             this.entity = entity;
             chefAttributeSensors = Maps.newLinkedHashMap();
             for (ChefAttributePollConfig<?> config : polls) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/JavaAppUtils.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/JavaAppUtils.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import javax.management.openmbean.CompositeData;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.feed.jmx.JmxAttributePollConfig;
@@ -51,11 +50,11 @@ public class JavaAppUtils {
     }
 
     /**
-     * @see #connectJavaAppServerPolicies(EntityLocal, Duration)
-     * @see #getMxBeanSensorsBuilder(EntityLocal)
+     * @see #connectJavaAppServerPolicies(Entity, Duration)
+     * @see #getMxBeanSensorsBuilder(Entity)
      */
     @Nullable
-    public static JmxFeed connectMXBeanSensors(EntityLocal entity) {
+    public static JmxFeed connectMXBeanSensors(Entity entity) {
         if (isEntityMxBeanStatsEnabled(entity)) {
             return getMxBeanSensorsBuilder(entity).build();
         } else {
@@ -63,9 +62,9 @@ public class JavaAppUtils {
         }
     }
 
-    /** @see #connectJavaAppServerPolicies(EntityLocal, Duration) */
+    /** @see #connectJavaAppServerPolicies(Entity, Duration) */
     @Nullable
-    public static JmxFeed connectMXBeanSensors(EntityLocal entity, long jmxPollPeriodMs) {
+    public static JmxFeed connectMXBeanSensors(Entity entity, long jmxPollPeriodMs) {
         if (isEntityMxBeanStatsEnabled(entity)) {
             return getMxBeanSensorsBuilder(entity, jmxPollPeriodMs).build();
         } else {
@@ -81,7 +80,7 @@ public class JavaAppUtils {
      * @see org.apache.brooklyn.entity.java.UsesJavaMXBeans#MXBEAN_STATS_ENABLED
      */
     @Nullable
-    public static JmxFeed connectMXBeanSensors(EntityLocal entity, Duration jmxPollPeriod) {
+    public static JmxFeed connectMXBeanSensors(Entity entity, Duration jmxPollPeriod) {
         if (isEntityMxBeanStatsEnabled(entity)) {
             return getMxBeanSensorsBuilder(entity, jmxPollPeriod).build();
         } else {
@@ -89,11 +88,11 @@ public class JavaAppUtils {
         }
     }
     
-    public static void connectJavaAppServerPolicies(EntityLocal entity) {
+    public static void connectJavaAppServerPolicies(Entity entity) {
         connectJavaAppServerPolicies(entity, Duration.TEN_SECONDS);
     }
 
-    public static void connectJavaAppServerPolicies(EntityLocal entity, Duration windowPeriod) {
+    public static void connectJavaAppServerPolicies(Entity entity, Duration windowPeriod) {
         entity.enrichers().add(new TimeFractionDeltaEnricher<Double>(entity, UsesJavaMXBeans.PROCESS_CPU_TIME, 
                 UsesJavaMXBeans.PROCESS_CPU_TIME_FRACTION_LAST, TimeUnit.MILLISECONDS));
 
@@ -105,16 +104,16 @@ public class JavaAppUtils {
     /**
      * @param entity The entity at which to poll
      * @return A {@link JmxFeed.Builder} configured to poll entity every ten seconds
-     * @see #getMxBeanSensorsBuilder(EntityLocal, Duration)
+     * @see #getMxBeanSensorsBuilder(Entity, Duration)
      */
     @Nonnull
-    public static JmxFeed.Builder getMxBeanSensorsBuilder(EntityLocal entity) {
+    public static JmxFeed.Builder getMxBeanSensorsBuilder(Entity entity) {
         return getMxBeanSensorsBuilder(entity, Duration.TEN_SECONDS);
     }
 
-    /** @see #getMxBeanSensorsBuilder(EntityLocal, Duration) */
+    /** @see #getMxBeanSensorsBuilder(Entity, Duration) */
     @Nonnull
-    public static JmxFeed.Builder getMxBeanSensorsBuilder(EntityLocal entity, long jmxPollPeriod) {
+    public static JmxFeed.Builder getMxBeanSensorsBuilder(Entity entity, long jmxPollPeriod) {
         return getMxBeanSensorsBuilder(entity, Duration.millis(jmxPollPeriod));
     }
 
@@ -127,11 +126,11 @@ public class JavaAppUtils {
      *         If an entity does not have MXBean stats enabled (i.e. {@link UsesJavaMXBeans#MXBEAN_STATS_ENABLED} is
      *         configured to false) then returns a builder configured with entity and duration but no polls.
      *         <p/>
-     *         Use {@link #connectMXBeanSensors(EntityLocal, Duration)} to create and build in one step.
+     *         Use {@link #connectMXBeanSensors(Entity, Duration)} to create and build in one step.
      */
     @Nonnull
     @SuppressWarnings({"unchecked"})
-    public static JmxFeed.Builder getMxBeanSensorsBuilder(EntityLocal entity, Duration jmxPollPeriod) {
+    public static JmxFeed.Builder getMxBeanSensorsBuilder(Entity entity, Duration jmxPollPeriod) {
         JmxFeed.Builder builder = JmxFeed.builder()
                 .entity(entity)
                 .period(jmxPollPeriod);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/JmxSupport.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/JmxSupport.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -88,7 +87,7 @@ public class JmxSupport implements UsesJmx {
     }
 
     <T> void setConfig(ConfigKey<T> key, T value) {
-        ((EntityLocal)getEntity()).config().set(key, value);
+        getEntity().config().set(key, value);
     }
 
     public Maybe<SshMachineLocation> getMachine() {
@@ -141,7 +140,7 @@ public class JmxSupport implements UsesJmx {
                 }
             }
 
-            ((EntityLocal)entity).config().set(JMX_AGENT_MODE, jmxAgentMode);
+            entity.config().set(JMX_AGENT_MODE, jmxAgentMode);
         }
 
         if (isSecure && jmxAgentMode!=JmxAgentModes.JMXMP) {
@@ -189,13 +188,13 @@ public class JmxSupport implements UsesJmx {
                     log.warn("Ignoring JMX_PORT "+jmxRemotePort+" when configuring agentless JMX on "+getEntity()+"; will use RMI_REGISTRY_PORT "+rmiRegistryPort);
                 }
                 jmxRemotePort = rmiRegistryPort;
-                ((EntityLocal)getEntity()).sensors().set(JMX_PORT, jmxRemotePort);
+                getEntity().sensors().set(JMX_PORT, jmxRemotePort);
             }
         } else {
             if (jmxRemotePort==null || jmxRemotePort<=0) {
                 throw new IllegalStateException("Invalid JMX_PORT "+jmxRemotePort+" and RMI_REGISTRY_PORT "+rmiRegistryPort+" when configuring JMX "+getJmxAgentMode()+" on "+getEntity());
             }
-            ((EntityLocal)getEntity()).sensors().set(RMI_REGISTRY_PORT, jmxRemotePort);
+            getEntity().sensors().set(RMI_REGISTRY_PORT, jmxRemotePort);
         }
         return jmxRemotePort;
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/AddMachineMetrics.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/AddMachineMetrics.java
@@ -31,6 +31,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.FluentIterable;
 import com.google.common.primitives.Doubles;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
@@ -69,7 +70,7 @@ public class AddMachineMetrics implements EntityInitializer {
         LOG.info("Configured machine metrics feed and enrichers on {}", entity);
     }
 
-    public static void addMachineMetricsEnrichers(EntityLocal entity) {
+    public static void addMachineMetricsEnrichers(Entity entity) {
         entity.enrichers().add(EnricherSpec.create(YamlTimeWeightedDeltaEnricher.class)
                 .configure(YamlTimeWeightedDeltaEnricher.SOURCE_SENSOR, MachineAttributes.USED_MEMORY)
                 .configure(YamlTimeWeightedDeltaEnricher.TARGET_SENSOR, MachineAttributes.USED_MEMORY_DELTA_PER_SECOND_LAST));
@@ -85,7 +86,7 @@ public class AddMachineMetrics implements EntityInitializer {
 
     }
 
-    public static SshFeed createMachineMetricsFeed(EntityLocal entity) {
+    public static SshFeed createMachineMetricsFeed(Entity entity) {
         boolean retrieveUsageMetrics = entity.config().get(SoftwareProcess.RETRIEVE_USAGE_METRICS);
         return SshFeed.builder()
                 .period(Duration.THIRTY_SECONDS)

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxFeed.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxFeed.java
@@ -31,6 +31,7 @@ import javax.management.NotificationFilter;
 import javax.management.NotificationListener;
 import javax.management.ObjectName;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -118,7 +119,7 @@ public class JmxFeed extends AbstractFeed {
     }
     
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private JmxHelper helper;
         private long jmxConnectionTimeout = JMX_CONNECTION_TIMEOUT_MS;
         private long period = 500;
@@ -129,7 +130,7 @@ public class JmxFeed extends AbstractFeed {
         private String uniqueTag;
         private volatile boolean built;
         
-        public Builder entity(EntityLocal val) {
+        public Builder entity(Entity val) {
             this.entity = val;
             return this;
         }
@@ -167,7 +168,7 @@ public class JmxFeed extends AbstractFeed {
         public JmxFeed build() {
             built = true;
             JmxFeed result = new JmxFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             result.start();
             return result;
         }

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxHelper.java
@@ -59,7 +59,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.entity.java.JmxSupport;
 import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -113,7 +113,7 @@ public class JmxHelper {
             .build();
 
     /** constructs a JMX URL suitable for connecting to the given entity, being smart about JMX/RMI vs JMXMP */
-    public static String toJmxUrl(EntityLocal entity) {
+    public static String toJmxUrl(Entity entity) {
         String url = entity.getAttribute(UsesJmx.JMX_URL);
         if (url != null) {
             return url;
@@ -149,7 +149,7 @@ public class JmxHelper {
         return "service:jmx:jmxmp://"+host+(jmxmpPort!=null ? ":"+jmxmpPort : "");
     }
     
-    final EntityLocal entity;
+    final Entity entity;
     final String url;
     final String user;
     final String password;
@@ -165,7 +165,7 @@ public class JmxHelper {
     // Tracks the MBeans we have failed to find for this JmsHelper's connection URL (so can log just once for each)
     private final Set<ObjectName> notFoundMBeans;
 
-    public JmxHelper(EntityLocal entity) {
+    public JmxHelper(Entity entity) {
         this(toJmxUrl(entity), entity, entity.getAttribute(UsesJmx.JMX_USER), entity.getAttribute(UsesJmx.JMX_PASSWORD));
         
         if (entity.getAttribute(UsesJmx.JMX_URL) == null) {
@@ -184,7 +184,7 @@ public class JmxHelper {
         this(url, null, user, password);
     }
     
-    public JmxHelper(String url, EntityLocal entity, String user, String password) {
+    public JmxHelper(String url, Entity entity, String user, String password) {
         this.url = url;
         this.entity = entity;
         this.user = user;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubHostLocation.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.location.NoMachinesAvailableException;

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeIntegrationTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
@@ -671,7 +670,7 @@ services:
         // Clear the startup app so it's not started second time, in addition to the rebind state
         // TODO remove this once the startup app is created only if no previous persistence state
         brooklynNode.config().set(BrooklynNode.APP, (String)null);
-        ((EntityLocal)brooklynNode).sensors().set(BrooklynNode.APP, null);
+        brooklynNode.sensors().set(BrooklynNode.APP, null);
         
         // Restart the process; expect persisted state to have been restored, so apps still known about
         brooklynNode.invoke(BrooklynNode.RESTART, ImmutableMap.<String, Object>of(

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertTrue;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolver;
@@ -109,7 +108,7 @@ public class BrooklynNodeTest {
                 .configure(BrooklynNode.SUGGESTED_VERSION, version));
         BrooklynNodeImpl entityImpl = (BrooklynNodeImpl) Entities.deproxy(entity);
 
-        ConfigToAttributes.apply((EntityLocal) entity);
+        ConfigToAttributes.apply(entity);
         BrooklynNodeSshDriver driver = new BrooklynNodeSshDriver(entityImpl, loc);
 
         DownloadResolver resolver = Entities.newDownloader(driver);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/brooklynnode/SelectMasterEffectorTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
@@ -245,11 +244,11 @@ public class SelectMasterEffectorTest extends BrooklynAppUnitTestSupport {
     }
 
     public static void setManagementState(Entity entity, ManagementNodeState state) {
-        ((EntityLocal)entity).sensors().set(BrooklynNode.MANAGEMENT_NODE_STATE, state);
+        entity.sensors().set(BrooklynNode.MANAGEMENT_NODE_STATE, state);
     }
 
     public static void setPriority(Entity entity, int priority) {
-        ((EntityLocal)entity).sensors().set(MockBrooklynNode.HA_PRIORITY, priority);
+        entity.sensors().set(MockBrooklynNode.HA_PRIORITY, priority);
     }
 
     private void selectMaster(DynamicCluster cluster, String id) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/java/VanillaJavaAppTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/java/VanillaJavaAppTest.java
@@ -39,7 +39,6 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
@@ -119,7 +118,7 @@ public class VanillaJavaAppTest {
         final VanillaJavaApp javaProcess = app.createAndManageChild(EntitySpec.create(VanillaJavaApp.class)
             .configure("main", "my.Main").configure("classpath", ImmutableList.of("c1", "c2"))
             .configure("args", ImmutableList.of("a1", "a2")));
-        ((EntityLocal)javaProcess).config().set(UsesJava.JAVA_SYSPROPS, ImmutableMap.of("fooKey", "fooValue", "barKey", "barValue"));
+        javaProcess.config().set(UsesJava.JAVA_SYSPROPS, ImmutableMap.of("fooKey", "fooValue", "barKey", "barValue"));
         // TODO: how to test: launch standalone app that outputs system properties to stdout? Probe via JMX?
     }
 
@@ -205,7 +204,7 @@ public class VanillaJavaAppTest {
             .configure("args", ImmutableList.of()));
         app.start(ImmutableList.of(loc));
 
-        JavaAppUtils.connectJavaAppServerPolicies((EntityLocal)javaProcess);
+        JavaAppUtils.connectJavaAppServerPolicies(javaProcess);
         
         final List<Double> fractions = new CopyOnWriteArrayList<Double>();
         app.getManagementContext().getSubscriptionManager().subscribe(javaProcess, VanillaJavaApp.PROCESS_CPU_TIME_FRACTION_LAST, new SensorEventListener<Double>() {
@@ -252,7 +251,7 @@ public class VanillaJavaAppTest {
         VanillaJavaApp javaProcess = app.createAndManageChild(EntitySpec.create(VanillaJavaApp.class)
             .configure("main", main).configure("classpath", ImmutableList.of(BROOKLYN_THIS_CLASSPATH))
             .configure("args", ImmutableList.of()));
-        ((EntityLocal)javaProcess).config().set(UsesJmx.JMX_PORT, PortRanges.fromInteger(port));
+        javaProcess.config().set(UsesJmx.JMX_PORT, PortRanges.fromInteger(port));
         app.start(ImmutableList.of(loc));
 
         assertEquals(javaProcess.getAttribute(UsesJmx.JMX_PORT), (Integer)port);
@@ -266,8 +265,8 @@ public class VanillaJavaAppTest {
         final VanillaJavaApp javaProcess = app.createAndManageChild(EntitySpec.create(VanillaJavaApp.class)
             .configure("main", main).configure("classpath", ImmutableList.of(BROOKLYN_THIS_CLASSPATH))
             .configure("args", ImmutableList.of()));
-        ((EntityLocal)javaProcess).config().set(UsesJmx.JMX_PORT, PortRanges.fromInteger(port));
-        ((EntityLocal)javaProcess).config().set(UsesJmx.JMX_SSL_ENABLED, true);
+        javaProcess.config().set(UsesJmx.JMX_PORT, PortRanges.fromInteger(port));
+        javaProcess.config().set(UsesJmx.JMX_SSL_ENABLED, true);
         
         app.start(ImmutableList.of(loc));
         // will fail above if JMX can't connect, but also do some add'l checks
@@ -320,7 +319,7 @@ public class VanillaJavaAppTest {
         public AsserterForJmxConnection(VanillaJavaApp e) throws MalformedURLException {
             this.entity = e;
             
-            JmxHelper jmxHelper = new JmxHelper((EntityLocal)entity);
+            JmxHelper jmxHelper = new JmxHelper(entity);
             this.url = new JMXServiceURL(jmxHelper.getUrl());
             this.env = Maps.newLinkedHashMap(jmxHelper.getConnectionEnvVars());
         }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityRebindTest.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
@@ -40,7 +39,6 @@ import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceProblemsLogic;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
-import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.MyService;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
@@ -87,7 +85,7 @@ public class SoftwareProcessEntityRebindTest extends RebindTestFixtureWithApp {
         assertEquals(origE.getAttribute(Attributes.SERVICE_STATE_EXPECTED).getState(), Lifecycle.RUNNING);
         EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
 
-        ServiceProblemsLogic.updateProblemsIndicator((EntityLocal)origE, "test", "fire");
+        ServiceProblemsLogic.updateProblemsIndicator(origE, "test", "fire");
         EntityAsserts.assertAttributeEqualsEventually(origE, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
 
         newApp = rebind();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasksTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/MachineLifecycleEffectorTasksTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertTrue;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -106,7 +105,7 @@ public class MachineLifecycleEffectorTasksTest {
             }
         });
         try {
-            ((EntityLocal) triggerEntity).sensors().set(ready, true);
+            triggerEntity.sensors().set(ready, true);
             task.get(Duration.THIRTY_SECONDS);
             Asserts.shouldHaveFailedPreviously("BailOutJcloudsLocation should have thrown");
         } catch (BailOutJcloudsLocation.BailOutException t) {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/group/DynamicClusterWithAvailabilityZonesMultiLocationTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/group/DynamicClusterWithAvailabilityZonesMultiLocationTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNull;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
@@ -82,7 +81,7 @@ public class DynamicClusterWithAvailabilityZonesMultiLocationTest extends Brookl
 
     @Test
     public void testReplacesEntityInSameZone() throws Exception {
-        ((EntityLocal)cluster).config().set(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true);
+        cluster.config().set(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true);
         cluster.start(ImmutableList.of(multiLoc));
         
         cluster.resize(4);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/sensor/core/PortAttributeSensorAndConfigKeyTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/sensor/core/PortAttributeSensorAndConfigKeyTest.java
@@ -45,8 +45,8 @@ public class PortAttributeSensorAndConfigKeyTest extends BrooklynAppUnitTestSupp
             PortAttributeSensorAndConfigKey.convertConfigToSensor(PortRange, Entity) line: 78   
             PortAttributeSensorAndConfigKey.convertConfigToSensor(Object, Entity) line: 1   
             PortAttributeSensorAndConfigKey(AttributeSensorAndConfigKey<ConfigType,SensorType>).getAsSensorValue(Entity) line: 93   
-            ConfigToAttributes.apply(EntityLocal, AttributeSensorAndConfigKey<?,T>) line: 28    
-            ConfigToAttributes.apply(EntityLocal) line: 17  
+            ConfigToAttributes.apply(Entity, AttributeSensorAndConfigKey<?,T>) line: 28    
+            ConfigToAttributes.apply(Entity) line: 17  
             SoftwareProcessDriverLifecycleEffectorTasks(MachineLifecycleEffectorTasks).preStartCustom(MachineLocation) line: 343    
             SoftwareProcessDriverLifecycleEffectorTasks.preStartCustom(MachineLocation) line: 69    
             MachineLifecycleEffectorTasks$6.run() line: 283 

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -110,14 +110,14 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
     }
 
     public static class Builder {
-        private EntityLocal entity;
+        private Entity entity;
         private Set<WindowsPerformanceCounterPollConfig<?>> polls = Sets.newLinkedHashSet();
         private Duration period = Duration.of(30, TimeUnit.SECONDS);
         private String uniqueTag;
         private volatile boolean built;
 
         public Builder entity(Entity val) {
-            this.entity = (EntityLocal) checkNotNull(val, "entity");
+            this.entity = checkNotNull(val, "entity");
             return this;
         }
         public Builder addSensor(WindowsPerformanceCounterPollConfig<?> config) {
@@ -150,7 +150,7 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
         public WindowsPerformanceCounterFeed build() {
             built = true;
             WindowsPerformanceCounterFeed result = new WindowsPerformanceCounterFeed(this);
-            result.setEntity(checkNotNull(entity, "entity"));
+            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             result.start();
             return result;
         }
@@ -250,9 +250,9 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
      */
     private static class CallInEntityExecutionContext<T> implements Callable<T> {
         private final Callable<T> job;
-        private EntityLocal entity;
+        private Entity entity;
 
-        private CallInEntityExecutionContext(EntityLocal entity, Callable<T> job) {
+        private CallInEntityExecutionContext(Entity entity, Callable<T> job) {
             this.job = job;
             this.entity = entity;
         }
@@ -266,12 +266,12 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
 
     @VisibleForTesting
     static class SendPerfCountersToSensors implements PollHandler<WinRmToolResponse> {
-        private final EntityLocal entity;
+        private final Entity entity;
         private final List<WindowsPerformanceCounterPollConfig<?>> polls;
         private final Set<AttributeSensor<?>> failedAttributes = Sets.newLinkedHashSet();
         private static final Pattern MACHINE_NAME_LOOKBACK_PATTERN = Pattern.compile(String.format("(?<=\\\\\\\\.{0,%d})\\\\.*", OUTPUT_COLUMN_WIDTH));
         
-        public SendPerfCountersToSensors(EntityLocal entity, Collection<WindowsPerformanceCounterPollConfig<?>> polls) {
+        public SendPerfCountersToSensors(Entity entity, Collection<WindowsPerformanceCounterPollConfig<?>> polls) {
             this.entity = entity;
             this.polls = ImmutableList.copyOf(polls);
         }

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/AdvertiseWinrmLoginPolicy.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/AdvertiseWinrmLoginPolicy.java
@@ -76,6 +76,6 @@ public class AdvertiseWinrmLoginPolicy extends AbstractPolicy implements SensorE
         
         LOG.info("Advertising user "+user+" @ "+hostname+":"+port);
         
-        ((EntityLocal)entity).sensors().set(VM_USER_CREDENTIALS, creds);
+        entity.sensors().set(VM_USER_CREDENTIALS, creds);
     }
 }


### PR DESCRIPTION
Deletes usage of the deprecated `EntityLocal` (folk should just use `Entity` wherever possible, as it's a lot simpler to explain/understand!).

This is careful to not change the signature of any interfaces or methods that folk might be overriding. It does change some static utility methods though, to take `Entity` instead of `EntityLocal` as a param, because that is safe.