### PR TITLE
Make SoftwareProcessDriverCopyResourcesTest an integration test.

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/SoftwareProcessDriverCopyResourcesTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/SoftwareProcessDriverCopyResourcesTest.java
@@ -49,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 
+@Test(groups="Integration")
 public class SoftwareProcessDriverCopyResourcesTest {
 
     File installDir;


### PR DESCRIPTION
Because it uses LocalhostMachineProvisioningLocation (breaks the Apache brooklyn-server Jenkins build).

Follows https://github.com/apache/brooklyn-server/pull/662.