### PR TITLE
Fix BROOKLYN-493 Rebind fails when using WinRmCommandSensor

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindAbstractCommandFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindAbstractCommandFeedTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.rebind;
+
+import com.google.common.io.Files;
+import org.apache.brooklyn.api.mgmt.rebind.RebindExceptionHandler;
+import org.apache.brooklyn.api.mgmt.rebind.RebindManager;
+import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.stream.Streams;
+
+import java.io.File;
+
+public abstract class RebindAbstractCommandFeedTest extends RebindTestFixtureWithApp {
+
+    @Override
+    protected TestApplication rebind() throws Exception {
+        RebindExceptionHandler exceptionHandler = RebindExceptionHandlerImpl.builder()
+                .danglingRefFailureMode(RebindManager.RebindFailureMode.FAIL_AT_END)
+                .rebindFailureMode(RebindManager.RebindFailureMode.FAIL_AT_END)
+                .addConfigFailureMode(RebindManager.RebindFailureMode.FAIL_AT_END)
+                .addPolicyFailureMode(RebindManager.RebindFailureMode.FAIL_AT_END)
+                .loadPolicyFailureMode(RebindManager.RebindFailureMode.FAIL_AT_END)
+                .build();
+        return super.rebind(RebindOptions.create().exceptionHandler(exceptionHandler));
+    }
+
+    protected void addMemento(BrooklynObjectType type, String label, String id) throws Exception {
+        String mementoFilename = label+"-"+id;
+        String memento = Streams.readFullyString(getClass().getResourceAsStream(mementoFilename));
+
+        File persistedFile = getPersistanceFile(type, id);
+        Files.write(memento.getBytes(), persistedFile);
+    }
+
+    protected File getPersistanceFile(BrooklynObjectType type, String id) {
+        String dir;
+        switch (type) {
+            case FEED: dir = "feeds"; break;
+            default: throw new UnsupportedOperationException("type="+type);
+        }
+        return new File(mementoDir, Os.mergePaths(dir, id));
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshFeedTest.java
@@ -18,26 +18,11 @@
  */
 package org.apache.brooklyn.core.mgmt.rebind;
 
-import java.io.File;
-
-import org.apache.brooklyn.api.mgmt.rebind.RebindExceptionHandler;
-import org.apache.brooklyn.api.mgmt.rebind.RebindManager.RebindFailureMode;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
-import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.util.os.Os;
-import org.apache.brooklyn.util.stream.Streams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.common.io.Files;
-
-public class RebindHistoricSshFeedTest extends RebindTestFixtureWithApp {
-
-    @SuppressWarnings("unused")
-    private static final Logger log = LoggerFactory.getLogger(RebindHistoricSshFeedTest.class);
-
+public class RebindHistoricSshFeedTest extends RebindAbstractCommandFeedTest {
     @Override
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
@@ -62,34 +47,5 @@ public class RebindHistoricSshFeedTest extends RebindTestFixtureWithApp {
     public void testFoo_2017_01_withoutBundlePrefixes() throws Exception {
         addMemento(BrooklynObjectType.FEED, "ssh-feed-no-bundle-prefixes", "zv7t8bim62");
         rebind();
-    }
-    
-    @Override
-    protected TestApplication rebind() throws Exception {
-        RebindExceptionHandler exceptionHandler = RebindExceptionHandlerImpl.builder()
-                .danglingRefFailureMode(RebindFailureMode.FAIL_AT_END)
-                .rebindFailureMode(RebindFailureMode.FAIL_AT_END)
-                .addConfigFailureMode(RebindFailureMode.FAIL_AT_END)
-                .addPolicyFailureMode(RebindFailureMode.FAIL_AT_END)
-                .loadPolicyFailureMode(RebindFailureMode.FAIL_AT_END)
-                .build();
-        return super.rebind(RebindOptions.create().exceptionHandler(exceptionHandler));
-    }
-    
-    protected void addMemento(BrooklynObjectType type, String label, String id) throws Exception {
-        String mementoFilename = label+"-"+id;
-        String memento = Streams.readFullyString(getClass().getResourceAsStream(mementoFilename));
-        
-        File persistedFile = getPersistanceFile(type, id);
-        Files.write(memento.getBytes(), persistedFile);
-    }
-    
-    protected File getPersistanceFile(BrooklynObjectType type, String id) {
-        String dir;
-        switch (type) {
-            case FEED: dir = "feeds"; break;
-            default: throw new UnsupportedOperationException("type="+type);
-        }
-        return new File(mementoDir, Os.mergePaths(dir, id));
     }
 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/CmdFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/CmdFeed.java
@@ -62,6 +62,12 @@ public class CmdFeed extends AbstractCommandFeed {
         return new CmdFeed.Builder();
     }
 
+    /**
+     * For rebind; do not call directly; use builder
+     */
+    public CmdFeed() {
+    }
+
     protected CmdFeed(final Builder builder) {
         super(builder);
     }

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebinWinrmCmdFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebinWinrmCmdFeedTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.feed.windows;
+
+import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.core.mgmt.rebind.RebindAbstractCommandFeedTest;
+import org.testng.annotations.Test;
+
+public class RebinWinrmCmdFeedTest extends RebindAbstractCommandFeedTest {
+
+    @Test
+    public void testSshFeed_2017_04() throws Exception {
+        addMemento(BrooklynObjectType.FEED, "winrm-cmd-feed", "a8pno3muco");
+        rebind();
+    }
+
+    @Test
+    public void testSshFeed_2017_04_withoutBundlePrefixes() throws Exception {
+        addMemento(BrooklynObjectType.FEED, "winrm-cmd-feed-no-bundle-prefixes", "akc24nlh2k");
+        rebind();
+    }
+}

--- a/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/winrm-cmd-feed-a8pno3muco
+++ b/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/winrm-cmd-feed-a8pno3muco
@@ -1,0 +1,123 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<feed>
+  <brooklynVersion>0.11.0-SNAPSHOT</brooklynVersion>
+  <type>org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.CmdFeed</type>
+  <id>a8pno3muco</id>
+  <displayName>org.apache.brooklyn.feed.windows.CmdFeed</displayName>
+  <tags>
+    <string>CmdFeed[ssh[echo &quot;test&quot;-&gt;test.sensor]]</string>
+  </tags>
+  <uniqueTag>CmdFeed[ssh[echo &quot;test&quot;-&gt;test.sensor]]</uniqueTag>
+  <config>
+    <feed.onlyIfServiceUp type="boolean">true</feed.onlyIfServiceUp>
+    <machine>
+      <null/>
+    </machine>
+    <execAsCommand type="boolean">false</execAsCommand>
+    <polls>
+      <com.google.guava:com.google.common.collect.HashMultimap serialization="custom">
+        <unserializable-parents/>
+        <com.google.guava:com.google.common.collect.HashMultimap>
+          <default/>
+          <int>2</int>
+          <int>1</int>
+          <org.apache.brooklyn.core:org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier>
+            <command class="org.apache.brooklyn.software-winrm:org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$2">
+              <outer-class>
+                <name>test.sensor</name>
+                <period>
+                  <nanos>30000000000</nanos>
+                </period>
+                <type>java.lang.String</type>
+                <sensor class="attributeSensor">
+                  <type>java.lang.String</type>
+                  <name>test.sensor</name>
+                  <description>test.sensor</description>
+                  <persistence>REQUIRED</persistence>
+                </sensor>
+                <params>
+                  <config>
+                    <name>test.sensor</name>
+                    <period>30s</period>
+                    <command>echo &quot;test&quot;</command>
+                  </config>
+                  <unusedConfig/>
+                  <live>false</live>
+                  <sealed>false</sealed>
+                </params>
+                <command>echo &quot;test&quot;</command>
+              </outer-class>
+            </command>
+            <env class="org.apache.brooklyn.core:org.apache.brooklyn.feed.CommandPollConfig$CombiningEnvSupplier">
+              <dynamicEnvironmentSupplier class="MutableList" serialization="custom">
+                <unserializable-parents/>
+                <list>
+                  <default>
+                    <size>1</size>
+                  </default>
+                  <int>1</int>
+                  <org.apache.brooklyn.software-winrm:org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor_-1>
+                    <outer-class reference="../../../../../command/outer-class"/>
+                  </org.apache.brooklyn.software-winrm:org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor_-1>
+                </list>
+              </dynamicEnvironmentSupplier>
+            </env>
+          </org.apache.brooklyn.core:org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier>
+          <int>1</int>
+          <org.apache.brooklyn.core:org.apache.brooklyn.feed.CommandPollConfig>
+            <sensor class="attributeSensor" reference="../../org.apache.brooklyn.core:org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command/outer-class/sensor"/>
+            <onsuccess class="com.google.guava:com.google.common.base.Functions$FunctionComposition">
+              <g class="org.apache.brooklyn.software-winrm:org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$3">
+                <outer-class reference="../../../../org.apache.brooklyn.core:org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command/outer-class"/>
+              </g>
+              <f class="org.apache.brooklyn.core:org.apache.brooklyn.feed.ssh.SshValueFunctions$Stdout"/>
+            </onsuccess>
+            <onfailure class="com.google.guava:com.google.common.base.Functions$ConstantFunction"/>
+            <onexception class="com.google.guava:com.google.common.base.Functions$ConstantFunction" reference="../onfailure"/>
+            <checkSuccess class="org.apache.brooklyn.utils-common:org.apache.brooklyn.util.guava.Functionals$1FunctionAsPredicate">
+              <val_-f class="com.google.guava:com.google.common.base.Functions$FunctionComposition">
+                <g class="com.google.guava:com.google.common.base.Functions$PredicateFunction">
+                  <predicate class="com.google.guava:com.google.common.base.Predicates$IsEqualToPredicate">
+                    <target class="int">0</target>
+                  </predicate>
+                </g>
+                <f class="org.apache.brooklyn.core:org.apache.brooklyn.feed.ssh.SshValueFunctions$ExitStatus"/>
+              </val_-f>
+            </checkSuccess>
+            <suppressDuplicates>false</suppressDuplicates>
+            <enabled>true</enabled>
+            <period>30000</period>
+            <commandSupplier class="org.apache.brooklyn.software-winrm:org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$2" reference="../../org.apache.brooklyn.core:org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command"/>
+            <dynamicEnvironmentSupplier class="MutableList" serialization="custom">
+              <unserializable-parents/>
+              <list>
+                <default>
+                  <size>0</size>
+                </default>
+                <int>0</int>
+              </list>
+            </dynamicEnvironmentSupplier>
+          </org.apache.brooklyn.core:org.apache.brooklyn.feed.CommandPollConfig>
+        </com.google.guava:com.google.common.collect.HashMultimap>
+      </com.google.guava:com.google.common.collect.HashMultimap>
+    </polls>
+  </config>
+</feed>

--- a/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/winrm-cmd-feed-no-bundle-prefixes-akc24nlh2k
+++ b/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/winrm-cmd-feed-no-bundle-prefixes-akc24nlh2k
@@ -1,0 +1,121 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<feed>
+  <brooklynVersion>0.11.0-SNAPSHOT</brooklynVersion>
+  <type>org.apache.brooklyn.feed.windows.CmdFeed</type>
+  <id>akc24nlh2k</id>
+  <displayName>org.apache.brooklyn.feed.windows.CmdFeed</displayName>
+  <searchPath class="ImmutableList"/>
+  <tags>
+    <string>CmdFeed[ssh[echo &quot;test&quot;-&gt;test.sensor]]</string>
+  </tags>
+  <uniqueTag>CmdFeed[ssh[echo &quot;test&quot;-&gt;test.sensor]]</uniqueTag>
+  <config>
+    <machine>
+      <null/>
+    </machine>
+    <execAsCommand type="boolean">false</execAsCommand>
+    <polls>
+      <com.google.common.collect.HashMultimap serialization="custom">
+        <unserializable-parents/>
+        <com.google.common.collect.HashMultimap>
+          <default/>
+          <int>2</int>
+          <int>1</int>
+          <org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier>
+            <command class="org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$2">
+              <outer-class>
+                <name>test.sensor</name>
+                <period>
+                  <nanos>30000000000</nanos>
+                </period>
+                <type>java.lang.String</type>
+                <sensor class="attributeSensor">
+                  <type>java.lang.String</type>
+                  <name>test.sensor</name>
+                  <description>test.sensor</description>
+                  <persistence>REQUIRED</persistence>
+                </sensor>
+                <params>
+                  <config>
+                    <name>test.sensor</name>
+                    <period>30s</period>
+                    <command>echo &quot;test&quot;</command>
+                  </config>
+                  <unusedConfig/>
+                  <live>false</live>
+                  <sealed>false</sealed>
+                </params>
+                <command>echo &quot;test&quot;</command>
+              </outer-class>
+            </command>
+            <env class="org.apache.brooklyn.feed.CommandPollConfig$CombiningEnvSupplier">
+              <dynamicEnvironmentSupplier class="MutableList" serialization="custom">
+                <unserializable-parents/>
+                <list>
+                  <default>
+                    <size>0</size>
+                  </default>
+                  <int>0</int>
+                </list>
+              </dynamicEnvironmentSupplier>
+            </env>
+          </org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier>
+          <int>1</int>
+          <org.apache.brooklyn.feed.CommandPollConfig>
+            <sensor class="attributeSensor" reference="../../org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command/outer-class/sensor"/>
+            <onsuccess class="com.google.common.base.Functions$FunctionComposition">
+              <g class="org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$3">
+                <outer-class reference="../../../../org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command/outer-class"/>
+              </g>
+              <f class="org.apache.brooklyn.feed.ssh.SshValueFunctions$Stdout"/>
+            </onsuccess>
+            <onfailure class="com.google.common.base.Functions$ConstantFunction"/>
+            <onexception class="com.google.common.base.Functions$ConstantFunction" reference="../onfailure"/>
+            <checkSuccess class="org.apache.brooklyn.util.guava.Functionals$1FunctionAsPredicate">
+              <val_-f class="com.google.common.base.Functions$FunctionComposition">
+                <g class="com.google.common.base.Functions$PredicateFunction">
+                  <predicate class="com.google.common.base.Predicates$IsEqualToPredicate">
+                    <target class="int">0</target>
+                  </predicate>
+                </g>
+                <f class="org.apache.brooklyn.feed.ssh.SshValueFunctions$ExitStatus"/>
+              </val_-f>
+            </checkSuccess>
+            <suppressDuplicates>false</suppressDuplicates>
+            <enabled>true</enabled>
+            <period>30000</period>
+            <commandSupplier class="org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor$2" reference="../../org.apache.brooklyn.feed.AbstractCommandFeed_-CommandPollIdentifier/command"/>
+            <dynamicEnvironmentSupplier class="MutableList" serialization="custom">
+              <unserializable-parents/>
+              <list>
+                <default>
+                  <size>0</size>
+                </default>
+                <int>0</int>
+              </list>
+            </dynamicEnvironmentSupplier>
+          </org.apache.brooklyn.feed.CommandPollConfig>
+        </com.google.common.collect.HashMultimap>
+      </com.google.common.collect.HashMultimap>
+    </polls>
+    <feed.onlyIfServiceUp type="boolean">true</feed.onlyIfServiceUp>
+  </config>
+</feed>


### PR DESCRIPTION
Tested with restart with Aled's blueprint.