### PR TITLE
Attempted non-determinate test fixes

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -1053,7 +1053,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         log.debug("Adding manual catalog item to "+mgmt+": "+type);
         checkNotNull(type, "type");
         if (manualAdditionsCatalog==null) loadManualAdditionsCatalog();
-        manualAdditionsClasses.addClass(type);
+        manualAdditionsClasses.registerClass(type);
         CatalogItem<?, ?> result = manualAdditionsCatalog.classpath.addCatalogEntry(type);
         
         // Clear spec-cache (in-case overwriting)

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/impl/DeleteOrphanedStateTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/impl/DeleteOrphanedStateTransformer.java
@@ -91,10 +91,10 @@ public class DeleteOrphanedStateTransformer extends CompoundTransformer {
         Set<String> enrichersToDelete = Sets.difference(input.getEnrichers().keySet(), enrichersToKeep.keySet());
         Set<String> policiesToDelete = Sets.difference(input.getPolicies().keySet(), policiesToKeep.keySet());
         Set<String> feedsToDelete = Sets.difference(input.getFeeds().keySet(), feedsToKeep.keySet());
-        LOG.info("Deleting {} orphaned location{}: {}", new Object[] {locsToDelete.size(), Strings.s(locsToDelete.size()), locsToDelete});
-        LOG.info("Deleting {} orphaned enricher{}: {}", new Object[] {enrichersToDelete.size(), Strings.s(enrichersToDelete.size()), enrichersToDelete});
-        LOG.info("Deleting {} orphaned polic{}: {}", new Object[] {policiesToDelete.size(), (policiesToDelete.size() == 1 ? "y" : "ies"), policiesToDelete});
-        LOG.info("Deleting {} orphaned feed{}: {}", new Object[] {feedsToDelete.size(), Strings.s(feedsToDelete.size()), feedsToDelete});
+        LOG.info("Deleting {} orphaned location{} (of {}): {}", new Object[] {locsToDelete.size(), Strings.s(locsToDelete.size()), input.getLocations().size(), locsToDelete});
+        LOG.info("Deleting {} orphaned enricher{} (of {}): {}", new Object[] {enrichersToDelete.size(), Strings.s(enrichersToDelete.size()), input.getEnrichers().size(), enrichersToDelete});
+        LOG.info("Deleting {} orphaned polic{} (of {}): {}", new Object[] {policiesToDelete.size(), (policiesToDelete.size() == 1 ? "y" : "ies"), input.getPolicies().size(), policiesToDelete});
+        LOG.info("Deleting {} orphaned feed{} (of {}): {}", new Object[] {feedsToDelete.size(), Strings.s(feedsToDelete.size()), input.getFeeds().size(), feedsToDelete});
         
         return BrooklynMementoRawData.builder()
                 .brooklynVersion(input.getBrooklynVersion())

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -371,7 +371,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
             
             ManagementPlaneSyncRecord planeState = managementContext.getHighAvailabilityManager().loadManagementPlaneSyncRecord(true);
             
-            LOG.info("Persisting state to "+destinationDir+(destinationLocationSpec!=null ? " @ "+destinationLocationSpec : ""));
+            LOG.info("Copying persisted state to "+destinationDir+(destinationLocationSpec!=null ? " @ "+destinationLocationSpec : ""));
             PersistenceObjectStore destinationObjectStore = BrooklynPersistenceUtils.newPersistenceObjectStore(
                 managementContext, destinationLocationSpec, destinationDir);
             BrooklynPersistenceUtils.writeMemento(managementContext, memento, destinationObjectStore);

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -46,7 +46,6 @@ import org.apache.brooklyn.core.catalog.internal.CatalogInitialization;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.StartableApplication;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
@@ -426,7 +425,10 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
         CatalogInitialization catInit = ((ManagementContextInternal)managementContext).getCatalogInitialization();
 
         markCatalogStartingUp(catInit);
+        
+        // note: web console is started by subclass overriding this method
         startingUp();
+        
         initCamp();
         handlePersistence();
         populateCatalog(catInit);

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -326,7 +326,7 @@ public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {
             webServer.start();
 
         } catch (Exception e) {
-            LOG.warn("Failed to start Brooklyn web-console (rethrowing): " + Exceptions.collapseText(e));
+            LOG.warn("Failed to start Brooklyn web-console (rethrowing) on "+bindAddress+" (port constraint "+port+"): " + Exceptions.collapseText(e));
             throw new FatalRuntimeException("Failed to start Brooklyn web-console: " + Exceptions.collapseText(e), e);
         }
     }

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -453,8 +453,7 @@ public class BrooklynWebServer {
         try {
             server.start();
         } catch (BindException e) {
-            // port discovery routines may take some time to clear, e.g. 250ms for SO_TIMEOUT
-            // tests fail because of this; see if adding a delay improves things
+            // retry once just in case it was some fluke or race
             log.warn("Initial server start-up failed binding (retrying after a delay): "+e);
             Time.sleep(Duration.millis(500));
             server.start();

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
@@ -293,7 +293,7 @@ public class BrooklynLauncherTest {
                 }))
                 .installSecurityFilter(false)
                 .start();
