### PR TITLE
Adds perf test for xml serialiser (and memento-gem)

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerPerformanceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+package org.apache.brooklyn.core.mgmt.persist;
+
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.rebind.mementos.Memento;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.rebind.dto.MementosGenerators;
+import org.apache.brooklyn.core.objs.BasicSpecParameter;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.test.policy.TestEnricher;
+import org.apache.brooklyn.core.test.policy.TestPolicy;
+import org.apache.brooklyn.core.test.qa.performance.AbstractPerformanceTest;
+import org.apache.brooklyn.test.performance.PerformanceTestDescriptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class XmlMementoSerializerPerformanceTest extends AbstractPerformanceTest {
+
+    private XmlMementoSerializer<Object> serializer;
+    
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerPerformanceTest.class.getClassLoader());
+    }
+
+    protected int numIterations() {
+        return 1000;
+    }
+    
+     @Test(groups={"Live", "Acceptance"})
+     public void testSerializeEntityMemento() throws Exception {
+         int numIterations = numIterations();
+         double minRatePerSec = 10 * PERFORMANCE_EXPECTATION;
+
+         // Create an entity with lots of config/parameters, and sensors
+         Map<ConfigKey<?>, String> config = Maps.newLinkedHashMap();
+         List<BasicSpecParameter<?>> params = Lists.newArrayList();
+         for (int i = 0; i < 100; i++) {
+             ConfigKey<String> key = ConfigKeys.newStringConfigKey("myparam"+i);
+             params.add(new BasicSpecParameter<String>("mylabel"+i, false, key));
+             config.put(key, "val"+i);
+         }
+         Entity entity = app.addChild(EntitySpec.create(TestEntity.class)
+                 .configure(TestEntity.CONF_NAME, "myname")
+                 .configure(config)
+                 .parametersAdd(params)
+                 .tags(ImmutableList.<Object>of("tag1", "tag2"))
+                 .enricher(EnricherSpec.create(TestEnricher.class))
+                 .policy(PolicySpec.create(TestPolicy.class)));
+         
+         for (int i = 0; i < 100; i++) {
+             AttributeSensor<String> sensor = Sensors.newStringSensor("mysensor"+i);
+             entity.sensors().set(sensor, "valsensor"+i);
+         }
+
+         // Create the memento for that entity (only once)
+         final Memento memento = MementosGenerators.newBasicMemento(Entities.deproxy(entity));
+         int serializedLength = serializeToString(memento).length();
+
+         // Run the performance test
+         measure(PerformanceTestDescriptor.create()
+                 .summary("mementoSerializer.serializeEntityMemento(size="+serializedLength+"chars)")
+                 .iterations(numIterations)
+                 .minAcceptablePerSecond(minRatePerSec)
+                 .job(new Runnable() {
+                     @Override public void run() {
+                         serializeToString(memento);
+                     }}));
+     }
+     
+     private String serializeToString(Object val) {
+         StringWriter writer = new StringWriter();
+         serializer.serialize(val, writer);
+         return writer.toString();
+     }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementoGeneratorsPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementoGeneratorsPerformanceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+package org.apache.brooklyn.core.mgmt.rebind.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.objs.BasicSpecParameter;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.test.policy.TestEnricher;
+import org.apache.brooklyn.core.test.policy.TestPolicy;
+import org.apache.brooklyn.core.test.qa.performance.AbstractPerformanceTest;
+import org.apache.brooklyn.test.performance.PerformanceTestDescriptor;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class MementoGeneratorsPerformanceTest extends AbstractPerformanceTest {
+
+    protected int numIterations() {
+        return 100;
+    }
+    
+    @Test(groups={"Live", "Acceptance"})
+    public void testGenerateEntityMemento() throws Exception {
+        int numIterations = numIterations();
+        double minRatePerSec = 10 * PERFORMANCE_EXPECTATION;
+
+        // Create an entity with lots of config/parameters, and sensors
+        Map<ConfigKey<?>, String> config = Maps.newLinkedHashMap();
+        List<BasicSpecParameter<?>> params = Lists.newArrayList();
+        for (int i = 0; i < 100; i++) {
+            ConfigKey<String> key = ConfigKeys.newStringConfigKey("myparam"+i);
+            params.add(new BasicSpecParameter<String>("mylabel"+i, false, key));
+            config.put(key, "val"+i);
+        }
+        Entity entity = app.addChild(EntitySpec.create(TestEntity.class)
+                .configure(TestEntity.CONF_NAME, "myname")
+                .configure(config)
+                .parametersAdd(params)
+                .tags(ImmutableList.<Object>of("tag1", "tag2"))
+                .enricher(EnricherSpec.create(TestEnricher.class))
+                .policy(PolicySpec.create(TestPolicy.class)));
+        
+        for (int i = 0; i < 100; i++) {
+            AttributeSensor<String> sensor = Sensors.newStringSensor("mysensor"+i);
+            entity.sensors().set(sensor, "valsensor"+i);
+        }
+
+        final Entity deproxiedEntity = Entities.deproxy(entity);
+
+        // Run the performance test
+        measure(PerformanceTestDescriptor.create()
+                .summary("mementosGenerators.newBasicMemento(entity)")
+                .iterations(numIterations)
+                .minAcceptablePerSecond(minRatePerSec)
+                .job(new Runnable() {
+                    @Override public void run() {
+                        MementosGenerators.newBasicMemento(deproxiedEntity);
+                    }}));
+    }
+}


### PR DESCRIPTION
The output on my machine is shown below. This is with a deliberately big entity (100 config keys and 100 sensor values).

```
2017-03-20 14:38:06,468 INFO  test=PerformanceTestDescriptor{summary=mementoSerializer.serializeEntityMemento(size=65850chars), iterations=1000, warmupIterations=100, job=org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializerPerformanceTest$1@28e5dd6d, minAcceptablePerSecond=1.0}; result=PerformanceTestResult{duration=2s 350ms, warmup=574ms, iterations=1000, warmupIterations=100, ratePerSecond=425.531914893617, histogram={1.049ms-2.097ms: 119, 2.097ms-4.194ms: 876, 4.194ms-8.389ms: 5}, cpuTotalFraction=1.0238435008590299, cpuSampleFractions=[1.038314, 1.016156843156843], minAcceptablePerSecond=1.0}
```
and:
```
2017-03-20 14:37:21,040 INFO  test=PerformanceTestDescriptor{summary=mementosGenerators.newBasicMemento(entity), iterations=100, warmupIterations=10, job=org.apache.brooklyn.core.mgmt.rebind.dto.MementoGeneratorsPerformanceTest$1@12fc1b3, minAcceptablePerSecond=1.0}; result=PerformanceTestResult{duration=85ms, warmup=45ms, iterations=100, warmupIterations=10, ratePerSecond=1176.4705882352941, histogram={524.3us-1.049ms: 84, 1.049ms-2.097ms: 16}, cpuTotalFraction=2.5921956613806407, cpuSampleFractions=[], minAcceptablePerSecond=1.0}
```