### PR TITLE
Use boolean Options correctly in ItemLister

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/enricher/AbstractEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/core/enricher/AbstractEnricher.java
@@ -45,8 +45,9 @@ import com.google.common.collect.Maps;
 */
 public abstract class AbstractEnricher extends AbstractEntityAdjunct implements Enricher {
 
-    public static final ConfigKey<Boolean> SUPPRESS_DUPLICATES = ConfigKeys.newBooleanConfigKey("enricher.suppressDuplicates",
-        "Whether duplicate values published by this enricher should be suppressed");
+    public static final ConfigKey<Boolean> SUPPRESS_DUPLICATES = ConfigKeys.newBooleanConfigKey(
+            "enricher.suppressDuplicates",
+            "Whether duplicate values published by this enricher should be suppressed");
 
     private final EnricherDynamicType enricherType;
     protected Boolean suppressDuplicates;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
@@ -50,25 +50,37 @@ public abstract class AbstractAggregator<T,U> extends AbstractEnricher implement
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractAggregator.class);
 
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer", "The entity whose children/members will be aggregated");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
+            "enricher.producer", "The entity whose children/members will be aggregated");
 
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor");
 
     // FIXME this is not just for "members" i think -Alex
-    public static final ConfigKey<?> DEFAULT_MEMBER_VALUE = ConfigKeys.newConfigKey(Object.class, "enricher.defaultMemberValue");
+    public static final ConfigKey<?> DEFAULT_MEMBER_VALUE = ConfigKeys.newConfigKey(Object.class,
+            "enricher.defaultMemberValue");
 
-    public static final ConfigKey<Set<? extends Entity>> FROM_HARDCODED_PRODUCERS = ConfigKeys.newConfigKey(new TypeToken<Set<? extends Entity>>() {}, "enricher.aggregating.fromHardcodedProducers");
+    public static final ConfigKey<Set<? extends Entity>> FROM_HARDCODED_PRODUCERS = ConfigKeys.newConfigKey(new TypeToken<Set<? extends Entity>>() {},
+            "enricher.aggregating.fromHardcodedProducers");
 
-    public static final ConfigKey<Boolean> FROM_MEMBERS = ConfigKeys.newBooleanConfigKey("enricher.aggregating.fromMembers",
-        "Whether this enricher looks at members; only supported if a Group producer is supplier; defaults to true for Group entities");
+    public static final ConfigKey<Boolean> FROM_MEMBERS = ConfigKeys.newBooleanConfigKey(
+            "enricher.aggregating.fromMembers",
+            "Whether this enricher looks at members; only supported if a Group producer is supplier; " +
+                    "defaults to true for Group entities");
 
-    public static final ConfigKey<Boolean> FROM_CHILDREN = ConfigKeys.newBooleanConfigKey("enricher.aggregating.fromChildren",
-        "Whether this enricher looks at children; this is the default for non-Group producers");
+    public static final ConfigKey<Boolean> FROM_CHILDREN = ConfigKeys.newBooleanConfigKey(
+            "enricher.aggregating.fromChildren",
+            "Whether this enricher looks at children; this is the default for non-Group producers");
 
-    public static final ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<? super Entity>>() {}, "enricher.aggregating.entityFilter");
+    public static final ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<? super Entity>>() {},
+            "enricher.aggregating.entityFilter");
 
-    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<?>>() {}, "enricher.aggregating.valueFilter");
-    public static final ConfigKey<Boolean> EXCLUDE_BLANK = ConfigKeys.newBooleanConfigKey("enricher.aggregator.excludeBlank", "Whether explicit nulls or blank strings should be excluded (default false); may only apply if no value filter set", false);
+    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<?>>() {},
+            "enricher.aggregating.valueFilter");
+    public static final ConfigKey<Boolean> EXCLUDE_BLANK = ConfigKeys.newBooleanConfigKey(
+            "enricher.aggregator.excludeBlank",
+            "Whether explicit nulls or blank strings should be excluded (default false); " +
+                    "may only apply if no value filter set", false);
 
     protected Entity producer;
     protected Sensor<U> targetSensor;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