-        // such an error should be thrown, then caught in this calling thread
+        // 'deliberate-exception' error above should be thrown, then caught in this calling thread
         ManagementContext mgmt = launcher.getServerDetails().getManagementContext();
         Assert.assertFalse( ((ManagementContextInternal)mgmt).errors().isEmpty() );
         Assert.assertTrue( ((ManagementContextInternal)mgmt).errors().get(0).toString().contains("deliberate"), ""+((ManagementContextInternal)mgmt).errors() );

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.core.server.BrooklynServerPaths;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -147,6 +148,7 @@ public class CleanOrphanedLocationsIntegrationTest extends AbstractCleanOrphaned
 
     @Test
     public void testCleanedCopiedPersistedState() throws Exception {
+        LOG.info(JavaClassNames.niceClassAndMethod()+" taking persistence from "+persistenceDirWithOrphanedLocations);
         BrooklynLauncher launcher = BrooklynLauncher.newInstance()
                 .webconsole(false)
                 .brooklynProperties(OsgiManager.USE_OSGI, false)

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
@@ -121,6 +121,7 @@ public class CleanOrphanedLocationsIntegrationTest extends AbstractCleanOrphaned
         PersistenceExceptionHandler persistenceExceptionHandler = PersistenceExceptionHandlerImpl.builder().build();
         ((RebindManagerImpl) rebindManager).setPeriodicPersistPeriod(Duration.ONE_SECOND);
         rebindManager.setPersister(persister, persistenceExceptionHandler);
+        ((RebindManagerImpl) rebindManager).forcePersistNow();
     }
 
     @Test

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/CleanOrphanedLocationsIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.launcher;
 
 import java.io.File;
 import java.util.Set;
+import java.util.zip.ZipFile;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
@@ -41,6 +42,10 @@ import org.apache.brooklyn.core.server.BrooklynServerPaths;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.file.ArchiveUtils;
+import org.apache.brooklyn.util.core.osgi.BundleMaker;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.time.Duration;
@@ -67,13 +72,26 @@ public class CleanOrphanedLocationsIntegrationTest extends AbstractCleanOrphaned
     private Set<ManagementContext> mgmts;
     private ManagementContext mgmt;
 
