### PR TITLE
Terminate winrm client context on Brooklyn exit

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
@@ -88,6 +88,10 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
     protected WinRmMachineLocation machine;
     protected Entity app;
     
+    protected boolean useDefaultProperties() {
+        return true;
+    }
+    
     @BeforeClass(alwaysRun = true)
     public void setUpClass() throws Exception {
         super.setUp();
@@ -102,7 +106,7 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
                 "  byon:",
                 "    hosts:",
                 "    - winrm: "+ip+":5985",
-                "      password: "+password,
+                "      password: \""+password.replace("\"", "\\\"") + "\"",
                 "      user: Administrator",
                 "      osFamily: windows");
     }
@@ -319,7 +323,7 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
                 app = createAndStartApplication(Joiner.on("\n").join(yaml));
                 fail("start should have failed for app="+app);
             } catch (Exception e) {
-                if (e.toString().contains("invalid result") && e.toString().contains("for "+cmdFailed)) throw e;
+                if (!e.toString().contains("invalid result") || !e.toString().contains("for "+cmdFailed)) throw e;
             }
         }
     }
@@ -391,9 +395,7 @@ public class WindowsYamlLiveTest extends AbstractYamlTest {
         for (Task<?> task : tasks) {
             if (matcher.apply(task)) return Optional.<Task<?>>of(task);
 
-            if (!(task instanceof HasTaskChildren)) {
-                return Optional.absent();
-            } else {
+            if (task instanceof HasTaskChildren) {
                 Optional<Task<?>> subResult = findTaskOrSubTask(((HasTaskChildren) task).getChildren(), matcher);
                 if (subResult.isPresent()) return subResult;
             }

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/Windows7zipBlueprintLiveTest.java
@@ -75,7 +75,7 @@ public class Windows7zipBlueprintLiveTest extends AbstractBlueprintTest {
                 "  byon:",
                 "    hosts:",
                 "    - winrm: "+machine.getAddress().getHostAddress()+":5985",
-                "      password: "+machine.config().get(WinRmMachineLocation.PASSWORD),
+                "      password: \""+machine.config().get(WinRmMachineLocation.PASSWORD).replace("\"", "\\\"") + "\"",
                 "      user: Administrator",
                 "      osFamily: windows",
                 "services:",
@@ -89,7 +89,7 @@ public class Windows7zipBlueprintLiveTest extends AbstractBlueprintTest {
                 String user = Strings.getFirstWord(winRMAddress);
                 String password = Strings.getFirstWordAfter(winRMAddress, ":");
                 
-                WinRmTool winRmTool = WinRmTool.connect(ipPort, user, password);
+                WinRmTool winRmTool = WinRmTool.Builder.builder(ipPort, user, password).build();
                 WinRmToolResponse winRmResponse = winRmTool.executePs(ImmutableList.of("(Get-Item \"C:\\\\Program Files\\\\7-Zip\\\\7z.exe\").name"));
                 
                 LOG.info("winRmResponse: code="+winRmResponse.getStatusCode()+"; out="+winRmResponse.getStdOut()+"; err="+winRmResponse.getStdErr());

--- a/launcher/src/test/resources/install7zip.ps1
+++ b/launcher/src/test/resources/install7zip.ps1
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-$Path="C:\InstallTemp"
+$Path = "C:\InstallTemp"
 New-Item -ItemType Directory -Force -Path $Path
 
 $Url = "${config['installer.download.url']}"
@@ -23,13 +23,6 @@ $Dl = [System.IO.Path]::Combine($Path, "installer.msi")
 
 $WebClient = New-Object System.Net.WebClient
 
-$WebClient.DownloadFile($Url, $Dl)
+$WebClient.DownloadFile( $Url, $Dl )
 
-$pass = '${attribute['windows.password']}'
-$secpasswd = ConvertTo-SecureString $pass -AsPlainText -Force
-$mycreds = New-Object System.Management.Automation.PSCredential ($($env:COMPUTERNAME + "\Administrator"), $secpasswd)
-
-Invoke-Command -ComputerName localhost -credential $mycreds -scriptblock {
-    param($Dl)
-    Start-Process "msiexec" -ArgumentList '/qn','/i',$Dl,'/L c:\7ziplog.txt' -Wait
-} -Authentication CredSSP -argumentlist $Dl
+Start-Process "msiexec" -ArgumentList '/qn','/i',$Dl -RedirectStandardOutput ( [System.IO.Path]::Combine($Path, "stdout.txt") ) -RedirectStandardError ( [System.IO.Path]::Combine($Path, "stderr.txt") ) -Wait

--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -184,7 +184,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshingLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshingLiveTest.java
@@ -54,6 +54,7 @@ public class JcloudsSshingLiveTest extends AbstractJcloudsLiveTest {
         JcloudsSshMachineLocation machine = obtainMachine(MutableMap.<String,Object>builder()
                 .putIfAbsent("inboundPorts", ImmutableList.of(22))
                 .build());
+        machine.execCommands("test commands", ImmutableList.of("echo test"));
         assertSshable(machine);
         assertEquals(machine.getUser(), "myname");
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -456,11 +456,6 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,8 @@
         <cxf.version>3.1.10</cxf.version>
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
-        <httpclient.version>4.4.1</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
+        <!-- @deprecated since 0.11 -->
+        <httpclient.version>4.5.2</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.3.7</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes -->
         <jsr305.version>2.0.1</jsr305.version>
@@ -187,12 +188,8 @@
         <commons-collections.version>3.2.1</commons-collections.version>
         <javax.mail.version>1.4.4</javax.mail.version>
         <cxf.javax.annotation-api.version>1.2</cxf.javax.annotation-api.version>
-
-        <!-- Testing Dependency Versions -->
-        <!-- testng 6.9.13 has this problem https://github.com/cbeust/testng/issues/1168, to be fixed in the release following 6.9.13.8. -->
-        <!-- Recent versions of testng are not pushed to maven central, they are publishing to jcentral. -->
-        <testng.version>6.9.10</testng.version>
-        <mockito.version>1.10.8</mockito.version>
+        <testng.version>6.10</testng.version>
+        <mockito.version>2.7.12</mockito.version>
         <assertj.version>2.2.0</assertj.version> <!-- v 2.2.0 is being used as v 3.20 introduces Java8 dependencies-->
         <cobertura.plugin.version>2.7</cobertura.plugin.version>
         <surefire.version>2.19.1</surefire.version>

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinrmExitStatusLiveTest.java
@@ -217,12 +217,14 @@ public class VanillaWindowsProcessWinrmExitStatusLiveTest {
         runExecPsNonZeroExitCode("launch-command");
     }
 
-    @Test(groups = "Live")
+    // Failed stop command doesn't fail the effector if machine is destroyed successfully.
+    @Test(groups = {"Live","WIP"})
     public void testPsCheckRunningNonZeroExitCode() {
         runExecPsNonZeroExitCode("is-running-command");
     }
 
-    @Test(groups = "Live")
+    // Failed stop command doesn't fail the effector if machine is destroyed successfully.
+    @Test(groups = {"Live","WIP"})
     public void testPsStopNonZeroExitCode() {
         runExecPsNonZeroExitCode("stop-command");
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelperUnitTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelperUnitTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.entity.software.base.lifecycle;
 
 import org.apache.brooklyn.entity.software.base.DoNothingWinRmSoftwareProcessDriver;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -42,7 +43,7 @@ public class WinRmExecuteHelperUnitTest {
     @Test
     public void testNonZeroExitCode() {
         DoNothingWinRmSoftwareProcessDriver nativeWindowsScriptRunner = mock(DoNothingWinRmSoftwareProcessDriver.class);
-        when(nativeWindowsScriptRunner.executeNativeOrPsCommand(any(Map.class), any(String.class), any(String.class), any(String.class), any(Boolean.class))).thenReturn(1);
+        when(nativeWindowsScriptRunner.executeNativeOrPsCommand(any(Map.class), any(String.class), Mockito.<String>isNull(), any(String.class), any(Boolean.class))).thenReturn(1);
 
         WinRmExecuteHelper scriptHelper = new WinRmExecuteHelper(nativeWindowsScriptRunner, "test-zero-code-task")
                 .setCommand(NON_ZERO_CODE_COMMAND);
@@ -52,7 +53,7 @@ public class WinRmExecuteHelperUnitTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testNonZeroExitCodeException() {
         DoNothingWinRmSoftwareProcessDriver nativeWindowsScriptRunner = mock(DoNothingWinRmSoftwareProcessDriver.class);
-        when(nativeWindowsScriptRunner.executeNativeOrPsCommand(any(Map.class), any(String.class), any(String.class), any(String.class), any(Boolean.class))).thenReturn(1);
+        when(nativeWindowsScriptRunner.executeNativeOrPsCommand(any(Map.class), any(String.class), Mockito.<String>isNull(), any(String.class), any(Boolean.class))).thenReturn(1);
 
         WinRmExecuteHelper scriptHelper = new WinRmExecuteHelper(nativeWindowsScriptRunner, "test-zero-code-task")
                 .failOnNonZeroResultCode()

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.core.location.access.PortForwardManagerLocationResolver;
+import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
@@ -355,6 +356,9 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
             String toolClass = args.get(WINRM_TOOL_CLASS);
             if (toolClass == null) toolClass = Winrm4jTool.class.getName();
             WinRmTool tool = (WinRmTool) new ClassLoaderUtils(this, getManagementContext()).loadClass(toolClass).getConstructor(Map.class).newInstance(args.getAllConfig());
+            if (tool instanceof ManagementContextInjectable) {
+                ((ManagementContextInjectable)tool).setManagementContext(getManagementContext());
+            }
 
             if (LOG.isTraceEnabled()) LOG.trace("using ssh-tool {} (of type {}); props ", tool, toolClass);
 

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -113,7 +113,7 @@ public class LogWatcher implements Closeable {
         Answer<Void> answer = new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                ILoggingEvent event = invocation.getArgumentAt(0, ILoggingEvent.class);
+                ILoggingEvent event = invocation.getArgument(0);
                 if (event != null && filter.apply(event)) {
                     events.add(event);
                 }


### PR DESCRIPTION
Update to new Winrm4j API, sharing a single context for all clients. Also updates some libraries to avoid convergence errors with the winrm4j dependencies.

Do not merge until Winrm4j 5.0 is released.