### PR TITLE
Adds authSudo support (for sudo’ing with password)

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/ShellTool.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/ShellTool.java
@@ -43,7 +43,9 @@ public interface ShellTool {
     // config which applies to calls:
     
     public static final ConfigKey<Boolean> PROP_RUN_AS_ROOT = newConfigKey("runAsRoot", "When running a script, whether to run as root", Boolean.FALSE);
-    
+    public static final ConfigKey<Boolean> PROP_AUTH_SUDO = newConfigKey("authSudo", "When to run `sudo` commands with password authentication", Boolean.FALSE);
+    public static final ConfigKey<String> PROP_PASSWORD = newStringConfigKey("password", "Password to use (e.g. for authSudo, or for ssh to connect)", null);
+
     public static final ConfigKey<OutputStream> PROP_OUT_STREAM = newConfigKey(OutputStream.class, "out", "Stream to which to capture stdout");
     public static final ConfigKey<OutputStream> PROP_ERR_STREAM = newConfigKey(OutputStream.class, "err", "Stream to which to capture stderr");
     

--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
@@ -66,7 +66,6 @@ public interface SshTool extends ShellTool {
     public static final ConfigKey<String> PROP_HOST = newStringConfigKey("host", "Host to connect to (required)", null);
     public static final ConfigKey<Integer> PROP_PORT = newConfigKey("port", "Port on host to connect to", 22);
     public static final ConfigKey<String> PROP_USER = newConfigKey("user", "User to connect as", System.getProperty("user.name"));
-    public static final ConfigKey<String> PROP_PASSWORD = newStringConfigKey("password", "Password to use to connect", null);
     
     public static final ConfigKey<String> PROP_PRIVATE_KEY_FILE = newStringConfigKey("privateKeyFile", "the path of an ssh private key file; leave blank to use defaults (i.e. ~/.ssh/id_rsa and id_dsa)", null);
     public static final ConfigKey<String> PROP_PRIVATE_KEY_DATA = newStringConfigKey("privateKeyData", "the private ssh key (e.g. contents of an id_rsa or id_dsa file)", null);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1702,14 +1702,19 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                 }
 
                 String initialUser = initialCredentials.getUser();
-
+                boolean authSudo = initialCredentials.shouldAuthenticateSudo();
+                Optional<String> password = initialCredentials.getOptionalPassword();
+                
                 // TODO Retrying lots of times as workaround for vcloud-director. There the guest customizations
                 // can cause the VM to reboot shortly after it was ssh'able.
-                Map<String,Object> execProps = Maps.newLinkedHashMap();
-                execProps.put(ShellTool.PROP_RUN_AS_ROOT.getName(), true);
-                execProps.put(SshTool.PROP_ALLOCATE_PTY.getName(), true);
-                execProps.put(SshTool.PROP_SSH_TRIES.getName(), 50);
-                execProps.put(SshTool.PROP_SSH_TRIES_TIMEOUT.getName(), 10*60*1000);
+                Map<String,Object> execProps = MutableMap.<String, Object>builder()
+                        .put(ShellTool.PROP_RUN_AS_ROOT.getName(), true)
+                        .put(SshTool.PROP_AUTH_SUDO.getName(), authSudo)
+                        .put(SshTool.PROP_ALLOCATE_PTY.getName(), true)
+                        .putIfNotNull(SshTool.PROP_PASSWORD.getName(), authSudo ? password.orNull() : null)
+                        .put(SshTool.PROP_SSH_TRIES.getName(), 50)
+                .put(SshTool.PROP_SSH_TRIES_TIMEOUT.getName(), 10*60*1000)
+                .build();
 
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("VM {}: executing user creation/setup via {}@{}; commands: {}", new Object[] {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/ssh/BashCommands.java
@@ -91,10 +91,21 @@ public class BashCommands {
      * If null is supplied, it is returned (sometimes used to indicate no command desired).
      */
     public static String sudo(String command) {
+        if (command==null) return null;
         if (command.startsWith("( ") || command.endsWith(" &"))
             return sudoNew(command);
         else
             return sudoOld(command);
+    }
+
+    public static String authSudo(String command, String password) {
+        checkNotNull(password, "password must not be null");
+        if (command==null) return null;
+        if (command.startsWith("( ") || command.endsWith(" &")) {
+            throw new UnsupportedOperationException("authSudo supports only simple commands, not those wrapped in parentheses or backgrounded: cmd="+command);
+        }
+        // some OS's (which?) fail if you try running sudo when you're already root (dumb but true)
+        return format("( if test \"$UID\" -eq 0; then ( %s ); else echo -e '%s\\n' | sudo -E -S -- %s; fi )", command, password, command);
     }
 
     // TODO would like to move away from sudoOld -- but needs extensive testing!


### PR DESCRIPTION
Required for some clouds (e.g. azure-arm), when using `useJcloudsSshInit: false`

Tested on `azure-arm` using a location like that below (which previously failed):

```
brooklyn.catalog:
  id: azure-arm-lon-centos7
  name: "Azure ARM UK South Centos 7.3"
  itemType: location
  item:
    type: jclouds:azurecompute-arm
    brooklyn.config:
      identity: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
      credential: xxxxxxxx
      endpoint: https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
      oauth.endpoint: https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/oauth2/token
      jclouds.azurecompute.arm.publishers: OpenLogic
      jclouds.azurecompute.operation.timeout: 120000
  
      jclouds.compute.resourcename-prefix: myprefix
      useJcloudsSshInit: false
      destroyOnFailure: false
      machineCreateAttempts: 1
      logCredentials: true

      installDevUrandom: true
      osVersionRegex: 7.3
      region: uksouth
      minRam: 2000
      waitForSshable: 10m
      waitForConnectable: 10m
      user: myname
```

The reason this works is that `authSudo` is set in `JcloudsLocation` based on the jclouds `LoginCredentialsshouldAuthenticateSudo()`. jclouds gets this from a combination of the `jclouds.image.authenticate-sudo` property and the equivalent template option (https://github.com/jclouds/jclouds/blob/rel/jclouds-2.0.1/compute/src/main/java/org/jclouds/compute/options/TemplateOptions.java#L196). For azure-arm, jclouds hard-codes the default to true so it works out-of-the-box (see https://github.com/jclouds/jclouds-labs/blob/rel/jclouds-labs-2.0.1/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureComputeProviderMetadata.java#L96).