### PR TITLE
BROOKLYN-323: Use proper WWW-Authorization header in karaf

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -40,10 +40,17 @@ public interface LogoutApi {
     })
     Response logout();
 
+
+    @POST
+    @Path("/unauthorize")
+    @ApiOperation(value = "Return UNAUTHORIZED 401 response")
+    Response unAuthorize();
+
     @POST
     @Path("/{user}")
     @ApiOperation(value = "Logout and clean session if matching user logged")
     Response logoutUser(
         @ApiParam(value = "User to log out", required = true)
         @PathParam("user") final String user);
+
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
@@ -62,6 +62,13 @@ public class LogoutResource extends AbstractBrooklynRestResource implements Logo
     }
 
     @Override
+    public Response unAuthorize() {
+        return Response.status(Status.UNAUTHORIZED)
+            .header(HttpHeaders.WWW_AUTHENTICATE, BASIC_REALM_WEBCONSOLE)
+            .build();
+    }
+
+    @Override
     public Response logoutUser(String user) {
         // Will work when switching users, but will keep re-authenticating if user types in same user name.
         // Could improve by keeping state in cookies to decide whether to request auth or declare successfull re-auth.

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -114,6 +114,7 @@ limitations under the License.
             <bean class="org.apache.brooklyn.rest.util.FormMapProvider"/>
             <bean class="org.apache.cxf.jaxrs.security.JAASAuthenticationFilter">
                 <property name="contextName" value="webconsole"/>
+                <property name="realmName" value="webconsole"/>
             </bean>
             <bean class="org.apache.brooklyn.rest.util.ManagementContextProvider">
                 <argument ref="localManagementContext"/>


### PR DESCRIPTION
 - Give valid WWW-Authorization header to the client.
   Previously it was just WWW-Authorization: Basic
   Where it has to be WWW-Authorization: Basic realm="something" _That was major Chrome complain for dissrespecting that header._
 - LogoutApi#unAuthorize method useful for making browsers forget Basic Authentication


This PR should be reviewed and merged together with https://github.com/apache/brooklyn-ui/pull/36