### PR TITLE
Add Openstack live test.

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractEc2LiveTest.java
@@ -48,7 +48,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Runs a test with many different distros and versions.
  */
-public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
+public abstract class AbstractEc2LiveTest extends AbstractMultiDistroLiveTest {
     
     // FIXME Currently have just focused on test_Debian_6; need to test the others as well!
 
@@ -60,6 +60,16 @@ public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
     
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEc2LiveTest.class);
 
+    @Override
+    public String getProvider() {
+        return PROVIDER;
+    }
+
+    @Override
+    public String getLocationSpec() {
+        return LOCATION_SPEC;
+    }
+
     public static final String PROVIDER = "aws-ec2";
     public static final String REGION_NAME = "us-east-1";
     public static final String LOCATION_SPEC = PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME);
@@ -70,25 +80,6 @@ public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
     
     protected Location jcloudsLocation;
     
-    @BeforeMethod(alwaysRun=true)
-    @Override
-    public void setUp() throws Exception {
-        // Don't let any defaults from brooklyn.properties (except credentials) interfere with test
-        brooklynProperties = BrooklynProperties.Factory.newDefault();
-        brooklynProperties.remove("brooklyn.jclouds."+PROVIDER+".image-description-regex");
-        brooklynProperties.remove("brooklyn.jclouds."+PROVIDER+".image-name-regex");
-        brooklynProperties.remove("brooklyn.jclouds."+PROVIDER+".image-id");
-        brooklynProperties.remove("brooklyn.jclouds."+PROVIDER+".inboundPorts");
-        brooklynProperties.remove("brooklyn.jclouds."+PROVIDER+".hardware-id");
-
-        // Also removes scriptHeader (e.g. if doing `. ~/.bashrc` and `. ~/.profile`, then that can cause "stdin: is not a tty")
-        brooklynProperties.remove("brooklyn.ssh.config.scriptHeader");
-        
-        mgmt = new LocalManagementContextForTests(brooklynProperties);
-        
-        super.setUp();
-    }
-
     // Image ids for Debian: https://wiki.debian.org/Cloud/AmazonEC2Image/Squeeze
     @Test(groups = {"Live"})
     public void test_Debian_6() throws Exception {
@@ -147,47 +138,5 @@ public abstract class AbstractEc2LiveTest extends BrooklynAppLiveTestSupport {
     public void test_Suse_11sp3() throws Exception {
         // Image: {id=us-east-1/ami-c08fcba8, providerId=ami-c08fcba8, name=suse-sles-11-sp3-v20150127-pv-ssd-x86_64, location={scope=REGION, id=us-east-1, description=us-east-1, parent=aws-ec2, iso3166Codes=[US-VA]}, os={family=suse, arch=paravirtual, version=, description=amazon/suse-sles-11-sp3-v20150127-pv-ssd-x86_64, is64Bit=true}, description=SUSE Linux Enterprise Server 11 Service Pack 3 (PV, 64-bit, SSD-Backed), version=x86_64, status=AVAILABLE[available], loginUser=root, userMetadata={owner=013907871322, rootDeviceType=ebs, virtualizationType=paravirtual, hypervisor=xen}}
         runTest(ImmutableMap.of("imageId", "us-east-1/ami-c08fcba8", "hardwareId", SMALL_HARDWARE_ID, "loginUser", "ec2-user"));//, JcloudsLocationConfig.OPEN_IPTABLES.getName(), "true"));
-    }
-    
-    protected void runTest(Map<String,?> flags) throws Exception {
-        Map<String,?> allFlags = MutableMap.<String,Object>builder()
-                .put("tags", ImmutableList.of(getClass().getName()))
-                .putAll(flags)
-                .build();
-        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC, allFlags);
-
-        doTest(jcloudsLocation);
-    }
-    
-    protected abstract void doTest(Location loc) throws Exception;
-    
-    protected void assertExecSsh(SoftwareProcess entity, List<String> commands) {
-        SshMachineLocation machine = Machines.findUniqueMachineLocation(entity.getLocations(), SshMachineLocation.class).get();
-        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
-        int result = machine.execScript(ImmutableMap.of("out", outStream, "err", errStream), "url-reachable", commands);
-        String out = new String(outStream.toByteArray());
-        String err = new String(errStream.toByteArray());
-        if (result == 0) {
-            LOG.debug("Successfully executed: cmds="+commands+"; stderr="+err+"; out="+out);
-        } else {
-            fail("Failed to execute: result="+result+"; cmds="+commands+"; stderr="+err+"; out="+out);
-        }
-    }
-    
-    protected void assertViaSshLocalPortListeningEventually(final SoftwareProcess server, final int port) {
-        Asserts.succeedsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), new Runnable() {
-            @Override
-            public void run() {
-                assertExecSsh(server, ImmutableList.of("netstat -antp", "netstat -antp | grep LISTEN | grep "+port));
-            }});
-    }
-    
-    protected void assertViaSshLocalUrlListeningEventually(final SoftwareProcess server, final String url) {
-        Asserts.succeedsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), new Runnable() {
-            @Override
-            public void run() {
-                assertExecSsh(server, ImmutableList.of(BashCommands.installPackage("curl"), "netstat -antp", "curl -k --retry 3 "+url));
-            }});
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractMultiDistroLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractMultiDistroLiveTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity;
+
+import static org.testng.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.location.Machines;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.ssh.BashCommands;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * How to use:
+ * <p>
+ * Define immediate abstract subclasses with @Test methods for the platforms supported by the
+ * cloud with provider returned by {@link #getProvider()}.
+ * <p>
+ * Then those subclasses can get concrete subclasses of their own that define {@code {@link #doTest(Location)}}
+ * in order to run a test on all those platforms.
+ * </p>
+ * At a minimum the {@code doTest} is going to have to create an application with something
+ * of interest to test in it, and start the app:
+ * <pre>
+ * final XYZEntity xyz = app.createAndManageChild(EntitySpec.create(XYZEntity.class));
+ * app.start(ImmutableList.of(loc));
+ * </pre>
+ */
+public abstract class AbstractMultiDistroLiveTest extends BrooklynAppLiveTestSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractMultiDistroLiveTest.class);
+    
+    protected BrooklynProperties brooklynProperties;
+    protected Location jcloudsLocation;
+
+    public abstract String getProvider();
+
+    public abstract String getLocationSpec();
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        // Don't let any defaults from brooklyn.properties (except credentials) interfere with test
+        List<String> propsToRemove = ImmutableList.of("imageId", "imageDescriptionRegex", "imageNameRegex", "inboundPorts", "hardwareId", "minRam");
+
+        // Don't let any defaults from brooklyn.properties (except credentials) interfere with test
+        brooklynProperties = BrooklynProperties.Factory.newDefault();
+        for (String propToRemove : propsToRemove) {
+            for (String propVariant : ImmutableList.of(propToRemove,
+                CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, propToRemove))) {
+
+                brooklynProperties.remove("brooklyn.locations.jclouds."+getProvider()+"."+propVariant);
+                brooklynProperties.remove("brooklyn.locations."+propVariant);
+                brooklynProperties.remove("brooklyn.jclouds."+getProvider()+"."+propVariant);
+                brooklynProperties.remove("brooklyn.jclouds."+propVariant);
+            }
+        }
+
+        // Also removes scriptHeader (e.g. if doing `. ~/.bashrc` and `. ~/.profile`, then that can cause "stdin: is not a tty")
+        brooklynProperties.remove("brooklyn.ssh.config.scriptHeader");
+        
+        mgmt = new LocalManagementContextForTests(brooklynProperties);
+        
+        super.setUp();
+    }
+
+
+    protected void runTest(Map<String,?> flags) throws Exception {
+        Map<String,?> allFlags = MutableMap.<String,Object>builder()
+                .put("tags", ImmutableList.of(getClass().getName()))
+                .putAll(flags)
+                .build();
+        jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(getLocationSpec(), allFlags);
+
+        doTest(jcloudsLocation);
+    }
+
+    protected abstract void doTest(Location loc) throws Exception;
+
+    protected void assertExecSsh(SoftwareProcess entity, List<String> commands) {
+        SshMachineLocation machine = Machines.findUniqueMachineLocation(entity.getLocations(), SshMachineLocation.class).get();
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+        int result = machine.execScript(ImmutableMap.of("out", outStream, "err", errStream), "url-reachable", commands);
+        String out = new String(outStream.toByteArray());
+        String err = new String(errStream.toByteArray());
+        if (result == 0) {
+            LOG.debug("Successfully executed: cmds="+commands+"; stderr="+err+"; out="+out);
+        } else {
+            fail("Failed to execute: result="+result+"; cmds="+commands+"; stderr="+err+"; out="+out);
+        }
+    }
+
+    protected void assertViaSshLocalPortListeningEventually(final SoftwareProcess server, final int port) {
+        Asserts.succeedsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), new Runnable() {
+            @Override
+            public void run() {
+                assertExecSsh(server, ImmutableList.of("netstat -antp", "netstat -antp | grep LISTEN | grep "+port));
+            }});
+    }
+
+    protected void assertViaSshLocalUrlListeningEventually(final SoftwareProcess server, final String url) {
+        Asserts.succeedsEventually(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), new Runnable() {
+            @Override
+            public void run() {
+                assertExecSsh(server, ImmutableList.of(BashCommands.installPackage("curl"), "netstat -antp", "curl -k --retry 3 "+url));
+            }});
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractOpenstackLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractOpenstackLiveTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Runs a test on Openstack with many different distros and versions.
+ * Relies on the something like the following being in brooklyn.properties:
+
+brooklyn.location.jclouds.openstack-nova.endpoint = https://your.endpoint.here:5000/v2.0
+brooklyn.location.jclouds.openstack-nova.identity = you:you
+brooklyn.location.jclouds.openstack-nova.credential = yourPa55w0rd
+brooklyn.location.jclouds.openstack-nova.jclouds.keystone.credential-type = passwordCredentials
+brooklyn.location.jclouds.openstack-nova.jclouds.openstack-nova.auto-create-floating-ips = false
+brooklyn.location.jclouds.openstack-nova.jclouds.openstack-nova.auto-generate-keypairs = false
+brooklyn.location.jclouds.openstack-nova.loginUser = centos
+brooklyn.location.jclouds.openstack-nova.loginUser.privateKeyFile = ~/.ssh/openstack.pem
+brooklyn.location.jclouds.openstack-nova.generate.hostname = true
+brooklyn.location.jclouds.openstack-nova.securityGroups = VPN_local
+brooklyn.location.jclouds.openstack-nova.templateOptions={"networks":["abcdef12-1234-abcd-5678-00000000000"], "keyPairName": "openstack"}
+
+ */
+public abstract class AbstractOpenstackLiveTest extends AbstractMultiDistroLiveTest {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractOpenstackLiveTest.class);
+
+    @Override
+    public String getProvider() {
+        return PROVIDER;
+    }
+
+    @Override
+    public String getLocationSpec() {
+        return LOCATION_SPEC;
+    }
+
+    public static final String PROVIDER = "openstack-nova";
+    public static final String REGION_NAME = "RegionOne";
+    public static final String LOCATION_SPEC = PROVIDER + (REGION_NAME == null ? "" : ":" + REGION_NAME);
+
+    @Test(groups = {"Live"})
+    public void test_Centos_6() throws Exception {
+        // There are two images named "CentOS 6"; we need the newest so using the explicit imageId
+        runTest(ImmutableMap.of(
+            "imageId", "RegionOne/55e1fcb5-5a74-461c-b4fc-5b14c575b188",
+            "loginUser", "centos",
+            "minRam", "2000"));
+    }
+
+    @Test(groups = {"Live"})
+    public void test_Centos_7() throws Exception {
+        // release codename "squeeze"
+        runTest(ImmutableMap.of(
+            "imageNameRegex", "CentOS 7",
+            "loginUser", "centos",
+            "minRam", "2000"));
+    }
+
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/SimpleAppOpenstackLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/SimpleAppOpenstackLiveTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.test.Asserts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+public class SimpleAppOpenstackLiveTest extends AbstractOpenstackLiveTest {
+
+    private static Logger LOG = LoggerFactory.getLogger(SimpleAppOpenstackLiveTest.class);
+
+    public void test_Centos_6() throws Exception { }
+
+    @Override
+    protected void doTest(Location loc) throws Exception {
+
+        LOG.info("Testing in {}", loc);
+        final EmptySoftwareProcess server = app.createAndManageChild(EntitySpec.create(EmptySoftwareProcess.class));
+        app.start(ImmutableList.of(loc));
+
+        LOG.info("App started, waiting for RUNNING");
+        Asserts.succeedsEventually(new Runnable() {
+            @Override public void run() {
+                EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            }});
+    }
+}


### PR DESCRIPTION
A bit of refactoring to add openstack live test. There is some
work required to tidy and rationalize the various multi platform
live tests; this isn't it but may be a first step.

This change pulls up some functionality from the AbstractEc2LiveTest 
into a base class  AbstractMultiDistroLiveTest. 
The aws-ec2 live test then is a child of that, and there 
is also a new base class, AbstractOpenstackLiveTest, to do the same
job for Openstack. The comments describe how to use it.

This change is only to add this class as a basis for further tests to come.