+    private String copyResourcePathToTempPath(String resourcePath) {
+        BundleMaker bm = new BundleMaker(ResourceUtils.create(this));
+        bm.setDefaultClassForLoading(CleanOrphanedLocationsIntegrationTest.class);
+        File jar = bm.createJarFromClasspathDir(resourcePath);
+        File output = Os.newTempDir("brooklyn-test-resouce-from-"+resourcePath);
+        try {
+            ArchiveUtils.extractZip(new ZipFile(jar), output.getAbsolutePath());
+            return output.getAbsolutePath();
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+    
     @BeforeMethod(alwaysRun = true)
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        persistenceDirWithOrphanedLocations = getClass().getResource(PERSISTED_STATE_PATH_WITH_ORPHANED_LOCATIONS).getFile();
-        persistenceDirWithoutOrphanedLocations = getClass().getResource(PERSISTED_STATE_PATH_WITHOUT_ORPHANED_LOCATIONS).getFile();
-        persistenceDirWithMultipleLocationsOccurrence = getClass().getResource(PERSISTED_STATE_PATH_WITH_MULTIPLE_LOCATIONS_OCCURRENCE).getFile();
+        persistenceDirWithOrphanedLocations = copyResourcePathToTempPath(PERSISTED_STATE_PATH_WITH_ORPHANED_LOCATIONS);
+        persistenceDirWithoutOrphanedLocations = copyResourcePathToTempPath(PERSISTED_STATE_PATH_WITHOUT_ORPHANED_LOCATIONS);
+        persistenceDirWithMultipleLocationsOccurrence = copyResourcePathToTempPath(PERSISTED_STATE_PATH_WITH_MULTIPLE_LOCATIONS_OCCURRENCE);
 
         destinationDir = Os.newTempDir(getClass());
         

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/WebAppRunnerTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/WebAppRunnerTest.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.launcher;
 
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.http.HttpAsserts;
-import org.apache.brooklyn.util.net.Networking;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -78,14 +76,12 @@ public class WebAppRunnerTest {
     
     @Test
     public void testStartWar1() throws Exception {
-        if (!Networking.isPortAvailable(8090))
-            fail("Another process is using port 8090 which is required for this test.");
-        BrooklynWebServer server = createWebServer(MutableMap.of("port", 8090));
+        BrooklynWebServer server = createWebServer(MutableMap.of("port", "8091+"));
         assertNotNull(server);
         
         try {
             server.start();
-            assertBrooklynEventuallyAt("http://localhost:8090/");
+            assertBrooklynEventuallyAt("http://localhost:"+server.getActualPort()+"/");
         } finally {
             server.stop();
         }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/LoadedClassLoader.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/LoadedClassLoader.java
@@ -36,8 +36,16 @@ public class LoadedClassLoader extends ClassLoader {
         return result;
     }
 
-    public void addClass(Class<?> clazz) {
+    public void registerClass(Class<?> clazz) {
         loadedClasses.put(clazz.getName(), clazz);
+    }
+    
+    /** @deprecated since 0.11.0 because there is a private superclass method with the same signature;
+     *  use {@link #registerClass(Class)} instead to avoid confusion
+     */
+    @Deprecated 
+    public void addClass(Class<?> clazz) {
+        registerClass(clazz);
     }
     
     // TODO could also add resources

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -103,12 +103,14 @@ public class Networking {
                 ss = new ServerSocket();
                 ss.setSoTimeout(250);
                 ss.setReuseAddress(true);
+                if (!ss.getReuseAddress()) { logReuseAddressNotSupported(); }
                 ss.bind(new InetSocketAddress(localAddress, port));
 
                 // Check UDP port
                 ds = new DatagramSocket(null);
                 ds.setSoTimeout(250);
                 ds.setReuseAddress(true);
+                if (!ds.getReuseAddress()) { logReuseAddressNotSupported(); }
                 ds.bind(new InetSocketAddress(localAddress, port));
             } catch (IOException e) {
                 if (log.isTraceEnabled()) log.trace("Failed binding to " + localAddress + " : " + port, e);
@@ -176,6 +178,10 @@ public class Networking {
         }
     }
 
+    private static void logReuseAddressNotSupported() {
+        log.debug("Socket reuse-address not supported on this platform; port discovery may mis-report available ports");
+    }
+    
     /**
      * Bind to the specified IP, but let the OS pick a port.
      * If the operation fails we know it's not because of

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -66,6 +66,10 @@ public class Networking {
     public static final int MIN_PORT_NUMBER = 1;
     public static final int MAX_PORT_NUMBER = 65535;
 
+    // set this `false` because not all routines that want a port will be as forgiving as reuse_address is;
+    // in some cases it might be preferable for this to be true, if needed we can expand API
+    public static final Boolean SET_REUSE_ADDRESS = false;
+
     // based on http://stackoverflow.com/questions/106179/regular-expression-to-match-hostname-or-ip-address
     // but updated to allow leading zeroes
     public static final String VALID_IP_ADDRESS_REGEX = "^((0*[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}(0*[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$";
@@ -102,15 +106,13 @@ public class Networking {
                 // Check TCP port
                 ss = new ServerSocket();
                 ss.setSoTimeout(250);
-                ss.setReuseAddress(true);
-                if (!ss.getReuseAddress()) { logReuseAddressNotSupported(); }
+                if (SET_REUSE_ADDRESS!=null) { ss.setReuseAddress(SET_REUSE_ADDRESS); }
                 ss.bind(new InetSocketAddress(localAddress, port));
 
                 // Check UDP port
                 ds = new DatagramSocket(null);
                 ds.setSoTimeout(250);
-                ds.setReuseAddress(true);
-                if (!ds.getReuseAddress()) { logReuseAddressNotSupported(); }
+                if (SET_REUSE_ADDRESS!=null) { ss.setReuseAddress(SET_REUSE_ADDRESS); }
                 ds.bind(new InetSocketAddress(localAddress, port));
             } catch (IOException e) {
                 if (log.isTraceEnabled()) log.trace("Failed binding to " + localAddress + " : " + port, e);
@@ -178,10 +180,6 @@ public class Networking {
         }
     }
 
-    private static void logReuseAddressNotSupported() {
-        log.debug("Socket reuse-address not supported on this platform; port discovery may mis-report available ports");
-    }
-    
     /**
      * Bind to the specified IP, but let the OS pick a port.
      * If the operation fails we know it's not because of

--- a/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/os/Os.java
@@ -553,7 +553,7 @@ public class Os {
 
     /** creates a temp dir which will be deleted on exit */
     public static File newTempDir(String prefix) {
-        String sanitizedPrefix = (prefix==null ? "" : prefix + "-");
+        String sanitizedPrefix = (prefix==null ? "" : Strings.makeValidFilename(prefix) + "-");
         String tmpParent = tmp();
         
         //With lots of stale temp dirs it is possible to have 


### PR DESCRIPTION
Prompted by the following (from https://builds.apache.org/job/brooklyn-server-pull-requests/1730/ ):

```
Test Result (3 failures / +3)

org.apache.brooklyn.launcher.CleanOrphanedLocationsIntegrationTest.testCleanedCopiedPersistedState
org.apache.brooklyn.launcher.CleanOrphanedLocationsIntegrationTest.testSelectionWithOrphanedLocationsInData
org.apache.brooklyn.launcher.BrooklynLauncherTest.testErrorsCaughtByApiAndRestApiWorks
```

The first two have been observed in several places, and might be fixed by the first commit here.  The second one is less frequent but the second commit here might help and should improve logging.