@@ -45,11 +45,14 @@ public abstract class AbstractTransformer<T,U> extends AbstractEnricher implemen
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractTransformer.class);
 
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
+            "enricher.producer");
 
-    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.sourceSensor");
+    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.sourceSensor");
 
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor");
     
     public static final ConfigKey<List<? extends Sensor<?>>> TRIGGER_SENSORS = ConfigKeys.newConfigKey(
             new TypeToken<List<? extends Sensor<?>>>() {}, 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
@@ -52,20 +52,29 @@ public class Aggregator<T,U> extends AbstractAggregator<T,U> implements SensorEv
 
     private static final Logger LOG = LoggerFactory.getLogger(Aggregator.class);
 
-    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.sourceSensor");
+    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.sourceSensor");
     
     @SetFromFlag("transformation")
-    public static final ConfigKey<Object> TRANSFORMATION_UNTYPED = ConfigKeys.newConfigKey(Object.class, "enricher.transformation.untyped",
-        "Specifies a transformation, as a function from a collection to the value, or as a string matching a pre-defined named transformation, "
-        + "such as 'average' (for numbers), 'sum' (for numbers), or 'list' (the default, putting any collection of items into a list)");
-    public static final ConfigKey<Function<? super Collection<?>, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(new TypeToken<Function<? super Collection<?>, ?>>() {}, "enricher.transformation");
+    public static final ConfigKey<Object> TRANSFORMATION_UNTYPED = ConfigKeys.newConfigKey(Object.class,
+            "enricher.transformation.untyped",
+            "Specifies a transformation, as a function from a collection to the value, or as a string " +
+                    "matching a pre-defined named transformation, such as 'average' (for numbers), " +
+                    "'sum' (for numbers), 'isQuorate' (to compute a quorum), " +
+                    "or 'list' (the default, putting any collection of items into a list)");
+
+    public static final ConfigKey<Function<? super Collection<?>, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(new TypeToken<Function<? super Collection<?>, ?>>() {},
+            "enricher.transformation");
     
     /**
      * @see QuorumChecks
      */
-    public static final ConfigKey<String> QUORUM_CHECK_TYPE = ConfigKeys.newStringConfigKey("quorum.check.type", "The requirement to be considered quorate -- possible values: 'all', 'allAndAtLeastOne', 'atLeastOne', 'atLeastOneUnlessEmpty', 'alwaysHealthy'", "allAndAtLeastOne");
+    public static final ConfigKey<String> QUORUM_CHECK_TYPE = ConfigKeys.newStringConfigKey(
+            "quorum.check.type", "The requirement to be considered quorate -- possible values: " +
+                    "'all', 'allAndAtLeastOne', 'atLeastOne', 'atLeastOneUnlessEmpty', 'alwaysHealthy'", "allAndAtLeastOne");
 
-    public static final ConfigKey<Integer> QUORUM_TOTAL_SIZE = ConfigKeys.newIntegerConfigKey("quorum.total.size", "The total size to consider when determining if quorate", 1);
+    public static final ConfigKey<Integer> QUORUM_TOTAL_SIZE = ConfigKeys.newIntegerConfigKey(
+            "quorum.total.size", "The total size to consider when determining if quorate", 1);
 
     protected Sensor<T> sourceSensor;
     protected Function<? super Collection<T>, ? extends U> transformation;
@@ -119,7 +128,6 @@ public class Aggregator<T,U> extends AbstractAggregator<T,U> implements SensorEv
             if (input==null) return null;
             return MutableList.copyOf(input).asUnmodifiable();
         }
-        
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
@@ -45,21 +45,36 @@ public class Joiner<T> extends AbstractEnricher implements SensorEventListener<T
 
     private static final Logger LOG = LoggerFactory.getLogger(Joiner.class);
 
-    public static ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
-    public static ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.sourceSensor");
-    public static ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
+            "enricher.producer");
+    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.sourceSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor");
     @SetFromFlag("separator")
