### PR TITLE
Allow passing "latest" as version for catalog endpoints

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -153,7 +153,11 @@ public interface CatalogApi {
 
     @DELETE
     @Path("/applications/{symbolicName}/{version}")
-    @ApiOperation(value = "Deletes a specific version of an application's definition from the catalog")
+    @ApiOperation(
+            value = "Deletes a specific version of an application's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'symbolicName'"
+    )
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "Entity not found")
     })
@@ -166,7 +170,11 @@ public interface CatalogApi {
 
     @DELETE
     @Path("/entities/{symbolicName}/{version}")
-    @ApiOperation(value = "Deletes a specific version of an entity's definition from the catalog")
+    @ApiOperation(
+            value = "Deletes a specific version of an entity's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'symbolicName'"
+    )
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "Entity not found")
     })
@@ -179,7 +187,10 @@ public interface CatalogApi {
 
     @DELETE
     @Path("/policies/{policyId}/{version}")
-    @ApiOperation(value = "Deletes a specific version of an policy's definition from the catalog")
+    @ApiOperation(
+            value = "Deletes a specific version of an policy's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'policyId'")
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "Policy not found")
     })
@@ -192,7 +203,11 @@ public interface CatalogApi {
 
     @DELETE
     @Path("/locations/{locationId}/{version}")
-    @ApiOperation(value = "Deletes a specific version of an location's definition from the catalog")
+    @ApiOperation(
+            value = "Deletes a specific version of an location's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'locationId'"
+    )
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "Location not found")
     })
