### PR TITLE
Deprecate groovy

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionManager.java
@@ -33,7 +33,7 @@ import org.apache.brooklyn.api.entity.Entity;
  * where jobs can be:
  * <ul>
  * <li>Tracked with tags/buckets
- * <li>Be {@link Runnable}s, {@link Callable}s, or {@link groovy.lang.Closure}s
+ * <li>Be {@link Runnable}s or {@link Callable}s, (support for {@link groovy.lang.Closure} is deprecated)
  * <li>Remembered after completion
  * <li>Treated as {@link Task} instances (see below)
  * <li>Given powerful synchronization capabilities
@@ -104,11 +104,17 @@ public interface ExecutionManager {
      *                      used for associating with contexts, mutex execution, and other purposes
      * <li><em>synchId</em> - A string, or {@link Collection} of strings, representing a category on which an object should own a synch lock 
      * <li><em>synchObj</em> - A string, or {@link Collection} of strings, representing a category on which an object should own a synch lock 
-     * <li><em>newTaskStartCallback</em> - A {@link groovy.lang.Closure} that will be invoked just before the task starts if it starts as a result of this call
-     * <li><em>newTaskEndCallback</em> - A {@link groovy.lang.Closure} that will be invoked when the task completes if it starts as a result of this call
+     * <li><em>newTaskStartCallback</em> - A callback that will be invoked just before the task starts if it starts as a result of this call.
+     * <li><em>newTaskEndCallback</em> - A callback that will be invoked when the task completes if it starts as a result of this call
      * </ul>
-     * Callbacks run in the task's thread, and if the callback is a {@link groovy.lang.Closure} it is passed the task for convenience. The closure can be any of the
-     * following types; either a {@link groovy.lang.Closure}, {@link Runnable} or {@link Callable}.
+     * 
+     * Callbacks run in the task's thread. It can be one of the following types:
+     * <ul>
+     * <li>{@link Runnable}
+     * <li>{@link Callable} 
+     * <li>{@link com.google.common.base.Function} that matches the generics {@code <? super Task, ?>}
+     * <li>Support for {@link groovy.lang.Closure} is deprecated.
+     * </ul>
      * <p>
      * If a Map is supplied it must be modifiable (currently; may allow immutable maps in future). 
      */

--- a/core/src/main/java/org/apache/brooklyn/core/effector/ExplicitEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/ExplicitEffector.java
@@ -18,18 +18,30 @@
  */
 package org.apache.brooklyn.core.effector;
 
-import groovy.lang.Closure;
-
 import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.api.effector.ParameterType;
 import org.apache.brooklyn.api.entity.Entity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
+import groovy.lang.Closure;
+
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted 
+ *             (currently only used via {@link #create(String, Class, List, String, Closure)}, 
+ *             so class is not deemed useful enough - extend {@link AbstractEffector} directly 
+ *             if really required).
+ */
+@Deprecated
 public abstract class ExplicitEffector<I,T> extends AbstractEffector<T> {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(ExplicitEffector.class);
+
     public ExplicitEffector(String name, Class<T> type, String description) {
         this(name, type, ImmutableList.<ParameterType<?>>of(), description);
     }
@@ -46,12 +58,20 @@ public abstract class ExplicitEffector<I,T> extends AbstractEffector<T> {
     
     /** convenience to create an effector supplying a closure; annotations are preferred,
      * and subclass here would be failback, but this is offered as 
-     * workaround for bug GROOVY-5122, as discussed in test class CanSayHi 
+     * workaround for bug GROOVY-5122, as discussed in test class CanSayHi.
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
      */
+    @Deprecated
     public static <I,T> ExplicitEffector<I,T> create(String name, Class<T> type, List<ParameterType<?>> parameters, String description, Closure body) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated, in ExplicitEffector.create()");
         return new ExplicitEffectorFromClosure<I,T>(name, type, parameters, description, body);
     }
-    
+
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     private static class ExplicitEffectorFromClosure<I,T> extends ExplicitEffector<I,T> {
         private static final long serialVersionUID = -5771188171702382236L;
         final Closure<T> body;

--- a/core/src/main/java/org/apache/brooklyn/core/effector/MethodEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/MethodEffector.java
@@ -133,6 +133,10 @@ public class MethodEffector<T> extends AbstractEffector<T> {
         this(new AnnotationsOnMethod(method.getDeclaringClass(), method), null);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public MethodEffector(MethodClosure mc) {
         this(new AnnotationsOnMethod((Class<?>)mc.getDelegate(), mc.getMethod()), null);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
@@ -385,8 +385,10 @@ public class BrooklynPropertiesImpl implements BrooklynProperties {
         }
         if (flags.get("failIfNone")!=null && !Boolean.FALSE.equals(flags.get("failIfNone"))) {
             Object f = flags.get("failIfNone");
-            if (f instanceof Closure)
+            if (f instanceof Closure) {
+                LOG.warn("Use of groovy.lang.Closure is deprecated as value for 'failIfNone', in BrooklynProperties.getFirst()");
                 ((Closure)f).call((Object[])keys);
+            }
             if (Boolean.TRUE.equals(f))
                 throw new NoSuchElementException("Brooklyn unable to find mandatory property "+keys[0]+
                         (keys.length>1 ? " (or "+(keys.length-1)+" other possible names, full list is "+Arrays.asList(keys)+")" : "") );

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicSubscriptionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicSubscriptionContext.java
@@ -66,14 +66,24 @@ public class BasicSubscriptionContext implements SubscriptionContext {
         if (flags!=null) this.flags.putAll(flags);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribe(Entity producer, Sensor<T> sensor, Closure c) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribe()");
         return subscribe(Collections.<String,Object>emptyMap(), producer, sensor, c);
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribe(Map<String, ?> newFlags, Entity producer, Sensor<T> sensor, Closure c) {
-        return subscribe(newFlags, producer, sensor, toSensorEventListener(c));        
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribe()");
+        return subscribe(newFlags, producer, sensor, toSensorEventListener(c));       
     }
 
     @Override
@@ -88,13 +98,23 @@ public class BasicSubscriptionContext implements SubscriptionContext {
         return manager.subscribe(subscriptionFlags, producer, sensor, listener);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribeToChildren(Entity parent, Sensor<T> sensor, Closure c) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribeToChildren()");
         return subscribeToChildren(Collections.<String,Object>emptyMap(), parent, sensor, c);
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribeToChildren(Map<String, Object> newFlags, Entity parent, Sensor<T> sensor, Closure c) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribeToChildren()");
         return subscribeToChildren(newFlags, parent, sensor, toSensorEventListener(c));
     }
 
@@ -110,13 +130,23 @@ public class BasicSubscriptionContext implements SubscriptionContext {
         return manager.subscribeToChildren(subscriptionFlags, parent, sensor, listener);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribeToMembers(Group parent, Sensor<T> sensor, Closure c) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribeToMembers()");
         return subscribeToMembers(Collections.<String,Object>emptyMap(), parent, sensor, c);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public <T> SubscriptionHandle subscribeToMembers(Map<String, Object> newFlags, Group parent, Sensor<T> sensor, Closure c) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in BasicSubscriptionContext.subscribeToMembers()");
         return subscribeToMembers(newFlags, parent, sensor, toSensorEventListener(c));
     }
     
@@ -171,6 +201,10 @@ public class BasicSubscriptionContext implements SubscriptionContext {
         return count;
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     private <T> SensorEventListener<T> toSensorEventListener(final Closure c) {
         return new SensorEventListener<T>() {

--- a/core/src/main/java/org/apache/brooklyn/core/policy/Policies.java
+++ b/core/src/main/java/org/apache/brooklyn/core/policy/Policies.java
@@ -25,14 +25,22 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
-import org.apache.brooklyn.core.policy.AbstractPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import groovy.lang.Closure;
 
 @SuppressWarnings({"rawtypes","unchecked"})
 public class Policies {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Policies.class);
+
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static SensorEventListener listenerFromValueClosure(final Closure code) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in Policies.listenerFromValueClosure()");
         return new SensorEventListener() {
             @Override
             public void onEvent(SensorEvent event) {
@@ -41,7 +49,12 @@ public class Policies {
         };
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T> Policy newSingleSensorValuePolicy(final Sensor<T> sensor, final Closure code) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in Policies.newSingleSensorValuePolicy()");
         return new AbstractPolicy() {
             @Override
             public void setEntity(EntityLocal entity) {
@@ -51,8 +64,13 @@ public class Policies {
         };
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <S,T> Policy newSingleSensorValuePolicy(final Entity remoteEntity, final Sensor<T> remoteSensor, 
             final Closure code) {
+        LOG.warn("Use of groovy.lang.Closure is deprecated in Policies.newSingleSensorValuePolicy()");
         return new AbstractPolicy() {
             @Override
             public void setEntity(EntityLocal entity) {

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -119,6 +119,10 @@ public class DependentConfiguration {
         return attributeWhenReady(source, sensor, GroovyJavaMethods.truthPredicate());
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T> Task<T> attributeWhenReady(Entity source, AttributeSensor<T> sensor, Closure<Boolean> ready) {
         Predicate<Object> readyPredicate = (ready != null) ? GroovyJavaMethods.<Object>predicateFromClosure(ready) : GroovyJavaMethods.truthPredicate();
         return attributeWhenReady(source, sensor, readyPredicate);
@@ -134,12 +138,20 @@ public class DependentConfiguration {
 
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T,V> Task<V> attributePostProcessedWhenReady(Entity source, AttributeSensor<T> sensor, Closure<Boolean> ready, Closure<V> postProcess) {
         Predicate<? super T> readyPredicate = (ready != null) ? GroovyJavaMethods.predicateFromClosure(ready) : GroovyJavaMethods.truthPredicate();
         Function<? super T, V> postProcessFunction = GroovyJavaMethods.<T,V>functionFromClosure(postProcess);
         return attributePostProcessedWhenReady(source, sensor, readyPredicate, postProcessFunction);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T,V> Task<V> attributePostProcessedWhenReady(Entity source, AttributeSensor<T> sensor, Closure<V> postProcess) {
         return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), GroovyJavaMethods.<T,V>functionFromClosure(postProcess));
     }
@@ -152,10 +164,18 @@ public class DependentConfiguration {
         return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), valueProvider);
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T,V> Task<V> valueWhenAttributeReady(Entity source, AttributeSensor<T> sensor, Closure<V> valueProvider) {
         return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), valueProvider);
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T,V> Task<V> attributePostProcessedWhenReady(final Entity source, final AttributeSensor<T> sensor, final Predicate<? super T> ready, final Closure<V> postProcess) {
         return attributePostProcessedWhenReady(source, sensor, ready, GroovyJavaMethods.<T,V>functionFromClosure(postProcess));
     }
@@ -395,13 +415,20 @@ public class DependentConfiguration {
         return transform(MutableMap.of("displayName", "transforming "+task), task, transformer);
     }
  
-    /** @see #transform(Task, Function) */
+    /** 
+     * @see #transform(Task, Function)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <U,T> Task<T> transform(Task<U> task, Closure transformer) {
         return transform(task, GroovyJavaMethods.functionFromClosure(transformer));
     }
     
-    /** @see #transform(Task, Function) */
+    /**
+     * @see #transform(Task, Function)
+     */
     @SuppressWarnings({ "rawtypes" })
     public static <U,T> Task<T> transform(final Map flags, final TaskAdaptable<U> task, final Function<U,T> transformer) {
         return new BasicTask<T>(flags, new Callable<T>() {
@@ -421,13 +448,23 @@ public class DependentConfiguration {
         return transformMultiple(MutableMap.of("displayName", "transforming multiple"), transformer, tasks);
     }
 
-    /** @see #transformMultiple(Function, TaskAdaptable...) */
+    /**
+     * @see #transformMultiple(Function, TaskAdaptable...)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <U,T> Task<T> transformMultiple(Closure transformer, TaskAdaptable<U> ...tasks) {
         return transformMultiple(GroovyJavaMethods.functionFromClosure(transformer), tasks);
     }
 
-    /** @see #transformMultiple(Function, TaskAdaptable...) */
+    /**
+     * @see #transformMultiple(Function, TaskAdaptable...)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <U,T> Task<T> transformMultiple(Map flags, Closure transformer, TaskAdaptable<U> ...tasks) {
         return transformMultiple(flags, GroovyJavaMethods.functionFromClosure(transformer), tasks);
@@ -736,7 +773,11 @@ public class DependentConfiguration {
     public static <T> Task<List<T>> listAttributesWhenReady(AttributeSensor<T> sensor, Iterable<Entity> entities) {
         return listAttributesWhenReady(sensor, entities, GroovyJavaMethods.truthPredicate());
     }
-    
+
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T> Task<List<T>> listAttributesWhenReady(AttributeSensor<T> sensor, Iterable<Entity> entities, Closure<Boolean> readiness) {
         Predicate<Object> readinessPredicate = (readiness != null) ? GroovyJavaMethods.<Object>predicateFromClosure(readiness) : GroovyJavaMethods.truthPredicate();
         return listAttributesWhenReady(sensor, entities, readinessPredicate);
@@ -850,6 +891,10 @@ public class DependentConfiguration {
             abortIfOnFire();
             return (Builder<T2, T2>) this;
         }
+        /**
+         * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+         */
+        @Deprecated
         public Builder<T,V> readiness(Closure<Boolean> val) {
             this.readiness = GroovyJavaMethods.predicateFromClosure(checkNotNull(val, "val"));
             return this;
@@ -858,6 +903,10 @@ public class DependentConfiguration {
             this.readiness = checkNotNull(val, "ready");
             return this;
         }
+        /**
+         * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+         */
+        @Deprecated
         @SuppressWarnings({ "unchecked", "rawtypes" })
         public <V2> Builder<T,V2> postProcess(Closure<V2> val) {
             this.postProcess = (Function) GroovyJavaMethods.<T,V2>functionFromClosure(checkNotNull(val, "postProcess"));
@@ -1008,6 +1057,10 @@ public class DependentConfiguration {
             return postProcessFromMultiple(Functions.forPredicate(val));
         }
         
+        /**
+         * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+         */
+        @Deprecated
         public <V1> MultiBuilder<T, V1, V2> postProcess(Closure<V1> val) {
             builder.postProcess(val);
             return (MultiBuilder<T, V1, V2>) this;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/CustomAggregatingEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/CustomAggregatingEnricher.java
@@ -54,7 +54,7 @@ public class CustomAggregatingEnricher<S,T> extends AbstractAggregatingEnricher<
      * - producers: a collection of entities to be aggregated
      * - allMembers: indicates that should track members of the entity that the aggregator is associated with,
      *               to aggregate across all those members.
-     * - filter:     a Predicate or Closure, indicating which entities to include
+     * - filter:     a Predicate indicating which entities to include (support for {@link groovy.lang.Closure} is deprecated)
      * 
      * @param flags
      * @param source
@@ -92,21 +92,36 @@ public class CustomAggregatingEnricher<S,T> extends AbstractAggregatingEnricher<
      * @param defaultValueForUnreportedSensors
      * 
      * @see #CustomAggregatingEnricher(Map, AttributeSensor, AttributeSensor, Function, Object)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
      */
+     @Deprecated
     @SuppressWarnings("unchecked")
     public CustomAggregatingEnricher(Map<String,?> flags, AttributeSensor<? extends S> source, AttributeSensor<T> target,
             Closure<?> aggregator, S defaultValueForUnreportedSensors) {
         this(flags, source, target, GroovyJavaMethods.<Collection<S>, T>functionFromClosure((Closure<T>)aggregator), defaultValueForUnreportedSensors);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+     @Deprecated
     public CustomAggregatingEnricher(Map<String,?> flags, AttributeSensor<? extends S> source, AttributeSensor<T> target, Closure<?> aggregator) {
         this(flags, source, target, aggregator, null);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public CustomAggregatingEnricher(AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator, S defaultValueForUnreportedSensors) {
         this(Collections.<String,Object>emptyMap(), source, target, aggregator, defaultValueForUnreportedSensors);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public CustomAggregatingEnricher(AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator) {
         this(Collections.<String,Object>emptyMap(), source, target, aggregator, null);
     }
@@ -152,14 +167,26 @@ public class CustomAggregatingEnricher<S,T> extends AbstractAggregatingEnricher<
             Map<String,?> flags, AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator, S defaultVal) {
         return new CustomAggregatingEnricher<S,T>(flags, source, target, aggregator, defaultVal);
     }
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <S,T> CustomAggregatingEnricher<S,T> newEnricher(
             Map<String,?> flags, AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator) {
         return newEnricher(flags, source, target, aggregator, null);
     }
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <S,T> CustomAggregatingEnricher<S,T> newEnricher(
             AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator, S defaultVal) {
         return newEnricher(Collections.<String,Object>emptyMap(), source, target, aggregator, defaultVal);
     }
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <S,T> CustomAggregatingEnricher<S,T> newEnricher(
             AttributeSensor<S> source, AttributeSensor<T> target, Closure<?> aggregator) {
         return newEnricher(Collections.<String,Object>emptyMap(), source, target, aggregator, null);

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/SensorTransformingEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/SensorTransformingEnricher.java
@@ -43,6 +43,10 @@ public class SensorTransformingEnricher<T,U> extends AbstractTypeTransformingEnr
         this.uniqueTag = JavaClassNames.simpleClassName(getClass())+":"+source.getName()+"*->"+target.getName();;
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public SensorTransformingEnricher(Entity producer, Sensor<T> source, Sensor<U> target, Closure transformation) {
         this(producer, source, target, GroovyJavaMethods.functionFromClosure(transformation));
     }
@@ -51,11 +55,16 @@ public class SensorTransformingEnricher<T,U> extends AbstractTypeTransformingEnr
         this(null, source, target, transformation);
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public SensorTransformingEnricher(Sensor<T> source, Sensor<U> target, Closure transformation) {
         this(null, source, target, GroovyJavaMethods.functionFromClosure(transformation));
     }
 
     @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public void onEvent(SensorEvent event) {
         if (accept((T)event.getValue())) {
             if (target instanceof AttributeSensor)

--- a/core/src/main/java/org/apache/brooklyn/feed/function/FunctionPollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/function/FunctionPollConfig.java
@@ -97,6 +97,10 @@ public class FunctionPollConfig<S, T> extends PollConfig<S, T, FunctionPollConfi
         return (FunctionPollConfig<newS, T>) this;
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public FunctionPollConfig<S, T> closure(Closure<?> val) {
         this.callable = GroovyJavaMethods.callableFromClosure(checkNotNull(val, "closure"));
         return this;

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/FlagUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/FlagUtils.java
@@ -286,7 +286,11 @@ public class FlagUtils {
     }
 
     /** returns all fields on the given class, superclasses, and interfaces thereof, in that order of preference,
-     * (excluding fields on Object) */
+     * (excluding fields on Object)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static List<Field> getAllFields(Class<?> base, Closure<Boolean> filter) {
         return getAllFields(base, GroovyJavaMethods.<Field>predicateFromClosure(filter));
     }
@@ -300,6 +304,10 @@ public class FlagUtils {
     public static List<Field> getLocalFields(List<Class<?>> classes) {
         return getLocalFields(classes, Predicates.<Field>alwaysTrue());
     }
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static List<Field> getLocalFields(List<Class<?>> classes, Closure<Boolean> filter) {
         return getLocalFields(classes, GroovyJavaMethods.<Field>predicateFromClosure(filter));
     }
@@ -321,6 +329,10 @@ public class FlagUtils {
             }
         });
     }
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static List<Class<?>> getAllAssignableTypes(Class<?> base, Closure<Boolean> filter) {
         return getAllAssignableTypes(base, GroovyJavaMethods.<Class<?>>predicateFromClosure(filter));
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -117,11 +117,16 @@ public class TypeCoercions {
         });
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     @SuppressWarnings("rawtypes")
     public static void registerGroovyAdapters() {
         registerAdapter(Closure.class, Predicate.class, new Function<Closure,Predicate>() {
             @Override
             public Predicate<?> apply(final Closure closure) {
+                log.warn("Use of groovy.lang.Closure is deprecated, in TypeCoercions Closure->Predicate");
                 return new Predicate<Object>() {
                     @Override public boolean apply(Object input) {
                         return (Boolean) closure.call(input);
@@ -132,6 +137,7 @@ public class TypeCoercions {
         registerAdapter(Closure.class, Function.class, new Function<Closure,Function>() {
             @Override
             public Function apply(final Closure closure) {
+                log.warn("Use of groovy.lang.Closure is deprecated, in TypeCoercions Closure->Function");
                 return new Function() {
                     @Override public Object apply(Object input) {
                         return closure.call(input);
@@ -140,7 +146,6 @@ public class TypeCoercions {
             }
         });
         registerAdapter(Object.class, TimeDuration.class, new Function<Object,TimeDuration>() {
-            @SuppressWarnings("deprecation")
             @Override
             public TimeDuration apply(final Object input) {
                 log.warn("deprecated automatic coercion of Object to TimeDuration (set breakpoint in TypeCoercions to inspect, convert to Duration)");

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
@@ -792,7 +792,13 @@ public class BasicExecutionManager implements ExecutionManager {
     // not ideal, such loose typing on the callback -- should prefer Function<Task,Object>
     // but at least it's package-private
     static Object invokeCallback(Object callable, Task<?> task) {
-        if (callable instanceof Closure) return ((Closure<?>)callable).call(task);
+        if (callable instanceof Closure) {
+            if (!loggedClosureDeprecatedInInvokeCallback) {
+                log.warn("Use of groovy.lang.Closure is deprecated, in ExecutionManager.invokeCallback");
+                loggedClosureDeprecatedInInvokeCallback = true;
+            }
+            return ((Closure<?>)callable).call(task);
+        }
         if (callable instanceof Callable) {
             try {
                 return ((Callable<?>)callable).call();
@@ -805,6 +811,7 @@ public class BasicExecutionManager implements ExecutionManager {
         if (callable==null) return null;
         throw new IllegalArgumentException("Cannot invoke unexpected callback object "+callable+" of type "+callable.getClass()+" on "+task);
     }
+    private static boolean loggedClosureDeprecatedInInvokeCallback;
     
     /** normally (if not interrupted) called once for each call to {@link #beforeSubmitScheduledTaskAllIterations(Map, Task)} */
     protected void afterEndScheduledTaskAllIterations(Map<?,?> flags, Task<?> task) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -67,8 +67,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 /**
  * The basic concrete implementation of a {@link Task} to be executed.
  *
- * A {@link Task} is a wrapper for an executable unit, such as a {@link Closure} or a {@link Runnable} or
- * {@link Callable} and will run in its own {@link Thread}.
+ * A {@link Task} is a wrapper for an executable unit, such as a {@link Runnable} or
+ * {@link Callable} ({@link Closure} support is deprecated), and will run in its own {@link Thread}.
  * <p>
  * The task can be given an optional displayName and description in its constructor (as named
  * arguments in the first {@link Map} parameter). It is guaranteed to have {@link Object#notify()} called
@@ -102,8 +102,12 @@ public class BasicTask<T> implements TaskInternal<T> {
      * Constructor needed to prevent confusion in groovy stubs when looking for default constructor,
      *
      * The generics on {@link Closure} break it if that is first constructor.
+     * 
+     * @deprecated since 0.11.0; present only as a workaround for Groovy.
      */
+    @Deprecated
     protected BasicTask() { this(Collections.emptyMap()); }
+    
     protected BasicTask(Map<?,?> flags) { this(flags, (Callable<T>) null); }
 
     public BasicTask(Callable<T> job) { this(Collections.emptyMap(), job); }
@@ -128,7 +132,17 @@ public class BasicTask<T> implements TaskInternal<T> {
 
     public BasicTask(Runnable job) { this(GroovyJavaMethods.<T>callableFromRunnable(job)); }
     public BasicTask(Map<?,?> flags, Runnable job) { this(flags, GroovyJavaMethods.<T>callableFromRunnable(job)); }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public BasicTask(Closure<T> job) { this(GroovyJavaMethods.callableFromClosure(job)); }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public BasicTask(Map<?,?> flags, Closure<T> job) { this(flags, GroovyJavaMethods.callableFromClosure(job)); }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/CompoundTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/CompoundTask.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A {@link Task} that is comprised of other units of work: possibly a heterogeneous mix of {@link Task},
- * {@link Runnable}, {@link Callable} and {@link Closure} instances.
+ * {@link Runnable} and {@link Callable} instances (support for {@link Closure} is deprecated).
  * 
  * This class holds the collection of child tasks, but subclasses have the responsibility of executing them in a
  * sensible manner by implementing the abstract {@link #runJobs} method.
@@ -56,7 +56,8 @@ public abstract class CompoundTask<T> extends BasicTask<List<T>> implements HasT
     /**
      * Constructs a new compound task containing the specified units of work.
      * 
-     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable}, {@link Closure} and {@link Task} can be provided. 
+     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable}, and {@link Task} can be provided
+     *              (support for {@link Closure} is deprecated).
      * @throws IllegalArgumentException if any of the passed child jobs is not one of the above types 
      */
     public CompoundTask(Object... jobs) {
@@ -66,7 +67,8 @@ public abstract class CompoundTask<T> extends BasicTask<List<T>> implements HasT
     /**
      * Constructs a new compound task containing the specified units of work.
      * 
-     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable}, {@link Closure} and {@link Task} can be provided. 
+     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable} and {@link Task} can be provided
+     *              (support for {@link Closure}  is deprecated).
      * @throws IllegalArgumentException if any of the passed child jobs is not one of the above types 
      */
     public CompoundTask(Collection<?> jobs) {
@@ -87,12 +89,15 @@ public abstract class CompoundTask<T> extends BasicTask<List<T>> implements HasT
         for (Object job : jobs) {
             Task subtask;
             if (job instanceof TaskAdaptable) { subtask = ((TaskAdaptable)job).asTask(); }
-            else if (job instanceof Closure)  { subtask = new BasicTask<T>((Closure) job); }
+            else if (job instanceof Closure)  {
+                log.warn("Use of groovy.lang.Closure is deprecated, in CompoundTask jobs");
+                subtask = new BasicTask<T>((Closure) job);
+            }
             else if (job instanceof Callable) { subtask = new BasicTask<T>((Callable) job); }
             else if (job instanceof Runnable) { subtask = new BasicTask<T>((Runnable) job); }
             
             else throw new IllegalArgumentException("Invalid child "+(job == null ? null : job.getClass() + " ("+job+")")+
-                " passed to compound task; must be Runnable, Callable, Closure or Task");
+                " passed to compound task; must be Runnable, Callable or Task (Closure support is deprecated)");
             
             BrooklynTaskTags.addTagDynamically(subtask, ManagementContextInternal.SUB_TASK_TAG);
             children.add(subtask);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicSequentialTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicSequentialTask.java
@@ -126,7 +126,8 @@ public class DynamicSequentialTask<T> extends BasicTask<T> implements HasTaskChi
     /**
      * Constructs a new compound task containing the specified units of work.
      * 
-     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable}, {@link Closure} and {@link Task} can be provided. 
+     * @param jobs  A potentially heterogeneous mixture of {@link Runnable}, {@link Callable} and {@link Task} can be provided
+     *              (support for {@link Closure} is deprecated).
      * @throws IllegalArgumentException if any of the passed child jobs is not one of the above types 
      */
     public DynamicSequentialTask() {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/hello/LocalEntitiesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/hello/LocalEntitiesTest.java
@@ -25,7 +25,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import groovy.lang.Closure;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -50,6 +49,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.time.Time;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
@@ -262,7 +262,7 @@ public class LocalEntitiesTest extends BrooklynAppUnitTestSupport {
         HelloEntity dad = app.createAndManageChild(EntitySpec.create(HelloEntity.class));
         // the unnecessary (HelloEntity) cast is required as a work-around to an IntelliJ issue that prevents Brooklyn from launching from the IDE
         HelloEntity son = (HelloEntity) dad.addChild(EntitySpec.create(HelloEntity.class)
-                .configure(HelloEntity.MY_NAME, transform(attributeWhenReady(dad, HelloEntity.FAVOURITE_NAME, (Closure)null), new Function<String,String>() {
+                .configure(HelloEntity.MY_NAME, transform(attributeWhenReady(dad, HelloEntity.FAVOURITE_NAME, (Predicate<String>)null), new Function<String,String>() {
                     @Override
                     public String apply(String input) {
                         return input+input.charAt(input.length()-1)+"y";

--- a/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
@@ -228,6 +228,7 @@ public class AutoScalerPolicy extends AbstractPolicy {
         TypeCoercions.registerAdapter(Closure.class, ResizeOperator.class, new Function<Closure,ResizeOperator>() {
             @Override
             public ResizeOperator apply(final Closure closure) {
+                LOG.warn("Use of groovy.lang.Closure is deprecated in AutoScalerPolicy type-coercion Closure -> ResizeOperator");
                 return new ResizeOperator() {
                     @Override public Integer resize(Entity entity, Integer input) {
                         return (Integer) closure.call(entity, input);

--- a/policy/src/main/java/org/apache/brooklyn/policy/enricher/TimeWeightedDeltaEnricher.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/enricher/TimeWeightedDeltaEnricher.java
@@ -74,9 +74,15 @@ public class TimeWeightedDeltaEnricher<T extends Number> extends AbstractTypeTra
 
     public TimeWeightedDeltaEnricher() { // for rebind
     }
+    
     public TimeWeightedDeltaEnricher(Entity producer, Sensor<T> source, Sensor<Double> target, int unitMillis) {
         this(producer, source, target, unitMillis, Functions.<Double>identity());
     }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public TimeWeightedDeltaEnricher(Entity producer, Sensor<T> source, Sensor<Double> target, int unitMillis, Closure<Double> postProcessor) {
         this(producer, source, target, unitMillis, GroovyJavaMethods.<Double,Double>functionFromClosure(postProcessor));
     }

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/Main.java
@@ -207,14 +207,14 @@ public class Main extends AbstractMain {
 
         @Option(name = { "-a", "--app" }, title = "application class or file",
                 description = "The Application to start. " +
-                        "For example, my.AppName, file://my/app.yaml, or classpath://my/AppName.groovy -- "
-                        + "note that a BROOKLYN_CLASSPATH environment variable may be required to "
-                        + "load classes from other locations")
+                        "For example, my.AppName, file://my/app.yaml, or classpath://my/AppName.groovy " 
+                        + "(but passing groovy scripts is deprecated) -- note that a BROOKLYN_CLASSPATH "
+                        + "environment variable may be required to load classes from other locations")
         public String app;
 
         @Beta
         @Option(name = { "-s", "--script" }, title = "script URI",
-                description = "EXPERIMENTAL. URI for a Groovy script to parse and load." +
+                description = "DEPRECATED. URI for a Groovy script to parse and load." +
                         " This script will run before starting the app.")
         public String script = null;
 
@@ -414,6 +414,7 @@ public class Main extends AbstractMain {
     
                 // First, run a setup script if the user has provided one
                 if (script != null) {
+                    log.warn("Use of --script for groovy-script execution is deprecated");
                     execGroovyScript(utils, loader, script);
                 }
     
@@ -747,6 +748,7 @@ public class Main extends AbstractMain {
                 log.debug("Loading \"{}\" as class on classpath failed, now trying as .groovy source file", app);
                 String content = utils.getResourceAsString(app);
                 tempclazz = loader.parseClass(content);
+                log.warn("Use of --app with a groovy source file is deprecated");
             }
             final Class<?> clazz = tempclazz;
             

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -476,6 +476,11 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
     public void waitForServiceUp(Duration duration) {
         Entities.waitForServiceUp(this, duration);
     }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public void waitForServiceUp(TimeDuration duration) {
         waitForServiceUp(duration.toMilliseconds(), TimeUnit.MILLISECONDS);
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelper.java
@@ -87,7 +87,10 @@ public class ScriptHelper {
     /**
      * Takes a closure which accepts this ScriptHelper and returns true or false
      * as to whether the script needs to run (or can throw error if desired)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
      */
+    @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public ScriptHelper executeIf(Closure c) {
         Predicate<ScriptHelper> predicate = GroovyJavaMethods.predicateFromClosure(c);
@@ -176,7 +179,10 @@ public class ScriptHelper {
      * and returns false if it is invalid. Default is that this resultCodeCheck
      * closure always returns true (and the exit code is made available to the
      * caller if they care)
+     * 
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
      */
+    @Deprecated
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public ScriptHelper requireResultCode(Closure integerFilter) {
         Predicate<Integer> objectPredicate = GroovyJavaMethods.predicateFromClosure(integerFilter);

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxHelper.java
@@ -556,6 +556,11 @@ public class JmxHelper {
     public Set<ObjectInstance> doesMBeanExistsEventually(final ObjectName objectName, Duration timeout) {
         return doesMBeanExistsEventually(objectName, timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
     }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public Set<ObjectInstance> doesMBeanExistsEventually(final ObjectName objectName, TimeDuration timeout) {
         return doesMBeanExistsEventually(objectName, timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
     }
@@ -567,6 +572,11 @@ public class JmxHelper {
     public Set<ObjectInstance> doesMBeanExistsEventually(String objectName, Duration timeout) {
         return doesMBeanExistsEventually(createObjectName(objectName), timeout);
     }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public Set<ObjectInstance> doesMBeanExistsEventually(String objectName, TimeDuration timeout) {
         return doesMBeanExistsEventually(createObjectName(objectName), timeout);
     }
@@ -601,6 +611,11 @@ public class JmxHelper {
     public void assertMBeanExistsEventually(ObjectName objectName, Duration timeout) {
         assertMBeanExistsEventually(objectName, timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
     }
+    
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public void assertMBeanExistsEventually(ObjectName objectName, TimeDuration timeout) {
         assertMBeanExistsEventually(objectName, timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1062,6 +1062,10 @@ public class Asserts {
         assertFailsWith(c, Predicates.alwaysTrue());
     }
     
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static void assertFailsWith(Callable<?> c, final Closure<Boolean> exceptionChecker) {
         assertFailsWith(c, new Predicate<Throwable>() {
             @Override

--- a/utils/common/src/main/java/org/apache/brooklyn/util/JavaGroovyEquivalents.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/JavaGroovyEquivalents.java
@@ -171,6 +171,10 @@ public class JavaGroovyEquivalents {
         }
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+     */
+    @Deprecated
     public static <T> Predicate<T> toPredicate(final Closure<Boolean> c) {
         return new Predicate<T>() {
             @Override public boolean apply(T input) {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/ShellUtils.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/ShellUtils.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.util.stream.StreamGobbler;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
@@ -43,6 +44,8 @@ import com.google.common.io.Closer;
  */
 @Deprecated
 public class ShellUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ShellUtils.class);
 
     public static long TIMEOUT = 60*1000;
 
@@ -84,6 +87,7 @@ public class ShellUtils {
         if (tf instanceof Number) {
             timeout = ((Number) tf).longValue();
         } else if (tf instanceof TimeDuration) {
+            LOG.warn("Use of groovy.time.TimeuDuration is deprecated in ShellUtils, for configuring timeout");
             timeout = ((TimeDuration) tf).toMilliseconds();
         }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/repeat/Repeater.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/repeat/Repeater.java
@@ -194,6 +194,10 @@ public class Repeater implements Callable<Boolean> {
         return delayOnIteration(Functions.constant(duration));
     }
 
+    /**
+     * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted (instead use {@link #every(Duration)}).
+     */
+    @Deprecated
     public Repeater every(groovy.time.Duration duration) {
         return every(Duration.of(duration));
     }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/repeat/RepeaterTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/repeat/RepeaterTest.java
@@ -163,7 +163,7 @@ public class RepeaterTest {
      * Check that the {@link Repeater} will stop after a time limit.
      *
      * The repeater is configured to run every 100ms and never stop until the limit is reached.
-     * This is given as {@link Repeater#limitTimeTo(groovy.time.Duration)} and the execution time
+     * This is given as {@link Repeater#limitTimeTo(org.apache.brooklyn.util.time.Duration)} and the execution time
      * is then checked to ensure it is between 100% and 400% of the specified value. Due to scheduling
      * delays and other factors in a non RTOS system it is expected that the repeater will take much
      * longer to exit occasionally.

--- a/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromCallableClosure.java
+++ b/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromCallableClosure.java
@@ -22,6 +22,10 @@ import java.util.concurrent.Callable;
 
 import groovy.lang.Closure;
 
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class FromCallableClosure<T> extends Closure<T> {
     private static final long serialVersionUID = 1L;
     private Callable<T> job;

--- a/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromFunctionClosure.java
+++ b/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromFunctionClosure.java
@@ -22,6 +22,10 @@ import groovy.lang.Closure;
 
 import com.google.common.base.Function;
 
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class FromFunctionClosure<T> extends Closure<T> {
     private static final long serialVersionUID = 1L;
     private Function<Object, T> job;

--- a/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromRunnableClosure.java
+++ b/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/FromRunnableClosure.java
@@ -24,6 +24,10 @@ import java.util.concurrent.Callable;
 
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class FromRunnableClosure<T> extends Closure<T> {
     private static final long serialVersionUID = 1L;
     private Runnable job;

--- a/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/GroovyJavaMethods.java
+++ b/utils/groovy/src/main/java/org/apache/brooklyn/util/groovy/GroovyJavaMethods.java
@@ -34,8 +34,13 @@ import com.google.common.base.Predicate;
 import groovy.lang.Closure;
 import groovy.lang.GString;
 
-/** handy methods available in groovy packaged so they can be consumed from java,
- *  and other conversion/conveniences; but see JavaGroovyEquivalents for faster alternatives */
+/**
+ * Handy methods available in groovy packaged so they can be consumed from java,
+ * and other conversion/conveniences; but see JavaGroovyEquivalents for faster alternatives.
+ * 
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class GroovyJavaMethods {
     private static final CallSiteArray CALL_SITE_ARRAY = new CallSiteArray(GroovyJavaMethods.class, new String[] {"metaClass", "invokeMethod"});
 

--- a/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/GroovJavaMethodsTest.java
+++ b/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/GroovJavaMethodsTest.java
@@ -34,6 +34,10 @@ import com.google.common.collect.ImmutableList;
 import groovy.lang.Closure;
 import groovy.lang.GString;
 
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class GroovJavaMethodsTest {
 
     private String gstringVal = "exampleGString";

--- a/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/PojoTestingFields.java
+++ b/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/PojoTestingFields.java
@@ -18,6 +18,10 @@
  */
 package org.apache.brooklyn.util.groovy;
 
+/**
+ * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
+ */
+@Deprecated
 public class PojoTestingFields {
     private final int privateInt;
     


### PR DESCRIPTION
As discussed on the dev@brooklyn mailing list (subject "[PROPOSAL] Remove groovy dependency/support").

Deprecate methods that take explicit groovy types (e.g. `groovy.lang.Closure`, `groovy.time.TimeDuration`, etc).
    
Also updates some javadoc that mentioned `Closure` to say that its usage is deprecated.

In some places, it does a `LOG.warn()` about the deprecation when a groovy Closure etc is passed in - this is when we can't just deprecate the method, e.g. for use of `TypeCoercion` on when the method takes `Object` and does an ugly `instanceof`.

This does not touch:
* The `org.apache.brooklyn.rest.resources.ScriptResource` (for groovy-script execution)
* Internal usage of groovy (e.g. `AbstractManagementContext.invokeEffectorMethodLocal()` calling `GroovyJavaMethods.invokeMethodOnMetaClass`)
