### PR TITLE
Fix itests

### DIFF
--- a/karaf/itests/pom.xml
+++ b/karaf/itests/pom.xml
@@ -148,6 +148,7 @@
                         <configuration>
                             <features>
                                 <feature>brooklyn-core</feature>
+                                <feature>brooklyn-locations-jclouds</feature>
                             </features>
                             <descriptors>
                                 <descriptor>file:${project.build.directory}/features.xml</descriptor>

--- a/karaf/itests/src/test/java/org/apache/brooklyn/karaf/itests/FeatureInstallationTest.java
+++ b/karaf/itests/src/test/java/org/apache/brooklyn/karaf/itests/FeatureInstallationTest.java
@@ -76,7 +76,7 @@ public class FeatureInstallationTest extends TestBase {
                 editConfigurationFileExtend(
                     "etc/org.ops4j.pax.url.mvn.cfg",
                     "org.ops4j.pax.url.mvn.repositories",
-                    "file:"+System.getProperty("features.repo")+"@id=local@snapshots@releases"),
+                    "file:"+System.getProperty("features.repo")+"@id=local@snapshots"),
                 logLevel(LogLevelOption.LogLevel.INFO),
         };
     }


### PR DESCRIPTION
Without these fixes, it fails if the local .m2 doesn't already have the pre-built artifacts it needs.

For example, the command below fails if your local .m2 is empty. I think this is important for being able to build RCs cleanly, rather than it relying on finding existing artifacts on the file system.
```
mvn clean install -Dmaven.repo.local=/Users/aledsage/temp/mvn-repo-for-itest-testing
```
The failures were:
```
  FeatureInstallationTest.testBrooklynApiFeature » Multi Error
  FeatureInstallationTest.testBrooklynCoreFeature » Multi Error
  FeatureInstallationTest.testBrooklynLocationsJcloudsFeature » Multi Error
```
with errors like:
```
2017-04-11 19:53:22,005 | WARN  | pool-28-thread-1 | AetherBasedResolver              | 7 - org.ops4j.pax.url.mvn - 2.5.2 | Error resolving artifact org.apache.brooklyn:brooklyn-api:jar:0.11
.0: [Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in central (http://repo1.maven.org/maven2/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in s
pring.ebr.release (http://repository.springsource.com/maven/bundles/release/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in spring.ebr.external (http://repository.s
pringsource.com/maven/bundles/external/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in gemini (http://zodiac.springsource.com/maven/bundles/release/), Could not fin
d artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in local (file:/Users/aledsage/repos/apache/brooklyn/brooklyn-server/karaf/itests/target/features-repo@releases/)]
java.io.IOException: Error resolving artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0: [Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in central (http://repo1.maven
.org/maven2/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in spring.ebr.release (http://repository.springsource.com/maven/bundles/release/), Could not find artifact 
org.apache.brooklyn:brooklyn-api:jar:0.11.0 in spring.ebr.external (http://repository.springsource.com/maven/bundles/external/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:
0.11.0 in gemini (http://zodiac.springsource.com/maven/bundles/release/), Could not find artifact org.apache.brooklyn:brooklyn-api:jar:0.11.0 in local (file:/Users/aledsage/repos/apache/broo
klyn/brooklyn-server/karaf/itests/target/features-repo@releases/)]
```