-    public static ConfigKey<String> SEPARATOR = ConfigKeys.newStringConfigKey("enricher.joiner.separator", "Separator string to insert between each argument", ",");
+    public static final ConfigKey<String> SEPARATOR = ConfigKeys.newStringConfigKey(
+            "enricher.joiner.separator",
+            "Separator string to insert between each argument", ",");
     @SetFromFlag("keyValueSeparator")
-    public static ConfigKey<String> KEY_VALUE_SEPARATOR = ConfigKeys.newStringConfigKey("enricher.joiner.keyValueSeparator", "Separator string to insert between each key-value pair", "=");
+    public static final ConfigKey<String> KEY_VALUE_SEPARATOR = ConfigKeys.newStringConfigKey(
+            "enricher.joiner.keyValueSeparator",
+            "Separator string to insert between each key-value pair", "=");
     @SetFromFlag("joinMapEntries")
-    public static ConfigKey<Boolean> JOIN_MAP_ENTRIES = ConfigKeys.newBooleanConfigKey("enricher.joiner.joinMapEntries", "Whether to add map entries as key-value pairs or just use the value, defaulting to false", false);
+    public static final ConfigKey<Boolean> JOIN_MAP_ENTRIES = ConfigKeys.newBooleanConfigKey(
+            "enricher.joiner.joinMapEntries",
+            "Whether to add map entries as key-value pairs or just use the value, defaulting to false", false);
     @SetFromFlag("quote")
-    public static ConfigKey<Boolean> QUOTE = ConfigKeys.newBooleanConfigKey("enricher.joiner.quote", "Whether to bash-escape each parameter and wrap in double-quotes, defaulting to true", true);
+    public static final ConfigKey<Boolean> QUOTE = ConfigKeys.newBooleanConfigKey(
+            "enricher.joiner.quote",
+            "Whether to bash-escape each parameter and wrap in double-quotes, defaulting to true", true);
     @SetFromFlag("minimum")
-    public static ConfigKey<Integer> MINIMUM = ConfigKeys.newIntegerConfigKey("enricher.joiner.minimum", "Minimum number of elements to join; if fewer than this, sets null; default 0 (no minimum)");
+    public static final ConfigKey<Integer> MINIMUM = ConfigKeys.newIntegerConfigKey(
+            "enricher.joiner.minimum",
+            "Minimum number of elements to join; if fewer than this, sets null; default 0 (no minimum)");
     @SetFromFlag("maximum")
-    public static ConfigKey<Integer> MAXIMUM = ConfigKeys.newIntegerConfigKey("enricher.joiner.maximum", "Maximum number of elements to join; default null means all elements always taken");
+    public static final ConfigKey<Integer> MAXIMUM = ConfigKeys.newIntegerConfigKey(
+            "enricher.joiner.maximum",
+            "Maximum number of elements to join; default null means all elements always taken");
     
     protected Entity producer;
     protected AttributeSensor<T> sourceSensor;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Propagator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Propagator.java
@@ -63,21 +63,27 @@ public class Propagator extends AbstractEnricher implements SensorEventListener<
         Attributes.SERVICE_STATE_ACTUAL, Attributes.SERVICE_STATE_EXPECTED, Attributes.SERVICE_PROBLEMS);
 
     @SetFromFlag("producer")
-    public static ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
+            "enricher.producer");
 
     @SetFromFlag("propagatingAllBut")
