### PR TITLE
Add series of meta effectors for composite operations

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
@@ -54,31 +54,31 @@ import com.google.common.base.Preconditions;
  * are only those supplied by a user at runtime; in order to merge with default
  * values, use {@link #getMergedParams(Effector, ConfigBag)}.
  *  
- * @since 0.7.0 */
-@Beta
+ * @since 0.7.0
+ */
 public class AddEffector implements EntityInitializer {
-    
+
     public static final ConfigKey<String> EFFECTOR_NAME = ConfigKeys.newStringConfigKey("name");
     public static final ConfigKey<String> EFFECTOR_DESCRIPTION = ConfigKeys.newStringConfigKey("description");
-    
+
     public static final ConfigKey<Map<String,Object>> EFFECTOR_PARAMETER_DEFS = new MapConfigKey<Object>(Object.class, "parameters");
 
-    final Effector<?> effector;
-    
+    protected final Effector<?> effector;
+
     public AddEffector(Effector<?> effector) {
         this.effector = Preconditions.checkNotNull(effector, "effector");
     }
-    
+
     @Override
     public void apply(EntityLocal entity) {
         ((EntityInternal)entity).getMutableEntityType().addEffector(effector);
     }
-    
+
     public static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
         String name = Preconditions.checkNotNull(params.get(EFFECTOR_NAME), "name must be supplied when defining an effector: %s", params);
         EffectorBuilder<T> eff = Effectors.effector(type, name);
         eff.description(params.get(EFFECTOR_DESCRIPTION));
-        
+
         Map<String, Object> paramDefs = params.get(EFFECTOR_PARAMETER_DEFS);
         if (paramDefs!=null) {
             for (Map.Entry<String, Object> paramDef: paramDefs.entrySet()){
@@ -97,7 +97,7 @@ public class AddEffector implements EntityInitializer {
                 }
             }
         }
-        
+
         return eff;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/composite/AbstractCompositeEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/composite/AbstractCompositeEffector.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.composite;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.util.collections.CollectionFunctionals;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.Iterables;
+
+@Beta
+public abstract class AbstractCompositeEffector extends AddEffector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCompositeEffector.class);
+
+    public AbstractCompositeEffector(Effector<?> effector) {
+        super(effector);
+    }
+
+    @Override
+    public void apply(EntityLocal entity) {
+        Maybe<Effector<?>> effectorMaybe = entity.getEntityType().getEffectorByName(effector.getName());
+        if (!effectorMaybe.isAbsentOrNull()) {
+//            Effector<?> original = Effectors.effector(effectorMaybe.get()).name(ORIGINAL_PREFIX + effector.getName()).build();
+//            ((EntityInternal) entity).getMutableEntityType().addEffector(original);
+        }
+        super.apply(entity);
+    }
+
+    protected static abstract class Body<T> extends EffectorBody<T> {
+        protected final Effector<?> effector;
+        protected final ConfigBag params;
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            this.effector = eff;
+            this.params = params;
+        }
+
+        @Override
+        public abstract T call(final ConfigBag params);
+
+        protected String getEffectorName(Object effectorDetails) {
+            String effectorName = null;
+            if (effectorDetails instanceof String) {
+                effectorName = (String) effectorDetails;
+            } else if (effectorDetails instanceof Map) {
+                Map<String,Object> effectorMap = (Map) effectorDetails;
+                Set<String> keys = effectorMap.keySet();
+                if (keys.size() != 1) {
+                    throw new IllegalArgumentException("Effector parameter cannot be parsed: " + effectorDetails);
+                }
+                effectorName = Iterables.getOnlyElement(keys);
+            } else {
+                effectorName = Strings.toString(effectorDetails);
+            }
+            return effectorName;
+        }
+
+        protected Entity getTargetEntity(Object effectorDetails) {
+            Entity targetEntity = entity();
+            if (effectorDetails instanceof Map) {
+                Map<String,Object> effectorMap = (Map) effectorDetails;
+                Set<String> keys = effectorMap.keySet();
+                if (keys.size() != 1) {
+                    throw new IllegalArgumentException("Effector parameter cannot be parsed: " + effectorDetails);
+                }
+                String effectorName = Iterables.getOnlyElement(keys);
+                Object effectorParams = effectorMap.get(effectorName);
+                if (effectorParams instanceof Map) {
+                    Map<String,Object> effectorParamsMap = (Map) effectorParams;
+                    if (effectorParamsMap.containsKey("target")) {
+                        Object targetObject = effectorParamsMap.get("target");
+                        if (targetObject instanceof Entity) {
+                            targetEntity = (Entity) targetObject;
+                        } else {
+                            throw new IllegalArgumentException("Effector target is not an Entity: " + targetObject);
+                        }
+                    }
+                }
+            }
+            return targetEntity;
+        }
+
+        protected String getInputArgument(Object effectorDetails) {
+            String inputArgument = null;
+            if (effectorDetails instanceof Map) {
+                Map<String,Object> effectorMap = (Map) effectorDetails;
+                Set<String> keys = effectorMap.keySet();
+                if (keys.size() != 1) {
+                    throw new IllegalArgumentException("Effector parameter cannot be parsed: " + effectorDetails);
+                }
+                String effectorName = Iterables.getOnlyElement(keys);
+                Object effectorParams = effectorMap.get(effectorName);
+                if (effectorParams instanceof Map) {
+                    Map<String,Object> effectorParamsMap = (Map) effectorParams;
+                    if (effectorParamsMap.containsKey("input")) {
+                        Object inputDetails = effectorParamsMap.get("input");
+                        if (inputDetails instanceof String) {
+                            inputArgument = (String) inputDetails;
+                        } else if (inputDetails instanceof Map) {
+                            Map<String,Object> inputMap = (Map) inputDetails;
+                            Set<String> inputKeys = inputMap.keySet();
+                            if (inputKeys.size() != 1) {
+                                throw new IllegalArgumentException("Effector input cannot be parsed: " + inputDetails);
+                            }
+                            inputArgument = Iterables.getOnlyElement(inputKeys);
+                        } else {
+                            inputArgument = Strings.toString(inputDetails);
+                        }
+                    }
+                }
+            }
+            return inputArgument;
+        }
+
+        protected String getInputParameter(Object effectorDetails) {
+            String inputArgument = getInputArgument(effectorDetails);
+            String inputParameter = null;
+            if (inputArgument != null && effectorDetails instanceof Map) {
+                Map<String,Object> effectorMap = (Map) effectorDetails;
+                Set<String> keys = effectorMap.keySet();
+                if (keys.size() != 1) {
+                    throw new IllegalArgumentException("Effector parameter cannot be parsed: " + effectorDetails);
+                }
+                String effectorName = Iterables.getOnlyElement(keys);
+                Object effectorParams = effectorMap.get(effectorName);
+                if (effectorParams instanceof Map) {
+                    Map<String,Object> effectorParamsMap = (Map) effectorParams;
+                    if (effectorParamsMap.containsKey("input")) {
+                        Object inputDetails = effectorParamsMap.get("input");
+                        if (inputDetails instanceof Map) {
+                            Map<String,Object> inputMap = (Map) inputDetails;
+                            if (inputMap.size() != 1) {
+                                throw new IllegalArgumentException("Effector input cannot be parsed: " + inputDetails);
+                            }
+                            inputParameter = Strings.toString(inputMap.get(inputArgument));
+                        }
+                    }
+                }
+            }
+            return inputParameter;
+        }
+
+        protected Object invokeEffectorNamed(Entity target, String effectorName, ConfigBag params) {
+            LOG.info("{} invoking effector on {}, effector={}, parameters={}",
+                    new Object[]{this, target, effectorName, params});
+            Maybe<Effector<?>> effector = target.getEntityType().getEffectorByName(effectorName);
+            if (effector.isAbsent()) {
+                throw new IllegalStateException("Cannot find effector " + effectorName);
+            }
+            return target.invoke(effector.get(), params.getAllConfig()).getUnchecked();
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/composite/ComposeEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/composite/ComposeEffector.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.composite;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+
+@Beta
+public class ComposeEffector extends AbstractCompositeEffector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ComposeEffector.class);
+
+    public static final ConfigKey<List<Object>> COMPOSE = ConfigKeys.newConfigKey(
+            new TypeToken<List<Object>>() { },
+            "compose",
+            "Effector details list for the compose effector",
+            ImmutableList.<Object>of());
+
+    public ComposeEffector(ConfigBag params) {
+        super(newEffectorBuilder(params).build());
+    }
+
+    public ComposeEffector(Map<?, ?> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    public static EffectorBuilder<Object> newEffectorBuilder(ConfigBag params) {
+        EffectorBuilder<Object> eff = AddEffector.newEffectorBuilder(Object.class, params);
+        EffectorBody<Object> body = new Body(eff.buildAbstract(), params);
+        eff.impl(body);
+        return eff;
+    }
+
+    protected static class Body extends AbstractCompositeEffector.Body<Object> {
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            super(eff, params);
+            Preconditions.checkNotNull(params.getAllConfigRaw().get(COMPOSE.getName()), "Effector names must be supplied when defining this effector");
+        }
+
+        @Override
+        public Object call(final ConfigBag params) {
+            ConfigBag config = ConfigBag.newInstanceCopying(this.params).putAll(params);
+            List<Object> effectors = EntityInitializers.resolve(config, COMPOSE);
+
+            Object result = null;
+
+            for (Object effectorDetails : effectors) {
+                String effectorName = getEffectorName(effectorDetails);
+                String inputArgument = getInputArgument(effectorDetails);
+                String inputParameter = getInputParameter(effectorDetails);
+                Entity targetEntity = getTargetEntity(effectorDetails);
+
+                if (inputArgument == null) {
+                    throw new IllegalArgumentException("Input is not set for this effector: " + effectorDetails);
+                }
+                if (inputParameter == null) {
+                    if (result == null) {
+                        Object input = config.getStringKey(inputArgument);
+                        config.putStringKey(inputArgument, input);
+                    } else {
+                        config.putStringKey(inputArgument, result);
+                    }
+                } else {
+                    Object input = config.getStringKey(inputParameter);
+                    config.putStringKey(inputArgument, input);
+                }
+
+                result = invokeEffectorNamed(targetEntity, effectorName, config);
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/composite/LoopEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/composite/LoopEffector.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.composite;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+@Beta
+public class LoopEffector extends AbstractCompositeEffector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoopEffector.class);
+
+    public static final ConfigKey<String> INPUT = ConfigKeys.newStringConfigKey(
+            "input",
+            "Loop input parameter");
+
+    public static final ConfigKey<Object> LOOP = ConfigKeys.newConfigKey(
+            Object.class,
+            "loop",
+            "Effector details for the loop effector");
+
+    public LoopEffector(ConfigBag params) {
+        super(newEffectorBuilder(params).build());
+    }
+
+    public LoopEffector(Map<?, ?> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    public static EffectorBuilder<List> newEffectorBuilder(ConfigBag params) {
+        EffectorBuilder<List> eff = AddEffector.newEffectorBuilder(List.class, params);
+        EffectorBody<List> body = new Body(eff.buildAbstract(), params);
+        eff.impl(body);
+        return eff;
+    }
+
+    protected static class Body extends AbstractCompositeEffector.Body<List> {
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            super(eff, params);
+            Preconditions.checkNotNull(params.getAllConfigRaw().get(LOOP.getName()), "Effector names must be supplied when defining this effector");
+        }
+
+        @Override
+        public List call(final ConfigBag params) {
+            ConfigBag config = ConfigBag.newInstanceCopying(this.params).putAll(params);
+            Object effectorDetails = EntityInitializers.resolve(config, LOOP);
+            String input = config.get(INPUT);
+            Object inputObject = config.getStringKey(input);
+            if (!(inputObject instanceof Collection)) {
+                throw new IllegalArgumentException("Input to loop is not a collection: " + inputObject);
+            }
+            Collection<?> inputCollection = (Collection) inputObject;
+
+            List<Object> result = Lists.newArrayList();
+
+            String effectorName = getEffectorName(effectorDetails);
+            String inputArgument = getInputArgument(effectorDetails);
+            Entity targetEntity = getTargetEntity(effectorDetails);
+
+            if (inputArgument == null) {
+                throw new IllegalArgumentException("Input is not set for this effector: " + effectorDetails);
+            }
+
+            for (Object inputEach : inputCollection) {
+                config.putStringKey(inputArgument, inputEach);
+
+                result.add(invokeEffectorNamed(targetEntity, effectorName, config));
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/composite/SequenceEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/composite/SequenceEffector.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.composite;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+
+@Beta
+public class SequenceEffector extends AbstractCompositeEffector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceEffector.class);
+
+    public static final ConfigKey<List<Object>> SEQUENCE = ConfigKeys.newConfigKey(
+            new TypeToken<List<Object>>() { },
+            "sequence",
+            "Effector details list for the sequence effector",
+            ImmutableList.<Object>of());
+
+    public SequenceEffector(ConfigBag params) {
+        super(newEffectorBuilder(params).build());
+    }
+
+    public SequenceEffector(Map<?, ?> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    public static EffectorBuilder<Object> newEffectorBuilder(ConfigBag params) {
+        EffectorBuilder<Object> eff = AddEffector.newEffectorBuilder(Object.class, params);
+        EffectorBody<Object> body = new Body(eff.buildAbstract(), params);
+        eff.impl(body);
+        return eff;
+    }
+
+    protected static class Body extends AbstractCompositeEffector.Body<Object> {
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            super(eff, params);
+            Preconditions.checkNotNull(params.getAllConfigRaw().get(SEQUENCE.getName()), "Effector names must be supplied when defining this effector");
+        }
+
+        @Override
+        public Object call(final ConfigBag params) {
+            ConfigBag config = ConfigBag.newInstanceCopying(this.params).putAll(params);
+            List<Object> effectors = EntityInitializers.resolve(config, SEQUENCE);
+
+            Object result = null;
+
+            for (Object effectorDetails : effectors) {
+                String effectorName = getEffectorName(effectorDetails);
+                String inputArgument = getInputArgument(effectorDetails);
+                Entity targetEntity = getTargetEntity(effectorDetails);
+
+                if (inputArgument == null) {
+                    throw new IllegalArgumentException("Input is not set for this effector: " + effectorDetails);
+                }
+                Object input = config.getStringKey(inputArgument);
+                config.putStringKey(inputArgument, input);
+
+                result = invokeEffectorNamed(targetEntity, effectorName, config);
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/composite/TransformEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/composite/TransformEffector.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.composite;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
+
+@Beta
+public class TransformEffector extends AbstractCompositeEffector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TransformEffector.class);
+
+    public static final ConfigKey<String> INPUT = ConfigKeys.newStringConfigKey(
+            "input",
+            "Transformer input parameter");
+
+    public static final ConfigKey<Function<Object,Object>> FUNCTION = ConfigKeys.newConfigKey(
+            new TypeToken<Function<Object,Object>>() { },
+            "function",
+            "Transformer function to apply",
+            Functions.identity());
+
+    public TransformEffector(ConfigBag params) {
+        super(newEffectorBuilder(params).build());
+    }
+
+    public TransformEffector(Map<?, ?> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+    public static EffectorBuilder<Object> newEffectorBuilder(ConfigBag params) {
+        EffectorBuilder<Object> eff = AddEffector.newEffectorBuilder(Object.class, params);
+        EffectorBody<Object> body = new Body(eff.buildAbstract(), params);
+        eff.impl(body);
+        return eff;
+    }
+
+    protected static class Body extends AbstractCompositeEffector.Body<Object> {
+
+        public Body(Effector<?> eff, ConfigBag params) {
+            super(eff, params);
+            Preconditions.checkNotNull(params.getAllConfigRaw().get(FUNCTION.getName()), "Function must be supplied when defining this effector");
+        }
+
+        @Override
+        public Object call(final ConfigBag params) {
+            ConfigBag config = ConfigBag.newInstanceCopying(this.params).putAll(params);
+            Function<Object,Object> function = EntityInitializers.resolve(config, FUNCTION);
+
+            String input = config.get(INPUT);
+            Object value = config.getStringKey(input);
+            Object result = function.apply(value);
+
+            return result;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds `ComposeEffector`, `SequenceEffector`, `TransformEffector` and `LoopEffector` for orchestrating effector calls in blueprints.