### PR TITLE
BROOKLYN-334: ascii art banner says “Apache Brooklyn”

### DIFF
--- a/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/AbstractMain.java
@@ -72,14 +72,14 @@ public abstract class AbstractMain {
     private static final Logger log = LoggerFactory.getLogger(AbstractMain.class);
 
     // Launch banner
+    // http://patorjk.com/software/taag/#p=display&f=Standard&t=Apache%20Brooklyn
     public static final String DEFAULT_BANNER =
-        " _                     _    _             \n" +
-        "| |__  _ __ ___   ___ | | _| |_   _ _ __ (R)\n" +
-        "| '_ \\| '__/ _ \\ / _ \\| |/ / | | | | '_ \\ \n" +
-        "| |_) | | | (_) | (_) |   <| | |_| | | | |\n" +
-        "|_.__/|_|  \\___/ \\___/|_|\\_\\_|\\__, |_| |_|\n" +
-        "                              |___/             "+BrooklynVersion.get()+"\n";
-
+        "    _                     _            ____                  _    _             \n" +             
+        "   / \\   _ __   __ _  ___| |__   ___  | __ ) _ __ ___   ___ | | _| |_   _ _ __ (R)\n" +
+        "  / _ \\ | '_ \\ / _` |/ __| '_ \\ / _ \\ |  _ \\| '__/ _ \\ / _ \\| |/ / | | | | '_ \\ \n" +
+        " / ___ \\| |_) | (_| | (__| | | |  __/ | |_) | | | (_) | (_) |   <| | |_| | | | |\n" +
+        "/_/   \\_\\ .__/ \\__,_|\\___|_| |_|\\___| |____/|_|  \\___/ \\___/|_|\\_\\_|\\__, |_| |_|\n" +
+        "        |_|                                                         |___/      "+BrooklynVersion.get()+"\n";
     // Error codes
     public static final int SUCCESS = 0;
     public static final int PARSE_ERROR = 1;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BROOKLYN-334

Switching to:
```
    _                     _            ____                  _    _             
   / \   _ __   __ _  ___| |__   ___  | __ ) _ __ ___   ___ | | _| |_   _ _ __ (R)
  / _ \ | '_ \ / _` |/ __| '_ \ / _ \ |  _ \| '__/ _ \ / _ \| |/ / | | | | '_ \ 
 / ___ \| |_) | (_| | (__| | | |  __/ | |_) | | | (_) | (_) |   <| | |_| | | | |
/_/   \_\ .__/ \__,_|\___|_| |_|\___| |____/|_|  \___/ \___/|_|\_\_|\__, |_| |_|
        |_|                                                         |___/      0.11.0
```

That is unfortunately 85 characters long (including the 0.11.0 subscript), which is more than the standard 80 characters (http://stackoverflow.com/questions/4651012/why-is-the-default-terminal-width-80-characters).

Alternatively, we could use a smaller format such as:
```
    _                 _          ___              _   _           
   /_\  _ __  __ _ __| |_  ___  | _ )_ _ ___  ___| |_| |_  _ _ _  
  / _ \| '_ \/ _` / _| ' \/ -_) | _ \ '_/ _ \/ _ \ / / | || | ' \ 
 /_/ \_\ .__/\__,_\__|_||_\___| |___/_| \___/\___/_\_\_|\_, |_||_|
       |_|                                              |__/      
```

See http://patorjk.com/software/taag/#p=display&f=Standard&t=Apache%20Brooklyn and http://patorjk.com/software/taag/#p=display&f=Small&t=Apache%20Brooklyn

Personally, I like the upper case for A and B.

@rdowner what do you think?