-    public static ConfigKey<Collection<? extends Sensor<?>>> PROPAGATING_ALL_BUT = ConfigKeys.newConfigKey(
+    public static final ConfigKey<Collection<? extends Sensor<?>>> PROPAGATING_ALL_BUT = ConfigKeys.newConfigKey(
             new TypeToken<Collection<? extends Sensor<?>>>() {}, 
             "enricher.propagating.propagatingAllBut");
 
     @SetFromFlag("propagatingAll")
-    public static ConfigKey<Boolean> PROPAGATING_ALL = ConfigKeys.newBooleanConfigKey("enricher.propagating.propagatingAll");
+    public static final ConfigKey<Boolean> PROPAGATING_ALL = ConfigKeys.newBooleanConfigKey(
+            "enricher.propagating.propagatingAll");
 
     @SetFromFlag("propagating")
-    public static ConfigKey<Collection<? extends Sensor<?>>> PROPAGATING = ConfigKeys.newConfigKey(new TypeToken<Collection<? extends Sensor<?>>>() {}, "enricher.propagating.inclusions");
+    public static final ConfigKey<Collection<? extends Sensor<?>>> PROPAGATING = ConfigKeys.newConfigKey(
+            new TypeToken<Collection<? extends Sensor<?>>>() {},
+            "enricher.propagating.inclusions");
 
     @SetFromFlag("sensorMapping")
-    public static ConfigKey<Map<? extends Sensor<?>, ? extends Sensor<?>>> SENSOR_MAPPING = ConfigKeys.newConfigKey(new TypeToken<Map<? extends Sensor<?>, ? extends Sensor<?>>>() {}, "enricher.propagating.sensorMapping");
+    public static final ConfigKey<Map<? extends Sensor<?>, ? extends Sensor<?>>> SENSOR_MAPPING = ConfigKeys.newConfigKey(
+            new TypeToken<Map<? extends Sensor<?>, ? extends Sensor<?>>>() {},
+            "enricher.propagating.sensorMapping");
 
     protected Entity producer;
     protected Map<Sensor<?>, Sensor<?>> sensorMapping;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -39,9 +39,12 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
     private static final Logger LOG = LoggerFactory.getLogger(Transformer.class);
 
     // exactly one of these should be supplied to set a value
-    public static final ConfigKey<Object> TARGET_VALUE = ConfigKeys.newConfigKey(Object.class, "enricher.targetValue");
-    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation");
-    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation.fromevent");
+    public static final ConfigKey<Object> TARGET_VALUE = ConfigKeys.newConfigKey(Object.class,
+            "enricher.targetValue");
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {},
+            "enricher.transformation");
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {},
+            "enricher.transformation.fromevent");
 
     public Transformer() { }
     

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
@@ -52,15 +52,21 @@ public class Reducer extends AbstractEnricher implements SensorEventListener<Obj
     private static final Logger LOG = LoggerFactory.getLogger(Reducer.class);
 
     @SetFromFlag("producer")
-    public static ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
-    public static ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
-    public static ConfigKey<List<? extends AttributeSensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(new TypeToken<List<? extends AttributeSensor<?>>>() {}, "enricher.sourceSensors");
-    public static ConfigKey<Function<List<?>,?>> REDUCER_FUNCTION = ConfigKeys.newConfigKey(new TypeToken<Function<List<?>, ?>>() {}, "enricher.reducerFunction");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
+            "enricher.producer");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor");
+    public static final ConfigKey<List<? extends AttributeSensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(new TypeToken<List<? extends AttributeSensor<?>>>() {},
+            "enricher.sourceSensors");
+    public static final ConfigKey<Function<List<?>,?>> REDUCER_FUNCTION = ConfigKeys.newConfigKey(new TypeToken<Function<List<?>, ?>>() {},
+            "enricher.reducerFunction");
     @SetFromFlag("transformation")
-    public static final ConfigKey<String> REDUCER_FUNCTION_TRANSFORMATION = ConfigKeys.newStringConfigKey("enricher.reducerFunction.transformation",
-        "A string matching a pre-defined named reducer function, such as joiner");
-    public static final ConfigKey<Map<String, Object>> PARAMETERS = ConfigKeys.newConfigKey(new TypeToken<Map<String, Object>>() {}, "enricher.reducerFunction.parameters", 
-        "A map of parameters to pass into the reducer function");
+    public static final ConfigKey<String> REDUCER_FUNCTION_TRANSFORMATION = ConfigKeys.newStringConfigKey(
+            "enricher.reducerFunction.transformation",
+            "A string matching a pre-defined named reducer function, such as joiner");
+    public static final ConfigKey<Map<String, Object>> PARAMETERS = ConfigKeys.newConfigKey(new TypeToken<Map<String, Object>>() {},
+            "enricher.reducerFunction.parameters",
+            "A map of parameters to pass into the reducer function");
    
     protected Entity producer;
     protected List<AttributeSensor<?>> subscribedSensors;

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <reflections.version>0.9.9-RC1</reflections.version>
         <jetty.version>9.2.13.v20150730</jetty.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
