### PR TITLE
Do not runtime-inherit catalog item in the spec to fix config key list problem

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -75,7 +75,6 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     protected AbstractBrooklynObjectSpec(Class<? extends T> type) {
         checkValidType(type);
         this.type = type;
-        this.catalogItemId = ApiObjectsFactory.get().getCatalogItemIdFromContext();
     }
     
     @SuppressWarnings("unchecked")
@@ -98,13 +97,18 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
         return self();
     }
     
+    /** Set the catalog item ID that defined this object, also used for searching for type and resources referenced */
+    // since https://issues.apache.org/jira/browse/BROOKLYN-445 this must no longer be used to indicate
+    // a caller-context catalog item that should be used for search purposes;
+    // if that behaviour is desired, the child should be refactored to be its own item in the catalog BOM
+    // (or TODO we add a separate field to record other catalog item IDs that could be applied for searching, see below)
     public SpecT catalogItemId(String val) {
         catalogItemId = val;
         return self();
     }
     // TODO in many places (callers to this method) we prefer a wrapper item ID;
     // that is right, because the wrapper's defn will refer to the wrapped,
-    // but we might need also to collect the item ID's so that *all* can be searched.
+    // but we might need also to collect the item ID's so that *all* can be searched, see #catalogItemId.
     // e.g. if R3 references R2 which references R1 any one of these might supply config keys 
     // referencing resources or types in their local bundles. 
     @Beta

--- a/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/internal/AbstractBrooklynObjectSpec.java
@@ -114,7 +114,7 @@ public abstract class AbstractBrooklynObjectSpec<T,SpecT extends AbstractBrookly
     @Beta
     public SpecT catalogItemIdIfNotNull(String val) {
         if (val!=null) {
-            catalogItemId = val;
+            catalogItemId(val);
         }
         return self();
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -796,7 +796,7 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
     }
     
     @Test
-    public void testManuallyAddSpec() throws Exception {
+    public void testManuallyAdd() throws Exception {
         String yaml = Joiner.on("\n").join(
                 "services:",
                 "- type: "+TestEntity.class.getName());
@@ -812,10 +812,12 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());
         Assert.assertEquals(entity2.getEntityType().getConfigKeys(), entity1.getEntityType().getConfigKeys());
+        Assert.assertEquals(entity1.getCatalogItemId(), null);
+        Assert.assertEquals(entity2.getCatalogItemId(), null);
     }
     
     @Test
