### PR TITLE
Reuse embedded OSGi container in tests

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -90,7 +90,8 @@ public abstract class AbstractYamlTest {
     }
     
     protected LocalManagementContext newTestManagementContext() {
-        Builder builder = LocalManagementContextForTests.builder(true).disableOsgi(disableOsgi());
+        Builder builder = LocalManagementContextForTests.builder(true).
+            setOsgiEnablementAndReuse(!disableOsgi(), !disallowOsgiReuse());
         if (useDefaultProperties()) {
             builder.useDefaultProperties();
         }
@@ -100,6 +101,11 @@ public abstract class AbstractYamlTest {
     /** Override to enable OSGi in the management context for all tests in the class. */
     protected boolean disableOsgi() {
         return true;
+    }
+
+    /** Override to disable OSGi reuse */
+    protected boolean disallowOsgiReuse() {
+        return false;
     }
     
     protected boolean useDefaultProperties() {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
@@ -91,7 +91,7 @@ public class ExternalConfigYamlTest extends AbstractYamlTest {
 
         return LocalManagementContextForTests.builder(true)
                 .useProperties(props)
-                .disableOsgi(false)
+                .enableOsgiReusable()
                 .build();
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WinRmMachineLocationExternalConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WinRmMachineLocationExternalConfigYamlTest.java
@@ -44,7 +44,7 @@ public class WinRmMachineLocationExternalConfigYamlTest extends AbstractYamlTest
 
         return LocalManagementContextForTests.builder(true)
                 .useProperties(props)
-                .disableOsgi(false)
+                .enableOsgiReusable()
                 .build();
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/AbstractCatalogXmlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/AbstractCatalogXmlTest.java
@@ -58,7 +58,7 @@ public class AbstractCatalogXmlTest extends AbstractYamlTest {
         properties.put(BrooklynServerConfig.BROOKLYN_CATALOG_URL, catalog.toURI().toString());
         return LocalManagementContextForTests.builder(true)
                 .useProperties(properties)
-                .disableOsgi(false)
+                .enableOsgiReusable()
                 .build();
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
@@ -70,7 +70,7 @@ public class CatalogMakeOsgiBundleTest extends AbstractYamlTest {
     @Override
     protected LocalManagementContext newTestManagementContext() {
         return LocalManagementContextForTests.builder(true)
-                .disableOsgi(false)
+                .enableOsgiReusable()
                 .build();
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/BrooklynVersionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/BrooklynVersionTest.java
@@ -95,7 +95,7 @@ public class BrooklynVersionTest {
     public void testGetFeatures() throws Exception {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_PATH);
         LocalManagementContext mgmt = LocalManagementContextForTests.builder(true)
-                .disableOsgi(false)
+                .enableOsgiReusable()
                 .build();
         String symName = "org.apache.brooklyn.test.resources.osgi.brooklyn-test-osgi-entities";
         String version = "0.1.0";

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/classloading/ClassLoaderFromBrooklynClassLoadingContextTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/classloading/ClassLoaderFromBrooklynClassLoadingContextTest.java
@@ -38,7 +38,7 @@ public class ClassLoaderFromBrooklynClassLoadingContextTest {
     @BeforeMethod(alwaysRun=true)
     @SuppressWarnings("deprecation")
     public void setUp() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         item = mgmt.getCatalog().addItem(BasicApplication.class);
         
         BrooklynClassLoadingContext clc = new OsgiBrooklynClassLoadingContext(mgmt, item.getCatalogItemId(), ImmutableList.<OsgiBundleWithUrl>of());

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiPathTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiPathTest.java
@@ -48,9 +48,9 @@ public class OsgiPathTest {
         if (mgmt!=null) Entities.destroyAll(mgmt);
     }
     
-    @Test(groups="Integration") // integration only because OSGi takes ~200ms
+    @Test(groups="Integration") // integration only because non-reusable OSGi takes ~200ms
     public void testOsgiPathDefault() {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiNonReusable().build();
         String path = BrooklynServerPaths.getOsgiCacheDir(mgmt).getAbsolutePath();
         Assert.assertTrue(path.startsWith(BrooklynServerPaths.getMgmtBaseDir(mgmt)), path);
         Assert.assertTrue(path.contains(mgmt.getManagementNodeId()), path);
@@ -58,12 +58,12 @@ public class OsgiPathTest {
         assertExistsThenIsCleaned(path);
     }
 
-    @Test(groups="Integration") // integration only because OSGi takes ~200ms
+    @Test(groups="Integration") // integration only because non-reusable OSGi takes ~200ms
     public void testOsgiPathCustom() {
         BrooklynProperties bp = BrooklynProperties.Factory.newEmpty();
         String randomSeg = "osgi-test-"+Identifiers.makeRandomId(4);
         bp.put(BrooklynServerConfig.OSGI_CACHE_DIR, "${brooklyn.os.tmpdir}"+"/"+randomSeg+"/"+"${brooklyn.mgmt.node.id}");
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).useProperties(bp).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiNonReusable().useProperties(bp).build();
         String path = BrooklynServerPaths.getOsgiCacheDir(mgmt).getAbsolutePath();
         Os.deleteOnExitRecursivelyAndEmptyParentsUpTo(new File(path), new File(Os.tmp()+"/"+randomSeg));
         
@@ -73,12 +73,12 @@ public class OsgiPathTest {
         assertExistsThenIsCleaned(path);
     }
 
-    @Test(groups="Integration") // integration only because OSGi takes ~200ms
+    @Test(groups="Integration") // integration only because non-reusable OSGi takes ~200ms
     public void testOsgiPathCustomWithoutNodeIdNotCleaned() {
         BrooklynProperties bp = BrooklynProperties.Factory.newEmpty();
         String randomSeg = "osgi-test-"+Identifiers.makeRandomId(4);
         bp.put(BrooklynServerConfig.OSGI_CACHE_DIR, "${brooklyn.os.tmpdir}"+"/"+randomSeg+"/"+"sample");
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).useProperties(bp).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiNonReusable().useProperties(bp).build();
         String path = BrooklynServerPaths.getOsgiCacheDir(mgmt).getAbsolutePath();
         Os.deleteOnExitRecursivelyAndEmptyParentsUpTo(new File(path), new File(Os.tmp()+"/"+randomSeg));
         

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiTestingLeaksAndSpeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiTestingLeaksAndSpeedTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.osgi;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.internal.BrooklynGarbageCollector;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
+import org.apache.brooklyn.util.javalang.MemoryUsageTracker;
+import org.apache.brooklyn.util.osgi.OsgiTestResources;
+import org.apache.brooklyn.util.text.ByteSizeStrings;
+import org.apache.brooklyn.util.time.Duration;
+import org.osgi.framework.BundleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Stopwatch;
+
+
+/** 
+ * Tests that starting with the OSGi subsystem 
+ * (a) does not leak memory (which should fix test failures in jenkins), and
+ * (b) is fast (or we can make it faster...)
+ */ 
+public class OsgiTestingLeaksAndSpeedTest implements OsgiTestResources {
+
+    private static final Logger log = LoggerFactory.getLogger(OsgiTestingLeaksAndSpeedTest.class);
+    
+    protected LocalManagementContext mgmt;
+    protected TestApplication app;
+
+    void up() throws Exception {
+        mgmt = LocalManagementContextForTests.builder(true)
+            .enableOsgiReusable()
+//            .disableOsgi()
+//            .enableOsgiNonReusable()
+            .build();
+        app = TestApplication.Factory.newManagedInstanceForTests(mgmt);
+    }
+
+    void down() throws BundleException, IOException, InterruptedException {
+        Entities.destroyAll(mgmt);
+    }
+    
+    @Test(groups="Integration")
+    public void testUpDownManyTimes() throws Exception {
+        final int NUM_ITERS = 10;
+        // do a couple beforehand to eliminate one-off expenses
+        up(); down(); up(); down();
+        forceGc();
+        long memUsed0 = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        Stopwatch sF = Stopwatch.createUnstarted();
+        Stopwatch sG = Stopwatch.createStarted();
+        for (int i=0; i<NUM_ITERS; i++) {
+            log.info(JavaClassNames.niceClassAndMethod()+" iteration "+i+": "+
+                BrooklynGarbageCollector.makeBasicUsageString());
+            sF.start();
+            up();
+            // confirmed this has no effect, even with OSGi
+            // Time.sleep(Duration.millis(200));
+            down();
+            sF.stop();
+            forceGc();
+        }
+        forceGc();
+        sG.stop();
+        long memUsed1 = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        log.info(JavaClassNames.niceClassAndMethod()+" AFTER "+NUM_ITERS+": "+
+            BrooklynGarbageCollector.makeBasicUsageString());
+        long memLeakBytesPerIter = (memUsed1-memUsed0)/NUM_ITERS;
+        long upDownTimeMillisPerIter = sF.elapsed(TimeUnit.MILLISECONDS)/NUM_ITERS;
+        log.info(JavaClassNames.niceClassAndMethod()+" PER ITER (over "+NUM_ITERS+"): "+
+                ByteSizeStrings.metric().makeSizeString( memLeakBytesPerIter )+", "+
+                Duration.millis(upDownTimeMillisPerIter)+" per up+down, "+
+                Duration.millis(sG.elapsed(TimeUnit.MILLISECONDS)/NUM_ITERS)+" per up+down+gc"
+            );
+
+        // with OSGi reusable (new)
+        // PER ITER (over 10): 1156 B, 23ms per up+down, 240ms per up+down+gc
+        // PER ITER (over 100): 727 B, 18ms per up+down, 249ms per up+down+gc
+        
+        // with OSGi non-reusable
+        // PER ITER (over 10): 3.60 MB, 276ms per up+down, 642ms per up+down+gc
+        // PER ITER (over 100): 1692 kB, 222ms per up+down, 988ms per up+down+gc
+        
+        // without OSGi
+        // PER ITER (over 10): 605 B, 24ms per up+down, 185ms per up+down+gc
+        // PER ITER (over 100): 747 B, 16ms per up+down, 184ms per up+down+gc
+        
+        Assert.assertTrue(memLeakBytesPerIter < 100*1000, "Leaked too much memory: "+memLeakBytesPerIter);
+        Assert.assertTrue(upDownTimeMillisPerIter < 200, "Took too long to startup: "+upDownTimeMillisPerIter);
+        
+        // can keep up to attach debugger
+//        Time.sleep(Duration.ONE_DAY);
+    }
+
+    protected void forceGc() {
+        MemoryUsageTracker.forceClearSoftReferences();
+        System.gc(); System.gc();
+    }
+            
+}

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiVersionMoreEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiVersionMoreEntityTest.java
@@ -77,7 +77,7 @@ public class OsgiVersionMoreEntityTest implements OsgiTestResources {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         app = TestApplication.Factory.newManagedInstanceForTests(mgmt);
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerDelegatingClassLoaderTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerDelegatingClassLoaderTest.java
@@ -48,7 +48,7 @@ public class XmlMementoSerializerDelegatingClassLoaderTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
     }
 
     @AfterMethod(alwaysRun=true)

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
@@ -376,7 +376,7 @@ public class XmlMementoSerializerTest {
     @Test
     public void testEntitySpecFromOsgi() throws Exception {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), OsgiTestResources.BROOKLYN_TEST_MORE_ENTITIES_V1_PATH);
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         
         RegisteredType ci = OsgiVersionMoreEntityTest.addMoreEntityV1(mgmt, "1.0");
             
@@ -390,7 +390,7 @@ public class XmlMementoSerializerTest {
     
     @Test
     public void testOsgiBundleNameNotIncludedForWhiteListed() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
 
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
         
@@ -410,7 +410,7 @@ public class XmlMementoSerializerTest {
         String bundleUrl = OsgiStandaloneTest.BROOKLYN_TEST_OSGI_ENTITIES_URL;
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
         
         Bundle bundle = installBundle(mgmt, bundleUrl);
@@ -449,7 +449,7 @@ public class XmlMementoSerializerTest {
         String classname = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_OBJECT;
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = installBundle(mgmt, bundleUrl);
 
         String bundlePrefix = bundle.getSymbolicName();
@@ -477,7 +477,7 @@ public class XmlMementoSerializerTest {
         String classname = OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_OBJECT;
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = installBundle(mgmt, bundleUrl);
         
         String oldBundlePrefix = "com.old.symbolicname";
@@ -509,7 +509,7 @@ public class XmlMementoSerializerTest {
         String oldClassname = "com.old.package.name.OldClassName";
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = installBundle(mgmt, bundleUrl);
         
         String bundlePrefix = bundle.getSymbolicName();
@@ -535,7 +535,7 @@ public class XmlMementoSerializerTest {
     // how we're using Felix? Would it also be true in Karaf?
     @Test(groups="Broken")
     public void testOsgiBundleNamePrefixIncludedForDownstreamDependency() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
         
         // Using a guava type (which is a downstream dependency of Brooklyn)

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ActivePartialRebindVersionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ActivePartialRebindVersionTest.java
@@ -42,7 +42,7 @@ public class ActivePartialRebindVersionTest extends RebindTestFixtureWithApp {
                 .persistPeriodMillis(getPersistPeriodMillis())
                 .forLive(useLiveManagementContext())
                 .emptyCatalog(useEmptyCatalog())
-                .enableOsgi(true)
+                .enableOsgiReusable()
                 .buildStarted();
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/ManagementPlaneIdTest.java
@@ -215,7 +215,7 @@ public class ManagementPlaneIdTest {
                 .enablePersistenceBackups(backedUp)
                 .emptyCatalog(true)
                 .properties(props)
-                .enableOsgi(false)
+                .setOsgiEnablementAndReuse(false, false)
                 .buildStarted();
         markForTermination(mgmt);
         return mgmt;

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
@@ -108,7 +108,7 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
                 .enablePersistenceBackups(enablePersistenceBackups())
                 .emptyCatalog(useEmptyCatalog())
                 .properties(createBrooklynProperties())
-                .enableOsgi(useOsgi())
+                .setOsgiEnablementAndReuse(useOsgi(), !disallowOsgiReuse())
                 .buildStarted();
     }
 
@@ -141,7 +141,7 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
                 .haMode(haMode)
                 .emptyCatalog(useEmptyCatalog())
                 .properties(brooklynProperties)
-                .enableOsgi(useOsgi())
+                .setOsgiEnablementAndReuse(useOsgi(), !disallowOsgiReuse())
                 .buildUnstarted();
     }
 
@@ -206,6 +206,10 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
     }
 
     protected boolean useOsgi() {
+        return false;
+    }
+    
+    protected boolean disallowOsgiReuse() {
         return false;
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
@@ -154,6 +154,7 @@ public class RebindTestUtils {
         HighAvailabilityMode haMode = HighAvailabilityMode.DISABLED;
         boolean forLive;
         boolean enableOsgi = false;
+        boolean reuseOsgi = true;
         boolean emptyCatalog;
         private boolean enablePersistenceBackups = true;
         
@@ -192,9 +193,25 @@ public class RebindTestUtils {
             this.enablePersistenceBackups  = val;
             return this;
         }
+        /** @deprecated since 0.12.0 use {@link #enableOsgiNonReusable()} or {@link #enableOsgiReusable()} */
+        @Deprecated
         public ManagementContextBuilder enableOsgi(boolean val) {
             this.enableOsgi = val;
             return this;
+        }
+
+        /** as {@link LocalManagementContextForTests.Builder#setOsgiEnablementAndReuse(boolean, boolean)} */
+        public ManagementContextBuilder setOsgiEnablementAndReuse(boolean enableOsgi, boolean reuseOsgi) {
+            this.enableOsgi = enableOsgi;
+            this.reuseOsgi = reuseOsgi;
+            return this;
+        }
+        
+        public ManagementContextBuilder enableOsgiReusable() {
+            return setOsgiEnablementAndReuse(true, true);
+        }
+        public ManagementContextBuilder enableOsgiNonReusable() {
+            return setOsgiEnablementAndReuse(true, false);
         }
 
         public ManagementContextBuilder emptyCatalog() {
@@ -244,7 +261,7 @@ public class RebindTestUtils {
             } else {
                 unstarted = LocalManagementContextForTests.builder(true)
                         .useProperties(properties)
-                        .disableOsgi(!enableOsgi)
+                        .setOsgiEnablementAndReuse(enableOsgi, reuseOsgi)
                         .disablePersistenceBackups(!enablePersistenceBackups)
                         .build();
             }

--- a/core/src/test/java/org/apache/brooklyn/util/core/ClassLoaderUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/ClassLoaderUtilsTest.java
@@ -110,7 +110,7 @@ public class ClassLoaderUtilsTest {
         
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
 
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = installBundle(mgmt, bundleUrl);
         @SuppressWarnings("unchecked")
         Class<? extends Entity> clazz = (Class<? extends Entity>) bundle.loadClass(classname);
@@ -136,7 +136,7 @@ public class ClassLoaderUtilsTest {
         
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), bundlePath);
 
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = installBundle(mgmt, bundleUrl);
         Class<?> clazz = bundle.loadClass(classname);
         Entity entity = createSimpleEntity(bundleUrl, clazz);
@@ -193,7 +193,7 @@ public class ClassLoaderUtilsTest {
         Class<?> clazz = BasicEntity.class;
         String classname = clazz.getName();
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = getBundle(mgmt, "org.apache.brooklyn.core");
         Entity entity = createSimpleEntity(bundle.getLocation(), clazz);
         
@@ -213,7 +213,7 @@ public class ClassLoaderUtilsTest {
         Class<?> clazz = Entity.class;
         String classname = clazz.getName();
         
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         Bundle bundle = getBundle(mgmt, "org.apache.brooklyn.api");
         
         ClassLoaderUtils cluMgmt = new ClassLoaderUtils(getClass(), mgmt);
@@ -228,7 +228,7 @@ public class ClassLoaderUtilsTest {
     
     @Test
     public void testIsBundleWhiteListed() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         ClassLoaderUtils clu = new ClassLoaderUtils(getClass(), mgmt);
         
         assertTrue(clu.isBundleWhiteListed(getBundle(mgmt, "org.apache.brooklyn.core")));
@@ -242,7 +242,7 @@ public class ClassLoaderUtilsTest {
      */
     @Test(groups={"Integration"})
     public void testLoadsFromRightGuavaVersion() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         ClassLoaderUtils clu = new ClassLoaderUtils(getClass(), mgmt);
         
         String bundleUrl = MavenRetriever.localUrl(MavenArtifact.fromCoordinate("com.google.guava:guava:jar:18.0"));
@@ -255,7 +255,7 @@ public class ClassLoaderUtilsTest {
     
     @Test
     public void testLoadBrooklynClass() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         new ClassLoaderUtils(this, mgmt).loadClass(
                 "org.apache.brooklyn.api",
                 BrooklynVersion.get(),

--- a/core/src/test/java/org/apache/brooklyn/util/core/osgi/BundleMakerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/osgi/BundleMakerTest.java
@@ -62,7 +62,7 @@ public class BundleMakerTest extends BrooklynMgmtUnitTestSupport {
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
-        mgmt = LocalManagementContextForTests.builder(true).disableOsgi(false).build();
+        mgmt = LocalManagementContextForTests.builder(true).enableOsgiReusable().build();
         super.setUp();
         
         bundleMaker = new BundleMaker(mgmt);

--- a/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFramework.java
+++ b/utils/rt-felix/src/main/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFramework.java
@@ -116,7 +116,7 @@ public class EmbeddedFelixFramework {
         return framework;
     }
 
-        public static void stopFramework(Framework framework) throws RuntimeException {
+    public static void stopFramework(Framework framework) throws RuntimeException {
         try {
             if (framework != null) {
                 framework.stop();


### PR DESCRIPTION
This speeds up build time from 17m to 11m on my machine by reusing OSGi framework containers where possible.  That also fixes an OSGi container which is causing lots of build failures on Jenkins.

See the last commit which is the only thing new, and the `OsgiManager` class is the main significant difference in that.  Other things are just wiring to control bundle reuse or not.

This includes #645 and #647 so if this build passes we can assume the failures in those PR's are ignorable (they seem to be due to memory leaks).  But merge those before merging this (and I can rebase this if needed once they are merged.)

/cc @neykov @aledsage @geomacy 