### PR TITLE
[WIP] CXF upgrade

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -292,11 +292,17 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
+                        <!-- 
+                            Requires an explicit "Export-Package" because otherwise the packages with "internal"
+                            in the name will not be exported.
+                        -->
                         <Export-Package>brooklyn.*,org.apache.brooklyn.*</Export-Package>
                         <!--
-                          org.apache.brooklyn.rt.felix and org.apache.felix.framework are not used by code paths when working in Karaf
-                          javax.annotation;version=[1.2,2) is needed to force wiring the Brooklyn class space to javax.annotation-api.
-                            Avoids rewiring down the line when brooklyn-rest-resources is loaded.
+                          The excluded imports are for things used only for brooklyn-classic, rather than in karaf.
+                          Without the explicit javax.annotation version range, it binds to 1.1 and then rewires when
+                          jclouds bundles are added (even though we have explicitly added the java.annotation-api:1.2.0 bundle).
+                          This is because bundle org.apache.felix.framework exports the package javax.annotation;version=1.0.0,
+                          so we bind to that.
                         -->
                         <Import-Package>
                             !org.apache.brooklyn.rt.felix,

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -51,8 +51,8 @@
         <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
         <bundle dependency="true">mvn:org.slf4j/jul-to-slf4j/${slf4j.version}</bundle>
         <bundle dependency="true">mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpclient.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${httpcomponents.httpcore.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${httpcomponents.httpclient.version}</bundle>
 
         <bundle dependency="true">mvn:ch.qos.logback/logback-classic/${logback.version}</bundle>
         <bundle dependency="true">mvn:ch.qos.logback/logback-core/${logback.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -281,7 +281,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>${httpclient.version}</version>
+                <version>${httpcomponents.httpcore.version}</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>
@@ -311,13 +311,13 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
+                <version>${httpcomponents.httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <classifier>tests</classifier>
-                <version>${httpclient.version}</version>
+                <version>${httpcomponents.httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>aopalliance</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
         <fasterxml.jackson.version>2.7.5</fasterxml.jackson.version>
-        <cxf.version>3.1.4</cxf.version>
+        <cxf.version>3.1.10</cxf.version>
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
         <httpclient.version>4.4.1</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <jax-rs-api.version>2.0.1</jax-rs-api.version>
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
-        <winrm4j.version>0.4.0</winrm4j.version>
+        <winrm4j.version>0.5.0</winrm4j.version>
         <karaf.version>4.0.8</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,9 @@
         <!-- double-check downstream projects before changing jackson version -->
         <fasterxml.jackson.version>2.7.5</fasterxml.jackson.version>
         <cxf.version>3.1.4</cxf.version>
-        <httpclient.version>4.4.1</httpclient.version>
+        <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
+        <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
+        <httpclient.version>4.4.1</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.3.7</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes -->
         <jsr305.version>2.0.1</jsr305.version>

--- a/rest/rest-api/pom.xml
+++ b/rest/rest-api/pom.xml
@@ -152,11 +152,11 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Import-Package>
-                            javax.ws.rs;version="[1.1,2.0]",
-                            javax.ws.rs.core;version="[1.1,2.0]",
-                            *
-                        </Import-Package>
+                        <!-- 
+                            The default is to pull in javax.ws.rs;version="[2.0,3)", whereas jclouds-core 2.0 pulls
+                            in javax.ws.rs;version="[1.1,2)". However, that doesn't cause any harm because those
+                            are internal dependencies of jclouds (i.e. not part of the API).
+                        -->
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This upgrade CXF to 3.1.9.

It also bumps httpcomponents to 4.4.4 (thus replacing https://github.com/apache/brooklyn-server/pull/362)

~~It cherry-picks @neykov's https://github.com/apache/brooklyn-server/pull/334 (for karaf 4.0.8 upgrade).~~

It requires a new release of winrm4j (which must include https://github.com/cloudsoft/winrm4j/pull/48). This PR will fail to build until that dependency is available. For now, it says ~~0.5.0-ea1~~ 0.5.0 which I built for myself locally.

For this to work fully, it also requires https://github.com/apache/brooklyn-library/pull/73 to be merged.

~~It will require a change in brooklyn-dist as well (Svet's https://github.com/apache/brooklyn-dist/pull/48). I've been testing with https://github.com/apache/brooklyn-dist/pull/82, which builds on that.~~