@@ -245,7 +260,10 @@ public interface CatalogApi {
 
     @GET
     @Path("/entities/{symbolicName}/{version}")
-    @ApiOperation(value = "Fetch a specific version of an entity's definition from the catalog", 
+    @ApiOperation(
+            value = "Fetch a specific version of an entity's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'symbolicName'",
             response = CatalogEntitySummary.class,
             responseContainer = "List")
     @ApiResponses(value = {
@@ -274,7 +292,10 @@ public interface CatalogApi {
 
     @GET
     @Path("/applications/{symbolicName}/{version}")
-    @ApiOperation(value = "Fetch a specific version of an application's definition from the catalog", 
+    @ApiOperation(
+            value = "Fetch a specific version of an application's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'symbolicName'",
             response = CatalogEntitySummary.class,
             responseContainer = "List")
     @ApiResponses(value = {
@@ -316,7 +337,10 @@ public interface CatalogApi {
 
     @GET
     @Path("/policies/{policyId}/{version}")
-    @ApiOperation(value = "Fetch a policy's definition from the catalog", 
+    @ApiOperation(
+            value = "Fetch a policy's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'policyId'",
             response = CatalogItemSummary.class,
             responseContainer = "List")
     @ApiResponses(value = {
@@ -357,7 +381,10 @@ public interface CatalogApi {
 
     @GET
     @Path("/locations/{locationId}/{version}")
-    @ApiOperation(value = "Fetch a location's definition from the catalog", 
+    @ApiOperation(
+            value = "Fetch a location's definition from the catalog",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'locationId'",
             response = CatalogItemSummary.class,
             responseContainer = "List")
     @ApiResponses(value = {
@@ -384,7 +411,11 @@ public interface CatalogApi {
 
     @GET
     @Path("/icon/{itemId}/{version}")
-    @ApiOperation(value = "Return the icon for a given catalog entry (application/image or HTTP redirect)")
+    @ApiOperation(
+            value = "Return the icon for a given catalog entry (application/image or HTTP redirect)",
+            notes = "Version must exists, otherwise the API will return a 404. Alternatively, passing 'latest' will" +
+                    "pick up the latest version for the given 'itemId'"
+    )
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Item not found")
         })

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -114,6 +114,13 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         };
     };
 
+    private String processVersion(String version) {
+        if (version != null && LATEST.equals(version.toLowerCase())) {
+            version = null;
+        }
+        return version;
+    }
+
     static Set<String> missingIcons = MutableSet.of();
 
     @Override
@@ -333,9 +340,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
         
         RegisteredType item = mgmt().getTypeRegistry().get(symbolicName, version);
         if (item == null) {
@@ -354,9 +359,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
         
         RegisteredType item = mgmt().getTypeRegistry().get(policyId, version);
         if (item == null) {
@@ -375,9 +378,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
         
         RegisteredType item = mgmt().getTypeRegistry().get(locationId, version);
         if (item == null) {
@@ -435,9 +436,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
 
         //TODO These casts are not pretty, we could just provide separate get methods for the different types?
         //Or we could provide asEntity/asPolicy cast methods on the CataloItem doing a safety check internally
@@ -498,9 +497,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
 
         @SuppressWarnings("unchecked")
         CatalogItem<? extends Policy, PolicySpec<?>> result =
@@ -548,9 +545,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
 
         @SuppressWarnings("unchecked")
         CatalogItem<? extends Location, LocationSpec<?>> result =
@@ -601,9 +596,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
-        if (LATEST.equals(version)) {
-            version = null;
-        }
+        version = processVersion(version);
         
         return getCatalogItemIcon(mgmt().getTypeRegistry().get(itemId, version));
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -102,6 +102,7 @@ import com.google.common.io.Files;
 public class CatalogResource extends AbstractBrooklynRestResource implements CatalogApi {
 
     private static final Logger log = LoggerFactory.getLogger(CatalogResource.class);
+    private static final String LATEST = "latest";
     
     @SuppressWarnings("rawtypes")
     private Function<CatalogItem, CatalogItemSummary> toCatalogItemSummary(final UriInfo ui) {
@@ -331,6 +332,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.forbidden("User '%s' is not authorized to modify catalog",
                 Entitlements.getEntitlementContext().user());
         }
+
+        if (LATEST.equals(version)) {
+            version = null;
+        }
         
         RegisteredType item = mgmt().getTypeRegistry().get(symbolicName, version);
         if (item == null) {
@@ -348,6 +353,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.forbidden("User '%s' is not authorized to modify catalog",
                 Entitlements.getEntitlementContext().user());
         }
+
+        if (LATEST.equals(version)) {
+            version = null;
+        }
         
         RegisteredType item = mgmt().getTypeRegistry().get(policyId, version);
         if (item == null) {
@@ -364,6 +373,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.MODIFY_CATALOG_ITEM, StringAndArgument.of(locationId+(Strings.isBlank(version) ? "" : ":"+version), "delete"))) {
             throw WebResourceUtils.forbidden("User '%s' is not authorized to modify catalog",
                 Entitlements.getEntitlementContext().user());
+        }
+
+        if (LATEST.equals(version)) {
+            version = null;
         }
         
         RegisteredType item = mgmt().getTypeRegistry().get(locationId, version);
@@ -420,6 +433,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_CATALOG_ITEM, symbolicName+(Strings.isBlank(version)?"":":"+version))) {
             throw WebResourceUtils.forbidden("User '%s' is not authorized to see catalog entry",
                 Entitlements.getEntitlementContext().user());
+        }
+
+        if (LATEST.equals(version)) {
+            version = null;
         }
 
         //TODO These casts are not pretty, we could just provide separate get methods for the different types?
@@ -481,6 +498,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
                 Entitlements.getEntitlementContext().user());
         }
 
+        if (LATEST.equals(version)) {
+            version = null;
+        }
+
         @SuppressWarnings("unchecked")
         CatalogItem<? extends Policy, PolicySpec<?>> result =
                 (CatalogItem<? extends Policy, PolicySpec<?>>)brooklyn().getCatalog().getCatalogItem(policyId, version);
@@ -525,6 +546,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_CATALOG_ITEM, locationId+(Strings.isBlank(version)?"":":"+version))) {
             throw WebResourceUtils.forbidden("User '%s' is not authorized to see catalog entry",
                 Entitlements.getEntitlementContext().user());
+        }
+
+        if (LATEST.equals(version)) {
+            version = null;
         }
 
         @SuppressWarnings("unchecked")
@@ -574,6 +599,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SEE_CATALOG_ITEM, itemId+(Strings.isBlank(version)?"":":"+version))) {
             throw WebResourceUtils.forbidden("User '%s' is not authorized to see catalog entry",
                 Entitlements.getEntitlementContext().user());
+        }
+
+        if (LATEST.equals(version)) {
+            version = null;
         }
         
         return getCatalogItemIcon(mgmt().getTypeRegistry().get(itemId, version));

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
@@ -890,6 +890,19 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(application.getVersion(), TEST_LASTEST_VERSION);
     }
 
+    @Test(dependsOnMethods = {"testGetOnlyLatestApplication"})
+    public void testGetOnlyLatestDifferentCases() {
+        String symbolicName = "latest.catalog.application.id";
+
+        CatalogItemSummary application = client().path("/catalog/applications/" + symbolicName + "/LaTeSt")
+                .get(CatalogItemSummary.class);
+        assertEquals(application.getVersion(), TEST_LASTEST_VERSION);
+
+        application = client().path("/catalog/applications/" + symbolicName + "/LATEST")
+                .get(CatalogItemSummary.class);
+        assertEquals(application.getVersion(), TEST_LASTEST_VERSION);
+    }
+
     @Test
     public void testGetOnlyLatestEntity() {
         String symbolicName = "latest.catalog.entity.id";
@@ -932,14 +945,9 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(application.getVersion(), TEST_LASTEST_VERSION);
     }
 
-    @Test
+    @Test(dependsOnMethods = {"testGetOnlyLatestApplication", "testGetOnlyLatestDifferentCases"})
     public void testDeleteOnlyLatestApplication() throws IOException {
-        String symbolicName = "latest.catalog.application.delete.id";
-        String itemType = "template";
-        String serviceType = "org.apache.brooklyn.core.test.entity.TestEntity";
-
-        addTestCatalogItem(symbolicName, itemType, TEST_VERSION, serviceType);
-        addTestCatalogItem(symbolicName, itemType, TEST_LASTEST_VERSION, serviceType);
+        String symbolicName = "latest.catalog.application.id";
 
         Response deleteResponse = client().path("/catalog/applications/" + symbolicName + "/latest").delete();
         assertEquals(deleteResponse.getStatus(), HttpStatus.NO_CONTENT_204);
@@ -950,14 +958,9 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(applications.get(0).getVersion(), TEST_VERSION);
     }
 
-    @Test
+    @Test(dependsOnMethods = {"testGetOnlyLatestEntity"})
     public void testDeleteOnlyLatestEntity() throws IOException {
-        String symbolicName = "latest.catalog.entity.delete.id";
-        String itemType = "entity";
-        String serviceType = "org.apache.brooklyn.core.test.entity.TestEntity";
-
-        addTestCatalogItem(symbolicName, itemType, TEST_VERSION, serviceType);
-        addTestCatalogItem(symbolicName, itemType, TEST_LASTEST_VERSION, serviceType);
+        String symbolicName = "latest.catalog.entity.id";
 
         Response deleteResponse = client().path("/catalog/entities/" + symbolicName + "/latest").delete();
         assertEquals(deleteResponse.getStatus(), HttpStatus.NO_CONTENT_204);
@@ -968,14 +971,9 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(applications.get(0).getVersion(), TEST_VERSION);
     }
 
-    @Test
+    @Test(dependsOnMethods = {"testGetOnlyLatestPolicy"})
     public void testDeleteOnlyLatestPolicy() throws IOException {
-        String symbolicName = "latest.catalog.policy.delete.id";
-        String itemType = "policy";
-        String serviceType = "org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy";
-
-        addTestCatalogItem(symbolicName, itemType, TEST_VERSION, serviceType);
-        addTestCatalogItem(symbolicName, itemType, TEST_LASTEST_VERSION, serviceType);
+        String symbolicName = "latest.catalog.policy.id";
 
         Response deleteResponse = client().path("/catalog/policies/" + symbolicName + "/latest").delete();
         assertEquals(deleteResponse.getStatus(), HttpStatus.NO_CONTENT_204);
@@ -986,14 +984,9 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(applications.get(0).getVersion(), TEST_VERSION);
     }
 
-    @Test
+    @Test(dependsOnMethods = {"testGetOnlyLatestLocation"})
     public void testDeleteOnlyLatestLocation() throws IOException {
-        String symbolicName = "latest.catalog.location.delete.id";
-        String itemType = "location";
-        String serviceType = "localhost";
-
-        addTestCatalogItem(symbolicName, itemType, TEST_VERSION, serviceType);
-        addTestCatalogItem(symbolicName, itemType, TEST_LASTEST_VERSION, serviceType);
+        String symbolicName = "latest.catalog.location.id";
 
         Response deleteResponse = client().path("/catalog/locations/" + symbolicName + "/latest").delete();
         assertEquals(deleteResponse.getStatus(), HttpStatus.NO_CONTENT_204);


### PR DESCRIPTION
This allow passing `latest` as the version for the following endpoints:
- `GET /v1/catalog/applications/<symbolicName>/<version>`
- `GET /v1/catalog/entities/<symbolicName>/<version>`
- `GET /v1/catalog/policies/<symbolicName>/<version>`
- `GET /v1/catalog/locations/<symbolicName>/<version>`
- `DELETE /v1/catalog/applications/<symbolicName>/<version>`
- `DELETE /v1/catalog/entities/<symbolicName>/<version>`
- `DELETE /v1/catalog/policies/<symbolicName>/<version>`
- `DELETE /v1/catalog/locations/<symbolicName>/<version>`

For the `GET` requests, the latest catalog item matching the `symbolicName` will be returned. Similarly, for the `DELETE` requests, the latest catalog item matching the `symbolicName` will be deleted.

This is very useful to get the information back of an entity if one don't currently know the version. Most of the times, one will be interested in the latest version.