-    public void testManuallyAddSpecFromCatalog() throws Exception {
+    public void testManuallyAddWithParentFromCatalog() throws Exception {
         addCatalogItems(
             "brooklyn.catalog:",
             "  itemType: entity",
@@ -839,11 +841,17 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());
         Assert.assertEquals(entity2.getEntityType().getConfigKeys(), entity1.getEntityType().getConfigKeys());
+        Assert.assertEquals(entity1.getCatalogItemId(), "test-entity:0.0.0.SNAPSHOT");
+        
+        // TODO currently the child has item ID set from CatalogUtils.setCatalogItemIdOnAddition
+        // that should set a search path instead of setting the actual item
+        // (ideally we'd assert null here)
+        Assert.assertEquals(entity2.getCatalogItemId(), "test-entity:0.0.0.SNAPSHOT");
     }
     
 
     @Test
-    public void testManuallyAddSpecInTaskOfOtherEntity() throws Exception {
+    public void testManuallyAddInTaskOfOtherEntity() throws Exception {
         addCatalogItems(
             "brooklyn.catalog:",
             "  itemType: entity",
@@ -872,6 +880,12 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());
         Assert.assertEquals(entity2.getEntityType().getConfigKeys(), entity1.getEntityType().getConfigKeys());
+        Assert.assertEquals(entity1.getCatalogItemId(), "test-entity:0.0.0.SNAPSHOT");
+        
+        // TODO currently the child has item ID set from context in constructor of AbstractBrooklynObject;
+        // that should set a search path instead of setting the actual item
+        // (ideally we'd assert null here)
+        Assert.assertEquals(entity2.getCatalogItemId(), "test-entity:0.0.0.SNAPSHOT");
     }
     
     @Test

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -175,6 +175,7 @@ public class CatalogUtils {
         }
     }
 
+    // TODO should be addToCatalogSearchPathOnAddition
     public static void setCatalogItemIdOnAddition(Entity entity, BrooklynObject itemBeingAdded) {
         if (entity.getCatalogItemId()!=null) {
             if (itemBeingAdded.getCatalogItemId()==null) {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -94,6 +94,7 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -324,6 +325,9 @@ public class Entities {
         out.append(currentIndentation+e.toString()+" "+e.getId()+"\n");
 
         out.append(currentIndentation+tab+tab+"displayName = "+e.getDisplayName()+"\n");
+        if (Strings.isNonBlank(e.getCatalogItemId())) {
+            out.append(currentIndentation+tab+tab+"catalogItemId = "+e.getCatalogItemId()+"\n");
+        }
 
         out.append(currentIndentation+tab+tab+"locations = "+e.getLocations()+"\n");
 

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractBrooklynObject.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractBrooklynObject.java
@@ -22,14 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
 import org.apache.brooklyn.api.internal.ApiObjectsFactory;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.AbstractEntity;
@@ -40,6 +32,13 @@ import org.apache.brooklyn.core.relations.ByObjectBasicRelationSupport;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.text.Identifiers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 public abstract class AbstractBrooklynObject implements BrooklynObjectInternal {
 
@@ -80,6 +79,10 @@ public abstract class AbstractBrooklynObject implements BrooklynObjectInternal {
             _legacyConstruction = true;
         }
 
+        // TODO this will be overridden if the spec has a catalog item ID
+        // correct behaviour should be to inherit context's search path, perhaps, though maybe that's better done as spec?
+        // in any case, should not define it as _the_ catalog item ID; also see assignment based on parent
+        // in CatalogUtils.setCatalogItemIdOnAddition
         catalogItemId = ApiObjectsFactory.get().getCatalogItemIdFromContext();
 
         // rely on sub-class to call configure(properties), because otherwise its fields will not have been initialised

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -271,8 +271,14 @@ public class InternalEntityFactory extends InternalFactory {
     }
 
     private void addSpecParameters(EntitySpec<?> spec, EntityDynamicType edType) {
-        // if coming from a catalog item, the spec list of parameters is canonical, 
-        // ie it has just the right ones from the class, so clear the parameters on the type
+        // if coming from a catalog item, parsed by CAMP, then the spec list of parameters is canonical,
+        // the parent item has had its config keys set as parameters here with those non-inheritable
+        // via type definition removed, so wipe those on the EDT to make sure non-inheritable ones are removed; 
+        // OTOH if item is blank, it was set as a java type, not inheriting it,
+        // and the config keys on the dynamic type are the correct ones to use, and usually there is nothing in spec.parameters,
+        // except what is being added programmatically.
+        // (this logic could get confused if catalog item ID referred to some runtime-inherited context,
+        // but those semantics should no longer be used -- https://issues.apache.org/jira/browse/BROOKLYN-445)
         if (Strings.isNonBlank(spec.getCatalogItemId())) {
             edType.clearConfigKeys();
         }

--- a/rest/rest-server/pom.xml
+++ b/rest/rest-server/pom.xml
@@ -153,6 +153,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-software-nosql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-locations-jclouds</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTestFixture.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/BrooklynRestApiLauncherTestFixture.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class BrooklynRestApiLauncherTestFixture {
 
-    Server server = null;
+    protected Server server = null;
     
     @AfterMethod(alwaysRun=true)
     public void stopServer() throws Exception {

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/test/entity/RedisClusterIntegrationTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/test/entity/RedisClusterIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.rest.test.entity;
+
+import static org.apache.brooklyn.test.Asserts.assertTrue;
+import static org.testng.Assert.assertNotNull;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.entity.brooklynnode.BrooklynNode;
+import org.apache.brooklyn.entity.nosql.redis.RedisCluster;
+import org.apache.brooklyn.entity.nosql.redis.RedisStore;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.rest.BrooklynRestApiLauncherTestFixture;
+import org.apache.brooklyn.util.http.HttpAsserts;
+import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.yaml.Yamls;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class RedisClusterIntegrationTest extends BrooklynRestApiLauncherTestFixture {
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        useServerForTest(newServer());
+    }
+
+    @Test(groups = "Integration")
+    public void testDeployRedisCluster() throws InterruptedException, ExecutionException, TimeoutException {
+        final URI webConsoleUri = URI.create(getBaseUriRest());
+
+        // Test setup
+        final EntitySpec<BrooklynNode> spec = EntitySpec.create(BrooklynNode.class);
+        final ManagementContext mgmt = getManagementContextFromJettyServerAttributes(server);
+        final BrooklynNode node = mgmt.getEntityManager().createEntity(spec);
+        node.sensors().set(BrooklynNode.WEB_CONSOLE_URI, webConsoleUri);
+
+        // Deploy it.
+        final String blueprint = "location: localhost\n" +
+                "services:\n" +
+                "- type: org.apache.brooklyn.entity.nosql.redis.RedisCluster";
+        HttpToolResponse response = node.http().post(
+                "/applications",
+                ImmutableMap.of("Content-Type", "text/yaml"),
+                blueprint.getBytes());
+        HttpAsserts.assertHealthyStatusCode(response.getResponseCode());
+
+        // Assert application is eventually running and not on fire.
+        final Entity entity = mgmt.getApplications().iterator().next().getChildren().iterator().next();
+        assertTrue(entity instanceof RedisCluster,
+                "expected " + RedisCluster.class.getName() + ", found: " + entity);
+        RedisCluster cluster = RedisCluster.class.cast(entity);
+        Entities.dumpInfo(cluster);
+        assertDownloadUrl(cluster.getMaster());
+        for (Entity slave : cluster.getSlaves().getMembers()) {
+            assertDownloadUrl(slave);
+        }
+
+        @SuppressWarnings("unchecked")
+        String taskId = Strings.toString( ((Map<String,Object>) Yamls.parseAll(response.getContentAsString()).iterator().next()).get("id") );
+        Task<?> task = mgmt.getExecutionManager().getTask(taskId);
+        Assert.assertNotNull(task);
+        
+        task.get(Duration.minutes(20));
+        
+        Entities.dumpInfo(cluster);
+        
+        EntityAsserts.assertAttributeEquals(entity, SoftwareProcess.SERVICE_UP, true);
+    }
+    
+    private void assertDownloadUrl(Entity entity) {
+        assertNotNull(entity.config().get(RedisStore.DOWNLOAD_URL), "RedisStore.DOWNLOAD_URL");
+        assertNotNull(entity.config().get(SoftwareProcess.DOWNLOAD_URL), "SoftwareProcess.DOWNLOAD_URL");
+        assertNotNull(entity.config().get(Attributes.DOWNLOAD_URL), "Attributes.DOWNLOAD_URL");
+    }
+
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/BROOKLYN-445 and failing tests included here

means catalog BOMs should be written such that any entity/policy/etc which wants to access resources in the bundle is defined as its own item