### PR TITLE
Provide a scratchpad area per management context

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.api.mgmt;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Map;
 
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.entity.Application;
@@ -199,7 +198,7 @@ public interface ManagementContext {
      * <p>
      * The returned map is thread safe, no locking is required to use it from parallel threads.
      */
-    Map<Object, Object> getScratchpad();
+    Scratchpad getScratchpad();
     
     /**
      * Whether the management context has been initialized and not yet terminated.

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.api.mgmt;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
 import org.apache.brooklyn.api.entity.Application;
@@ -184,6 +185,21 @@ public interface ManagementContext {
      * Defaults to reading ~/.brooklyn/brooklyn.properties but configurable in the management context.
      */
     StringConfigMap getConfig();
+    
+    /**
+     * <p>
+     * Provides a scratchpad area for this ManagementContext. It can be used for storing any data useful to Brooklyn core
+     * or custom entities. Usually it's used for singleton-like objects per ManagementContext. The lifetime of he 
+     * scratch area is for the duration of the ManagementContext. It's not persisted or shared between HA nodes,
+     * doesn't survive restarts.
+     * <p>
+     * Code using {@link #getConfig()} for the same purpose should migrate to using this method as {@link #getConfig()}
+     * will become read-only in future releases. Note that the scratchpad is not reset on reloading {@code brooklyn.properties}
+     * unlike {@link #getConfig()}.
+     * <p>
+     * The returned map is thread safe, no locking is required to use it from parallel threads.
+     */
+    Map<Object, Object> getScratchpad();
     
     /**
      * Whether the management context has been initialized and not yet terminated.

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/Scratchpad.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/Scratchpad.java
@@ -16,23 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.mgmt.internal;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+package org.apache.brooklyn.api.mgmt;
 
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
-import org.testng.annotations.Test;
 
-public class LocalManagementContextRebindTest extends RebindTestFixtureWithApp {
-    @Test
-    public void testScratchpadLostOnRebind() throws Exception {
-        ConfigKey<String> myKey = ConfigKeys.newStringConfigKey("my");
-        origManagementContext.getScratchpad().put(myKey, "key");
-        assertEquals(origManagementContext.getScratchpad().get(myKey), "key");
-        rebind();
-        assertFalse(newManagementContext.getScratchpad().contains(myKey), "Scratchpad lost on rebind");
-    }
+public interface Scratchpad {
+    <T> T get(ConfigKey<T> key);
+    <T> void put(ConfigKey<T> key, T value);
+    boolean contains(ConfigKey<?> key);
 }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatform.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/BrooklynCampPlatform.java
@@ -65,7 +65,7 @@ public class BrooklynCampPlatform extends AggregatingCampPlatform implements Has
 
     /** finds and returns the {@link CampPlatform} registered for the management context, or null if none */
     @Nullable public static CampPlatform findPlatform(ManagementContext mgmt) {
-        return mgmt.getConfig().getConfig(BrooklynCampConstants.CAMP_PLATFORM);
+        return mgmt.getScratchpad().get(BrooklynCampConstants.CAMP_PLATFORM);
     }
     
     // --- brooklyn setup
@@ -85,8 +85,12 @@ public class BrooklynCampPlatform extends AggregatingCampPlatform implements Has
     }
 
     public BrooklynCampPlatform setConfigKeyAtManagmentContext() {
+        // Deprecated in 0.11.0. Add to release notes and remove in next release.
         ((ManagementContextInternal)bmc).getBrooklynProperties().put(BrooklynCampConstants.CAMP_PLATFORM, this);
         ((ManagementContextInternal)bmc).getBrooklynProperties().put(CampYamlParser.YAML_PARSER_KEY, new YamlParserImpl(this));
+
+        bmc.getScratchpad().put(BrooklynCampConstants.CAMP_PLATFORM, this);
+        bmc.getScratchpad().put(CampYamlParser.YAML_PARSER_KEY, new YamlParserImpl(this));
         return this;
     }
     

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
@@ -89,7 +89,7 @@ public class ExternalConfigYamlTest extends AbstractYamlTest {
 
     @Test
     public void testCampYamlParserHandlesExternalisedConfig() throws Exception {
-        CampYamlParser parser = mgmt().getConfig().getConfig(CampYamlParser.YAML_PARSER_KEY);
+        CampYamlParser parser = mgmt().getScratchpad().get(CampYamlParser.YAML_PARSER_KEY);
         
         DeferredSupplier<?> supplier = (DeferredSupplier<?>) parser.parse("$brooklyn:external(\"myprovider\", \"mykey\")");
         

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReloadBrooklynPropertiesTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReloadBrooklynPropertiesTest.java
@@ -56,17 +56,17 @@ public class ReloadBrooklynPropertiesTest {
     
     @Test
     public void testReloadBrooklynPropertiesNonDeploy() {
-        CampPlatform platform = brooklynMgmt.getConfig().getConfig(BrooklynCampConstants.CAMP_PLATFORM);
+        CampPlatform platform = brooklynMgmt.getScratchpad().get(BrooklynCampConstants.CAMP_PLATFORM);
         Assert.assertNotNull(platform);
         brooklynMgmt.reloadBrooklynProperties();
-        CampPlatform reloadedPlatform = brooklynMgmt.getConfig().getConfig(BrooklynCampConstants.CAMP_PLATFORM);
+        CampPlatform reloadedPlatform = brooklynMgmt.getScratchpad().get(BrooklynCampConstants.CAMP_PLATFORM);
         Assert.assertEquals(reloadedPlatform, platform);
     }
     
     @Test
     public void testReloadBrooklynPropertiesDeploy() {
         brooklynMgmt.reloadBrooklynProperties();
-        CampPlatform reloadedPlatform = brooklynMgmt.getConfig().getConfig(BrooklynCampConstants.CAMP_PLATFORM);
+        CampPlatform reloadedPlatform = brooklynMgmt.getScratchpad().get(BrooklynCampConstants.CAMP_PLATFORM);
         Assert.assertNotNull(reloadedPlatform);
         Reader input = Streams.reader(new ResourceUtils(this).getResourceFromUrl("test-entity-basic-template.yaml"));
         AssemblyTemplate template = reloadedPlatform.pdp().registerDeploymentPlan(input);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampPlatformWithJustBrooklynMgmt.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampPlatformWithJustBrooklynMgmt.java
@@ -30,7 +30,9 @@ public class CampPlatformWithJustBrooklynMgmt extends BasicCampPlatform implemen
 
     public CampPlatformWithJustBrooklynMgmt(ManagementContext mgmt) {
         this.mgmt = mgmt;
+        // Deprecated in 0.11.0. Add to release notes and remove in next release.
         ((BrooklynProperties)mgmt.getConfig()).put(BrooklynCampConstants.CAMP_PLATFORM, this);
+        mgmt.getScratchpad().put(BrooklynCampConstants.CAMP_PLATFORM, this);
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -456,7 +456,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 .build();
         
         // Parse CAMP-YAML DSL in item metadata (but not in item or items - those will be parsed only when used). 
-        CampYamlParser parser = mgmt.getConfig().getConfig(CampYamlParser.YAML_PARSER_KEY);
+        CampYamlParser parser = mgmt.getScratchpad().get(CampYamlParser.YAML_PARSER_KEY);
         if (parser != null) {
             itemMetadataWithoutItemDef = parser.parse((Map<String, Object>) itemMetadataWithoutItemDef);
             try {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -160,6 +161,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     private final AtomicLong totalEffectorInvocationCount = new AtomicLong();
 
     protected DeferredBrooklynProperties configMap;
+    protected Map<Object, Object> scratchpad;
     protected BasicLocationRegistry locationRegistry;
     protected final BasicBrooklynCatalog catalog;
     protected final BrooklynTypeRegistry typeRegistry;
@@ -193,6 +195,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
 
     public AbstractManagementContext(BrooklynProperties brooklynProperties, DataGridFactory datagridFactory) {
         this.configMap = new DeferredBrooklynProperties(brooklynProperties, this);
+        this.scratchpad = new ConcurrentHashMap<>();
         this.entityDriverManager = new BasicEntityDriverManager();
         this.downloadsManager = BasicDownloadsManager.newDefault(configMap);
         if (datagridFactory == null) {
@@ -380,6 +383,11 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     @Override
     public BrooklynProperties getBrooklynProperties() {
         return configMap;
+    }
+
+    @Override
+    public Map<Object, Object> getScratchpad() {
+        return scratchpad;
     }
 
     private final Object locationRegistrySemaphore = new Object();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -42,6 +41,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationRegistry;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.Scratchpad;
 import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
@@ -161,7 +161,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     private final AtomicLong totalEffectorInvocationCount = new AtomicLong();
 
     protected DeferredBrooklynProperties configMap;
-    protected Map<Object, Object> scratchpad;
+    protected Scratchpad scratchpad;
     protected BasicLocationRegistry locationRegistry;
     protected final BasicBrooklynCatalog catalog;
     protected final BrooklynTypeRegistry typeRegistry;
@@ -195,7 +195,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
 
     public AbstractManagementContext(BrooklynProperties brooklynProperties, DataGridFactory datagridFactory) {
         this.configMap = new DeferredBrooklynProperties(brooklynProperties, this);
-        this.scratchpad = new ConcurrentHashMap<>();
+        this.scratchpad = new BasicScratchpad();
         this.entityDriverManager = new BasicEntityDriverManager();
         this.downloadsManager = BasicDownloadsManager.newDefault(configMap);
         if (datagridFactory == null) {
@@ -386,7 +386,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     }
 
     @Override
-    public Map<Object, Object> getScratchpad() {
+    public Scratchpad getScratchpad() {
         return scratchpad;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicScratchpad.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicScratchpad.java
@@ -18,21 +18,26 @@
  */
 package org.apache.brooklyn.core.mgmt.internal;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-
+import org.apache.brooklyn.api.mgmt.Scratchpad;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
-import org.testng.annotations.Test;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 
-public class LocalManagementContextRebindTest extends RebindTestFixtureWithApp {
-    @Test
-    public void testScratchpadLostOnRebind() throws Exception {
-        ConfigKey<String> myKey = ConfigKeys.newStringConfigKey("my");
-        origManagementContext.getScratchpad().put(myKey, "key");
-        assertEquals(origManagementContext.getScratchpad().get(myKey), "key");
-        rebind();
-        assertFalse(newManagementContext.getScratchpad().contains(myKey), "Scratchpad lost on rebind");
+public class BasicScratchpad implements Scratchpad {
+    private final ConfigBag storage = ConfigBag.newInstance();
+
+    @Override
+    public <T> T get(ConfigKey<T> key) {
+        return storage.get(key);
     }
+
+    @Override
+    public <T> void put(ConfigKey<T> key, T value) {
+        storage.put(key, value);
+    }
+
+    @Override
+    public boolean contains(ConfigKey<?> key) {
+        return storage.containsKey(key);
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/DeferredBrooklynProperties.java
@@ -70,7 +70,7 @@ public class DeferredBrooklynProperties implements BrooklynProperties {
         if (value instanceof CharSequence) {
             String raw = value.toString();
             if (raw.startsWith(BROOKLYN_YAML_PREFIX)) {
-                CampYamlParser parser = mgmt.getConfig().getConfig(CampYamlParser.YAML_PARSER_KEY);
+                CampYamlParser parser = mgmt.getScratchpad().get(CampYamlParser.YAML_PARSER_KEY);
                 if (parser == null) {
                     // TODO Should we fail or return the untransformed value?
                     // Problem is this gets called during initialisation, e.g. by BrooklynFeatureEnablement calling asMapWithStringKeys()

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.api.mgmt.EntityManager;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ExecutionManager;
 import org.apache.brooklyn.api.mgmt.LocationManager;
+import org.apache.brooklyn.api.mgmt.Scratchpad;
 import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementManager;
@@ -297,7 +298,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     }
 
     @Override
-    public Map<Object, Object> getScratchpad() {
+    public Scratchpad getScratchpad() {
         checkInitialManagementContextReal();
         return initialManagementContext.getScratchpad();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -297,6 +297,12 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     }
 
     @Override
+    public Map<Object, Object> getScratchpad() {
+        checkInitialManagementContextReal();
+        return initialManagementContext.getScratchpad();
+    }
+
+    @Override
     public BrooklynStorage getStorage() {
         checkInitialManagementContextReal();
         return initialManagementContext.getStorage();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextRebindTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.internal;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
+import org.testng.annotations.Test;
+
+public class LocalManagementContextRebindTest extends RebindTestFixtureWithApp {
+    @Test
+    public void testScratchpadLostOnRebind() throws Exception {
+        origManagementContext.getScratchpad().put("my", "key");
+        assertEquals(origManagementContext.getScratchpad().get("my"), "key");
+        rebind();
+        assertTrue(newManagementContext.getScratchpad().isEmpty(), "Scratchpad lost on rebind");
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContextTest.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.core.mgmt.internal;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,9 +27,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext.PropertiesReloadListener;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.internal.BrooklynProperties.Factory.Builder;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.util.os.Os;
 import org.testng.annotations.AfterMethod;
@@ -136,10 +136,10 @@ public class LocalManagementContextTest {
             .globalPropertiesFile(globalPropertiesFile.getAbsolutePath())
             .build();
         context = LocalManagementContextForTests.builder(true).useProperties(brooklynProperties).build();
-        assertTrue(context.getScratchpad().isEmpty(), "New scratchpad should be empty, no config here.");
-        context.getScratchpad().put("my", "key");
-        assertEquals(context.getScratchpad().get("my"), "key");
+        ConfigKey<String> myKey = ConfigKeys.newStringConfigKey("my");
+        context.getScratchpad().put(myKey, "key");
+        assertEquals(context.getScratchpad().get(myKey), "key");
         context.reloadBrooklynProperties();
-        assertEquals(context.getScratchpad().get("my"), "key");
+        assertEquals(context.getScratchpad().get(myKey), "key");
     }
 }

--- a/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiLauncher.java
+++ b/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiLauncher.java
@@ -115,7 +115,11 @@ public class OsgiLauncher extends BasicLauncher<OsgiLauncher> {
         BrooklynProperties brooklynProperties = (BrooklynProperties) managementContext.getConfig();
         if (BrooklynWebConfig.hasNoSecurityOptions(brooklynProperties)) {
             LOG.info("No security provider options specified. Define a security provider or users to prevent a random password being created and logged.");
+            // Deprecated in 0.11.0. Add to release notes and remove in next release.
             brooklynProperties.put(
+                    BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE,
+                    new BrooklynUserWithRandomPasswordSecurityProvider(managementContext));
+            managementContext.getScratchpad().put(
                     BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE,
                     new BrooklynUserWithRandomPasswordSecurityProvider(managementContext));
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/jaas/BrooklynLoginModule.java
@@ -183,6 +183,8 @@ public class BrooklynLoginModule implements LoginModule {
             throw new IllegalStateException("Missing JAAS module property " + PROPERTY_BUNDLE_SYMBOLIC_NAME + " pointing at the bundle where to load the security provider from.");
         }
         if (provider != null) return;
+        provider = getManagementContext().getScratchpad().get(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE);
+        if (provider != null) return;
         if (symbolicName != null) {
             if (className == null) {
                 className = brooklynProperties.getConfig(BrooklynWebConfig.SECURITY_PROVIDER_CLASSNAME);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -105,9 +105,11 @@ public class DelegatingSecurityProvider implements SecurityProvider {
             log.warn("REST unable to instantiate security provider " + className + "; all logins are being disallowed", e);
             delegate = new BlackholeSecurityProvider();
         }
-        
+
+        // Deprecated in 0.11.0. Add to release notes and remove in next release.
         ((BrooklynProperties)mgmt.getConfig()).put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
-        
+        mgmt.getScratchpad().put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
+
         return delegate;
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
@@ -116,12 +116,12 @@ public class BrooklynJacksonJsonProvider extends JacksonJsonProvider implements
         checkNotNull(mgmt, "mgmt");
         synchronized (mgmt) {
             ConfigKey<ObjectMapper> key = ConfigKeys.newConfigKey(ObjectMapper.class, BROOKLYN_REST_OBJECT_MAPPER);
-            ObjectMapper mapper = mgmt.getConfig().getConfig(key);
+            ObjectMapper mapper = (ObjectMapper) mgmt.getScratchpad().get(key);
             if (mapper != null) return mapper;
 
             mapper = newPrivateObjectMapper(mgmt);
             log.debug("Storing new ObjectMapper against "+mgmt+" because no ServletContext available: "+mapper);
-            ((BrooklynProperties)mgmt.getConfig()).put(key, mapper);
+            mgmt.getScratchpad().put(key, mapper);
             return mapper;
         }
     }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/EntitlementContextFilterTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/filter/EntitlementContextFilterTest.java
@@ -56,7 +56,7 @@ public class EntitlementContextFilterTest extends BrooklynRestResourceTest {
         BrooklynProperties props = (BrooklynProperties)getManagementContext().getConfig();
         props.put(BrooklynWebConfig.USERS, USER_PASS);
         props.put(BrooklynWebConfig.PASSWORD_FOR_USER(USER_PASS), USER_PASS);
-        props.put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, new ExplicitUsersSecurityProvider(getManagementContext()));
+        getManagementContext().getScratchpad().put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, new ExplicitUsersSecurityProvider(getManagementContext()));
 
         super.configureCXF(sf);
 


### PR DESCRIPTION
Replaces analogous but incorrect usage of `ManagementContext.getConfig()`.