### PR TITLE
BROOKLYN-489: Fix XmlUtil.xpath character encoding

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlUtil.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlUtil.java
@@ -18,8 +18,8 @@
  */
 package org.apache.brooklyn.util.core.xstream;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -32,6 +32,7 @@ import javax.xml.xpath.XPathFactory;
 
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.google.common.annotations.Beta;
@@ -65,7 +66,7 @@ public class XmlUtil {
     public static Object xpath(String xml, String xpath, QName returnType) {
         try {
             DocumentBuilder builder = SharedDocumentBuilder.get();
-            Document doc = builder.parse(new ByteArrayInputStream(xml.getBytes()));
+            Document doc = builder.parse(new InputSource(new StringReader(xml)));
             XPathFactory xPathfactory = XPathFactory.newInstance();
             XPathExpression expr = xPathfactory.newXPath().compile(xpath);
             


### PR DESCRIPTION
Be explicit to use UTF_8. Otherwise, on some environments (e.g. windows?) it could use a different encoding.

See https://issues.apache.org/jira/browse/BROOKLYN-489

However, I'm struggling to test this. For @iyovcheva, the `XmlUtilTest` passed in her IDE. This included when we created another little test there to read the persisted state file that was failing (`qf4zems55y`, and call `XmlUtil.xpath`). Maybe there's something different about the character encodings when running brooklyn in karaf, versus in the IDE?!

I also tried reproducing by changing `parent/pom.xml`, the `maven-surefire-plugin` configuration to include `-Dfile.encoding=ISO-8859-1`. I then ran `mvn test -Dtest=XmlUtilTest -Dfile.encoding=ISO-8859-1`. I confirmed that `Charset.defaultCharset()` writes out `ISO-8859-1`, but the tests still passed even without the change in this PR.

---
Even though I can't reproduce, I think it's worth including the fix. Looking at the code, it's clearly wrong to not specify the character encoding.