### PR TITLE
Resolve release build failures due to optional JARs

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlEntityTest.java
@@ -826,6 +826,9 @@ public class CatalogOsgiYamlEntityTest extends AbstractYamlTest {
     }
     
     private void addCatalogOSGiEntity(String symbolicName, String serviceType, boolean extraLib) {
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_OSGI_TEST_A_0_1_0_PATH);
+
         addCatalogItems(
             "brooklyn.catalog:",
             "  id: " + symbolicName,
@@ -842,6 +845,8 @@ public class CatalogOsgiYamlEntityTest extends AbstractYamlTest {
     }
 
     private void addCatalogChildOSGiEntityWithServicesBlock(String symbolicName, String serviceType) {
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
+
         addCatalogItems(
             "brooklyn.catalog:",
             "  id: " + symbolicName,


### PR DESCRIPTION
Some testing resources are JARs and cannot be included in the release build. Tests must be written to gracefully handle the absence of those test resources. Some new tests failed to include the check for the presence of the resources and therefore fail the release build.