### PR TITLE
better presentation for sensor publishing tasks

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
@@ -71,6 +71,8 @@ public class BrooklynTaskTags extends TaskTags {
     public static final String BROOKLYN_SERVER_TASK_TAG = "BROOKLYN-SERVER";
     /** Tag for a task which represents an effector */
     public static final String EFFECTOR_TAG = "EFFECTOR";
+    /** Tag for a task which represents a sensor being published */
+    public static final String SENSOR_TAG = "SENSOR";
     /** Tag for a task which *is* interesting, in contrast to {@link #TRANSIENT_TASK_TAG} */
     public static final String NON_TRANSIENT_TASK_TAG = "NON-TRANSIENT";
     /** indicates a task is transient, roughly that is to say it is uninteresting -- 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManager.java
@@ -49,6 +49,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
 import org.apache.brooklyn.util.core.task.SingleThreadedScheduler;
 import org.apache.brooklyn.util.text.Identifiers;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,15 +234,17 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         
         StringBuilder name = new StringBuilder("sensor ");
         StringBuilder description = new StringBuilder("Sensor ");
-        String sensorName = s.sensor==null ? null : s.sensor.getName();
+        String sensorName = s.sensor==null ? "<null-sensor>" : s.sensor.getName();
         String sourceName = event.getSource()==null ? null : event.getSource().getId();
-        name.append(sourceName);
-        name.append(":");
+        if (Strings.isNonBlank(sourceName)) {
+            name.append(sourceName);
+            name.append(":");
+        }
         name.append(sensorName);
         
         description.append(sensorName);
         description.append(" on ");
-        description.append(sourceName);
+        description.append(sourceName==null ? "<null-source>" : sourceName);
         description.append(" publishing to ");
         description.append(s.subscriber instanceof Entity ? ((Entity)s.subscriber).getId() : s.subscriber);
         


### PR DESCRIPTION
previously they didn't even have a name; now they have a nice name, description, and a tag.
there is some attempt to optimize the use of toString so it isn't hugely computationally expensive,
although this will increase expense a bit; i tend to think it's worth it for increased visibility.
(if we are publishing vast numbers of sensor events maybe we are doing something wrong, and if this
is identified as the bottleneck we can parameterise it, and in any case when we come to be multi-host
we'll need to revisit how we do this as currently we're thinking a good datastore is good enough for
the intended volumes, as opposed to a dedicated message bus.)