### PR TITLE
Changes Application API behaviour so that returned location id is the catalog item id 

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/ApplicationTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/ApplicationTransformer.java
@@ -100,7 +100,7 @@ public class ApplicationTransformer {
             @Override
             @Nullable
             public String apply(@Nullable Location input) {
-                return input.getId();
+                return input.getCatalogItemId() != null ? input.getCatalogItemId() : input.getId();
             }
         });
         // okay to have entities and config as null, as this comes from a real instance


### PR DESCRIPTION
Updates ApplicationTransformer to return the catalogItemId (if available)
* If unavailable ID is returned.


**NOTE** This changes the behaviour of the Application API