### PR TITLE
Fix itest for running backgrounded

### DIFF
--- a/karaf/itests/src/test/java/org/apache/brooklyn/karaf/itests/FeatureInstallationTest.java
+++ b/karaf/itests/src/test/java/org/apache/brooklyn/karaf/itests/FeatureInstallationTest.java
@@ -17,6 +17,7 @@
 package org.apache.brooklyn.karaf.itests;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureSecurity;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
@@ -71,6 +72,7 @@ public class FeatureInstallationTest extends TestBase {
         return new Option[]{
                 karafDistributionConfiguration().frameworkUrl(karafUrl).name("Apache Karaf").unpackDirectory(new File("target/exam")),
                 configureSecurity().disableKarafMBeanServerBuilder(),
+                configureConsole().ignoreLocalConsole(),
                 keepRuntimeFolder(),
                 editConfigurationFilePut("etc/system.properties", "features.xml", System.getProperty("features.xml")),
                 editConfigurationFileExtend(


### PR DESCRIPTION
Without this, if you run:
```
nohup mvn clean install ... < /dev/null &
```
then your background process is stopped (according to `jobs`). When you foreground the process again (via `fg %1`) then it reports the tests have failed with the errors below:
```
22:12:34.027 [main] DEBUG o.o.p.e.k.c.i.KarafTestContainer - Shutting down the test container (Pax Runner)
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 1,175.983 sec <<< FAILURE! - in org.apache.brooklyn.karaf.itests.FeatureInstallationTest
org.apache.brooklyn.karaf.itests.FeatureInstallationTest  Time elapsed: 1,175.981 sec  <<< ERROR!
java.lang.RuntimeException: Cannot get the remote bundle context
        at org.ops4j.pax.exam.rbc.client.intern.RemoteBundleContextClientImpl.getRemoteBundleContext(RemoteBundleContextClientImpl.java:255)
        at org.ops4j.pax.exam.rbc.client.intern.RemoteBundleContextClientImpl.waitForState(RemoteBundleContextClientImpl.java:211)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.waitForState(KarafTestContainer.java:580)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.startKaraf(KarafTestContainer.java:230)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.start(KarafTestContainer.java:180)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.setUp(EagerSingleStagedReactor.java:86)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.beforeClass(EagerSingleStagedReactor.java:136)
        at org.ops4j.pax.exam.spi.reactors.ReactorManager.beforeClass(ReactorManager.java:448)
        at org.ops4j.pax.exam.junit.impl.ProbeRunner.run(ProbeRunner.java:97)
        at org.ops4j.pax.exam.junit.PaxExam.run(PaxExam.java:93)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
Caused by: java.rmi.NotBoundException: f39a285c-00da-49bc-b968-111ec37756be
        at sun.rmi.registry.RegistryImpl.lookup(RegistryImpl.java:209)
        at sun.rmi.registry.RegistryImpl_Skel.dispatch(Unknown Source)
        at sun.rmi.server.UnicastServerRef.oldDispatch(UnicastServerRef.java:450)
        at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:294)
        at sun.rmi.transport.Transport$1.run(Transport.java:200)
        at sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683)
        at java.security.AccessController.doPrivileged(Native Method)
        at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
        at sun.rmi.transport.StreamRemoteCall.exceptionReceivedFromServer(StreamRemoteCall.java:276)
        at sun.rmi.transport.StreamRemoteCall.executeCall(StreamRemoteCall.java:253)
        at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:379)
        at sun.rmi.registry.RegistryImpl_Stub.lookup(Unknown Source)
        at org.ops4j.pax.exam.rbc.client.intern.RemoteBundleContextClientImpl.getRemoteBundleContext(RemoteBundleContextClientImpl.java:242)
        at org.ops4j.pax.exam.rbc.client.intern.RemoteBundleContextClientImpl.waitForState(RemoteBundleContextClientImpl.java:211)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.waitForState(KarafTestContainer.java:580)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.startKaraf(KarafTestContainer.java:230)
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.start(KarafTestContainer.java:180)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.setUp(EagerSingleStagedReactor.java:86)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.beforeClass(EagerSingleStagedReactor.java:136)
        at org.ops4j.pax.exam.spi.reactors.ReactorManager.beforeClass(ReactorManager.java:448)
        at org.ops4j.pax.exam.junit.impl.ProbeRunner.run(ProbeRunner.java:97)
        at org.ops4j.pax.exam.junit.PaxExam.run(PaxExam.java:93)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)

org.apache.brooklyn.karaf.itests.FeatureInstallationTest  Time elapsed: 1,175.983 sec  <<< ERROR!
java.lang.RuntimeException: Container never came up
        at org.ops4j.pax.exam.karaf.container.internal.KarafTestContainer.stop(KarafTestContainer.java:550)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.tearDown(EagerSingleStagedReactor.java:118)
        at org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactor.afterClass(EagerSingleStagedReactor.java:132)
        at org.ops4j.pax.exam.spi.reactors.ReactorManager.afterClass(ReactorManager.java:432)
        at org.ops4j.pax.exam.junit.impl.ProbeRunner.run(ProbeRunner.java:107)
        at org.ops4j.pax.exam.junit.PaxExam.run(PaxExam.java:93)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)

Results :

Tests in error: 
  FeatureInstallationTest.org.apache.brooklyn.karaf.itests.FeatureInstallationTest » Runtime
  JUnit4Provider.invoke:128->executeTestSet:153->executeWithRerun:173->execute:283 » Runtime
```
