### PR TITLE
`BundleMaker` REST call allowing to add ZIP/JAR to catalog - Part #2

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScanner.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBomScanner.java
@@ -18,37 +18,18 @@
  */
 package org.apache.brooklyn.core.catalog.internal;
 
-import static org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType.TEMPLATE;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.util.List;
-import java.util.Map;
 
-import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
-import org.apache.brooklyn.util.yaml.Yamls;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleEvent;
 import org.osgi.framework.ServiceReference;
-import org.osgi.util.tracker.BundleTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
 /** Scans bundles being added, filtered by a whitelist and blacklist, and adds catalog.bom files to the catalog.
  * See karaf blueprint.xml for configuration, and tests in dist project. */
@@ -58,30 +39,27 @@ public class CatalogBomScanner {
     private final String ACCEPT_ALL_BY_DEFAULT = ".*";
 
     private static final Logger LOG = LoggerFactory.getLogger(CatalogBomScanner.class);
-    private static final String CATALOG_BOM_URL = "catalog.bom";
-    private static final String BROOKLYN_CATALOG = "brooklyn.catalog";
-    private static final String BROOKLYN_LIBRARIES = "brooklyn.libraries";
 
     private List<String> whiteList = ImmutableList.of(ACCEPT_ALL_BY_DEFAULT);
     private List<String> blackList = ImmutableList.of();
 
-    private CatalogPopulator catalogTracker;
+    private CatalogBundleTracker catalogBundleTracker;
 
     public void bind(ServiceReference<ManagementContext> managementContext) throws Exception {
         if (isEnabled()) {
             LOG.debug("Binding management context with whiteList [{}] and blacklist [{}]",
                 Strings.join(getWhiteList(), "; "),
                 Strings.join(getBlackList(), "; "));
-            catalogTracker = new CatalogPopulator(managementContext);
+            catalogBundleTracker = new CatalogBundleTracker(this, managementContext);
         }
     }
 
     public void unbind(ServiceReference<ManagementContext> managementContext) throws Exception {
         if (isEnabled()) {
             LOG.debug("Unbinding management context");
-            if (null != catalogTracker) {
-                CatalogPopulator temp = catalogTracker;
-                catalogTracker = null;
+            if (null != catalogBundleTracker) {
+                CatalogBundleTracker temp = catalogBundleTracker;
+                catalogBundleTracker = null;
                 temp.close();
             }
         }
@@ -91,7 +69,7 @@ public class CatalogBomScanner {
         return BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_LOAD_BUNDLE_CATALOG_BOM);
     }
 
-    private String[] bundleIds(Bundle bundle) {
+    public String[] bundleIds(Bundle bundle) {
         return new String[] {
             String.valueOf(bundle.getBundleId()), bundle.getSymbolicName(), bundle.getVersion().toString()
         };
@@ -121,233 +99,6 @@ public class CatalogBomScanner {
     public void setBlackList(String blackListText) {
         LOG.debug("Setting blackList to ", blackListText);
         this.blackList = Strings.parseCsv(blackListText);
-    }
-
-    public class CatalogPopulator extends BundleTracker<Iterable<? extends CatalogItem<?, ?>>> {
-
-        private ServiceReference<ManagementContext> mgmtContextReference;
-        private BundleContext bundleContext;
-        private ManagementContext managementContext;
-        private CatalogBundleLoader catalogBundleLoader;
-
-        public CatalogPopulator(ServiceReference<ManagementContext> serviceReference) {
-            super(serviceReference.getBundle().getBundleContext(), Bundle.ACTIVE, null);
-            this.mgmtContextReference = serviceReference;
-            open();
-        }
-        
-        public CatalogPopulator(BundleContext bundleContext, ManagementContext managementContext) {
-            super(Preconditions.checkNotNull(bundleContext, "bundleContext required; is OSGi running?"), Bundle.ACTIVE, null);
-            this.bundleContext = bundleContext;
-            this.managementContext = managementContext;
-            open();
-        }
-
-        @Override
-        public void open() {
-            if (mgmtContextReference != null) {
-                bundleContext = getBundleContext();
-                managementContext = getManagementContext();
-                catalogBundleLoader = new CatalogBundleLoader(managementContext);
-            }
-            super.open();
-        }
-
-        @Override
-        public void close() {
-            super.close();
-            if (mgmtContextReference != null) {
-                managementContext = null;
-                getBundleContext().ungetService(mgmtContextReference);
-                bundleContext = null;
-                catalogBundleLoader = null;
-            }
-        }
-
-        public BundleContext getBundleContext() {
-            if (bundleContext != null) return bundleContext;
-            if (mgmtContextReference != null) return mgmtContextReference.getBundle().getBundleContext();
-            throw new IllegalStateException("Bundle context or management context reference must be supplied");
-        }
-        
-        public ManagementContext getManagementContext() {
-            if (managementContext != null) return managementContext;
-            if (mgmtContextReference != null) return getBundleContext().getService(mgmtContextReference);
-            throw new IllegalStateException("Bundle context or management context reference must be supplied");
-        }
-
-        /**
-         * Scans the bundle being added for a catalog.bom file and adds any entries in it to the catalog.
-         *
-         * @param bundle The bundle being added to the bundle context.
-         * @param bundleEvent The event of the addition.
-         *
-         * @return The items added to the catalog; these will be tracked by the {@link BundleTracker} mechanism
-         *         and supplied to the {@link #removedBundle(Bundle, BundleEvent, Iterable)} method.
-         *
-         * @throws RuntimeException if the catalog items failed to be added to the catalog
-         */
-        @Override
-        public Iterable<? extends CatalogItem<?, ?>> addingBundle(Bundle bundle, BundleEvent bundleEvent) {
-            return catalogBundleLoader.scanForCatalog(bundle);
-        }
-
-        /**
-         * Remove the given entries from the catalog, related to the given bundle.
-         *
-         * @param bundle The bundle being removed to the bundle context.
-         * @param bundleEvent The event of the removal.
-         * @param items The items being removed
-         *
-         * @throws RuntimeException if the catalog items failed to be added to the catalog
-         */
-        @Override
-        public void removedBundle(Bundle bundle, BundleEvent bundleEvent, Iterable<? extends CatalogItem<?, ?>> items) {
-            if (!items.iterator().hasNext()) {
-                return;
-            }
-            LOG.debug("Unloading catalog BOM entries from {} {} {}", bundleIds(bundle));
-            for (CatalogItem<?, ?> item : items) {
-                LOG.debug("Unloading {} {} from catalog", item.getSymbolicName(), item.getVersion());
-
-                catalogBundleLoader.removeFromCatalog(item);
-            }
-        }
-    }
-
-    @Beta
-    public class CatalogBundleLoader {
-
-        private ManagementContext managementContext;
-
-        public CatalogBundleLoader(ManagementContext managementContext) {
-            this.managementContext = managementContext;
-        }
-
-        /**
-         * Scan the given bundle for a catalog.bom and adds it to the catalog.
-         *
-         * @param bundle The bundle to add
-         * @return A list of items added to the catalog
-         *
-         * @throws RuntimeException if the catalog items failed to be added to the catalog
-         */
-        public Iterable<? extends CatalogItem<?, ?>> scanForCatalog(Bundle bundle) {
-
-            Iterable<? extends CatalogItem<?, ?>> catalogItems = MutableList.of();
-
-            final URL bom = bundle.getResource(CATALOG_BOM_URL);
-            if (null != bom) {
-                LOG.debug("Found catalog BOM in {} {} {}", bundleIds(bundle));
-                String bomText = readBom(bom);
-                String bomWithLibraryPath = addLibraryDetails(bundle, bomText);
-                catalogItems = this.managementContext.getCatalog().addItems(bomWithLibraryPath);
-                for (CatalogItem<?, ?> item : catalogItems) {
-                    LOG.debug("Added to catalog: {}, {}", item.getSymbolicName(), item.getVersion());
-                }
-            } else {
-                LOG.debug("No BOM found in {} {} {}", bundleIds(bundle));
-            }
-
-            if (!passesWhiteAndBlacklists(bundle)) {
-                catalogItems = removeAnyApplications(catalogItems);
-            }
-
-            return catalogItems;
-        }
-
-        private String readBom(URL bom) {
-            try (final InputStream ins = bom.openStream()) {
-                return Streams.readFullyString(ins);
-            } catch (IOException e) {
-                throw Exceptions.propagate("Error loading Catalog BOM from " + bom, e);
-            }
-        }
-
-        private String addLibraryDetails(Bundle bundle, String bomText) {
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> bom = (Map<String, Object>)Iterables.getOnlyElement(Yamls.parseAll(bomText));
-            final Object catalog = bom.get(BROOKLYN_CATALOG);
-            if (null != catalog) {
-                if (catalog instanceof Map<?, ?>) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> catalogMap = (Map<String, Object>) catalog;
-                    addLibraryDetails(bundle, catalogMap);
-                } else {
-                    LOG.warn("Unexpected syntax for {} (expected Map, but got {}), ignoring", BROOKLYN_CATALOG, catalog.getClass().getName());
-                }
-            }
-            final String updatedBom = backToYaml(bom);
-            LOG.trace("Updated catalog bom:\n{}", updatedBom);
-            return updatedBom;
-        }
-
-        private void addLibraryDetails(Bundle bundle, Map<String, Object> catalog) {
-            if (!catalog.containsKey(BROOKLYN_LIBRARIES)) {
-                catalog.put(BROOKLYN_LIBRARIES, MutableList.of());
-            }
-            final Object librarySpec = catalog.get(BROOKLYN_LIBRARIES);
-            if (!(librarySpec instanceof List)) {
-                throw new RuntimeException("expected " + BROOKLYN_LIBRARIES + " to be a list, but got "
-                        + (librarySpec == null ? "null" : librarySpec.getClass().getName()));
-            }
-            @SuppressWarnings("unchecked")
-            List<Map<String,String>> libraries = (List<Map<String,String>>)librarySpec;
-            if (bundle.getSymbolicName() == null || bundle.getVersion() == null) {
-                throw new IllegalStateException("Cannot scan "+bundle+" for catalog files: name or version is null");
-            }
-            libraries.add(ImmutableMap.of(
-                    "name", bundle.getSymbolicName(),
-                    "version", bundle.getVersion().toString()));
-            LOG.debug("library spec is {}", librarySpec);
-        }
-
-        private String backToYaml(Map<String, Object> bom) {
-            final DumperOptions options = new DumperOptions();
-            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            options.setPrettyFlow(true);
-            return new Yaml(options).dump(bom);
-        }
-
-        private Iterable<? extends CatalogItem<?, ?>> removeAnyApplications(
-                Iterable<? extends CatalogItem<?, ?>> catalogItems) {
-
-            List<CatalogItem<?, ?>> result = MutableList.of();
-
-            for (CatalogItem<?, ?> item: catalogItems) {
-                if (TEMPLATE.equals(item.getCatalogItemType())) {
-                    removeFromCatalog(item);
-                } else {
-                    result.add(item);
-                }
-            }
-            return result;
-        }
-
-        private boolean passesWhiteAndBlacklists(Bundle bundle) {
-            return on(bundle, getWhiteList()) && !on(bundle, getBlackList());
-        }
-
-        private boolean on(Bundle bundle, List<String> list) {
-            for (String candidate : list) {
-                final String symbolicName = bundle.getSymbolicName();
-                if (symbolicName.matches(candidate.trim())) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void removeFromCatalog(CatalogItem<?, ?> item) {
-            try {
-                this.managementContext.getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
-            } catch (Exception e) {
-                Exceptions.propagateIfFatal(e);
-                LOG.warn(Strings.join(new String[] {
-                        "Failed to remove", item.getSymbolicName(), item.getVersion(), "from catalog"
-                }, " "), e);
-            }
-        }
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleLoader.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleLoader.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.catalog.internal;
+
+import static org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType.TEMPLATE;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.yaml.Yamls;
+import org.osgi.framework.Bundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+@Beta
+public class CatalogBundleLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CatalogBundleLoader.class);
+    private static final String CATALOG_BOM_URL = "catalog.bom";
+    private static final String BROOKLYN_CATALOG = "brooklyn.catalog";
+    private static final String BROOKLYN_LIBRARIES = "brooklyn.libraries";
+
+    private CatalogBomScanner catalogBomScanner;
+    private ManagementContext managementContext;
+
+    public CatalogBundleLoader(CatalogBomScanner catalogBomScanner, ManagementContext managementContext) {
+        this.catalogBomScanner = catalogBomScanner;
+        this.managementContext = managementContext;
+    }
+
+    /**
+     * Scan the given bundle for a catalog.bom and adds it to the catalog.
+     *
+     * @param bundle The bundle to add
+     * @return A list of items added to the catalog
+     * @throws RuntimeException if the catalog items failed to be added to the catalog
+     */
+    public Iterable<? extends CatalogItem<?, ?>> scanForCatalog(Bundle bundle) {
+
+        Iterable<? extends CatalogItem<?, ?>> catalogItems = MutableList.of();
+
+        final URL bom = bundle.getResource(CatalogBundleLoader.CATALOG_BOM_URL);
+        if (null != bom) {
+            LOG.debug("Found catalog BOM in {} {} {}", catalogBomScanner.bundleIds(bundle));
+            String bomText = readBom(bom);
+            String bomWithLibraryPath = addLibraryDetails(bundle, bomText);
+            catalogItems = this.managementContext.getCatalog().addItems(bomWithLibraryPath);
+            for (CatalogItem<?, ?> item : catalogItems) {
+                LOG.debug("Added to catalog: {}, {}", item.getSymbolicName(), item.getVersion());
+            }
+        } else {
+            LOG.debug("No BOM found in {} {} {}", catalogBomScanner.bundleIds(bundle));
+        }
+
+        if (!passesWhiteAndBlacklists(bundle)) {
+            catalogItems = removeAnyApplications(catalogItems);
+        }
+
+        return catalogItems;
+    }
+
+    /**
+     * Remove the given items from the catalog.
+     *
+     * @param item Catalog items to remove
+     */
+    public void removeFromCatalog(CatalogItem<?, ?> item) {
+        try {
+            this.managementContext.getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            LOG.warn(Strings.join(new String[]{
+                    "Failed to remove", item.getSymbolicName(), item.getVersion(), "from catalog"
+            }, " "), e);
+        }
+    }
+
+    private String readBom(URL bom) {
+        try (final InputStream ins = bom.openStream()) {
+            return Streams.readFullyString(ins);
+        } catch (IOException e) {
+            throw Exceptions.propagate("Error loading Catalog BOM from " + bom, e);
+        }
+    }
+
+    private String addLibraryDetails(Bundle bundle, String bomText) {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> bom = (Map<String, Object>) Iterables.getOnlyElement(Yamls.parseAll(bomText));
+        final Object catalog = bom.get(CatalogBundleLoader.BROOKLYN_CATALOG);
+        if (null != catalog) {
+            if (catalog instanceof Map<?, ?>) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> catalogMap = (Map<String, Object>) catalog;
+                addLibraryDetails(bundle, catalogMap);
+            } else {
+                LOG.warn("Unexpected syntax for {} (expected Map, but got {}), ignoring", CatalogBundleLoader.BROOKLYN_CATALOG, catalog.getClass().getName());
+            }
+        }
+        final String updatedBom = backToYaml(bom);
+        LOG.trace("Updated catalog bom:\n{}", updatedBom);
+        return updatedBom;
+    }
+
+    private void addLibraryDetails(Bundle bundle, Map<String, Object> catalog) {
+        if (!catalog.containsKey(CatalogBundleLoader.BROOKLYN_LIBRARIES)) {
+            catalog.put(CatalogBundleLoader.BROOKLYN_LIBRARIES, MutableList.of());
+        }
+        final Object librarySpec = catalog.get(CatalogBundleLoader.BROOKLYN_LIBRARIES);
+        if (!(librarySpec instanceof List)) {
+            throw new RuntimeException("expected " + CatalogBundleLoader.BROOKLYN_LIBRARIES + " to be a list, but got "
+                    + (librarySpec == null ? "null" : librarySpec.getClass().getName()));
+        }
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> libraries = (List<Map<String, String>>) librarySpec;
+        if (bundle.getSymbolicName() == null || bundle.getVersion() == null) {
+            throw new IllegalStateException("Cannot scan " + bundle + " for catalog files: name or version is null");
+        }
+        libraries.add(ImmutableMap.of(
+                "name", bundle.getSymbolicName(),
+                "version", bundle.getVersion().toString()));
+        LOG.debug("library spec is {}", librarySpec);
+    }
+
+    private String backToYaml(Map<String, Object> bom) {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options).dump(bom);
+    }
+
+    private Iterable<? extends CatalogItem<?, ?>> removeAnyApplications(
+            Iterable<? extends CatalogItem<?, ?>> catalogItems) {
+
+        List<CatalogItem<?, ?>> result = MutableList.of();
+
+        for (CatalogItem<?, ?> item : catalogItems) {
+            if (TEMPLATE.equals(item.getCatalogItemType())) {
+                removeFromCatalog(item);
+            } else {
+                result.add(item);
+            }
+        }
+        return result;
+    }
+
+    private boolean passesWhiteAndBlacklists(Bundle bundle) {
+        return on(bundle, catalogBomScanner.getWhiteList()) && !on(bundle, catalogBomScanner.getBlackList());
+    }
+
+    private boolean on(Bundle bundle, List<String> list) {
+        for (String candidate : list) {
+            final String symbolicName = bundle.getSymbolicName();
+            if (symbolicName.matches(candidate.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.catalog.internal;
+
+import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.BundleTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public class CatalogBundleTracker extends BundleTracker<Iterable<? extends CatalogItem<?, ?>>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CatalogBundleTracker.class);
+
+    private ServiceReference<ManagementContext> mgmtContextReference;
+    private ManagementContext managementContext;
+
+    private CatalogBomScanner catalogBomScanner;
+    private CatalogBundleLoader catalogBundleLoader;
+
+    public CatalogBundleTracker(CatalogBomScanner catalogBomScanner, ServiceReference<ManagementContext> serviceReference) {
+        super(serviceReference.getBundle().getBundleContext(), Bundle.ACTIVE, null);
+        this.mgmtContextReference = serviceReference;
+        this.catalogBomScanner = catalogBomScanner;
+        open();
+    }
+
+    @Override
+    public void open() {
+        managementContext = mgmtContextReference.getBundle().getBundleContext().getService(mgmtContextReference);
+        catalogBundleLoader = new CatalogBundleLoader(catalogBomScanner, managementContext);
+        super.open();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        managementContext = null;
+        mgmtContextReference.getBundle().getBundleContext().ungetService(mgmtContextReference);
+        catalogBundleLoader = null;
+    }
+
+    public ManagementContext getManagementContext() {
+        return managementContext;
+    }
+
+    /**
+     * Scans the bundle being added for a catalog.bom file and adds any entries in it to the catalog.
+     *
+     * @param bundle      The bundle being added to the bundle context.
+     * @param bundleEvent The event of the addition.
+     * @return The items added to the catalog; these will be tracked by the {@link BundleTracker} mechanism
+     * and supplied to the {@link #removedBundle(Bundle, BundleEvent, Iterable)} method.
+     * @throws RuntimeException if the catalog items failed to be added to the catalog
+     */
+    @Override
+    public Iterable<? extends CatalogItem<?, ?>> addingBundle(Bundle bundle, BundleEvent bundleEvent) {
+        return catalogBundleLoader.scanForCatalog(bundle);
+    }
+
+    /**
+     * Remove the given entries from the catalog, related to the given bundle.
+     *
+     * @param bundle      The bundle being removed to the bundle context.
+     * @param bundleEvent The event of the removal.
+     * @param items       The items being removed
+     * @throws RuntimeException if the catalog items failed to be added to the catalog
+     */
+    @Override
+    public void removedBundle(Bundle bundle, BundleEvent bundleEvent, Iterable<? extends CatalogItem<?, ?>> items) {
+        if (!items.iterator().hasNext()) {
+            return;
+        }
+        LOG.debug("Unloading catalog BOM entries from {} {} {}", catalogBomScanner.bundleIds(bundle));
+        for (CatalogItem<?, ?> item : items) {
+            LOG.debug("Unloading {} {} from catalog", item.getSymbolicName(), item.getVersion());
+
+            catalogBundleLoader.removeFromCatalog(item);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
@@ -20,10 +20,9 @@
 package org.apache.brooklyn.core.catalog.internal;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
-import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.BundleTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,36 +34,11 @@ public class CatalogBundleTracker extends BundleTracker<Iterable<? extends Catal
 
     private static final Logger LOG = LoggerFactory.getLogger(CatalogBundleTracker.class);
 
-    private ServiceReference<ManagementContext> mgmtContextReference;
-    private ManagementContext managementContext;
-
-    private CatalogBomScanner catalogBomScanner;
     private CatalogBundleLoader catalogBundleLoader;
 
-    public CatalogBundleTracker(CatalogBomScanner catalogBomScanner, ServiceReference<ManagementContext> serviceReference) {
-        super(serviceReference.getBundle().getBundleContext(), Bundle.ACTIVE, null);
-        this.mgmtContextReference = serviceReference;
-        this.catalogBomScanner = catalogBomScanner;
-        open();
-    }
-
-    @Override
-    public void open() {
-        managementContext = mgmtContextReference.getBundle().getBundleContext().getService(mgmtContextReference);
-        catalogBundleLoader = new CatalogBundleLoader(catalogBomScanner, managementContext);
-        super.open();
-    }
-
-    @Override
-    public void close() {
-        super.close();
-        managementContext = null;
-        mgmtContextReference.getBundle().getBundleContext().ungetService(mgmtContextReference);
-        catalogBundleLoader = null;
-    }
-
-    public ManagementContext getManagementContext() {
-        return managementContext;
+    public CatalogBundleTracker(BundleContext bundleContext, CatalogBundleLoader catalogBundleLoader) {
+        super(bundleContext, Bundle.ACTIVE, null);
+        this.catalogBundleLoader = catalogBundleLoader;
     }
 
     /**
@@ -94,7 +68,7 @@ public class CatalogBundleTracker extends BundleTracker<Iterable<? extends Catal
         if (!items.iterator().hasNext()) {
             return;
         }
-        LOG.debug("Unloading catalog BOM entries from {} {} {}", catalogBomScanner.bundleIds(bundle));
+        LOG.debug("Unloading catalog BOM entries from {} {} {}", CatalogUtils.bundleIds(bundle));
         for (CatalogItem<?, ?> item : items) {
             LOG.debug("Unloading {} {} from catalog", item.getSymbolicName(), item.getVersion());
 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -48,6 +48,7 @@ import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Time;
+import org.osgi.framework.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -323,4 +324,10 @@ public class CatalogUtils {
         mgmt.getCatalog().persist(item);
     }
 
+
+    public static String[] bundleIds(Bundle bundle) {
+        return new String[] {
+            String.valueOf(bundle.getBundleId()), bundle.getSymbolicName(), bundle.getVersion().toString()
+        };
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
@@ -36,7 +36,7 @@ import java.util.zip.ZipOutputStream;
 import javax.annotation.Nonnull;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ResourceUtils;
@@ -73,7 +73,7 @@ public class BundleMaker {
     }
     
     public BundleMaker(@Nonnull ManagementContext mgmt) {
-        this( ((LocalManagementContext)mgmt).getOsgiManager().get().getFramework(), ResourceUtils.create() );
+        this(((ManagementContextInternal) mgmt).getOsgiManager().get().getFramework(), ResourceUtils.create());
     }
 
     /** if set, this will be used to resolve relative classpath fragments;

--- a/rest/rest-api/pom.xml
+++ b/rest/rest-api/pom.xml
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>com.github.kongchen</groupId>
                 <artifactId>swagger-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.4</version>
                 <configuration>
                     <apiSources>
                         <apiSource>

--- a/rest/rest-api/pom.xml
+++ b/rest/rest-api/pom.xml
@@ -118,8 +118,13 @@
                     <apiSources>
                         <apiSource>
                             <springmvc>false</springmvc>
-                            <locations>org.apache.brooklyn.rest.api</locations>
-                            <schemes>http,https</schemes>
+                            <locations>
+                                <location>org.apache.brooklyn.rest.api</location>
+                            </locations>
+                            <schemes>
+                                <scheme>http</scheme>
+                                <scheme>https</scheme>
+                            </schemes>
                             <info>
                                 <title>Swagger API Specification for Brooklyn REST server</title>
                                 <version>v1</version>

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -52,7 +52,19 @@ import io.swagger.annotations.ApiResponses;
 @Produces(MediaType.APPLICATION_JSON)
 public interface CatalogApi {
 
-    @Deprecated /** @deprecated since 0.11.0 use {@link #createFromYaml(String)} instead */
+    /** @deprecated since 0.11.0 use {@link #createFromYaml(String)} instead */
+    @Deprecated
+    @POST
+    @ApiOperation(
+            value = "Add a catalog items (e.g. new type of entity, policy or location) by uploading YAML descriptor.",
+            notes = "Return value is map of ID to CatalogItemSummary.",
+            response = String.class,
+            hidden = true
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Error processing the given YAML"),
+            @ApiResponse(code = 201, message = "Catalog items added successfully")
+    })
     public Response create(String yaml);
 
     @POST

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -71,13 +71,13 @@ public interface CatalogApi {
     @ApiOperation(value = "Add items to the catalog, either YAML or JAR/ZIP, format autodetected. "
             + "Specify a content-type header to skip auto-detection and invoke one of the more specific methods. "
             + "Return value is 201 CREATED if bundle could be added.", response = String.class)
-    public Response createPoly(
+    public Response createFromUpload(
             @ApiParam(
                     name = "item",
                     value = "Item to install, as JAR/ZIP or Catalog YAML (autodetected)",
                     required = true)
             byte[] item);
-    
+
     @POST
     @Beta
     @Consumes({"application/x-zip", "application/x-jar"})

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -55,41 +55,66 @@ public interface CatalogApi {
     @Deprecated /** @deprecated since 0.11.0 use {@link #createFromYaml(String)} instead */
     public Response create(String yaml);
 
+    @POST
     @Consumes({MediaType.APPLICATION_JSON, "application/x-yaml",
         // see http://stackoverflow.com/questions/332129/yaml-mime-type
         "text/yaml", "text/x-yaml", "application/yaml"})
-    @POST
-    @ApiOperation(value = "Add a catalog item (e.g. new type of entity, policy or location) by uploading YAML descriptor. "
-        + "Return value is map of ID to CatalogItemSummary, with code 201 CREATED.", response = String.class)
+    @ApiOperation(
+            value = "Add a catalog items (e.g. new type of entity, policy or location) by uploading YAML descriptor.",
+            notes = "Return value is map of ID to CatalogItemSummary.",
+            response = String.class,
+            hidden = true
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Error processing the given YAML"),
+            @ApiResponse(code = 201, message = "Catalog items added successfully")
+    })
     public Response createFromYaml(
             @ApiParam(name = "yaml", value = "YAML descriptor of catalog item", required = true)
             @Valid String yaml);
 
-    @POST
     @Beta
-    @Consumes  // anything (if doesn't match other methods with specific content types
-    @ApiOperation(value = "Add items to the catalog, either YAML or JAR/ZIP, format autodetected. "
-            + "Specify a content-type header to skip auto-detection and invoke one of the more specific methods. "
-            + "Return value is 201 CREATED if bundle could be added.", response = String.class)
-    public Response createFromUpload(
-            @ApiParam(
-                    name = "item",
-                    value = "Item to install, as JAR/ZIP or Catalog YAML (autodetected)",
-                    required = true)
-            byte[] item);
-
     @POST
-    @Beta
     @Consumes({"application/x-zip", "application/x-jar"})
-    @ApiOperation(value = "Add a catalog item (e.g. new type of entity, policy or location) by uploading OSGi bundle JAR, or ZIP which will be turned into bundle JAR, "
-            + "containing catalog.bom containing bundle name and version. "
-            + "Return value is 201 CREATED if bundle could be added.", response = String.class)
+    @ApiOperation(
+            value = "Add a catalog items (e.g. new type of entity, policy or location) by uploading a ZIP/JAR archive.",
+            notes = "Accepts either an OSGi bundle JAR, or ZIP which will be turned into bundle JAR. Bother format must "
+                    + "contain a catalog.bom at the root of the archive, which must contain the bundle and version key."
+                    + "Return value is map of ID to CatalogItemSummary.",
+            response = String.class,
+            hidden = true)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Error processing the given archive, or the catalog.bom is invalid"),
+            @ApiResponse(code = 201, message = "Catalog items added successfully")
+    })
     public Response createFromArchive(
             @ApiParam(
                     name = "archive",
                     value = "Bundle to install, in ZIP or JAR format, requiring catalog.bom containing bundle name and version",
                     required = true)
             byte[] archive);
+
+    @Beta
+    @POST
+    @Consumes // anything (if doesn't match other methods with specific content types
+    @ApiOperation(
+            value = "Add a catalog items (e.g. new type of entity, policy or location) by uploading either YAML or ZIP/JAR archive (format autodetected)",
+            notes = "Specify a content-type header to skip auto-detection and invoke one of the more specific methods. "
+                    + "Accepts either an OSGi bundle JAR, or ZIP which will be turned into bundle JAR. Bother format must "
+                    + "contain a catalog.bom at the root of the archive, which must contain the bundle and version key."
+                    + "Return value is map of ID to CatalogItemSummary.",
+            response = String.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Error processing the given archive, or the catalog.bom is invalid"),
+            @ApiResponse(code = 201, message = "Catalog items added successfully")
+    })
+    public Response createFromUpload(
+            @ApiParam(
+                    name = "item",
+                    value = "Item to install, as JAR/ZIP or Catalog YAML (autodetected)",
+                    required = true)
+                    byte[] item);
     
     @POST
     @Consumes(MediaType.APPLICATION_XML)

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -50,7 +50,6 @@ import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.catalog.CatalogPredicates;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
-import org.apache.brooklyn.core.catalog.internal.CatalogBomScanner;
 import org.apache.brooklyn.core.catalog.internal.CatalogBundleLoader;
 import org.apache.brooklyn.core.catalog.internal.CatalogDto;
 import org.apache.brooklyn.core.catalog.internal.CatalogItemComparator;
@@ -184,7 +183,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        BundleMaker bm = new BundleMaker(mgmt());
+        BundleMaker bm = new BundleMaker(mgmtInternal());
         File f=null, f2=null;
         try {
             f = Os.newTempFile("brooklyn-posted-archive", "zip");
@@ -248,6 +247,8 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 // if the above feature is not enabled, let's do it manually (as a contract of this method)
                 try {
                     // TODO improve on this - it ignores the configuration of whitelists, see CatalogBomScanner.
+                    // One way would be to add the CatalogBomScanner to the new Scratchpad area, then retrieving the singleton
+                    // here to get back the predicate from it.
                     final Predicate<Bundle> applicationsPermitted = Predicates.<Bundle>alwaysTrue();
 
                     new CatalogBundleLoader(applicationsPermitted, mgmt()).scanForCatalog(bundle);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -85,10 +85,12 @@ import org.apache.brooklyn.util.yaml.Yamls;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -115,7 +117,8 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
     static Set<String> missingIcons = MutableSet.of();
 
     @Override
-    public Response createPoly(byte[] item) {
+    @Beta
+    public Response createFromUpload(byte[] item) {
         Throwable yamlException = null;
         try {
             MutableList.copyOf( Yamls.parseAll(new InputStreamReader(new ByteArrayInputStream(item))) );
@@ -129,14 +132,11 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             return createFromYaml(new String(item));
         }
         
-        try {
-            return createFromArchive(item);
-        } catch (Exception e) {
-            throw Exceptions.propagate("Unable to handle input: not YAML or compatible ZIP. Specify Content-Type to clarify.", e);
-        }
+        return createFromArchive(item);
     }
     
-    @Override @Deprecated
+    @Override
+    @Deprecated
     public Response create(String yaml) {
         return createFromYaml(yaml);
     }
@@ -177,6 +177,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
     }
 
     @Override
+    @Beta
     public Response createFromArchive(byte[] zipInput) {
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.ROOT, null)) {
             throw WebResourceUtils.forbidden("User '%s' is not authorized to add catalog item",
@@ -197,20 +198,20 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             try {
                 zf = new ZipFile(f);
             } catch (IOException e) {
-                throw WebResourceUtils.badRequest("Invalid ZIP/JAR archive: "+e);
+                throw new IllegalArgumentException("Invalid ZIP/JAR archive: "+e);
             }
             ZipArchiveEntry bom = zf.getEntry("catalog.bom");
             if (bom==null) {
                 bom = zf.getEntry("/catalog.bom");
             }
             if (bom==null) {
-                throw WebResourceUtils.badRequest("Archive must contain a catalog.bom file in the root");
+                throw new IllegalArgumentException("Archive must contain a catalog.bom file in the root");
             }
             String bomS;
             try {
                 bomS = Streams.readFullyString(zf.getInputStream(bom));
             } catch (IOException e) {
-                throw WebResourceUtils.badRequest("Error reading catalog.bom from ZIP/JAR archive: "+e);
+                throw new IllegalArgumentException("Error reading catalog.bom from ZIP/JAR archive: "+e);
             }
             VersionedName vn = BasicBrooklynCatalog.getVersionedName( BasicBrooklynCatalog.getCatalogMetadata(bomS) );
             
@@ -221,7 +222,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             String bundleNameInMF = mf.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
             if (Strings.isNonBlank(bundleNameInMF)) {
                 if (!bundleNameInMF.equals(vn.getSymbolicName())) {
-                    throw new IllegalStateException("JAR MANIFEST symbolic-name '"+bundleNameInMF+"' does not match '"+vn.getSymbolicName()+"' defined in BOM");
+                    throw new IllegalArgumentException("JAR MANIFEST symbolic-name '"+bundleNameInMF+"' does not match '"+vn.getSymbolicName()+"' defined in BOM");
                 }
             } else {
                 mf.getMainAttributes().putValue(Constants.BUNDLE_SYMBOLICNAME, vn.getSymbolicName());
@@ -230,7 +231,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             String bundleVersionInMF = mf.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
             if (Strings.isNonBlank(bundleVersionInMF)) {
                 if (!bundleVersionInMF.equals(vn.getVersion().toString())) {
-                    throw new IllegalStateException("JAR MANIFEST version '"+bundleVersionInMF+"' does not match '"+vn.getVersion()+"' defined in BOM");
+                    throw new IllegalArgumentException("JAR MANIFEST version '"+bundleVersionInMF+"' does not match '"+vn.getVersion()+"' defined in BOM");
                 }
             } else {
                 mf.getMainAttributes().putValue(Constants.BUNDLE_VERSION, vn.getVersion().toString());
@@ -245,13 +246,21 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             
             if (!BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_LOAD_BUNDLE_CATALOG_BOM)) {
                 // if the above feature is not enabled, let's do it manually (as a contract of this method)
-                new CatalogBomScanner().new CatalogPopulator(
-                        ((LocalManagementContext) mgmt()).getOsgiManager().get().getFramework().getBundleContext(),
-                        mgmt()).addingBundle(bundle, null);
+                try {
+                    new CatalogBomScanner().new CatalogBundleLoader(mgmt()).scanForCatalog(bundle);
+                } catch (RuntimeException ex) {
+                    try {
+                        bundle.uninstall();
+                    } catch (BundleException e) {
+                        log.error("Cannot uninstall bundle " + bundle.getSymbolicName() + ":" + bundle.getVersion(), e);
+                    }
+                    throw new IllegalArgumentException("Error installing catalog items", ex);
+                }
             }
             
             return Response.status(Status.CREATED).build();
-            
+        } catch (RuntimeException ex) {
+            throw WebResourceUtils.badRequest(ex);
         } finally {
             if (f!=null) f.delete();
             if (f2!=null) f2.delete();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -51,12 +51,12 @@ import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.catalog.CatalogPredicates;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import org.apache.brooklyn.core.catalog.internal.CatalogBomScanner;
+import org.apache.brooklyn.core.catalog.internal.CatalogBundleLoader;
 import org.apache.brooklyn.core.catalog.internal.CatalogDto;
 import org.apache.brooklyn.core.catalog.internal.CatalogItemComparator;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements.StringAndArgument;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
@@ -247,7 +247,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             if (!BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_LOAD_BUNDLE_CATALOG_BOM)) {
                 // if the above feature is not enabled, let's do it manually (as a contract of this method)
                 try {
-                    new CatalogBomScanner().new CatalogBundleLoader(mgmt()).scanForCatalog(bundle);
+                    new CatalogBundleLoader(new CatalogBomScanner(), mgmt()).scanForCatalog(bundle);
                 } catch (RuntimeException ex) {
                     try {
                         bundle.uninstall();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -247,7 +247,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             if (!BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_LOAD_BUNDLE_CATALOG_BOM)) {
                 // if the above feature is not enabled, let's do it manually (as a contract of this method)
                 try {
-                    new CatalogBundleLoader(new CatalogBomScanner(), mgmt()).scanForCatalog(bundle);
+                    // TODO improve on this - it ignores the configuration of whitelists, see CatalogBomScanner.
+                    final Predicate<Bundle> applicationsPermitted = Predicates.<Bundle>alwaysTrue();
+
+                    new CatalogBundleLoader(applicationsPermitted, mgmt()).scanForCatalog(bundle);
                 } catch (RuntimeException ex) {
                     try {
                         bundle.uninstall();

--- a/utils/common/src/test/java/org/apache/brooklyn/util/osgi/OsgiTestResources.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/osgi/OsgiTestResources.java
@@ -62,6 +62,9 @@ public class OsgiTestResources {
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_SYMBOLIC_NAME_FULL =
         "com.example.brooklyn.test.resources.osgi."+BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_SYMBOLIC_NAME_FINAL_PART;
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_PATH = "/brooklyn/osgi/brooklyn-test-osgi-com-example-entities.jar";
+    public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_URL = "classpath:"+BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_PATH;
+    public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_VERSION = "0.1.0";
+    public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_ICON_PATH = "/com/example/brooklyn/test/osgi/entities/icon.gif";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_APPLICATION = "com.example.brooklyn.test.osgi.entities.SimpleApplication";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_ENTITY = "com.example.brooklyn.test.osgi.entities.SimpleEntity";
     public static final String BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_POLICY = "com.example.brooklyn.test.osgi.entities.SimplePolicy";


### PR DESCRIPTION
Builds on top of #485. It implements the missing bits and pieces, such as:
- fields `version` and `bundle` are required under `brooklyn.catalog` when uploading a ZIP/JAR archive
- returns 400 HTTP status code is anything goes wrong during the process of the archive (as this is a bad input, therefore a bad request)
- avoid using the `CatalogPopulator` as it reloads all bundles. Instead, it uses the new `CatalogBundleLoader` that loads only a given bundle
- if the bundle has been installed, but the CAMP parser fails, the bundle is uninstalled
- adds more unit tests, especially to check error handling