### PR TITLE
Fix address publish bug

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
@@ -256,12 +256,8 @@ public class DefaultConnectivityResolver extends BasicConfigurableObject impleme
     }
 
     void publishNetworks(NodeMetadata node, Entity entity) {
-        if (entity.sensors().get(PRIVATE_ADDRESSES) == null) {
-            entity.sensors().set(PRIVATE_ADDRESSES, ImmutableSet.copyOf(node.getPrivateAddresses()));
-        }
-        if (entity.sensors().get(PUBLIC_ADDRESSES) == null) {
-            entity.sensors().set(PUBLIC_ADDRESSES, ImmutableSet.copyOf(node.getPublicAddresses()));
-        }
+        entity.sensors().set(PRIVATE_ADDRESSES, ImmutableSet.copyOf(node.getPrivateAddresses()));
+        entity.sensors().set(PUBLIC_ADDRESSES, ImmutableSet.copyOf(node.getPublicAddresses()));
     }
 
     // --------------------------------------------------------------------------------------


### PR DESCRIPTION
When a server provisions but JClouds fails to connect to it, the server is killed and re-provisioned. When this happens the private and public address of the old server remain in the `host.address` sensors because of a null check in `DefaultConnectivityResolver`. This PR removes that so the machine correctly obtains the address of the re-provisioned machine.