### PR TITLE
expand test of future value

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/config/DeferredConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/DeferredConfigTest.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.core.config;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -30,32 +29,51 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 
-public class ConfigTypeCoercionTest extends BrooklynAppUnitTestSupport {
+public class DeferredConfigTest extends BrooklynAppUnitTestSupport {
     private static ConfigKey<Object> SENSORS_UNTYPED = ConfigKeys.newConfigKey(Object.class, "sensors");
     @SuppressWarnings("serial")
     private static ConfigKey<List<? extends Sensor<?>>> SENSORS = ConfigKeys.newConfigKey(new TypeToken<List<? extends Sensor<?>>>() {}, "sensors");
     
     @Test
-    public void testSshConfigFromDefault() throws Exception {
+    public void testDeferredConfigInListWhenAvailable() throws Exception {
+        doTestDeferredConfigInList(false);
+    }
+    
+    @Test
+    public void testDeferredConfigInListNotAvailable() throws Exception {
+        doTestDeferredConfigInList(true);
+    }
+    
+    void doTestDeferredConfigInList(final boolean delay) throws Exception {
         // Simulate a deferred value
         Task<Sensor<?>> sensorFuture = app.getExecutionContext().submit(new Callable<Sensor<?>>() {
             @Override
             public Sensor<?> call() throws Exception {
+                if (delay) Time.sleep(Duration.FIVE_SECONDS);
                 return TestApplication.MY_ATTRIBUTE;
             }
         });
         app.config().set(SENSORS_UNTYPED, (Object)ImmutableList.of(sensorFuture));
 
+        if (!delay) sensorFuture.get(Duration.ONE_SECOND);
+        // should resolve if future completed
         Maybe<List<? extends Sensor<?>>> sensors = app.config().getNonBlocking(SENSORS);
-        assertTrue(sensors.isPresent(), "value expected");
-        Sensor<?> sensor = Iterables.getOnlyElement(sensors.get());
-        assertEquals(sensor, TestApplication.MY_ATTRIBUTE);
+        if (delay) {
+            Assert.assertFalse(sensors.isPresent(), "value shouldn't be available");
+        } else {
+            Assert.assertTrue(sensors.isPresent(), "value should be available");
+            Sensor<?> sensor = Iterables.getOnlyElement(sensors.get());
+            assertEquals(sensor, TestApplication.MY_ATTRIBUTE);
+        }
     }
 
 }


### PR DESCRIPTION
fix logic where future no longer guaranteed to be available when non-blocking