### PR TITLE
WinRmCommandSensor default executionDir

### DIFF
--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
@@ -144,15 +144,7 @@ public final class WinRmCommandSensor<T> extends AddSensor<T> {
     public static String makeCommandExecutingInDirectory(String command, String executionDir, Entity entity) {
         String finalCommand = command;
         String execDir = executionDir;
-        if (Strings.isBlank(execDir)) {
-            // default to run dir
-            execDir = entity.getAttribute(BrooklynConfigKeys.RUN_DIR);
-            // if no run dir, default to home
-            if (Strings.isBlank(execDir)) {
-                execDir = "%USERPROFILE%";
-            }
-        }
-        if (!"~".equals(execDir)) {
+        if (Strings.isNonBlank(execDir) && !"~".equals(execDir)) {
             finalCommand = "(if exist \"" + execDir + "\" (rundll32) else (mkdir \""+execDir+"\")) && cd \""+execDir+"\" && "+finalCommand;
         }
         return finalCommand;


### PR DESCRIPTION
Use default dir obtained on the winrm sesion
until Apache Brooklyn has working concept for RUN_DIR on VanillaWindowsProcess