### PR TITLE
BROOKLYN-421: Adds DSL for $brooklyn:urlEncode(...)

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
@@ -20,25 +20,33 @@ package org.apache.brooklyn.camp.brooklyn;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatform;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
 import org.apache.brooklyn.camp.spi.Assembly;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.StartableApplication;
+import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixture;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.stream.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -129,34 +137,31 @@ public class AbstractYamlRebindTest extends RebindTestFixture<StartableApplicati
         return new StringReader(builder.toString());
     }
     
+    /**
+     * @deprecated since 0.11.0, use {@link #createAndStartApplication(String)} instead,
+     *             in the same way as {@link AbstractYamlTest}.
+     */
+    @Deprecated
+    protected Entity createAndStartApplication(Reader input) throws Exception {
+        return createAndStartApplication(Streams.readFully(input));
+    }
+
     protected Entity createAndStartApplication(String... multiLineYaml) throws Exception {
         return createAndStartApplication(joinLines(multiLineYaml));
     }
     
     protected Entity createAndStartApplication(String input) throws Exception {
-        return createAndStartApplication(new StringReader(input));
+        return createAndStartApplication(input, MutableMap.<String,String>of());
     }
-
-    protected Entity createAndStartApplication(Reader input) throws Exception {
-        AssemblyTemplate at = platform.pdp().registerDeploymentPlan(input);
-        Assembly assembly;
-        try {
-            assembly = at.getInstantiator().newInstance().instantiate(at, platform);
-        } catch (Exception e) {
-            getLogger().warn("Unable to instantiate " + at + " (rethrowing): " + e);
-            throw e;
-        }
-        getLogger().info("Test - created " + assembly);
-        final Entity app = mgmt().getEntityManager().getEntity(assembly.getId());
-        getLogger().info("App - " + app);
+    
+    protected Entity createAndStartApplication(String input, Map<String,?> startParameters) throws Exception {
+        EntitySpec<?> spec = 
+            mgmt().getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, input, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+        final Entity app = mgmt().getEntityManager().createEntity(spec);
+        getLogger().info("Test created app, and will now start " + app);
         
-        // wait for app to have started
-        Set<Task<?>> tasks = mgmt().getExecutionManager().getTasksWithAllTags(ImmutableList.of(
-                BrooklynTaskTags.EFFECTOR_TAG, 
-                BrooklynTaskTags.tagForContextEntity(app), 
-                BrooklynTaskTags.tagForEffectorCall(app, "start", ConfigBag.newInstance(ImmutableMap.of("locations", ImmutableMap.of())))));
-        Iterables.getOnlyElement(tasks).get();
-        
+        // start the app (happens automatically if we use camp to instantiate, but not if we use crate spec approach)
+        app.invoke(Startable.START, startParameters).get();
         return app;
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -453,6 +453,34 @@ public class DslAndRebindYamlTest extends AbstractYamlRebindTest {
     }
 
     @Test
+    public void testDslUrlEncode() throws Exception {
+        String unescapedVal = "name@domain?!/&:%";
+        String escapedVal = "name%40domain%3F%21%2F%26%3A%25";
+
+        String unescapedUrlFormat = "http://%s:password@mydomain.com";
+        String escapedUrl = "http://" + escapedVal + ":password@mydomain.com";
+        
+        Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
+                "  brooklyn.config:",
+                "    test.confObject: \"" + unescapedVal + "\"",
+                "    test.confName:",
+                "      $brooklyn:urlEncode:",
+                "      - $brooklyn:config(\"test.confObject\")",
+                "    test.confUrl:",
+                "      $brooklyn:formatString:",
+                "      - " + unescapedUrlFormat,
+                "      - $brooklyn:urlEncode:",
+                "        - $brooklyn:config(\"test.confObject\")");
+
+        Assert.assertEquals(getConfigInTask(testEntity, TestEntity.CONF_NAME), escapedVal);
+        Assert.assertEquals(getConfigInTask(testEntity, ConfigKeys.newStringConfigKey("test.confUrl")), escapedUrl);
+        
+        Entity e2 = rebind(testEntity);
+        Assert.assertEquals(getConfigInTask(e2, TestEntity.CONF_NAME), escapedVal);
+        Assert.assertEquals(getConfigInTask(e2, ConfigKeys.newStringConfigKey("test.confUrl")), escapedUrl);
+    }
+
+    @Test
     public void testDslEntityById() throws Exception {
         Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
                 "  id: x",

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/UrlsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/UrlsTest.java
@@ -32,7 +32,7 @@ public class UrlsTest {
         Assert.assertEquals(Urls.toUrl(u).toString(), u);
         Assert.assertEquals(Urls.toUri(u).toString(), u);
         Assert.assertEquals(Urls.toUri(Urls.toUrl(u)).toString(), u);
-        Assert.assertEquals(Urls.toUrl(Urls.toUri(u)).toString(), u);        
+        Assert.assertEquals(Urls.toUrl(Urls.toUri(u)).toString(), u);
     }
     
     @Test
@@ -50,7 +50,29 @@ public class UrlsTest {
 
     @Test
     public void testPathEncode() throws Exception {
-        assertEquals(Urls.encode("name_with/%!"), "name_with%2F%25%21");
+        encodeAndDecodeUrl("simple", "simple");
+        encodeAndDecodeUrl("name_with/%!", "name_with%2F%25%21");
+
+        StringBuilder allcharsBuilder = new StringBuilder();
+        for (int i = 1; i < 128; i++) {
+            if (i == 32 || i == 42) continue; // See testUserOrPasswordOrHostEncode()
+            allcharsBuilder.append((char)i);
+        }
+        String allchars = allcharsBuilder.toString();
+        encodeAndDecodeUrl(allchars, "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%21%22%23%24%25%26%27%28%29%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D%7E%7F");
+    }
+
+    // TODO java.net.URLEncoder.encode() gets it wrong for:
+    //  " " (i.e. space - char %20). It turns that into "+" in the url.
+    //  "*" (i.e char %2A) is not escaped - this is wrong according to https://en.wikipedia.org/wiki/Percent-encoding (RFC 3986).
+    @Test(groups="Broken")
+    public void testUserOrPasswordOrHostEncode() throws Exception {
+        StringBuilder passwordBuilder = new StringBuilder();
+        for (int i = 1; i < 128; i++) {
+            passwordBuilder.append((char)i);
+        }
+        String allchars = passwordBuilder.toString();
+        encodeAndDecodeUrl(allchars, "%01%02%03%04%05%06%07%08%09%0A%0B%0C%0D%0E%0F%10%11%12%13%14%15%16%17%18%19%1A%1B%1C%1D%1E%1F%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D%7E%7F");
     }
 
     @Test
@@ -88,4 +110,18 @@ public class UrlsTest {
         // tests for parsing are in core in ResourceUtilsTest
     }
 
+
+    @Test
+    public void testEncodeAndDecodeUrl() throws Exception {
+        encodeAndDecodeUrl("simple", "simple");
+        encodeAndDecodeUrl("!@#$%^&*", "%21%40%23%24%25%5E%26*"); // TODO "*" should really be encoded!
+        encodeAndDecodeUrl("a/b", "a%2Fb");
+    }
+    
+    private void encodeAndDecodeUrl(String val, String expectedEncoding) {
+        String actualEncoding = Urls.encode(val);
+        String actualDecoded = Urls.decode(actualEncoding);
+        assertEquals(actualDecoded, val, "Encode+decode does not match original: orig="+val+"; decoded="+actualDecoded);
+        assertEquals(actualEncoding, expectedEncoding, "Does not match expected encoding: orig="+val+"; decoded="+actualDecoded);
+    }
 }


### PR DESCRIPTION
As stated in the comments within the code, the url encoding is based on "x-www-form-urlencoded". Therefore care must be taken if encoding username or password (e.g. in http://myuser:mypass@myhost"). It will not encode space correctly, and will not escape "*". The latter we can probably live with, but the former will be wrong.