### PR TITLE
Fixed BlobStoreContextFactoryImpl. It can now have dsl in its config

### DIFF
--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
@@ -329,7 +329,7 @@ public abstract class CloudExplorerSupport implements Callable<Void> {
 
         @Override
         protected void doCall(JcloudsLocation loc, String indent) throws Exception {
-            BlobStoreContext context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(loc.config().getBag());
+            BlobStoreContext context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(loc);
             try {
                 org.jclouds.blobstore.BlobStore blobStore = context.getBlobStore();
                 doCall(blobStore, indent);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
@@ -93,7 +93,7 @@ public class JcloudsBlobStoreBasedObjectStore implements PersistenceObjectStore 
                 location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
             }
             
-            context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location.config().getBag());
+            context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location);
      
             // TODO do we need to get location from region? can't see the jclouds API.
             // doesn't matter in some places because it's already in the endpoint

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BlobStoreContextFactory.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BlobStoreContextFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.blobstore.BlobStoreContext;
 
@@ -33,5 +34,5 @@ public interface BlobStoreContextFactory {
     //
     // However, for now we have just kept the separation of interface and implementation.
     
-    public BlobStoreContext newBlobStoreContext(ConfigBag conf);
+    BlobStoreContext newBlobStoreContext(Location location);
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BlobStoreContextFactoryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BlobStoreContextFactoryImpl.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
@@ -68,12 +69,12 @@ public class BlobStoreContextFactoryImpl implements BlobStoreContextFactory {
     }
 
     @Override
-    public BlobStoreContext newBlobStoreContext(ConfigBag conf) {
-        String rawProvider = checkNotNull(conf.get(LocationConfigKeys.CLOUD_PROVIDER), "provider must not be null");
+    public BlobStoreContext newBlobStoreContext(Location location) {
+        String rawProvider = checkNotNull(location.getConfig(LocationConfigKeys.CLOUD_PROVIDER), "provider must not be null");
         String provider = DeserializingJcloudsRenamesProvider.INSTANCE.applyJcloudsRenames(rawProvider);
-        String identity = checkNotNull(conf.get(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");
-        String credential = checkNotNull(conf.get(LocationConfigKeys.ACCESS_CREDENTIAL), "credential must not be null");
-        String endpoint = conf.get(CloudLocationConfig.CLOUD_ENDPOINT);
+        String identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");
+        String credential = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_CREDENTIAL), "credential must not be null");
+        String endpoint = location.getConfig(CloudLocationConfig.CLOUD_ENDPOINT);
 
         Properties overrides = new Properties();
         // * Java 7,8 bug workaround - sockets closed by GC break the internal bookkeeping
@@ -87,7 +88,7 @@ public class BlobStoreContextFactoryImpl implements BlobStoreContextFactory {
         overrides.setProperty(Constants.PROPERTY_STRIP_EXPECT_HEADER, "true");
 
         // Add extra jclouds-specific configuration
-        Map<String, Object> extra = Maps.filterKeys(conf.getAllConfig(), Predicates.containsPattern("^jclouds\\."));
+        Map<String, Object> extra = Maps.filterKeys(location.getAllConfig(true), Predicates.containsPattern("^jclouds\\."));
         if (extra.size() > 0) {
             LOG.debug("Configuring custom jclouds property overrides for {}: {}", provider, Sanitizer.sanitize(extra));
         }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsUtil.java
@@ -261,30 +261,6 @@ public class JcloudsUtil {
     }
 
     /**
-     *  Temporary constructor to address https://issues.apache.org/jira/browse/JCLOUDS-615.
-     *  <p>
-     *  See https://issues.apache.org/jira/browse/BROOKLYN-6 .
-     *  When https://issues.apache.org/jira/browse/JCLOUDS-615 is fixed in the jclouds we use,
-     *  we can remove the useSoftlayerFix argument.
-     *  <p>
-     *  (Marked Beta as that argument will likely be removed.)
-     *
-     *  @since 0.7.0
-     *  @deprecated since 0.11.0; instead use BlobStoreContextFactoryImpl.INSTANCE
-     */
-    @Beta
-    @Deprecated
-    public static BlobStoreContext newBlobstoreContext(String provider, @Nullable String endpoint, String identity, String credential) {
-        ConfigBag conf = ConfigBag.newInstance();
-        conf.put(LocationConfigKeys.CLOUD_PROVIDER, provider);
-        conf.put(LocationConfigKeys.ACCESS_IDENTITY, identity);
-        conf.put(LocationConfigKeys.ACCESS_CREDENTIAL, credential);
-        conf.put(CloudLocationConfig.CLOUD_ENDPOINT, endpoint);
-
-        return BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(conf);
-    }
-
-    /**
      * @deprecated since 0.7
      */
     @Deprecated

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreExpiryTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreExpiryTest.java
@@ -142,7 +142,7 @@ public class BlobStoreExpiryTest {
         identity = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_IDENTITY), "identity must not be null");
         credential = checkNotNull(location.getConfig(LocationConfigKeys.ACCESS_CREDENTIAL), "credential must not be null");
         endpoint = location.getConfig(CloudLocationConfig.CLOUD_ENDPOINT);
-        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location.config().getBag());
+        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location);
     }
     
     @AfterMethod(alwaysRun=true)
@@ -207,7 +207,7 @@ public class BlobStoreExpiryTest {
     }
     
     private Set<Service> getServices(Credentials creds) throws Exception {
-        BlobStoreContext tmpContext = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location.config().getBag());
+        BlobStoreContext tmpContext = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location);
         try {
             tmpContext.getBlobStore().list();
             LoadingCache<Credentials, Access> authCache = getAuthCache(tmpContext);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
@@ -68,7 +68,7 @@ public class BlobStoreTest {
         testContainerName = CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(8);
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
         location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
-        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location.config().getBag());
+        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location);
     }
     
     @AfterMethod(alwaysRun=true)

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsExpect100ContinueTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsExpect100ContinueTest.java
@@ -61,7 +61,7 @@ public class JcloudsExpect100ContinueTest {
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
         JcloudsLocation jcloudsLocation = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(LOCATION_SPEC);
         
-        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(jcloudsLocation.config().getBag());
+        context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(jcloudsLocation);
 
         containerName = BlobStoreTest.CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(8);
         context.getBlobStore().createContainerInLocation(null, containerName);


### PR DESCRIPTION
Fixes a bug introduced in this PR https://github.com/apache/brooklyn-server/commit/013b38bf0f146114d3a67423c0dcc3661b50f88c#diff-30cb47bc0f055776b4a246abeddd4ad7L99

Before that change we would ask the JCloudsLocation directly for config. JCloudsLocation uses a ResolvingConfigBag which will resolve dsl (e.g. "$brooklyn:external").

After the above change, we get the ConfigBag from the location first and ask the ConfigBag for the result. When we get the ConfigBag from the location we create a new ConfigBag to return, but we do not create a resolving config bag.

This PR changes back to asking the location directly for config