### PR TITLE
Add contributing guidelines and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here (either GitHub or JIRA issue) -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Related PRs
+<!--- If there qre related PRs, please link them here --->
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My PR has a single focus.
+- [ ] My code follows the [code style](https://brooklyn.apache.org/developers/code-standards.html) of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly (and linked the related PRs)
+- [ ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+Welcome and thank you for your interest in contributing to Apache Brooklyn! This guide will take you through the process of making contributions to the Apache Brooklyn code base.
+
+## Contributor License Agreement
+Apache Brooklyn is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). All contributions will be under this license, so please read and understand this license before contributing.
+
+For all but the most trivial patches, we need a **Contributor License Agreement for you** on file with the Apache Software Foundation. Please read the [guide to CLAs](https://www.apache.org/licenses/#clas) to find out how to file a CLA with the Foundation.
+
+## Join the Community
+If it’s your first contribution or it’s a particularly big or complex contribution, things typically go much more smoothly when they start off with a conversation. Significant changes are normally discussed on the mailing list in any case, sometimes with a [feature proposal](https://drive.google.com/drive/#folders/0B3XurVLRa7pIUHNFV3NuVVRkRlE/0B3XurVLRa7pIblN4NGRNN2dYUGM/0B3XurVLRa7pIMlZQSUxrdTh4Wmc) document.
+
+Visit our [Community](https://brooklyn.apache.org/developers/index.html) page to see how to contact Brooklyners via IRC or email.
+
+Create an Issue in Jira
+The first step is usually to create or find an issue in [Brooklyn’s Jira](https://issues.apache.org/jira/browse/BROOKLYN) for your feature request or fix. For small changes this isn’t necessary, but it’s good to see if your change fixes an existing issue anyway.


### PR DESCRIPTION
Based on the recent discussion, I created a `CONTRIBUTING.md` (taken from [this page](https://brooklyn.apache.org/developers/how-to-contribute.html)) as well as a comprehensive GitHub PR template (new [GitHub feature](https://github.com/blog/2111-issue-and-pull-request-templates))

I plan to do the same in all Brooklyn's repos but want to make sure first that the common text is fine before opening the other PRs