### PR TITLE
Fix application start problems

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractApplication.java
@@ -147,24 +147,35 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
         Collection<? extends Location> locationsToUse = locations==null ? ImmutableSet.<Location>of() : locations;
         ServiceProblemsLogic.clearProblemsIndicator(this, START);
         ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(this, Attributes.SERVICE_STATE_ACTUAL, "Application starting");
+        ServiceStateLogic.ServiceNotUpLogic.clearNotUpIndicator(this, START.getName());
         setExpectedStateAndRecordLifecycleEvent(Lifecycle.STARTING);
         try {
-            preStart(locationsToUse);
-
-            // Opportunity to block startup until other dependent components are available
-            Object val = config().get(START_LATCH);
-            if (val != null) log.debug("{} finished waiting for start-latch; continuing...", this);
-
-            doStart(locationsToUse);
-            postStart(locationsToUse);
-
+            try {
+                
+                preStart(locationsToUse);
+                
+                // Opportunity to block startup until other dependent components are available
+                Object val = config().get(START_LATCH);
+                if (val != null) log.debug("{} finished waiting for start-latch; continuing...", this);
+                
+                doStart(locationsToUse);
+                postStart(locationsToUse);
+                
+            } catch (ProblemStartingChildrenException e) {
+                throw Exceptions.propagate(e);
+            } catch (Exception e) {
+                // should remember problems, apart from those that happened starting children
+                // fixed bug introduced by the fix in dacf18b831e1e5e1383d662a873643a3c3cabac6
+                // where failures in special code at application root don't cause app to go on fire 
+                ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(this, START.getName(), Exceptions.collapseText(e));
+                throw Exceptions.propagate(e);
+            }
+            
         } catch (Exception e) {
-            // TODO should probably remember these problems then clear?  if so, do it here ... or on all effectors?
-            // ServiceProblemsLogic.updateProblemsIndicator(this, START, e);
-
             recordApplicationEvent(Lifecycle.ON_FIRE);
             // no need to log here; the effector invocation should do that
             throw Exceptions.propagate(e);
+            
         } finally {
             ServiceStateLogic.ServiceNotUpLogic.clearNotUpIndicator(this, Attributes.SERVICE_STATE_ACTUAL);
             ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
@@ -180,9 +191,23 @@ public abstract class AbstractApplication extends AbstractEntity implements Star
     }
     
     protected void doStart(Collection<? extends Location> locations) {
-        StartableMethods.start(this, locations);        
+        doStartChildren(locations);        
+    }
+    
+    protected void doStartChildren(Collection<? extends Location> locations) {
+        try {
+            StartableMethods.start(this, locations);
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            throw new ProblemStartingChildrenException(e);
+        }
     }
 
+    private static class ProblemStartingChildrenException extends RuntimeException {
+        private static final long serialVersionUID = 7710856289284536803L;
+        private ProblemStartingChildrenException(Exception cause) { super(cause); }
+    }
+    
     /**
      * Default is no-op. Subclasses can override.
      * */

--- a/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.trait.FailingEntity;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.entity.TestApplicationImpl;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
@@ -67,6 +68,21 @@ public class ApplicationLifecycleStateTest extends BrooklynMgmtUnitTestSupport {
         
         startAndAssertException(app, ImmutableList.<Location>of());
         assertHealthEventually(child, Lifecycle.ON_FIRE, false);
+        assertHealthEventually(app, Lifecycle.ON_FIRE, false);
+    }
+    
+    public static class TestApplicationDoStartFailing extends TestApplicationImpl {
+        @Override
+        protected void doStart(Collection<? extends Location> locations) {
+            super.doStart(locations);
+            throw new RuntimeException("deliberate failure");
+        }
+    }
+    public void testAppFailsCausesAppToFail() throws Exception {
+        TestApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(TestApplication.class,
+                TestApplicationDoStartFailing.class));
+        
+        startAndAssertException(app, ImmutableList.<Location>of());
         assertHealthEventually(app, Lifecycle.ON_FIRE, false);
     }
     


### PR DESCRIPTION
A bug was introduced in https://github.com/apache/brooklyn-server/pull/393 where if there are errors in a custom `Application.doStart(...)`, the `start` effector fails but the application does not.

This corrects that using a special exception to allow children problems to pass through.

/cc @sjcorbett @neykov