### PR TITLE
use http://httpbin instead of https for tests

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CompositeEffectorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CompositeEffectorYamlTest.java
@@ -37,7 +37,7 @@ import com.google.common.collect.Iterables;
 public class CompositeEffectorYamlTest extends AbstractYamlTest {
     private static final Logger log = LoggerFactory.getLogger(CompositeEffectorYamlTest.class);
 
-    @Test
+    @Test(groups="Integration")
     public void testCompositeEffector() throws Exception {
         Entity app = createAndStartApplication(
             "location: localhost",

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CompositeEffectorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CompositeEffectorYamlTest.java
@@ -51,7 +51,7 @@ public class CompositeEffectorYamlTest extends AbstractYamlTest {
             "    brooklyn.config:",
             "      name: myEffector",
             "      description: myDescription",
-            "      uri: https://httpbin.org/get?id=myId",
+            "      uri: http://httpbin.org/get?id=myId",
             "      httpVerb: GET",
             "      jsonPath: $.args.id",
             "      publishSensor: results",

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/HttpCommandEffectorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/HttpCommandEffectorYamlTest.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Iterables;
 public class HttpCommandEffectorYamlTest extends AbstractYamlTest {
     private static final Logger log = LoggerFactory.getLogger(HttpCommandEffectorYamlTest.class);
 
-    @Test
+    @Test(groups="Integration")
     public void testHttpCommandEffectorWithParameters() throws Exception {
         Entity app = createAndStartApplication(
             "location: localhost",

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/HttpCommandEffectorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/HttpCommandEffectorYamlTest.java
@@ -48,7 +48,7 @@ public class HttpCommandEffectorYamlTest extends AbstractYamlTest {
             "    brooklyn.config:",
             "      name: myEffector",
             "      description: myDescription",
-            "      uri: https://httpbin.org/get?id=myId",
+            "      uri: http://httpbin.org/get?id=myId",
             "      httpVerb: GET",
             "      jsonPath: $.args.id",
             "      publishSensor: results"
@@ -60,7 +60,7 @@ public class HttpCommandEffectorYamlTest extends AbstractYamlTest {
 
         // Invoke with parameters
         {
-            Object result = entity.invoke(effector, ImmutableMap.of("uri", "https://httpbin.org/get?pwd=passwd", "jsonPath", "$.args.pwd")).get();
+            Object result = entity.invoke(effector, ImmutableMap.of("uri", "http://httpbin.org/get?pwd=passwd", "jsonPath", "$.args.pwd")).get();
             assertEquals(((String)result).trim(), "passwd");
 
         }


### PR DESCRIPTION
this should fix the build failures we are seeing after 16th March

cc @geomacy please have a look at this 