### PR TITLE
[WIP] Fix sensor changes event ordering 

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AttributeMap.java
@@ -129,9 +129,13 @@ public final class AttributeMap {
     }
 
     public <T> T update(AttributeSensor<T> attribute, T newValue) {
-        T oldValue = updateWithoutPublishing(attribute, newValue);
-        entity.emitInternal(attribute, newValue);
-        return oldValue;
+        // guarantees the order in which the attribute is set is
+        // the order in which the events are sent (and received)
+        synchronized (values) {
+            T oldValue = updateWithoutPublishing(attribute, newValue);
+            entity.emitInternal(attribute, newValue);
+            return oldValue;
+        }
     }
     
     public <T> T updateWithoutPublishing(AttributeSensor<T> attribute, T newValue) {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateStressTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateStressTest.java
@@ -67,28 +67,21 @@ public class ApplicationLifecycleStateStressTest extends ApplicationLifecycleSta
         super.testStartsThenSomeChildFailsCausesAppToFail();
     }
 
-    /** See {@link ApplicationLifecycleStateTest#testChildFailuresOnStartButWithQuorumCausesAppToSucceed()} for details on the failure */
-    @Test(groups="Broken")
     @Override
     public void testChildFailuresOnStartButWithQuorumCausesAppToSucceed() throws Exception {
         super.testChildFailuresOnStartButWithQuorumCausesAppToSucceed();
     }
-    
-    /** See {@link ApplicationLifecycleStateTest#testChildFailuresOnStartButWithQuorumCausesAppToSucceed()} for details on the failure */
-    @Test(groups="Broken")
+
     @Override
     public void testStartsThenChildFailsButWithQuorumCausesAppToSucceed() throws Exception {
         super.testStartsThenChildFailsButWithQuorumCausesAppToSucceed();
     }
 
-    /** See {@link ApplicationLifecycleStateTest#testChildFailuresOnStartButWithQuorumCausesAppToSucceed()} for details on the failure */
-    @Test(groups="Broken")
     @Override
     public void testStartsThenChildFailsButWithQuorumCausesAppToStayHealthy() throws Exception {
         super.testStartsThenChildFailsButWithQuorumCausesAppToStayHealthy();
     }
 
-    @Test(groups="Broken")
     @Override
     public void testSettingSensorFromThreads() {
         super.testSettingSensorFromThreads();


### PR DESCRIPTION
Makes sure that events are fired (and thus handled) in the order the attribute is set. Without syncronyzing the last event fired might not match the last value of the attribute breaking the logic in the ComputeServiceIndicatorsFromChildrenAndMembers enricher.

Possibly related:
* https://issues.apache.org/jira/browse/BROOKLYN-518
* https://issues.apache.org/jira/browse/BROOKLYN-243