### PR TITLE
Multi distro live test improvements

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractMultiDistroLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractMultiDistroLiveTest.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -92,7 +93,11 @@ public abstract class AbstractMultiDistroLiveTest extends BrooklynAppLiveTestSup
         // Also removes scriptHeader (e.g. if doing `. ~/.bashrc` and `. ~/.profile`, then that can cause "stdin: is not a tty")
         brooklynProperties.remove("brooklyn.ssh.config.scriptHeader");
         
-        mgmt = new LocalManagementContextForTests(brooklynProperties);
+        LocalManagementContextForTests localManagementContextForTests = new LocalManagementContextForTests(brooklynProperties);
+        localManagementContextForTests.generateManagementPlaneId();
+
+        mgmt = localManagementContextForTests;
+        mgmt.getHighAvailabilityManager().disabled();
         
         super.setUp();
     }
@@ -101,6 +106,7 @@ public abstract class AbstractMultiDistroLiveTest extends BrooklynAppLiveTestSup
     protected void runTest(Map<String,?> flags) throws Exception {
         Map<String,?> allFlags = MutableMap.<String,Object>builder()
                 .put("tags", ImmutableList.of(getClass().getName()))
+                .put(JcloudsLocationConfig.MACHINE_CREATE_ATTEMPTS.getName(), 1)
                 .putAll(flags)
                 .build();
         jcloudsLocation = mgmt.getLocationRegistry().getLocationManaged(getLocationSpec(), allFlags);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/AbstractOpenstackLiveTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/AbstractOpenstackLiveTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.brooklyn.entity;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Map;
+
+import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -42,9 +43,6 @@ brooklyn.location.jclouds.openstack-nova.templateOptions={"networks":["abcdef12-
 
  */
 public abstract class AbstractOpenstackLiveTest extends AbstractMultiDistroLiveTest {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractOpenstackLiveTest.class);
-
     @Override
     public String getProvider() {
         return PROVIDER;
@@ -61,20 +59,25 @@ public abstract class AbstractOpenstackLiveTest extends AbstractMultiDistroLiveT
 
     @Test(groups = {"Live"})
     public void test_Centos_6() throws Exception {
-        // There are two images named "CentOS 6"; we need the newest so using the explicit imageId
-        runTest(ImmutableMap.of(
-            "imageId", "RegionOne/55e1fcb5-5a74-461c-b4fc-5b14c575b188",
-            "loginUser", "centos",
-            "minRam", "2000"));
+        runTest(getCentos6Config());
+    }
+
+    protected Map<String, ?> getCentos6Config() {
+        return ImmutableMap.of(
+            "osFamily", "centos",
+            "osVersionRegex", "6",
+            "loginUser", "centos");
     }
 
     @Test(groups = {"Live"})
     public void test_Centos_7() throws Exception {
-        // release codename "squeeze"
-        runTest(ImmutableMap.of(
-            "imageNameRegex", "CentOS 7",
-            "loginUser", "centos",
-            "minRam", "2000"));
+        runTest(getCentos7Config());
     }
 
+    protected Map<String, ?> getCentos7Config() {
+        return ImmutableMap.of(
+            "osFamily", "centos",
+            "osVersionRegex", "7",
+            "loginUser", "centos");
+    }
 }


### PR DESCRIPTION
* explicitly disable HA - marks the node as MASTER instead of INITIALIZING
* don't retry machine creation - just slows down the test when the node being tested is misconfigured
* makes the centos config overridable by extending tests
* don't require beefy machines for tests - can be overrided if needed