### PR TITLE
Fix publication of EC2 host address in DefaultConnectivityResolver

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
@@ -220,6 +220,10 @@ public class DefaultConnectivityResolver extends BasicConfigurableObject impleme
             }
         }
 
+        if (contextEntity != null) {
+            contextEntity.sensors().set(Attributes.ADDRESS, hapChoice.getHostText());
+        }
+
         // Treat AWS as a special case because the DNS fully qualified hostname in AWS is
         // (normally?!) a good way to refer to the VM from both inside and outside of the region.
         if (!isNetworkModeSet() && !options.isWindows()) {
@@ -241,9 +245,6 @@ public class DefaultConnectivityResolver extends BasicConfigurableObject impleme
             }
         }
 
-        if (contextEntity != null) {
-            contextEntity.sensors().set(Attributes.ADDRESS, hapChoice.getHostText());
-        }
         ManagementAddressResolveResult result = new ManagementAddressResolveResult(hapChoice, credChoice);
         LOG.debug("{} resolved management parameters for {} in {}: {}",
                 new Object[]{this, location, Duration.of(timer), result});


### PR DESCRIPTION
Publish Attributes.ADDRESS before guessing the EC2 hostname.
Fixes the case where host.address was set to the FQDN in EC2.