### PR TITLE
Improve test location rebind stub

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
@@ -115,6 +115,7 @@ public abstract class AbstractJcloudsStubYamlTest extends AbstractJcloudsStubbed
                 "    brooklyn.config:",
                 "      identity: myidentity",
                 "      credential: mycredential",
+                "      lookupAwsHostname: false",
                 "      jclouds.computeServiceRegistry:",
                 "        $brooklyn:object:",
                 "          type: " + ByonComputeServiceStaticRef.class.getName(),

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
@@ -238,6 +238,7 @@ public class RebindTestUtils {
                     classLoader);
             ((RebindManagerImpl) unstarted.getRebindManager()).setPeriodicPersistPeriod(persistPeriod);
             unstarted.getRebindManager().setPersister(newPersister, PersistenceExceptionHandlerImpl.builder().build());
+            unstarted.getHighAvailabilityManager().disabled();
             // set the HA persister, in case any children want to use HA
             unstarted.getHighAvailabilityManager().setPersister(new ManagementPlaneSyncRecordPersisterToObjectStore(unstarted, objectStore, classLoader));
             return unstarted;

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedUnitTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsStubbedUnitTest.java
@@ -100,6 +100,7 @@ public abstract class AbstractJcloudsStubbedUnitTest extends AbstractJcloudsLive
                 .put(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshTool.class.getName())
                 .put(WinRmMachineLocation.WINRM_TOOL_CLASS, RecordingWinRmTool.class.getName())
                 .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS_PREDICATE, Predicates.alwaysTrue())
+                .put(JcloudsLocationConfig.LOOKUP_AWS_HOSTNAME, Boolean.FALSE)
                 .build();
         final ImmutableMap.Builder<Object, Object> flags = ImmutableMap.builder()
                 .putAll(jcloudsLocationConfig);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubUnitTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsRebindStubUnitTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.location.jclouds;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -169,7 +170,8 @@ public class JcloudsRebindStubUnitTest extends RebindTestFixtureWithApp {
         
         assertEquals(newHostname, origHostname);
         assertEquals(origNode.getId(), newNodeId);
-        assertFalse(newNode.isPresent(), "newNode="+newNode);
+        assertTrue(newNode.isPresent(), "newNode="+newNode);
+        assertEquals(newNode.get(), origNode);
         assertFalse(newTemplate.isPresent(), "newTemplate="+newTemplate);
         
         assertEquals(newJcloudsLoc.getProvider(), origJcloudsLoc.getProvider());
@@ -194,6 +196,7 @@ public class JcloudsRebindStubUnitTest extends RebindTestFixtureWithApp {
                         .put(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshTool.class.getName())
                         .put(WinRmMachineLocation.WINRM_TOOL_CLASS, RecordingWinRmTool.class.getName())
                         .put(JcloudsLocation.POLL_FOR_FIRST_REACHABLE_ADDRESS_PREDICATE, Predicates.alwaysTrue())
+                        .put(JcloudsLocationConfig.LOOKUP_AWS_HOSTNAME, Boolean.FALSE)
                         .putAll(jcloudsLocationConfig)
                         .build());
     }


### PR DESCRIPTION
* Makes the stubbed location more functional by implementing the getNodeMetadata, setting the location field on the NodeMetadata;
* Disabled aws hostname lookup - nothing to ssh into;
* Sets the HA manager for the new rebind management context to disabled. This fixes it to return MASTER state. That's what the launcher does when no HA configured.