-        <airline.version>0.6</airline.version>
+        <airline.version>0.7</airline.version>
         <mockwebserver.version>20121111</mockwebserver.version>
         <freemarker.version>2.3.25-incubating</freemarker.version>
         <commons-io.version>2.4</commons-io.version>

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
@@ -18,14 +18,14 @@
  */
 package org.apache.brooklyn.cli;
 
-import io.airlift.command.Arguments;
-import io.airlift.command.Cli;
-import io.airlift.command.Cli.CliBuilder;
-import io.airlift.command.Command;
-import io.airlift.command.Help;
-import io.airlift.command.Option;
-import io.airlift.command.OptionType;
-import io.airlift.command.ParseException;
+import io.airlift.airline.Arguments;
+import io.airlift.airline.Cli;
+import io.airlift.airline.Cli.CliBuilder;
+import io.airlift.airline.Command;
+import io.airlift.airline.Help;
+import io.airlift.airline.Option;
+import io.airlift.airline.OptionType;
+import io.airlift.airline.ParseException;
 
 import java.io.InputStream;
 import java.io.PrintStream;

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
@@ -101,10 +101,10 @@ public abstract class AbstractMain {
     public static abstract class BrooklynCommand implements Callable<Void> {
 
         @Option(type = OptionType.GLOBAL, name = { "-v", "--verbose" }, description = "Verbose mode")
-        public boolean verbose = false;
+        public boolean verbose;
 
         @Option(type = OptionType.GLOBAL, name = { "-q", "--quiet" }, description = "Quiet mode")
-        public boolean quiet = false;
+        public boolean quiet;
 
         @VisibleForTesting
         protected PrintStream stdout = System.out;

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
@@ -28,9 +28,9 @@ import org.apache.brooklyn.launcher.command.support.CloudExplorerSupport.ListIma
 import org.apache.brooklyn.launcher.command.support.CloudExplorerSupport.ListInstances;
 import org.apache.brooklyn.launcher.command.support.CloudExplorerSupport.ListHardwareProfiles;
 import org.apache.brooklyn.launcher.command.support.CloudExplorerSupport.TerminateInstances;
-import io.airlift.command.Command;
-import io.airlift.command.Option;
-import io.airlift.command.ParseException;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
+import io.airlift.airline.ParseException;
 
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/CloudExplorer.java
@@ -52,7 +52,7 @@ public class CloudExplorer {
 
         @Option(name = { "-y", "--yes" }, title = "auto-confirm",
                 description = CloudExplorerSupport.AUTOCONFIRM_DESC)
-        public boolean autoConfirm = false;
+        public boolean autoConfirm;
 
 
         protected abstract CloudExplorerSupport getExplorer(LocalManagementContext mgmt, boolean allLocations,

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
@@ -99,14 +99,16 @@ public class ItemLister {
         @Option(name = { "--type-regex" }, title = "Regex to restrict the Java types loaded")
         public String typeRegex;
 
-        @Option(name = { "--catalog-only" }, title = "When scanning JAR files, whether to include only items annotated with @Catalog (default true)")
-        public boolean catalogOnly = true;
+        @Option(name = {"--all-classes"}, description =
+                "When scanning JAR files, whether to include all items rather than only those annotated with @Catalog")
+        protected boolean allClasses;
 
-        @Option(name = { "--ignore-impls" }, title = "Ignore Entity class implementation where there is an Entity interface with @ImplementedBy (default true)")
-        public boolean ignoreImpls = true;
+        @Option(name = { "--include-impls" }, description =
+                "Include Entity class implementation where there is an Entity interface with @ImplementedBy")
+        public boolean includeImpls;
 
-        @Option(name = { "--headings-only" }, title = "Whether to only show name/type, and not config keys etc")
-        public boolean headingsOnly = false;
+        @Option(name = { "--headings-only" }, description = "Whether to only show name/type, and not config keys etc")
+        public boolean headingsOnly;
         
         @Option(name = { "--output-folder" }, title = "If supplied, generate HTML pages in the given folder; otherwise only generates JSON")
         public String outputFolder;
@@ -114,7 +116,7 @@ public class ItemLister {
         @SuppressWarnings("unchecked")
         @Override
         public Void call() throws Exception {
-            Map<String, Object> result = MutableMap.of();
+            Map<String, Object> result;
 
             result = populateDescriptors();
             String json = toJson(result);
@@ -334,12 +336,12 @@ public class ItemLister {
             if (typeRegex != null) {
                 fluent = fluent.filter(ClassFinder.withClassNameMatching(typeRegex));
             }
-            if (catalogOnlyOverride == null ? catalogOnly : catalogOnlyOverride) {
+            if (catalogOnlyOverride == null ? !allClasses : catalogOnlyOverride) {
                 fluent = fluent.filter(ClassFinder.withAnnotation(Catalog.class));
             }
             List<Class<? extends T>> filtered = fluent.toList();
             Collection<Class<? extends T>> result;
-            if (ignoreImpls) {
+            if (!includeImpls) {
                 result = MutableSet.copyOf(filtered);
                 for (Class<? extends T> clazz : filtered) {
                     ImplementedBy implementedBy = clazz.getAnnotation(ImplementedBy.class);

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
@@ -18,8 +18,8 @@
  */
 package org.apache.brooklyn.cli;
 
-import io.airlift.command.Command;
-import io.airlift.command.Option;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
 
 import java.io.File;
 import java.io.IOException;

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -96,10 +96,10 @@ import com.google.common.collect.Iterables;
 
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyShell;
-import io.airlift.command.Cli;
-import io.airlift.command.Cli.CliBuilder;
-import io.airlift.command.Command;
-import io.airlift.command.Option;
+import io.airlift.airline.Cli;
+import io.airlift.airline.Cli.CliBuilder;
+import io.airlift.airline.Command;
+import io.airlift.airline.Option;
 
 /**
  * This class is the primary CLI for brooklyn.

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -203,7 +203,7 @@ public class Main extends AbstractMain {
 
         @Option(name = { "--noGlobalBrooklynProperties" }, title = "do not use any global brooklyn.properties file found",
             description = "Do not use the default global brooklyn.properties file found")
-        public boolean noGlobalBrooklynProperties = false;
+        public boolean noGlobalBrooklynProperties;
 
         @Option(name = { "-a", "--app" }, title = "application class or file",
                 description = "The Application to start. " +
@@ -250,11 +250,11 @@ public class Main extends AbstractMain {
 
         @Option(name = { "--https" },
             description = "Launch the web console on https")
-        public boolean useHttps = false;
+        public boolean useHttps;
         
         @Option(name = { "-nc", "--noConsole" },
                 description = "Do not start the web console or REST API")
-        public boolean noConsole = false;
+        public boolean noConsole;
 
         @Option(name = { "-b", "--bindAddress" },
                 description = "Specifies the IP address of the NIC to bind the Brooklyn Management Console to")
@@ -266,39 +266,39 @@ public class Main extends AbstractMain {
 
         @Option(name = { "--noConsoleSecurity" },
                 description = "Whether to disable authentication and security filters for the web console (for use when debugging on a secure network or bound to localhost)")
-        public Boolean noConsoleSecurity = false;
+        public boolean noConsoleSecurity;
 
         @Option(name = { "--startupContinueOnWebErrors" },
             description = "Continue on web subsystem failures during startup "
                 + "(default is to abort if the web API fails to start, as management access is not normally possible)")
-        public boolean startupContinueOnWebErrors = false;
+        public boolean startupContinueOnWebErrors;
 
         @Option(name = { "--startupFailOnPersistenceErrors" },
             description = "Fail on persistence/HA subsystem failures during startup "
                 + "(default is to continue, so errors can be viewed via the API)")
-        public boolean startupFailOnPersistenceErrors = false;
+        public boolean startupFailOnPersistenceErrors;
 
         @Option(name = { "--startupFailOnCatalogErrors" },
             description = "Fail on catalog subsystem failures during startup "
                 + "(default is to continue, so errors can be viewed via the API)")
-        public boolean startupFailOnCatalogErrors = false;
+        public boolean startupFailOnCatalogErrors;
 
         @Option(name = { "--startupFailOnManagedAppsErrors" },
             description = "Fail startup on errors deploying of managed apps specified via the command line "
                 + "(default is to continue, so errors can be viewed via the API)")
-        public boolean startupFailOnManagedAppsErrors = false;
+        public boolean startupFailOnManagedAppsErrors;
 
         @Beta
         @Option(name = { "--startBrooklynNode" },
                 description = "Start a BrooklynNode entity representing this Brooklyn instance")
-        public boolean startBrooklynNode = false;
+        public boolean startBrooklynNode;
 
         // Note in some cases, you can get java.util.concurrent.RejectedExecutionException
         // if shutdown is not co-ordinated, looks like: {@linktourl https://gist.github.com/47066f72d6f6f79b953e}
         @Beta
         @Option(name = { "-sk", "--stopOnKeyPress" },
                 description = "Shutdown immediately on user text entry after startup (useful for debugging and demos)")
-        public boolean stopOnKeyPress = false;
+        public boolean stopOnKeyPress;
 
         final static String STOP_WHICH_APPS_ON_SHUTDOWN = "--stopOnShutdown";
         protected final static String STOP_ALL = "all";
@@ -321,7 +321,7 @@ public class Main extends AbstractMain {
         @Option(name = { "--exitAndLeaveAppsRunningAfterStarting" },
                 description = "Once the application to start (from --app) is running exit the process, leaving any entities running. "
                     + "Can be used in combination with --persist auto --persistenceDir <custom folder location> to attach to the running app at a later time.")
-        public boolean exitAndLeaveAppsRunningAfterStarting = false;
+        public boolean exitAndLeaveAppsRunningAfterStarting;
 
         final static String PERSIST_OPTION = "--persist";
         protected final static String PERSIST_OPTION_DISABLED = "disabled";

--- a/server-cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
+++ b/server-cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
@@ -86,9 +86,9 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
 import groovy.lang.GroovyClassLoader;
-import io.airlift.command.Cli;
-import io.airlift.command.Command;
-import io.airlift.command.ParseException;
+import io.airlift.airline.Cli;
+import io.airlift.airline.Command;
+import io.airlift.airline.ParseException;
 
 public class CliTest {
 

--- a/server-cli/src/test/java/org/apache/brooklyn/cli/CloudExplorerLiveTest.java
+++ b/server-cli/src/test/java/org/apache/brooklyn/cli/CloudExplorerLiveTest.java
@@ -37,8 +37,8 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import io.airlift.command.Cli;
-import io.airlift.command.ParseException;
+import io.airlift.airline.Cli;
+import io.airlift.airline.ParseException;
 
 public class CloudExplorerLiveTest {
 


### PR DESCRIPTION
Replaces list-objects' `--catalog-only` and `--ignore-impls` arguments with `--all-classes` and `--include-impls` respectively.

ItemLister defined a few options as booleans whose default was true. Airline treats boolean options as having zero arity and whose existence implies truth. See Airline's [MetadataLoader](https://github.com/airlift/airline/blob/0.7/src/main/java/io/airlift/airline/model/MetadataLoader.java#L156) class.

I've removed the default from all other boolean options to make it clearer that the value is set by Airline.

CloudExplorerLiveTest passes.