### PR TITLE
[WIP] [JCLOUDS 2.1.0] Remove Azure workarounds already included in jclouds 2.1.0

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/ComputeServiceRegistryImpl.java
@@ -147,13 +147,6 @@ public class ComputeServiceRegistryImpl implements ComputeServiceRegistry, Jclou
             if (Strings.isNonBlank(region)) {
                 properties.setProperty(LocationConstants.PROPERTY_REGIONS, region);
             }
-            // jclouds 2.0.0 does not include the rate limit module for Azure ARM. This quick fix enables this which will
-            // avoid provisioning to fail due to rate limit exceeded
-            // See https://issues.apache.org/jira/browse/JCLOUDS-1229
-            modules = ImmutableSet.<Module>builder()
-                    .addAll(modules)
-                    .add(new AzureComputeRateLimitModule())
-                    .build();
         }
 
         // Add extra jclouds-specific configuration

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsMachineNamer.java
@@ -18,10 +18,8 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
-import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.core.location.cloud.names.BasicCloudMachineNamer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.text.Identifiers;
 
 public class JcloudsMachineNamer extends BasicCloudMachineNamer {
 
@@ -41,19 +39,6 @@ public class JcloudsMachineNamer extends BasicCloudMachineNamer {
         // TODO other cloud max length rules
 
         return null;
-    }
-
-    @Override
-    protected String generateNewIdOfLength(ConfigBag setup, int len) {
-
-        // if it's azurecompute-arm it needs a different VM_NAME_ALLOWED_PATTERN
-        String pattern = setup.get(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS);
-        if ((pattern == null || pattern == CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS.getDefaultValue()) &&
-                "azurecompute-arm".equals(setup.peek(JcloudsLocationConfig.CLOUD_PROVIDER))) {
-        setup.put(CloudLocationConfig.VM_NAME_ALLOWED_CHARACTERS, Identifiers.UPPER_CASE_ALPHA+Identifiers.LOWER_CASE_ALPHA+Identifiers.NUMERIC);
-        }
-
-        return super.generateNewIdOfLength(setup, len);
     }
 
 }


### PR DESCRIPTION
* The Azure ARM provider now supports the standard naming convention with dashes in the names.
* Retry handler already part of [azurecompute-arm](https://github.com/jclouds/jclouds-labs/blob/master/azurecompute-arm/src/main/java/org/jclouds/azurecompute/arm/AzureManagementApiMetadata.java#L79)

Tested by deploying a three-tier app to azure using current jclouds master.

Merge only after switching to jclouds-2.1.0.

/cc @drigodwin