### PR TITLE
Persist management plane ID

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -67,18 +67,33 @@ public interface ManagementContext {
      * In other words the value of {@link Application#getManagementContext()#getManagementPlaneId()} 
      * will generally be constant (in contrast to {@link #getManagementNodeId()}).
      * <p>
-     * Throws an {@link NullPointerException} if the value hasn't been initialized yet. The value is set:
+     * This value should not be null unless the management context is still initialising. The value is set:
      * <ul>
      *   <li>no persistence - during launch
      *   <li>persistence enabled, HA disabled - on rebind (during launch)
      *   <li>persistence enabled, HA enabled - on the first HA state check (async to launch)
      * </ul>
+     * 
+     * @deprecated since 0.11.0, use {@link #getOptionalManagementPlaneId()} instead.
      */
+    @Deprecated
     String getManagementPlaneId();
 
     /**
-     * Same as {@link #getManagementPlaneId()}, but will return {@link Optional#absent()} if the
-     * {@code managementPlaneId} hasn't been initialized yet.
+     * UID for the Brooklyn management plane which this {@link ManagementContext} node is a part of.
+     * <p>
+     * Each Brooklyn entity is actively managed by a unique management plane 
+     * whose ID which should not normally change for the duration of that entity, 
+     * even though the nodes in that plane might, and the plane may go down and come back up. 
+     * In other words the value of {@link Application#getManagementContext()#getManagementPlaneId()} 
+     * will generally be constant (in contrast to {@link #getManagementNodeId()}).
+     * <p>
+     * Returns absent while the management context is still initialising. The value is set:
+     * <ul>
+     *   <li>no persistence - during launch
+     *   <li>persistence enabled, HA disabled - on rebind (during launch)
+     *   <li>persistence enabled, HA enabled - on the first HA state check (async to launch)
+     * </ul>
      */
     Optional<String> getOptionalManagementPlaneId();
     
@@ -87,7 +102,7 @@ public interface ManagementContext {
      * <p>
      * No two instances of {@link ManagementContext} should ever have the same node UID. 
      * The value of {@link Application#getManagementContext()#getManagementNodeId()} may
-     * change many times (in contrast to {@link #getManagementPlaneId()}). 
+     * change many times (in contrast to {@link #getOptionalManagementPlaneId()}). 
      * <p>
      * This value should not be null unless the management context is a non-functional
      * (non-deployment) instance. */

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Optional;
 
 /**
  * This is the entry point for accessing and interacting with a realm of applications and their entities in Brooklyn.
@@ -66,9 +67,20 @@ public interface ManagementContext {
      * In other words the value of {@link Application#getManagementContext()#getManagementPlaneId()} 
      * will generally be constant (in contrast to {@link #getManagementNodeId()}).
      * <p>
-     * This value should not be null unless the management context is a non-functional
-     * (non-deployment) instance. */
+     * Throws an {@link NullPointerException} if the value hasn't been initialized yet. The value is set:
+     * <ul>
+     *   <li>no persistence - during launch
+     *   <li>persistence enabled, HA disabled - on rebind (during launch)
+     *   <li>persistence enabled, HA enabled - on the first HA state check (async to launch)
+     * </ul>
+     */
     String getManagementPlaneId();
+
+    /**
+     * Same as {@link #getManagementPlaneId()}, but will return {@link Optional#absent()} if the
+     * {@code managementPlaneId} hasn't been initialized yet.
+     */
+    Optional<String> getOptionalManagementPlaneId();
     
     /** 
      * UID for this {@link ManagementContext} node (as part of a single management plane).

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementNodeSyncRecord.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementNodeSyncRecord.java
@@ -36,8 +36,6 @@ public interface ManagementNodeSyncRecord {
 
     // TODO Not setting URI currently; ManagementContext doesn't know its URI; only have one if web-console was enabled.
     
-    // TODO Add getPlaneId(); but first need to set it in a sensible way
-    
     String getBrooklynVersion();
     
     String getNodeId();

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecord.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecord.java
@@ -40,7 +40,7 @@ import com.google.common.annotations.Beta;
 @Beta
 public interface ManagementPlaneSyncRecord {
 
-    // TODO Add getPlaneId(); but first need to set it sensibly on each management node
+    String getPlaneId();
     
     String getMasterNodeId();
     

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/PersistenceExceptionHandler.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/PersistenceExceptionHandler.java
@@ -41,4 +41,7 @@ public interface PersistenceExceptionHandler {
     void onPersistRawMementoFailed(BrooklynObjectType type, String id, Exception e);
 
     void onDeleteMementoFailed(String id, Exception e);
+    
+    void onUpdatePlaneIdFailed(String planeId, Exception e);
+
 }

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMemento.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMemento.java
@@ -37,6 +37,8 @@ import java.util.Map;
  */
 public interface BrooklynMemento extends Serializable {
 
+    public String getPlaneId();
+
     public EntityMemento getEntityMemento(String id);
     public LocationMemento getLocationMemento(String id);
     public PolicyMemento getPolicyMemento(String id);

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoManifest.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoManifest.java
@@ -38,6 +38,8 @@ public interface BrooklynMementoManifest extends Serializable {
         public String getCatalogItemId();
     }
 
+    public String getPlaneId();
+
     public Map<String, EntityMementoManifest> getEntityIdToManifest();
 
     public Map<String, String> getLocationIdToType();

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
@@ -110,6 +110,8 @@ public interface BrooklynMementoPersister {
     /** All methods on this interface are unmodifiable by the caller. Sub-interfaces may introduce modifiers. */
     // NB: the type-specific methods aren't actually used anymore; we could remove them to simplify the impl (and use a multiset there)
     public interface Delta {
+        String planeId();
+
         Collection<LocationMemento> locations();
         Collection<EntityMemento> entities();
         Collection<PolicyMemento> policies();

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoRawData.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoRawData.java
@@ -195,7 +195,7 @@ public class BrooklynMementoRawData {
     }
     
     public boolean isEmpty() {
-        return entities.isEmpty() && locations.isEmpty() && policies.isEmpty() && enrichers.isEmpty() && feeds.isEmpty() && catalogItems.isEmpty();
+        return planeId == null && entities.isEmpty() && locations.isEmpty() && policies.isEmpty() && enrichers.isEmpty() && feeds.isEmpty() && catalogItems.isEmpty();
     }
     
     public Map<String, String> getObjectsOfType(BrooklynObjectType type) {

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoRawData.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoRawData.java
@@ -42,6 +42,7 @@ public class BrooklynMementoRawData {
     }
     
     public static class Builder {
+        protected String planeId;
         protected String brooklynVersion;
         protected final Map<String, String> entities = Maps.newConcurrentMap();
         protected final Map<String, String> locations = Maps.newConcurrentMap();
@@ -49,7 +50,12 @@ public class BrooklynMementoRawData {
         protected final Map<String, String> enrichers = Maps.newConcurrentMap();
         protected final Map<String, String> feeds = Maps.newConcurrentMap();
         protected final Map<String, String> catalogItems = Maps.newConcurrentMap();
-        
+
+        public Builder planeId(String val) {
+            planeId = val; return this;
+        }
+        /** @deprecated since 0.11.0; value not used */
+        @Deprecated
         public Builder brooklynVersion(String val) {
             brooklynVersion = val; return this;
         }
@@ -122,6 +128,7 @@ public class BrooklynMementoRawData {
         }
     }
 
+    private final String planeId;
     private final String brooklynVersion;
     private final Map<String, String> entities;
     private final Map<String, String> locations;
@@ -131,6 +138,7 @@ public class BrooklynMementoRawData {
     private final Map<String, String> catalogItems;
     
     private BrooklynMementoRawData(Builder builder) {
+        planeId = builder.planeId;
         brooklynVersion = builder.brooklynVersion;
         entities = builder.entities;
         locations = builder.locations;
@@ -140,10 +148,17 @@ public class BrooklynMementoRawData {
         catalogItems = builder.catalogItems;
     }
 
+    @Nullable
+    public String getPlaneId() {
+        return planeId;
+    }
+
     /**
      * Setting the brooklyn version explicitly is optional. 
+     * @deprecated since 0.11.0; value unused and not set anywhere
      */
     @Beta
+    @Deprecated
     @Nullable
     public String getBrooklynVersion() {
         return brooklynVersion;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -284,7 +284,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         boolean weAreRecognisedAsMaster = existingMaster!=null && ownNodeId.equals(existingMaster.getNodeId());
         boolean weAreMasterLocally = getInternalNodeState()==ManagementNodeState.MASTER;
         
-        updatePlaneId(planeRec);
+        updateLocalPlaneId(planeRec);
         
         // catch error in some tests where mgmt context has a different HA manager
         if (managementContext.getHighAvailabilityManager()!=this)
@@ -460,7 +460,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             registerPollTask();
     }
 
-    protected void updatePlaneId(ManagementPlaneSyncRecord existingMaster) {
+    protected void updateLocalPlaneId(ManagementPlaneSyncRecord existingMaster) {
         if (existingMaster.getPlaneId() != null) {
             ((LocalManagementContext)managementContext).setManagementPlaneId(existingMaster.getPlaneId());
         }
@@ -722,7 +722,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             return;
         }
         
-        updatePlaneId(memento);
+        updateLocalPlaneId(memento);
         
         String currMasterNodeId = memento.getMasterNodeId();
         ManagementNodeSyncRecord currMasterNodeRecord = memento.getManagementNodes().get(currMasterNodeId);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -56,6 +56,7 @@ import org.apache.brooklyn.core.mgmt.ha.dto.ManagementPlaneSyncRecordImpl;
 import org.apache.brooklyn.core.mgmt.ha.dto.ManagementPlaneSyncRecordImpl.Builder;
 import org.apache.brooklyn.core.mgmt.internal.BrooklynObjectManagementMode;
 import org.apache.brooklyn.core.mgmt.internal.LocalEntityManager;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.LocationManagerInternal;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.internal.ManagementTransitionMode;
@@ -278,9 +279,12 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         ownNodeId = managementContext.getManagementNodeId();
         // TODO Small race in that we first check, and then we'll do checkMaster() on first poll,
         // so another node could have already become master or terminated in that window.
-        ManagementNodeSyncRecord existingMaster = hasHealthyMaster();
+        ManagementPlaneSyncRecord planeRec = loadManagementPlaneSyncRecord(false);
+        ManagementNodeSyncRecord existingMaster = hasHealthyMaster(planeRec);
         boolean weAreRecognisedAsMaster = existingMaster!=null && ownNodeId.equals(existingMaster.getNodeId());
         boolean weAreMasterLocally = getInternalNodeState()==ManagementNodeState.MASTER;
+        
+        updatePlaneId(planeRec);
         
         // catch error in some tests where mgmt context has a different HA manager
         if (managementContext.getHighAvailabilityManager()!=this)
@@ -456,6 +460,12 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             registerPollTask();
     }
 
+    protected void updatePlaneId(ManagementPlaneSyncRecord existingMaster) {
+        if (existingMaster.getPlaneId() != null) {
+            ((LocalManagementContext)managementContext).setManagementPlaneId(existingMaster.getPlaneId());
+        }
+    }
+
     @Override
     public void setPriority(long priority) {
         this.priority = priority;
@@ -538,7 +548,6 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         return lastSyncRecord;
     }
     
-    @SuppressWarnings("unchecked")
     protected void registerPollTask() {
         final Runnable job = new Runnable() {
             private boolean lastFailed;
@@ -687,9 +696,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         return (timestampMe - timestampMaster) <= getHeartbeatTimeout().toMilliseconds();
     }
     
-    protected ManagementNodeSyncRecord hasHealthyMaster() {
-        ManagementPlaneSyncRecord memento = loadManagementPlaneSyncRecord(false);
-        
+    protected ManagementNodeSyncRecord hasHealthyMaster(ManagementPlaneSyncRecord memento ) {
         String nodeId = memento.getMasterNodeId();
         ManagementNodeSyncRecord masterMemento = (nodeId == null) ? null : memento.getManagementNodes().get(nodeId);
         
@@ -714,6 +721,8 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             // if failed or hot backup then we can't promote ourselves, so no point in checking who is master
             return;
         }
+        
+        updatePlaneId(memento);
         
         String currMasterNodeId = memento.getMasterNodeId();
         ManagementNodeSyncRecord currMasterNodeRecord = memento.getManagementNodes().get(currMasterNodeId);
@@ -971,6 +980,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         if (disabled) {
             // if HA is disabled, then we are the only node - no persistence; just load a memento to describe this node
             Builder builder = ManagementPlaneSyncRecordImpl.builder()
+                .planeId(managementContext.getOptionalManagementPlaneId().orNull())
                 .node(createManagementNodeSyncRecord(true));
             if (getTransitionTargetNodeState() == ManagementNodeState.MASTER) {
                 builder.masterNodeId(ownNodeId);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/ManagementPlaneSyncRecordImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/ManagementPlaneSyncRecordImpl.java
@@ -41,9 +41,13 @@ public class ManagementPlaneSyncRecordImpl implements ManagementPlaneSyncRecord,
     }
     
     public static class Builder {
+        protected String planeId;
         protected String masterNodeId;
         protected final Map<String,ManagementNodeSyncRecord> nodes = MutableMap.of();
         
+        public Builder planeId(String val) {
+            planeId = val; return this;
+        }
         public Builder masterNodeId(String val) {
             masterNodeId = val; return this;
         }
@@ -62,16 +66,23 @@ public class ManagementPlaneSyncRecordImpl implements ManagementPlaneSyncRecord,
         }
     }
 
+    private String planeId;
     private String masterNodeId;
     private Map<String, ManagementNodeSyncRecord> managementNodes;
     
     private ManagementPlaneSyncRecordImpl(Builder builder) {
+        planeId = builder.planeId;
         masterNodeId = builder.masterNodeId;
         managementNodes = Maps.newLinkedHashMap();
         for (ManagementNodeSyncRecord node : builder.nodes.values()) {
             checkState(!managementNodes.containsKey(node.getNodeId()), "duplicate nodeId %s", node.getNodeId());
             managementNodes.put(node.getNodeId(), node);
         }
+    }
+
+    @Override
+    public String getPlaneId() {
+        return planeId;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -224,6 +224,7 @@ public class LocalManagementContext extends AbstractManagementContext {
     public void setManagementPlaneId(String newPlaneId) {
         if (managementPlaneId != null && !managementPlaneId.equals(newPlaneId)) {
             log.warn("Management plane ID changed from {} to {}", managementPlaneId, newPlaneId);
+            log.debug("Management plane ID changed from {} to {}", new Object[] {managementPlaneId, newPlaneId, new RuntimeException("Stack trace for setManagementPlaneId")});
         }
         this.managementPlaneId = newPlaneId;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -211,14 +211,9 @@ public class LocalManagementContext extends AbstractManagementContext {
     }
 
     @Override
+    @Deprecated
     public String getManagementPlaneId() {
-        if (managementPlaneId != null) {
-            return managementPlaneId;
-        } else {
-            throw new NullPointerException("managementPlaneId not initialized yet. " +
-                    "Either it's too early in the process lifecycle or " +
-                    "ManagementContext hasn't been initialized properly");
-        }
+        return managementPlaneId;
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -76,6 +76,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -125,6 +126,11 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     @Override
     public String getManagementPlaneId() {
         return (initialManagementContext == null) ? null : initialManagementContext.getManagementPlaneId();
+    }
+    
+    @Override
+    public Optional<String> getOptionalManagementPlaneId() {
+        return (initialManagementContext == null) ? Optional.<String>absent() : initialManagementContext.getOptionalManagementPlaneId();
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -124,6 +124,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
     }
 
     @Override
+    @Deprecated
     public String getManagementPlaneId() {
         return (initialManagementContext == null) ? null : initialManagementContext.getManagementPlaneId();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -163,6 +163,7 @@ public class BrooklynPersistenceUtils {
         MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(mgmt.getClass().getClassLoader());
         RetryingMementoSerializer<Object> serializer = new RetryingMementoSerializer<Object>(rawSerializer, 1);
         
+        result.planeId(mgmt.getManagementPlaneId());
         for (Location instance: mgmt.getLocationManager().getLocations())
             result.location(instance.getId(), serializer.toString(newObjectMemento(instance)));
         for (Entity instance: mgmt.getEntityManager().getEntities()) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -163,7 +163,7 @@ public class BrooklynPersistenceUtils {
         MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(mgmt.getClass().getClassLoader());
         RetryingMementoSerializer<Object> serializer = new RetryingMementoSerializer<Object>(rawSerializer, 1);
         
-        result.planeId(mgmt.getManagementPlaneId());
+        result.planeId(mgmt.getOptionalManagementPlaneId().orNull());
         for (Location instance: mgmt.getLocationManager().getLocations())
             result.location(instance.getId(), serializer.toString(newObjectMemento(instance)));
         for (Entity instance: mgmt.getEntityManager().getEntities()) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/ActivePartialRebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/ActivePartialRebindIteration.java
@@ -131,6 +131,11 @@ public class ActivePartialRebindIteration extends RebindIteration {
     }
     
     @Override
+    protected void initPlaneId() {
+        // managementPlaneId is already initialized, no need to set it on partial rebind
+    }
+    
+    @Override
     protected void preprocessManifestFiles() throws Exception {
         for (CompoundTransformer transformer: transformers) {
             mementoRawData = transformer.transform(mementoRawData);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -401,6 +401,11 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
             if (!alreadyHasMutex) persistingMutex.acquire();
             if (!isActive() && state != ListenerState.STOPPING) return;
             
+            // Writes to the datastore are lossy. We'll just log failures and move on.
+            // (Most) entities will get updated multiple times in their lifecycle
+            // so not a huge deal. planeId does not get updated so if the first
+            // write fails it's not available to the HA cluster at all. That's why it
+            // gets periodically written to the datastore. 
             updatePlaneIdIfTimedOut();
 
             // Atomically switch the delta, so subsequent modifications will be done in the

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -28,8 +28,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
@@ -58,9 +56,12 @@ import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.CountdownTimer;
 import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -84,8 +85,11 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
 
     protected final AtomicLong checkpointLogCount = new AtomicLong();
     private static final int INITIAL_LOG_WRITES = 5;
+    private static final Duration PERSIST_PLANE_ID_PERIOD = Duration.ONE_HOUR;
 
     private static class DeltaCollector {
+        private String planeId;
+
         private Set<Location> locations = Sets.newLinkedHashSet();
         private Set<Entity> entities = Sets.newLinkedHashSet();
         private Set<Policy> policies = Sets.newLinkedHashSet();
@@ -101,7 +105,8 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
         private Set<String> removedCatalogItemIds = Sets.newLinkedHashSet();
 
         public boolean isEmpty() {
-            return locations.isEmpty() && entities.isEmpty() && policies.isEmpty() && 
+            return planeId == null &&
+                    locations.isEmpty() && entities.isEmpty() && policies.isEmpty() && 
                     enrichers.isEmpty() && feeds.isEmpty() &&
                     catalogItems.isEmpty() &&
                     removedEntityIds.isEmpty() && removedLocationIds.isEmpty() && removedPolicyIds.isEmpty() && 
@@ -109,6 +114,10 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                     removedCatalogItemIds.isEmpty();
         }
         
+        public void setPlaneId(String planeId) {
+            this.planeId = planeId;
+        }
+
         public void add(BrooklynObject instance) {
             BrooklynObjectType type = BrooklynObjectType.of(instance);
             getUnsafeCollectionOfType(type).add(instance);
@@ -187,8 +196,18 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
     private final AtomicInteger writeCount = new AtomicInteger(0);
 
     private PersistenceActivityMetrics metrics;
-    
-    public PeriodicDeltaChangeListener(ExecutionContext executionContext, BrooklynMementoPersister persister, PersistenceExceptionHandler exceptionHandler, PersistenceActivityMetrics metrics, Duration period) {
+
+    private CountdownTimer planeIdPersistTimer = CountdownTimer.newInstanceStarted(Duration.ZERO);
+    private Supplier<String> planeIdSupplier;
+
+    public PeriodicDeltaChangeListener(
+            Supplier<String> planeIdSupplier,
+            ExecutionContext executionContext,
+            BrooklynMementoPersister persister,
+            PersistenceExceptionHandler exceptionHandler,
+            PersistenceActivityMetrics metrics,
+            Duration period) {
+        this.planeIdSupplier = planeIdSupplier;
         this.executionContext = executionContext;
         this.persister = persister;
         this.exceptionHandler = exceptionHandler;
@@ -382,6 +401,8 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
             if (!alreadyHasMutex) persistingMutex.acquire();
             if (!isActive() && state != ListenerState.STOPPING) return;
             
+            updatePlaneIdIfTimedOut();
+
             // Atomically switch the delta, so subsequent modifications will be done in the
             // next scheduled persist
             DeltaCollector prevDeltaCollector;
@@ -411,7 +432,10 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                 if (LOG.isTraceEnabled()) LOG.trace("No changes to persist since last delta");
             } else {
                 PersisterDeltaImpl persisterDelta = new PersisterDeltaImpl();
-                
+
+                if (prevDeltaCollector.planeId != null) {
+                    persisterDelta.planeId = prevDeltaCollector.planeId;
+                }
                 for (BrooklynObjectType type: BrooklynPersistenceUtils.STANDARD_BROOKLYN_OBJECT_TYPE_PERSISTENCE_ORDER) {
                     for (BrooklynObject instance: prevDeltaCollector.getCollectionOfType(type)) {
                         try {
@@ -453,6 +477,14 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
         }
     }
     
+    private void updatePlaneIdIfTimedOut() {
+        if (planeIdPersistTimer.isExpired()) {
+            deltaCollector.setPlaneId(planeIdSupplier.get());
+            planeIdPersistTimer = PERSIST_PLANE_ID_PERIOD.countdownTimer();
+        }
+        
+    }
+
     private static String limitedCountString(Collection<?> items) {
         if (items==null) return null;
         int size = items.size();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PersistenceExceptionHandlerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PersistenceExceptionHandlerImpl.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Sets;
 
 public class PersistenceExceptionHandlerImpl implements PersistenceExceptionHandler {
@@ -82,7 +83,14 @@ public class PersistenceExceptionHandlerImpl implements PersistenceExceptionHand
         String errmsg = "delete for memento "+id;
         onErrorImpl(errmsg, e, prevFailedPersisters.add(id));
     }
-    
+
+    @Override
+    public void onUpdatePlaneIdFailed(String planeId, Exception e) {
+        String errmsg = "init planeId " + planeId;
+        String prevFailedId = MoreObjects.firstNonNull(planeId, "null-plane-id");
+        onErrorImpl(errmsg, e, prevFailedPersisters.add(prevFailedId));
+    }
+
     protected void onErrorImpl(String errmsg, Exception e, boolean isNew) {
         // TODO the default behaviour is simply to warn; we should have a "fail_at_end" behaviour,
         // and a way for other subsystems to tune in to such failures

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PersisterDeltaImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PersisterDeltaImpl.java
@@ -39,6 +39,8 @@ import com.google.common.collect.Sets;
 
 public class PersisterDeltaImpl implements Delta, MutableDelta {
     
+    String planeId;
+
     // use multiset?
     
     Collection<LocationMemento> locations = Sets.newLinkedHashSet();
@@ -54,6 +56,11 @@ public class PersisterDeltaImpl implements Delta, MutableDelta {
     Collection<String> removedEnricherIds = Sets.newLinkedHashSet();
     Collection <String> removedFeedIds = Sets.newLinkedHashSet();
     Collection<String> removedCatalogItemIds = Sets.newLinkedHashSet();
+    
+    @Override
+    public String planeId() {
+        return planeId;
+    }
 
     @Override
     public Collection<LocationMemento> locations() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -472,6 +472,10 @@ public abstract class RebindIteration {
     protected void initPlaneId() {
         String persistedPlaneId = mementoRawData.getPlaneId();
         if (persistedPlaneId == null) {
+            if (!mementoRawData.isEmpty()) {
+                LOG.warn("Rebinding against existing persisted state, but no planeId found. Will generate a new one. " +
+                        "Expected if this is the first rebind after upgrading to Brooklyn 0.12.0+");
+            }
             ((LocalManagementContext)managementContext).generateManagementPlaneId();
         } else {
             ((LocalManagementContext)managementContext).setManagementPlaneId(persistedPlaneId);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -76,6 +76,7 @@ import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContex
 import org.apache.brooklyn.core.mgmt.internal.BrooklynObjectManagementMode;
 import org.apache.brooklyn.core.mgmt.internal.BrooklynObjectManagerInternal;
 import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.LocationManagerInternal;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.internal.ManagementTransitionMode;
@@ -235,6 +236,7 @@ public abstract class RebindIteration {
     
     protected void doRun() throws Exception {
         loadManifestFiles();
+        initPlaneId();
         rebuildCatalog();
         instantiateLocationsAndEntities();
         instantiateMementos();
@@ -465,6 +467,15 @@ public abstract class RebindIteration {
         checkEnteringPhase(4);
         
         memento = persistenceStoreAccess.loadMemento(mementoRawData, rebindContext.lookup(), exceptionHandler);
+    }
+
+    protected void initPlaneId() {
+        String persistedPlaneId = mementoRawData.getPlaneId();
+        if (persistedPlaneId == null) {
+            ((LocalManagementContext)managementContext).generateManagementPlaneId();
+        } else {
+            ((LocalManagementContext)managementContext).setManagementPlaneId(persistedPlaneId);
+        }
     }
 
     protected void instantiateAdjuncts(BrooklynObjectInstantiator instantiator) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -52,8 +52,8 @@ import org.apache.brooklyn.core.mgmt.ha.HighAvailabilityManagerImpl;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
-import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils.CreateBackupMode;
+import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.mgmt.rebind.transformer.CompoundTransformer;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -169,6 +170,13 @@ public class RebindManagerImpl implements RebindManager {
             rebinding.set(Boolean.TRUE);
         }
     }
+    
+    private class PlaneIdSupplier implements Supplier<String> {
+        @Override
+        public String get() {
+            return managementContext.getOptionalManagementPlaneId().orNull();
+        }
+    }
 
     public RebindManagerImpl(ManagementContextInternal managementContext) {
         this.managementContext = managementContext;
@@ -238,7 +246,13 @@ public class RebindManagerImpl implements RebindManager {
         
         this.persistenceStoreAccess = checkNotNull(val, "persister");
         
-        this.persistenceRealChangeListener = new PeriodicDeltaChangeListener(managementContext.getServerExecutionContext(), persistenceStoreAccess, exceptionHandler, persistMetrics, periodicPersistPeriod);
+        this.persistenceRealChangeListener = new PeriodicDeltaChangeListener(
+                new PlaneIdSupplier(),
+                managementContext.getServerExecutionContext(),
+                persistenceStoreAccess,
+                exceptionHandler,
+                persistMetrics,
+                periodicPersistPeriod);
         this.persistencePublicChangeListener = new SafeChangeListener(persistenceRealChangeListener);
         
         if (persistenceRunning) {
@@ -278,7 +292,6 @@ public class RebindManagerImpl implements RebindManager {
         LOG.debug("Stopped rebind (persistence), mgmt "+managementContext.getManagementNodeId());
     }
     
-    @SuppressWarnings("unchecked")
     @Override
     public void startReadOnly(final ManagementNodeState mode) {
         if (!ManagementNodeState.isHotProxy(mode)) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BrooklynMementoImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BrooklynMementoImpl.java
@@ -47,6 +47,7 @@ public class BrooklynMementoImpl implements BrooklynMemento, Serializable {
     }
     
     public static class Builder {
+        protected String planeId;
         protected String brooklynVersion = BrooklynVersion.get();
         protected final List<String> applicationIds = Collections.synchronizedList(Lists.<String>newArrayList());
         protected final List<String> topLevelLocationIds = Collections.synchronizedList(Lists.<String>newArrayList());
@@ -58,6 +59,11 @@ public class BrooklynMementoImpl implements BrooklynMemento, Serializable {
         protected final Map<String, CatalogItemMemento> catalogItems = Maps.newConcurrentMap();
 
         
+        public Builder planeId(String val) {
+            planeId = val; return this;
+        }
+        /** @deprecated since 0.11.0; value unused */
+        @Deprecated
         public Builder brooklynVersion(String val) {
             brooklynVersion = val; return this;
         }
@@ -132,6 +138,7 @@ public class BrooklynMementoImpl implements BrooklynMemento, Serializable {
         }
     }
 
+    private String planeId;
     @SuppressWarnings("unused")
     private String brooklynVersion;
     private List<String> applicationIds;
@@ -144,6 +151,7 @@ public class BrooklynMementoImpl implements BrooklynMemento, Serializable {
     private Map<String, CatalogItemMemento> catalogItems;
     
     private BrooklynMementoImpl(Builder builder) {
+        planeId = builder.planeId;
         brooklynVersion = builder.brooklynVersion;
         applicationIds = builder.applicationIds;
         topLevelLocationIds = builder.topLevelLocationIds;
@@ -153,6 +161,11 @@ public class BrooklynMementoImpl implements BrooklynMemento, Serializable {
         enrichers = builder.enrichers;
         feeds = builder.feeds;
         catalogItems = builder.catalogItems;
+    }
+
+    @Override
+    public String getPlaneId() {
+        return planeId;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BrooklynMementoManifestImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BrooklynMementoManifestImpl.java
@@ -38,6 +38,7 @@ public class BrooklynMementoManifestImpl implements BrooklynMementoManifest, Ser
     }
     
     public static class Builder {
+        protected String planeId;
         protected String brooklynVersion;
         protected final Map<String, EntityMementoManifest> entityIdToManifest = Maps.newConcurrentMap();
         protected final Map<String, String> locationIdToType = Maps.newConcurrentMap();
@@ -45,7 +46,12 @@ public class BrooklynMementoManifestImpl implements BrooklynMementoManifest, Ser
         protected final Map<String, String> enricherIdToType = Maps.newConcurrentMap();
         protected final Map<String, String> feedIdToType = Maps.newConcurrentMap();
         protected final Map<String, CatalogItemMemento> catalogItems = Maps.newConcurrentMap();
-        
+
+        public Builder planeId(String planeId) {
+            this.planeId = planeId; return this;
+        }
+        /** @deprecated since 0.11.0; value is not used */
+        @Deprecated
         public Builder brooklynVersion(String val) {
             brooklynVersion = val; return this;
         }
@@ -103,6 +109,7 @@ public class BrooklynMementoManifestImpl implements BrooklynMementoManifest, Ser
         }
     }
 
+    private final String planeId;
     private final Map<String, EntityMementoManifest> entityIdToManifest;
     private final Map<String, String> locationIdToType;
     private final Map<String, String> policyIdToType;
@@ -111,12 +118,18 @@ public class BrooklynMementoManifestImpl implements BrooklynMementoManifest, Ser
     private Map<String, CatalogItemMemento> catalogItems;
     
     private BrooklynMementoManifestImpl(Builder builder) {
+        planeId = builder.planeId;
         entityIdToManifest = builder.entityIdToManifest;
         locationIdToType = builder.locationIdToType;
         policyIdToType = builder.policyIdToType;
         enricherIdToType = builder.enricherIdToType;
         feedIdToType = builder.feedIdToType;
         catalogItems = builder.catalogItems;
+    }
+
+    @Override
+    public String getPlaneId() {
+        return planeId;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MutableBrooklynMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MutableBrooklynMemento.java
@@ -51,6 +51,7 @@ public class MutableBrooklynMemento implements BrooklynMemento {
 
     private static final long serialVersionUID = -442895028005849060L;
     
+    private String planeId;
     private final Collection<String> applicationIds = Sets.newLinkedHashSet();
     private final Collection<String> topLevelLocationIds = Sets.newLinkedHashSet();
     private final Map<String, EntityMemento> entities = Maps.newLinkedHashMap();
@@ -68,6 +69,7 @@ public class MutableBrooklynMemento implements BrooklynMemento {
     }
     
     public void reset(BrooklynMemento memento) {
+        planeId = memento.getPlaneId();
         applicationIds.addAll(memento.getApplicationIds());
         topLevelLocationIds.addAll(memento.getTopLevelLocationIds());
         for (String entityId : memento.getEntityIds()) {
@@ -76,6 +78,10 @@ public class MutableBrooklynMemento implements BrooklynMemento {
         for (String locationId : memento.getLocationIds()) {
             locations.put(locationId, checkNotNull(memento.getLocationMemento(locationId), locationId));
         }
+    }
+
+    public void setPlaneId(String planeId) {
+        this.planeId = planeId;
     }
 
     public void updateEntityMemento(EntityMemento memento) {
@@ -188,6 +194,11 @@ public class MutableBrooklynMemento implements BrooklynMemento {
      */
     public void removeCatalogItems(Collection<String> ids) {
         catalogItems.keySet().removeAll(ids);
+    }
+    
+    @Override
+    public String getPlaneId() {
+        return planeId;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformer.java
@@ -353,6 +353,7 @@ public class CompoundTransformer {
         }
         
         return BrooklynMementoRawData.builder()
+                .planeId(rawData.getPlaneId())
                 .entities(entities)
                 .locations(locations)
                 .policies(policies)

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/impl/DeleteOrphanedStateTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/transformer/impl/DeleteOrphanedStateTransformer.java
@@ -97,6 +97,7 @@ public class DeleteOrphanedStateTransformer extends CompoundTransformer {
         LOG.info("Deleting {} orphaned feed{} (of {}): {}", new Object[] {feedsToDelete.size(), Strings.s(feedsToDelete.size()), input.getFeeds().size(), feedsToDelete});
         
         return BrooklynMementoRawData.builder()
+                .planeId(input.getPlaneId())
                 .brooklynVersion(input.getBrooklynVersion())
                 .catalogItems(input.getCatalogItems())
                 .entities(input.getEntities())

--- a/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerPaths.java
+++ b/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerPaths.java
@@ -224,7 +224,7 @@ public class BrooklynServerPaths {
     
     public static File getBrooklynWebTmpDir(ManagementContext mgmt) {
         String brooklynMgmtBaseDir = getMgmtBaseDir(mgmt);
-        File webappTempDir = new File(Os.mergePaths(brooklynMgmtBaseDir, "planes", mgmt.getManagementPlaneId(), mgmt.getManagementNodeId(), "jetty"));
+        File webappTempDir = new File(Os.mergePaths(brooklynMgmtBaseDir, "planes", mgmt.getManagementNodeId(), "jetty"));
         try {
             FileUtils.forceMkdir(webappTempDir);
             Os.deleteOnExitRecursivelyAndEmptyParentsUpTo(webappTempDir, new File(brooklynMgmtBaseDir)); 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/ImmutableManagementPlaneSyncRecord.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/ImmutableManagementPlaneSyncRecord.java
@@ -23,16 +23,23 @@ import java.util.Map;
 import org.apache.brooklyn.api.mgmt.ha.ManagementNodeSyncRecord;
 import org.apache.brooklyn.api.mgmt.ha.ManagementPlaneSyncRecord;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 public class ImmutableManagementPlaneSyncRecord implements ManagementPlaneSyncRecord {
+    private final String planeId;
     private final String masterNodeId;
     private final Map<String, ManagementNodeSyncRecord> managementNodes;
 
-    ImmutableManagementPlaneSyncRecord(String masterNodeId, Map<String, ManagementNodeSyncRecord> nodes) {
+    ImmutableManagementPlaneSyncRecord(String planeId, String masterNodeId, Map<String, ManagementNodeSyncRecord> nodes) {
+        this.planeId = planeId;
         this.masterNodeId = masterNodeId;
         this.managementNodes = ImmutableMap.copyOf(nodes);
+    }
+    
+    @Override
+    public String getPlaneId() {
+        return planeId;
     }
     
     @Override
@@ -47,11 +54,19 @@ public class ImmutableManagementPlaneSyncRecord implements ManagementPlaneSyncRe
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("master", masterNodeId).add("nodes", managementNodes.keySet()).toString();
+        return MoreObjects.toStringHelper(this)
+                .add("planeId", planeId)
+                .add("master", masterNodeId)
+                .add("nodes", managementNodes.keySet())
+                .toString();
     }
     
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).add("master", masterNodeId).add("nodes", managementNodes).toString();
+        return MoreObjects.toStringHelper(this)
+                .add("planeId", planeId)
+                .add("master", masterNodeId)
+                .add("nodes", managementNodes)
+                .toString();
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/MutableManagementPlaneSyncRecord.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/MutableManagementPlaneSyncRecord.java
@@ -26,8 +26,14 @@ import org.apache.brooklyn.api.mgmt.ha.ManagementPlaneSyncRecord;
 import com.google.common.collect.Maps;
 
 public class MutableManagementPlaneSyncRecord implements ManagementPlaneSyncRecord {
+    private String planeId;
     private String masterNodeId;
     private Map<String, ManagementNodeSyncRecord> managementNodes = Maps.newConcurrentMap();
+    
+    @Override
+    public String getPlaneId() {
+        return planeId;
+    }
 
     @Override
     public String getMasterNodeId() {
@@ -45,7 +51,11 @@ public class MutableManagementPlaneSyncRecord implements ManagementPlaneSyncReco
     }
 
     public ImmutableManagementPlaneSyncRecord snapshot() {
-        return new ImmutableManagementPlaneSyncRecord(masterNodeId, managementNodes);
+        return new ImmutableManagementPlaneSyncRecord(planeId, masterNodeId, managementNodes);
+    }
+    
+    public void setPlaneId(String planeId) {
+        this.planeId = planeId;
     }
     
     public void setMasterNodeId(String masterNodeId) {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.mgmt.rebind;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 
 import java.io.File;
@@ -75,12 +76,7 @@ public class ManagementPlaneIdTest {
     @Test
     public void testUninitializedThrows() {
         ManagementContext mgmt = new LocalManagementContext(BrooklynProperties.Factory.newEmpty());
-        try {
-            mgmt.getManagementPlaneId();
-            Asserts.shouldHaveFailedPreviously("managementPlaneId not initialized");
-        } catch (NullPointerException e) {
-            Asserts.expectedFailureContains(e, "not initialized");
-        }
+        assertFalse(mgmt.getOptionalManagementPlaneId().isPresent(), "expected managementPlaneId to be absent");
     }
     
     @Test
@@ -113,7 +109,7 @@ public class ManagementPlaneIdTest {
 
         LocalManagementContext rebindMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.DISABLED);
 
-        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+        assertEquals(origMgmt.getOptionalManagementPlaneId(), rebindMgmt.getOptionalManagementPlaneId());
     }
 
 
@@ -135,7 +131,7 @@ public class ManagementPlaneIdTest {
         Asserts.succeedsEventually(new Runnable() {
             @Override
             public void run() {
-                assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+                assertEquals(origMgmt.getOptionalManagementPlaneId(), rebindMgmt.getOptionalManagementPlaneId());
             }
         });
     }
@@ -148,7 +144,7 @@ public class ManagementPlaneIdTest {
         Asserts.succeedsEventually(new Runnable() {
             @Override
             public void run() {
-                assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+                assertEquals(origMgmt.getOptionalManagementPlaneId(), rebindMgmt.getOptionalManagementPlaneId());
             }
         });
 
@@ -164,7 +160,7 @@ public class ManagementPlaneIdTest {
             }
         });
 
-        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+        assertEquals(origMgmt.getOptionalManagementPlaneId(), rebindMgmt.getOptionalManagementPlaneId());
     }
     
     @Test
@@ -175,7 +171,7 @@ public class ManagementPlaneIdTest {
 
         LocalManagementContext rebindMgmt = createManagementContextWithBackups(PersistMode.AUTO, HighAvailabilityMode.AUTO);
 
-        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+        assertEquals(origMgmt.getOptionalManagementPlaneId(), rebindMgmt.getOptionalManagementPlaneId());
 
         String backupContainer = BrooklynServerPaths.newBackupPersistencePathResolver(rebindMgmt).resolve();
         
@@ -190,7 +186,7 @@ public class ManagementPlaneIdTest {
         
         File planeIdFile = new File(promotionFolders[0], BrooklynMementoPersisterToObjectStore.PLANE_ID_FILE_NAME);
         String planeId = readFile(planeIdFile);
-        assertEquals(origMgmt.getManagementPlaneId(), planeId);
+        assertEquals(origMgmt.getOptionalManagementPlaneId().get(), planeId);
     }
     
     @Test
@@ -239,7 +235,7 @@ public class ManagementPlaneIdTest {
             @Override
             public Void call() throws Exception {
                 String planeId = readFile(planeIdFile);
-                assertEquals(mgmt.getManagementPlaneId(), planeId);
+                assertEquals(mgmt.getOptionalManagementPlaneId().get(), planeId);
                 return null;
             }
         });

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.rebind;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
+import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore;
+import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
+import org.apache.brooklyn.core.mgmt.persist.PersistMode;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+import org.apache.brooklyn.core.server.BrooklynServerPaths;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ManagementPlaneIdTest {
+    private File mementoDir;
+
+    protected ClassLoader classLoader = getClass().getClassLoader();
+
+    private Collection<ManagementContext> managementContextForTermination;
+
+    @BeforeMethod
+    public void setUp() {
+        mementoDir = Os.newTempDir(getClass());
+        managementContextForTermination = new ArrayList<>();
+    }
+
+    @AfterMethod(alwaysRun=true)
+    public void tearDown() throws Exception {
+        if (managementContextForTermination != null) {
+            for (ManagementContext mgmt : managementContextForTermination) {
+                Entities.destroyAll(mgmt);
+            }
+        }
+        if (mementoDir != null) FileBasedObjectStore.deleteCompletely(mementoDir);
+    }
+
+    @Test
+    public void testUninitializedThrows() {
+        ManagementContext mgmt = new LocalManagementContext(BrooklynProperties.Factory.newEmpty());
+        try {
+            mgmt.getManagementPlaneId();
+            Asserts.shouldHaveFailedPreviously("managementPlaneId not initialized");
+        } catch (NullPointerException e) {
+            Asserts.expectedFailureContains(e, "not initialized");
+        }
+    }
+    
+    @Test
+    public void testPlaneIdPersists() throws Exception {
+        final ManagementContext mgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.DISABLED);
+        checkPlaneIdPersisted(mgmt);
+    }
+
+    @Test
+    public void testPlaneIdRolledBack() throws Exception {
+        final LocalManagementContext mgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.AUTO);
+
+        checkPlaneIdPersisted(mgmt);
+        final String oldPlaneId = mgmt.getOptionalManagementPlaneId().get();
+        mgmt.setManagementPlaneId(Strings.makeRandomId(8));
+        assertNotEquals(oldPlaneId, mgmt.getOptionalManagementPlaneId().get());
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(oldPlaneId, mgmt.getOptionalManagementPlaneId().get());
+            }
+        });
+    }
+
+    @Test
+    public void testColdRebindInitialisesPlaneId() throws Exception {
+        final LocalManagementContext origMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.DISABLED);
+        checkPlaneIdPersisted(origMgmt);
+        Entities.destroyAll(origMgmt);
+
+        LocalManagementContext rebindMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.DISABLED);
+
+        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+    }
+
+
+    @DataProvider
+    public Object[][] haSlaveModes() {
+        return new Object[][] {
+            {HighAvailabilityMode.AUTO},
+            {HighAvailabilityMode.STANDBY},
+            {HighAvailabilityMode.HOT_STANDBY},
+            {HighAvailabilityMode.HOT_BACKUP},
+        };
+    }
+
+    @Test(dataProvider="haSlaveModes")
+    public void testHaRebindInitialisesPlaneId(HighAvailabilityMode slaveMode) throws Exception {
+        final LocalManagementContext origMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.AUTO);
+        final LocalManagementContext rebindMgmt = createManagementContext(PersistMode.AUTO, slaveMode);
+
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+            }
+        });
+    }
+
+    @Test
+    public void testHaFailoverKeepsPlaneId() throws Exception {
+        final LocalManagementContext origMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.MASTER);
+        final LocalManagementContext rebindMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.STANDBY);
+
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+            }
+        });
+
+        Entities.destroyAll(origMgmt);
+
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertEquals(rebindMgmt.getHighAvailabilityManager().getNodeState(), ManagementNodeState.MASTER);
+                if (rebindMgmt.getRebindManager().isAwaitingInitialRebind()) {
+                    throw new IllegalStateException("still rebinding");
+                }
+            }
+        });
+
+        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+    }
+    
+    @Test
+    public void testPlaneIdBackedUp() throws Exception {
+        final LocalManagementContext origMgmt = createManagementContext(PersistMode.AUTO, HighAvailabilityMode.AUTO);
+        checkPlaneIdPersisted(origMgmt);
+        Entities.destroyAll(origMgmt);
+
+        LocalManagementContext rebindMgmt = createManagementContextWithBackups(PersistMode.AUTO, HighAvailabilityMode.AUTO);
+
+        assertEquals(origMgmt.getManagementPlaneId(), rebindMgmt.getManagementPlaneId());
+
+        String backupContainer = BrooklynServerPaths.newBackupPersistencePathResolver(rebindMgmt).resolve();
+        
+        File[] promotionFolders = new File(backupContainer).listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.contains("promotion");
+            }
+        });
+        
+        assertEquals(promotionFolders.length, 1);
+        
+        File planeIdFile = new File(promotionFolders[0], BrooklynMementoPersisterToObjectStore.PLANE_ID_FILE_NAME);
+        String planeId = readFile(planeIdFile);
+        assertEquals(origMgmt.getManagementPlaneId(), planeId);
+    }
+    
+    @Test
+    public void testFullPersist() throws Exception {
+        final LocalManagementContext origMgmt = createManagementContext(PersistMode.DISABLED, HighAvailabilityMode.DISABLED);
+        origMgmt.getRebindManager().getPersister().enableWriteAccess();
+        origMgmt.getRebindManager().forcePersistNow(true, null);
+        checkPlaneIdPersisted(origMgmt);
+    }
+    
+    protected LocalManagementContext createManagementContext(PersistMode persistMode, HighAvailabilityMode haMode) {
+        return createManagementContext(persistMode, haMode, false);
+    }
+    
+    protected LocalManagementContext createManagementContextWithBackups(PersistMode persistMode, HighAvailabilityMode haMode) {
+        return createManagementContext(persistMode, haMode, true);
+    }
+    
+    protected LocalManagementContext createManagementContext(PersistMode persistMode, HighAvailabilityMode haMode, boolean backedUp) {
+        BrooklynProperties props = BrooklynProperties.Factory.newEmpty();
+        props.put(BrooklynServerConfig.PERSISTENCE_BACKUPS_DIR, mementoDir);
+        LocalManagementContext mgmt = RebindTestUtils.managementContextBuilder(mementoDir, classLoader)
+                .persistPeriodMillis(1)
+                .persistMode(persistMode)
+                .haMode(haMode)
+                .enablePersistenceBackups(backedUp)
+                .emptyCatalog(true)
+                .properties(props)
+                .enableOsgi(false)
+                .buildStarted();
+        markForTermination(mgmt);
+        return mgmt;
+    }
+
+    private void markForTermination(ManagementContext mgmt) {
+        managementContextForTermination.add(mgmt);
+    }
+
+    protected static String readFile(File planeIdFile) throws IOException {
+        return new String(Files.readAllBytes(planeIdFile.toPath()), StandardCharsets.UTF_8);
+    }
+
+    protected void checkPlaneIdPersisted(final ManagementContext mgmt) {
+        final File planeIdFile = new File(mementoDir, BrooklynMementoPersisterToObjectStore.PLANE_ID_FILE_NAME);
+        Asserts.succeedsEventually(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                String planeId = readFile(planeIdFile);
+                assertEquals(mgmt.getManagementPlaneId(), planeId);
+                return null;
+            }
+        });
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
@@ -55,6 +55,7 @@ import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.javalang.Serializers;
 import org.apache.brooklyn.util.javalang.Serializers.ObjectReplacer;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -226,6 +227,7 @@ public class RebindTestUtils {
             }
             if (forLive) {
                 unstarted = new LocalManagementContext(properties);
+                unstarted.generateManagementPlaneId();
             } else {
                 unstarted = LocalManagementContextForTests.builder(true).useProperties(properties).disableOsgi(!enableOsgi).build();
             }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
@@ -169,6 +169,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
 
         // Assert has expected config/fields
         assertEquals(newApp.getId(), origApp.getId());
+        assertEquals(origManagementContext.getManagementPlaneId(), newManagementContext.getManagementPlaneId());
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
@@ -169,7 +169,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
 
         // Assert has expected config/fields
         assertEquals(newApp.getId(), origApp.getId());
-        assertEquals(origManagementContext.getManagementPlaneId(), newManagementContext.getManagementPlaneId());
+        assertEquals(origManagementContext.getOptionalManagementPlaneId(), newManagementContext.getOptionalManagementPlaneId());
     }
     
     @Test

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -571,7 +571,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
         if (persistMode == PersistMode.DISABLED) {
             LOG.info("Persistence disabled");
             objectStore = null;
-            
+            ((LocalManagementContext)managementContext).generateManagementPlaneId();
         } else {
             try {
                 if (persistenceLocation == null) {

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/AbstractCleanOrphanedStateTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/AbstractCleanOrphanedStateTest.java
@@ -52,6 +52,7 @@ public abstract class AbstractCleanOrphanedStateTest extends RebindTestFixtureWi
         @Override
         public BrooklynMementoRawData apply(BrooklynMementoRawData input) {
             return BrooklynMementoRawData.builder()
+                    .planeId(input.getPlaneId())
                     .brooklynVersion(input.getBrooklynVersion())
                     .catalogItems(input.getCatalogItems())
                     .entities(MutableMap.<String, String>builder().putAll(input.getEntities()).removeAll(deletions.entities).build())

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
@@ -101,7 +101,7 @@ public class BrooklynLauncherTest {
                 .start();
         
         ManagementContext managementContext = launcher.getServerDetails().getManagementContext();
-        String expectedTempDir = Os.mergePaths(Os.home(), dataDirName, "planes", managementContext.getManagementPlaneId(), managementContext.getManagementNodeId(), "jetty");
+        String expectedTempDir = Os.mergePaths(Os.home(), dataDirName, "planes", managementContext.getManagementNodeId(), "jetty");
         
         File webappTempDir = launcher.getServerDetails().getWebServer().getWebappTempDir();
         assertEquals(webappTempDir.getAbsolutePath(), expectedTempDir);


### PR DESCRIPTION
Some considerations on where to place the planeId initialisation:
 * BrooklynMemento (RebindManager). `planeId` will be available only after rebind, so it will
   be available to MASTER nodes only (and potentially HOT_STANDBY)
 * ManagementPlaneSyncRecord (HighAvailabilityManager). Used only when HA is enabled. When HA is disabled
   HighAvailabilityManager is not initialised, doesn't access the store at all, no
   records are getting written.
 * Separate init step in BrooklynLauncher. Early in the lifecycle so users need not to care
   too much when they are allowed to read it. On the other hand it's not encapsulated so
   need to touch all places that use persistence (i.e. launcher, copy-state, backup). Can
   only read from the store at this point, write access is not enabled yet. If HA is configured
   store writes are enabled only after becoming master. Writing to the store in this case would
   be risky, even if we know that it's a clean state (no planeId file). Better leave only the
   master update the store.

Because of the above I decided to go for a mixed approach:
  * persist the `planeId` immediately after starting persistence (i.e. MASTER when HA) and repeat hourly
  * don't overwrite persisted store `planeId` if different
  * init `planeId` as part of the rebind sequence; if no `planeId` exists in store generate one
  * init `planeId` when reading the management records so we have it initialized for non-`MASTER` nodes as well; don't generate one if not in persisted store