### PR TITLE
BundleMaker copy fix

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
@@ -244,8 +244,9 @@ public class BundleMaker {
             Enumeration<? extends ZipEntry> zfe = zf.entries();
             while (zfe.hasMoreElements()) {
                 ZipEntry ze = zfe.nextElement();
+                ZipEntry newZipEntry = new ZipEntry(ze.getName());
                 if (filter.apply(ze.getName())) {
-                    zout.putNextEntry(ze);
+                    zout.putNextEntry(newZipEntry);
                     InputStream zin = zf.getInputStream(ze);
                     Streams.copy(zin, zout);
                     Streams.closeQuietly(zin);


### PR DESCRIPTION
When cloning a zip, we were using the ZipEntry from the input zip.
This causes issues, as the info in the input ZipEntry is not necessarily correct for the output zip.
Specifically, compressed size can be different. This causes exceptions when the wrong amount of bytes are written.

This change means that a new ZipEntry is created, and the info from the input ZipEntry is ignored.