### PR TITLE
WinRmMachineLocation obtaining WinRmTool parameters via its config().get

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WinRmMachineLocationExternalConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WinRmMachineLocationExternalConfigYamlTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import com.google.common.base.Joiner;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test
+public class WinRmMachineLocationExternalConfigYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(WinRmMachineLocationExternalConfigYamlTest.class);
+
+    @Override
+    protected LocalManagementContext newTestManagementContext() {
+        BrooklynProperties props = BrooklynProperties.Factory.newEmpty();
+        props.put("brooklyn.external.inPlaceSupplier1", "org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier");
+        props.put("brooklyn.external.inPlaceSupplier1.byonPassword", "passw0rd");
+
+        return LocalManagementContextForTests.builder(true)
+                .useProperties(props)
+                .disableOsgi(false)
+                .build();
+    }
+
+    @Test()
+    public void testWindowsMachinesPasswordExternalProvider() throws Exception {
+        RecordingWinRmTool.constructorProps.clear();
+        final String yaml = Joiner.on("\n").join("location:",
+                "  byon:",
+                "    hosts:",
+                "    - winrm: 127.0.0.1",
+                "      user: admin",
+                "      brooklyn.winrm.config.winrmToolClass: org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool",
+                "      password: $brooklyn:external(\"inPlaceSupplier1\", \"byonPassword\")",
+                "      osFamily: windows",
+                "services:",
+                "- type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess",
+                "  brooklyn.config:",
+                "    launch.command: echo launch",
+                "    checkRunning.command: echo running");
+
+        BasicApplication app = (BasicApplication) createAndStartApplication(yaml);
+        waitForApplicationTasks(app);
+        assertEquals(RecordingWinRmTool.constructorProps.get(0).get(WinRmMachineLocation.PASSWORD.getName()), "passw0rd");
+    }
+
+    @Test()
+    public void testWindowsMachinesNoPasswordExternalProvider() throws Exception {
+        RecordingWinRmTool.constructorProps.clear();
+        final String yaml = Joiner.on("\n").join("location:",
+                "  byon:",
+                "    hosts:",
+                "    - winrm: 127.0.0.1",
+                "      user: admin",
+                "      brooklyn.winrm.config.winrmToolClass: org.apache.brooklyn.util.core.internal.winrm.RecordingWinRmTool",
+                "      password: $brooklyn:external(\"inPlaceSupplier1\", \"byonPasswordddd\")",
+                "      osFamily: windows",
+                "services:",
+                "- type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess",
+                "  brooklyn.config:",
+                "    launch.command: echo launch",
+                "    checkRunning.command: echo running");
+
+        BasicApplication app = (BasicApplication) createAndStartApplication(yaml);
+        waitForApplicationTasks(app);
+        assertNull(RecordingWinRmTool.constructorProps.get(0).get(WinRmMachineLocation.PASSWORD.getName()));
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -314,21 +314,21 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
         try {
             ConfigBag args = new ConfigBag();
 
-            for (Map.Entry<String,Object> entry: config().getBag().getAllConfig().entrySet()) {
+            for (Map.Entry<ConfigKey<?>, ?> entry: config().getBag().getAllConfigAsConfigKeyMap().entrySet()) {
     
                 boolean include = false;
-                String key = entry.getKey();
-                if (key.startsWith(WinRmTool.BROOKLYN_CONFIG_KEY_PREFIX)) {
-                    key = Strings.removeFromStart(key, WinRmTool.BROOKLYN_CONFIG_KEY_PREFIX);
+                String keyName = entry.getKey().getName();
+                if (keyName.startsWith(WinRmTool.BROOKLYN_CONFIG_KEY_PREFIX)) {
+                    keyName = Strings.removeFromStart(keyName, WinRmTool.BROOKLYN_CONFIG_KEY_PREFIX);
                     include = true;
                 }
                 
-                if (key.startsWith(WINRM_TOOL_CLASS_PROPERTIES_PREFIX)) {
-                    key = Strings.removeFromStart(key, WINRM_TOOL_CLASS_PROPERTIES_PREFIX);
+                if (keyName.startsWith(WINRM_TOOL_CLASS_PROPERTIES_PREFIX)) {
+                    keyName = Strings.removeFromStart(keyName, WINRM_TOOL_CLASS_PROPERTIES_PREFIX);
                     include = true;
                 }
                 
-                if (ALL_WINRM_CONFIG_KEY_NAMES.contains(entry.getKey())) {
+                if (ALL_WINRM_CONFIG_KEY_NAMES.contains(keyName)) {
                     // key should be included, and does not need to be changed
     
                     // TODO make this config-setting mechanism more universal
@@ -338,10 +338,9 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
                     // (require use of BROOKLYN_CONFIG_KEY_PREFIX)
                     include = true;
                 }
-                
-    
+
                 if (include) {
-                    args.putStringKey(key, entry.getValue());
+                    args.putStringKey(keyName, config().get(entry.getKey()));
                 }
             }
             


### PR DESCRIPTION
- This allows WinrmTool props to be supplied via external configuration providers.
- WinRmTool instantiation is made to be the same as in SshMachineLocation#connectSsh