### PR TITLE
Generalised Entities.waitFor()

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/Functionals.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/Functionals.java
@@ -148,4 +148,16 @@ public class Functionals {
         return new FunctionAsPredicate();
     }
 
+    /**
+     * Simple adapter from {@link Predicate} to {@link Callable} by currying the passed <tt>subject</tt> parameter.
+     */
+    public static <T> Callable<Boolean> isSatisfied(final T subject, final Predicate<T> predicate) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+                return predicate.apply(subject);
+            }
+        };
+    }
+
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/guava/FunctionalsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/guava/FunctionalsTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.brooklyn.util.guava;
 
-import org.apache.brooklyn.util.guava.Functionals;
 import org.apache.brooklyn.util.math.MathFunctions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Suppliers;
 
@@ -53,6 +53,17 @@ public class FunctionalsTest {
     @Test
     public void testIfNotEqual() {
         IfFunctionsTest.checkTF(Functionals.ifNotEquals(false).value("T").defaultValue("F").build(), "T");
+    }
+
+    @Test
+    public void testIsSatisfied() throws Exception {
+        Predicate<Integer> isEven = new Predicate<Integer>() {
+            @Override public boolean apply(Integer input) {
+                return (input % 2 == 0);
+            }
+        };
+        Assert.assertFalse(Functionals.isSatisfied(11, isEven).call());
+        Assert.assertTrue(Functionals.isSatisfied(22, isEven).call());
     }
 
 }


### PR DESCRIPTION
Provides general-purpose blocking wait on any entity predicate. Example:
````
    Entities.waitFor(
        machineEntity,
        EntityPredicates.attributeEqualTo(MACHINE_STATE, MachineState.REBOOTING),
        Duration.FIVE_SECONDS);
````