### PR TITLE
Add catalog "itemType" to the CatalogItemSummary response from the REST API

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.api.catalog;
 
 import java.util.Collection;
+import java.util.Locale;
 
 import javax.annotation.Nullable;
 
@@ -61,6 +62,11 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
             if (Application.class.isAssignableFrom(type)) return TEMPLATE;
             if (Entity.class.isAssignableFrom(type)) return ENTITY;
             return null;
+        }
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ENGLISH);
         }
     }
     

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogEntitySummary.java
@@ -46,6 +46,7 @@ public class CatalogEntitySummary extends CatalogItemSummary {
             @JsonProperty("version") String version,
             @JsonProperty("name") String name,
             @JsonProperty("javaType") String javaType,
+            @JsonProperty("itemType") String itemType,
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
@@ -56,7 +57,7 @@ public class CatalogEntitySummary extends CatalogItemSummary {
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
+        super(symbolicName, version, name, javaType, itemType, planYaml, description, iconUrl, tags, deprecated, links);
         this.config = config;
         this.sensors = sensors;
         this.effectors = effectors;

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogItemSummary.java
@@ -50,6 +50,8 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
 
     private final String javaType;
 
+    private final String itemType;
+
     private final String name;
     @JsonSerialize(include = JsonSerialize.Inclusion.NON_EMPTY)
     private final String description;
@@ -67,6 +69,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
             @JsonProperty("version") String version,
             @JsonProperty("name") String displayName,
             @JsonProperty("javaType") String javaType,
+            @JsonProperty("itemType") String itemType,
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
@@ -80,6 +83,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
         this.version = version;
         this.name = displayName;
         this.javaType = javaType;
+        this.itemType = itemType;
         this.planYaml = planYaml;
         this.description = description;
         this.iconUrl = iconUrl;
@@ -103,6 +107,10 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
 
     public String getJavaType() {
         return javaType;
+    }
+
+    public String getItemType() {
+        return itemType;
     }
 
     public String getType() {
@@ -148,6 +156,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
                 Objects.equals(symbolicName, that.symbolicName) &&
                 Objects.equals(version, that.version) &&
                 Objects.equals(type, that.type) &&
+                Objects.equals(itemType, that.itemType) &&
                 Objects.equals(javaType, that.javaType) &&
                 Objects.equals(name, that.name) &&
                 Objects.equals(description, that.description) &&
@@ -159,7 +168,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, symbolicName, version, type, javaType, name, description, iconUrl, planYaml, tags, deprecated, links);
+        return Objects.hash(id, symbolicName, version, type, javaType, itemType, name, description, iconUrl, planYaml, tags, deprecated, links);
     }
 
     @Override
@@ -170,6 +179,7 @@ public class CatalogItemSummary implements HasId, HasName, Serializable {
                 ", version='" + version + '\'' +
                 ", type='" + type + '\'' +
                 ", javaType='" + javaType + '\'' +
+                ", itemType='" + itemType + '\'' +
                 ", name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", iconUrl='" + iconUrl + '\'' +

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogLocationSummary.java
@@ -37,6 +37,7 @@ public class CatalogLocationSummary extends CatalogItemSummary {
             @JsonProperty("version") String version,
             @JsonProperty("name") String name,
             @JsonProperty("javaType") String javaType,
+            @JsonProperty("itemType") String itemType,
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
@@ -45,7 +46,7 @@ public class CatalogLocationSummary extends CatalogItemSummary {
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
+        super(symbolicName, version, name, javaType, itemType, planYaml, description, iconUrl, tags, deprecated, links);
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<LocationConfigSummary>of() : config;
     }

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/CatalogPolicySummary.java
@@ -39,6 +39,7 @@ public class CatalogPolicySummary extends CatalogItemSummary {
             @JsonProperty("version") String version,
             @JsonProperty("name") String name,
             @JsonProperty("javaType") String javaType,
+            @JsonProperty("itemType") String itemType,
             @JsonProperty("planYaml") String planYaml,
             @JsonProperty("description") String description,
             @JsonProperty("iconUrl") String iconUrl,
@@ -47,7 +48,7 @@ public class CatalogPolicySummary extends CatalogItemSummary {
             @JsonProperty("deprecated") boolean deprecated,
             @JsonProperty("links") Map<String, URI> links
         ) {
-        super(symbolicName, version, name, javaType, planYaml, description, iconUrl, tags, deprecated, links);
+        super(symbolicName, version, name, javaType, itemType, planYaml, description, iconUrl, tags, deprecated, links);
         // TODO expose config from policies
         this.config = (config == null) ? ImmutableSet.<PolicyConfigSummary>of() : config;
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -103,7 +103,7 @@ public class CatalogTransformer {
         }
         
         return new CatalogEntitySummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
-            item.getJavaType(), item.getPlanYaml(),
+            item.getJavaType(), item.getCatalogItemType().toString(), item.getPlanYaml(),
             item.getDescription(), tidyIconLink(b, item, item.getIconUrl(), ub),
             makeTags(spec, item), config, sensors, effectors,
             item.isDeprecated(), makeLinks(item, ub));
@@ -128,7 +128,7 @@ public class CatalogTransformer {
             log.warn("Invalid item in catalog when converting REST summaries (supplying generic item), at "+item+": "+e, e);
         }
         return new CatalogItemSummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
-            item.getJavaType(), item.getPlanYaml(),
+            item.getJavaType(), item.getCatalogItemType().toString(), item.getPlanYaml(),
             item.getDescription(), tidyIconLink(b, item, item.getIconUrl(), ub), item.tags().getTags(), item.isDeprecated(), makeLinks(item, ub));
     }
 
@@ -144,7 +144,7 @@ public class CatalogTransformer {
             log.trace("Unable to create policy spec for "+item+": "+e, e);
         }
         return new CatalogPolicySummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
-                item.getJavaType(), item.getPlanYaml(),
+                item.getJavaType(), item.getCatalogItemType().toString(), item.getPlanYaml(),
                 item.getDescription(), tidyIconLink(b, item, item.getIconUrl(), ub), config,
                 item.tags().getTags(), item.isDeprecated(), makeLinks(item, ub));
     }
@@ -152,7 +152,7 @@ public class CatalogTransformer {
     public static CatalogLocationSummary catalogLocationSummary(BrooklynRestResourceUtils b, CatalogItem<? extends Location,LocationSpec<?>> item, UriBuilder ub) {
         Set<LocationConfigSummary> config = ImmutableSet.of();
         return new CatalogLocationSummary(item.getSymbolicName(), item.getVersion(), item.getDisplayName(),
-                item.getJavaType(), item.getPlanYaml(),
+                item.getJavaType(), item.getCatalogItemType().toString(), item.getPlanYaml(),
                 item.getDescription(), tidyIconLink(b, item, item.getIconUrl(), ub), config,
                 item.tags().getTags(), item.isDeprecated(), makeLinks(item, ub));
     }


### PR DESCRIPTION
As for today, when a user submit catalog item(s), the UI redirects to the catalog page, not to the newly created catalog item. This is due to the fact that the UI does not know what type of catalog item has been created and therefore cannot redirect the user properly.

As the title says, this adds the `itemType` field to the `CatalogItemSummary` object which will allow to do that.