### PR TITLE
Increase timeout in ReachableSocketFinderTest

### DIFF
--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
@@ -72,7 +71,7 @@ public class ReachableSocketFinderTest {
     public void setUp() throws Exception {
         reachabilityResults = Maps.newConcurrentMap();
         executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
-        finder = new ReachableSocketFinder(socketTester, Duration.ZERO);
+        finder = new ReachableSocketFinder(socketTester);
     }
 
     @AfterMethod(alwaysRun=true)
@@ -118,7 +117,7 @@ public class ReachableSocketFinderTest {
 
         // When port is reached, it completes
         reachabilityResults.put(socket1, true);
-        assertEquals(future.get(5, TimeUnit.SECONDS), socket1);
+        assertEquals(future.get(), socket1);
     }
 
     @Test
@@ -143,7 +142,8 @@ public class ReachableSocketFinderTest {
     public void testSocketResultIgnoredIfGracePeriodExpiresAfterFirstResultAvailable() {
         reachabilityResults.put(socket1, false);
         reachabilityResults.put(socket2, true);
-
+        // Override the default test grace period.
+        finder = new ReachableSocketFinder(socketTester, Duration.ZERO);
         final Iterable<HostAndPort> actual = finder.findOpenSocketsOnNode(ImmutableList.of(socket1, socket2), TIMEOUT);
         // Sleep through the grace period.
         Time.sleep(50);


### PR DESCRIPTION
Use the default grace period. I think leaving it as `ZERO` was an oversight on my behalf.