### PR TITLE
[WIP] [JCLOUDS 2.1.0] Upgrade to jclouds 2.1

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -146,7 +146,8 @@
         <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/1.1.3_2</bundle> <!-- jzlib version is 1.1.3, but bundle is 1.1.3_2 -->
+        <bundle dependency="true">mvn:net.i2p.crypto/eddsa/${eddsa.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/${jzlib.servicemix.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
         <!-- Dependency Versions -->
-        <jclouds.version>2.0.2</jclouds.version> <!-- JCLOUDS_VERSION -->
+        <jclouds.version>2.1.0-SNAPSHOT</jclouds.version> <!-- JCLOUDS_VERSION -->
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->
@@ -115,6 +115,8 @@
         <xstream.version>1.4.8</xstream.version>
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
+        <jzlib.servicemix.version>1.1.3_2</jzlib.servicemix.version>
+        <eddsa.version>0.1.0</eddsa.version>
         <!-- double-check downstream projects before changing jackson version -->
         <fasterxml.jackson.version>2.7.5</fasterxml.jackson.version>
         <cxf.version>3.1.10</cxf.version>
@@ -133,7 +135,7 @@
         <ivy.version>2.2.0</ivy.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.51</bouncycastle.version>
-        <sshj.version>0.12.0</sshj.version>
+        <sshj.version>0.20.0</sshj.version>
         <felix.framework.version>5.6.1</felix.framework.version>
         <reflections.version>0.9.9-RC1</reflections.version>
         <jetty.version>9.2.13.v20150730</jetty.version>


### PR DESCRIPTION
These are the changes I needed to implement in order to run Brooklyn against current jclouds master.
Leaving them around to be reused for the jclouds 2.1.0 upgrade once released.