### PR TITLE
yaml-test assertions: fix use of “matches”

### DIFF
--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestFrameworkAssertions.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
+
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -62,6 +64,7 @@ public class TestFrameworkAssertions {
     public static final String EQUALS = "equals";
     public static final String NOT_EQUAL = "notEqual";
     public static final String MATCHES = "matches";
+    public static final String CONTAINS_MATCH = "containsMatch";
     public static final String CONTAINS = "contains";
     public static final String IS_EMPTY = "isEmpty";
     public static final String NOT_EMPTY = "notEmpty";
@@ -333,7 +336,11 @@ public class TestFrameworkAssertions {
         case NOT_EMPTY:
             return isTrue(expected) == ((null != actual && Strings.isNonEmpty(actual.toString())));
         case MATCHES:
-            return null != actual && actual.toString().matches(expected.toString());
+            Pattern matchesPattern = Pattern.compile(expected.toString());
+            return null != actual && matchesPattern.matcher(actual.toString()).matches();
+        case CONTAINS_MATCH:
+            Pattern containsMatchPattern = Pattern.compile(expected.toString());
+            return null != actual && containsMatchPattern.matcher(actual.toString()).find();
         case HAS_TRUTH_VALUE:
             return isTrue(expected) == isTrue(actual);
         case GREATER_THAN:
@@ -349,7 +356,7 @@ public class TestFrameworkAssertions {
         // Everything but UNKNOWN_CONDITION. The conditions should really be an enum!
         Set<String> allConditions = ImmutableSet.of(
                 IS_NULL, NOT_NULL, IS_EQUAL_TO, EQUAL_TO, EQUALS, NOT_EQUAL,
-                MATCHES, CONTAINS, IS_EMPTY, NOT_EMPTY, HAS_TRUTH_VALUE,
+                MATCHES, CONTAINS_MATCH, CONTAINS, IS_EMPTY, NOT_EMPTY, HAS_TRUTH_VALUE,
                 GREATER_THAN, LESS_THAN);
         return allConditions.contains(condition);
     }
@@ -362,7 +369,7 @@ public class TestFrameworkAssertions {
                 && actual.getClass().equals(expected.getClass());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private static int compare(@Nullable Object actual, @Nullable Object expected) {
         if (!canCompare(actual, expected)) {
             throw new IllegalArgumentException("Arguments are not comparable: " + actual + ", " + expected);

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestFrameworkAssertionsTest.java
@@ -60,17 +60,30 @@ public class TestFrameworkAssertionsTest {
                 {"some-sensor-value", Arrays.asList(ImmutableMap.of("equals", "some-sensor-value"))},
                 {"some-sensor-value", Arrays.asList(ImmutableMap.of("notEqual", "other-sensor-value"))},
                 {10, Arrays.asList(ImmutableMap.of("notEqual", 20))},
-                {"some-regex-value-to-match", Arrays.asList(ImmutableMap.of("matches", "some.*match", "isEqualTo", "some-regex-value-to-match"))},
+                
                 {null, Arrays.asList(ImmutableMap.of("isNull", Boolean.TRUE))},
                 {"some-non-null-value", Arrays.asList(ImmutableMap.of("isNull", Boolean.FALSE))},
                 {null, Arrays.asList(ImmutableMap.of("notNull", Boolean.FALSE))},
                 {"some-non-null-value", Arrays.asList(ImmutableMap.of("notNull", Boolean.TRUE))},
+                
                 {"<html><body><h1>Im a H1 tag!</h1></body></html>", Arrays.asList(ImmutableMap.of("contains", "Im a H1 tag!"))},
                 {"{\"a\":\"b\",\"c\":\"d\",\"e\":123,\"g\":false}", Arrays.asList(ImmutableMap.of("contains", "false"))},
+                
+                {"some-regex-value-to-match", Arrays.asList(ImmutableMap.of("matches", "some.*match", "isEqualTo", "some-regex-value-to-match"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("matches", "(?s).*line2.*"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("matches", "(?m)line1\n^line2$\nline3\n"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("matches", "(?m)(?s).*^line2$.*"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("matches", "^line1\nline2\nline3\n$"))},
+                
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("containsMatch", "line1"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("containsMatch", "lin.*1"))},
+                {"line1\nline2\nline3\n", Arrays.asList(ImmutableMap.of("containsMatch", "lin.1\nlin.2"))},
+                
                 {"", Arrays.asList(ImmutableMap.of("isEmpty", Boolean.TRUE))},
                 {"some-non-null-value", Arrays.asList(ImmutableMap.of("isEmpty", Boolean.FALSE))},
                 {null, Arrays.asList(ImmutableMap.of("notEmpty", Boolean.FALSE))},
                 {"some-non-null-value", Arrays.asList(ImmutableMap.of("notEmpty", Boolean.TRUE))},
+                
                 {"true", Arrays.asList(ImmutableMap.of("hasTruthValue", Boolean.TRUE))},
                 {"false", Arrays.asList(ImmutableMap.of("hasTruthValue", Boolean.FALSE))},
 
@@ -144,6 +157,14 @@ public class TestFrameworkAssertionsTest {
 
                 {"<html><body><h1>Im a H1 tag!</h1></body></html>", "contains", "quack", Arrays.asList(ImmutableMap.of("contains", "quack"))},
                 {"{\"a\":\"b\",\"c\":\"d\",\"e\":123,\"g\":false}", "contains", "moo", Arrays.asList(ImmutableMap.of("contains", "moo"))},
+
+                {"line1\nline2\nline3\n", "matches", "notthere", Arrays.asList(ImmutableMap.of("matches", "notthere"))},
+                {"line1\nline2\nline3\n", "matches", ".*line2.*", Arrays.asList(ImmutableMap.of("matches", ".*line2.*"))}, // default is not DOTALL
+                {"line1\nline2\nline3\n", "matches", "line1\n^line2$\nline3\n", Arrays.asList(ImmutableMap.of("matches", "line1\n^line2$\nline3\n"))}, // default is not MULTILINE
+
+                {"line1", "containsMatch", "quack", Arrays.asList(ImmutableMap.of("containsMatch", "quack"))},
+                {"line1\nline2\nline3\n", "containsMatch", ".*line1.*line2", Arrays.asList(ImmutableMap.of("containsMatch", ".*line1.*line2"))}, // default is not DOTALL
+                {"line1\nline2\nline3\n", "containsMatch", "^line2$", Arrays.asList(ImmutableMap.of("containsMatch", "^line2$"))}, // default is not MULTILINE
 
                 {25, "lessThan", 24, Collections.singletonList(ImmutableMap.of("lessThan", 24))},
                 {"b", "lessThan", "a", Collections.singletonList(ImmutableMap.of("lessThan", "a"))},


### PR DESCRIPTION
Previously `matches: <regex>` would not work well for multi-line.

For example, if using something like:
```
type: TestSshCommand
brooklyn.config:
  assert.out:
  - matches: ".*foo.*"
```
and the ssh command outputs:
```
foo1
foo2
```
then it would not match.

You can see this in pure java: `"foo1\nfoo2\n".matches(".*foo.*")` is false.

This PR changes our "matches" to do two things: first it tries to match the regex against the entire string; but if that does't work then it splits the input string into multiple lines and checks if the regex matches against any single line - if it does, then it considers it a match.

Do you agree that is what the user will find most intuitive?