### PR TITLE
JcloudsLocationCustomizer.onObtainError

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigLocationInheritanceYamlTest.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.camp.brooklyn;
 import static org.testng.Assert.assertEquals;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -142,9 +141,9 @@ public class ConfigLocationInheritanceYamlTest extends AbstractYamlTest {
         public final List<ConfigBag> templateConfigs = Lists.newCopyOnWriteArrayList();
         
         @Override
-        public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
+        public Template buildTemplate(ComputeService computeService, ConfigBag config, JcloudsLocationCustomizer customizersDelegate) {
             templateConfigs.add(config);
-            return super.buildTemplate(computeService, config, customizers);
+            return super.buildTemplate(computeService, config, customizersDelegate);
         }
     }
 

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/command/support/CloudExplorerSupport.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.launcher.command.support;
 
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +31,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.location.jclouds.BlobStoreContextFactoryImpl;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationCustomizer;
+import org.apache.brooklyn.location.jclouds.LocationCustomizerDelegate;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.FatalConfigurationRuntimeException;
 import org.apache.brooklyn.util.stream.Streams;
@@ -273,9 +273,9 @@ public abstract class CloudExplorerSupport implements Callable<Void> {
 
             ComputeService computeService = loc.getComputeService();
             ConfigBag setup = loc.config().getBag();
-            Collection<JcloudsLocationCustomizer> customizers = loc.getCustomizers(setup);
-
-            Template template = loc.buildTemplate(computeService, setup, customizers);
+            
+            JcloudsLocationCustomizer customizersDelegate = LocationCustomizerDelegate.newInstance(loc.getManagementContext(), setup);
+            Template template = loc.buildTemplate(computeService, setup, customizersDelegate);
             Image image = template.getImage();
             Hardware hardware = template.getHardware();
             org.jclouds.domain.Location location = template.getLocation();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -29,10 +31,8 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
-import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.objs.BasicConfigurableObject;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.task.Tasks;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
@@ -121,6 +121,16 @@ public class BasicJcloudsLocationCustomizer extends BasicConfigurableObject impl
 
     @Override
     public void postRelease(JcloudsMachineLocation machine) {
+        // no-op
+    }
+
+    @Override
+    public void preReleaseOnObtainError(JcloudsLocation jcloudsLocation, @Nullable JcloudsMachineLocation machineLocation, Exception cause) {
+        // no-op
+    }
+
+    @Override
+    public void postReleaseOnObtainError(JcloudsLocation jcloudsLocation, @Nullable JcloudsMachineLocation machineLocation, Exception cause) {
         // no-op
     }
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1055,6 +1055,13 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     + ": "+e.getMessage());
             LOG.debug(Throwables.getStackTraceAsString(e));
 
+            try {
+                customizersDelegate.preReleaseOnObtainError(this, machineLocation, e);
+            } catch (Exception customizerException) {
+                LOG.info("Got exception on calling customizer preReleaseOnObtainError, ignoring. Location is {}, machine location is {}, node is {}",
+                        new Object[] {this, machineLocation, node, customizerException});
+            }
+
             if (destroyNode) {
                 Stopwatch destroyingStopwatch = Stopwatch.createStarted();
                 if (machineLocation != null) {
@@ -1064,6 +1071,14 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                 }
                 LOG.info("Destroyed " + (machineLocation != null ? "machine " + machineLocation : "node " + node)
                         + " in " + Duration.of(destroyingStopwatch).toStringRounded());
+
+                try {
+                    customizersDelegate.postReleaseOnObtainError(this, machineLocation, e);
+                } catch (Exception customizerException) {
+                    LOG.debug("Got exception on calling customizer postReleaseOnObtainError, ignoring. Location is {}, machine Location is {}, node is {}",
+                            new Object[] {this, machineLocation, node, customizerException});
+                }
+
             }
 
             throw Exceptions.propagate(e);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -391,45 +391,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     }
 
     public Collection<JcloudsLocationCustomizer> getCustomizers(ConfigBag setup) {
-        @SuppressWarnings("deprecation")
-        JcloudsLocationCustomizer customizer = setup.get(JCLOUDS_LOCATION_CUSTOMIZER);
-        Collection<JcloudsLocationCustomizer> customizers = setup.get(JCLOUDS_LOCATION_CUSTOMIZERS);
-        @SuppressWarnings("deprecation")
-        String customizerType = setup.get(JCLOUDS_LOCATION_CUSTOMIZER_TYPE);
-        @SuppressWarnings("deprecation")
-        String customizersSupplierType = setup.get(JCLOUDS_LOCATION_CUSTOMIZERS_SUPPLIER_TYPE);
-
-        ClassLoader catalogClassLoader = getManagementContext().getCatalogClassLoader();
-        List<JcloudsLocationCustomizer> result = new ArrayList<JcloudsLocationCustomizer>();
-        if (customizer != null) result.add(customizer);
-        if (customizers != null) result.addAll(customizers);
-        if (Strings.isNonBlank(customizerType)) {
-            Maybe<JcloudsLocationCustomizer> customizerByType = Reflections.invokeConstructorFromArgs(catalogClassLoader, JcloudsLocationCustomizer.class, customizerType, setup);
-            if (customizerByType.isPresent()) {
-                result.add(customizerByType.get());
-            } else {
-                customizerByType = Reflections.invokeConstructorFromArgs(catalogClassLoader, JcloudsLocationCustomizer.class, customizerType);
-                if (customizerByType.isPresent()) {
-                    result.add(customizerByType.get());
-                } else {
-                    throw new IllegalStateException("Failed to create JcloudsLocationCustomizer "+customizersSupplierType+" for location "+this);
-                }
-            }
+        try {
+            return LocationCustomizerDelegate.getCustomizers(getManagementContext(), setup);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create initialize customizers for location "+this);
         }
-        if (Strings.isNonBlank(customizersSupplierType)) {
-            Maybe<Supplier<Collection<JcloudsLocationCustomizer>>> supplier = Reflections.<Supplier<Collection<JcloudsLocationCustomizer>>>invokeConstructorFromArgsUntyped(catalogClassLoader, customizersSupplierType, setup);
-            if (supplier.isPresent()) {
-                result.addAll(supplier.get().get());
-            } else {
-                supplier = Reflections.<Supplier<Collection<JcloudsLocationCustomizer>>>invokeConstructorFromArgsUntyped(catalogClassLoader, customizersSupplierType);
-                if (supplier.isPresent()) {
-                    result.addAll(supplier.get().get());
-                } else {
-                    throw new IllegalStateException("Failed to create JcloudsLocationCustomizer supplier "+customizersSupplierType+" for location "+this);
-                }
-            }
-        }
-        return result;
     }
 
     public ConnectivityResolver getLocationNetworkInfoCustomizer(ConfigBag setup) {
@@ -438,8 +404,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     }
 
     protected Collection<MachineLocationCustomizer> getMachineCustomizers(ConfigBag setup) {
-        Collection<MachineLocationCustomizer> customizers = setup.get(MACHINE_LOCATION_CUSTOMIZERS);
-        return (customizers == null ? ImmutableList.<MachineLocationCustomizer>of() : customizers);
+        try {
+            return LocationCustomizerDelegate.getMachineCustomizers(getManagementContext(), setup);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create initialize customizers for location "+this);
+        }
     }
 
     public void setDefaultImageId(String val) {
@@ -675,6 +644,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         Duration customizedTimestamp = null;
         Stopwatch provisioningStopwatch = Stopwatch.createStarted();
 
+        JcloudsLocationCustomizer customizersDelegate = LocationCustomizerDelegate.newInstance(getManagementContext(), setup);
+
         try {
             LOG.info("Creating VM "+getCreationString(setup)+" in "+this);
 
@@ -693,12 +664,10 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             LoginCredentials userCredentials = null;
             Set<? extends NodeMetadata> nodes;
             Template template;
-            Collection<JcloudsLocationCustomizer> customizers = getCustomizers(setup);
-            Collection<MachineLocationCustomizer> machineCustomizers = getMachineCustomizers(setup);
 
             try {
                 // Setup the template
-                template = buildTemplate(computeService, setup, customizers);
+                template = buildTemplate(computeService, setup, ImmutableList.of(customizersDelegate));
                 boolean expectWindows = isWindows(template, setup);
                 if (!options.skipJcloudsSshing()) {
                     if (expectWindows) {
@@ -732,7 +701,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     }
                 }
 
-                customizeTemplate(computeService, template, customizers);
+                customizeTemplate(computeService, template, customizersDelegate);
 
                 LOG.debug("jclouds using template {} / options {} to provision machine in {}",
                         new Object[] {template, template.getOptions(), getCreationString(setup)});
@@ -748,9 +717,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             if (node == null)
                 throw new IllegalStateException("No nodes returned by jclouds create-nodes in " + getCreationString(setup));
 
-            for (JcloudsLocationCustomizer customizer : customizers) {
-                customizer.customize(this, node, setup);
-            }
+            customizersDelegate.customize(this, node, setup);
 
             boolean windows = isWindows(node, setup);
 
@@ -1037,15 +1004,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                 // ssh to exec these commands!
             }
 
-            // Apply any optional app-specific customization.
-            for (JcloudsLocationCustomizer customizer : customizers) {
-                LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
-                customizer.customize(this, computeService, machineLocation);
-            }
-            for (MachineLocationCustomizer customizer : machineCustomizers) {
-                LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
-                customizer.customize(machineLocation);
-            }
+            customizersDelegate.customize(this, computeService, machineLocation);
 
             customizedTimestamp = Duration.of(provisioningStopwatch);
             String logMessage = "Finished VM "+getCreationString(setup)+" creation:"
@@ -1275,11 +1234,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             .build();
 
     /** hook whereby template customizations can be made for various clouds */
-    protected void customizeTemplate(ComputeService computeService, Template template, Collection<JcloudsLocationCustomizer> customizers) {
-        for (JcloudsLocationCustomizer customizer : customizers) {
-            customizer.customize(this, computeService, template);
-            customizer.customize(this, computeService, template.getOptions());
-        }
+    protected void customizeTemplate(ComputeService computeService, Template template, JcloudsLocationCustomizer customizersDelegate) {
+        customizersDelegate.customize(this, computeService, template);
+        customizersDelegate.customize(this, computeService, template.getOptions());
 
         // these things are nice on softlayer
         if (template.getOptions() instanceof SoftLayerTemplateOptions) {
@@ -1341,8 +1298,15 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         return BrooklynImageChooser.cloneFor(chooser, computeService, config);
     }
 
-    /** returns the jclouds Template which describes the image to be built, for the given config and compute service */
+    /** @deprecated since 0.11.0. Use {@link #buildTemplate(ComputeService, ConfigBag, JcloudsLocationCustomizer)} instead. */
+    @Deprecated
     public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
+        JcloudsLocationCustomizer customizersDelegate = LocationCustomizerDelegate.newInstance(customizers);
+        return buildTemplate(computeService, config, customizersDelegate);
+    }
+
+    /** returns the jclouds Template which describes the image to be built, for the given config and compute service */
+    public Template buildTemplate(ComputeService computeService, ConfigBag config, JcloudsLocationCustomizer customizersDelegate) {
         TemplateBuilder templateBuilder = config.get(TEMPLATE_BUILDER);
         if (templateBuilder==null) {
             templateBuilder = new PortableTemplateBuilder<PortableTemplateBuilder<?>>();
@@ -1396,10 +1360,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             }
         }
 
-        // Then apply any optional app-specific customization.
-        for (JcloudsLocationCustomizer customizer : customizers) {
-            customizer.customize(this, computeService, templateBuilder);
-        }
+        customizersDelegate.customize(this, computeService, templateBuilder);
 
         LOG.debug("jclouds using templateBuilder {} for provisioning in {} for {}", new Object[] {
             templateBuilder, this, getCreationString(config)});
@@ -2130,21 +2091,16 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         Exception tothrow = null;
 
         ConfigBag setup = ((LocationInternal)machine).config().getBag();
-        Collection<JcloudsLocationCustomizer> customizers = getCustomizers(setup);
-        Collection<MachineLocationCustomizer> machineCustomizers = getMachineCustomizers(setup);
-        
-        for (JcloudsLocationCustomizer customizer : customizers) {
-            try {
-                customizer.preRelease(machine);
-            } catch (Exception e) {
-                LOG.error("Problem invoking pre-release customizer "+customizer+" for machine "+machine+" in "+this+", instance id "+instanceId+
+
+        JcloudsLocationCustomizer customizersDelegate = LocationCustomizerDelegate.newInstance(getManagementContext(), setup);
+
+        try {
+            customizersDelegate.preRelease(machine);
+        } catch (Exception e) {
+            LOG.error("Problem invoking pre-release for machine "+machine+" in "+this+", instance id "+instanceId+
                     "; ignoring and continuing, "
                     + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
-                if (tothrow==null) tothrow = e;
-            }
-        }
-        for (MachineLocationCustomizer customizer : machineCustomizers) {
-            customizer.preRelease(machine);
+            if (tothrow==null) tothrow = e;
         }
 
         try {
@@ -2170,15 +2126,13 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
         removeChild(machine);
 
-        for (JcloudsLocationCustomizer customizer : customizers) {
-            try {
-                customizer.postRelease(machine);
-            } catch (Exception e) {
-                LOG.error("Problem invoking pre-release customizer "+customizer+" for machine "+machine+" in "+this+", instance id "+instanceId+
+        try {
+            customizersDelegate.postRelease(machine);
+        } catch (Exception e) {
+            LOG.error("Problem invoking post-release for machine "+machine+" in "+this+", instance id "+instanceId+
                     "; ignoring and continuing, "
                     + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
-                if (tothrow==null) tothrow = e;
-            }
+            if (tothrow==null) tothrow = e;
         }
         
         if (tothrow != null) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
@@ -87,4 +90,19 @@ public interface JcloudsLocationCustomizer {
      * Override to handle machine-related cleanup after Jclouds is called to release (destroy) the machine.
      */
     void postRelease(JcloudsMachineLocation machine);
+
+    /**
+     * Override to handle cleanup after failure to obtain a machine. Could be called as a result of an {@link InterruptedException}
+     * in which case return as quickly as possible.
+     */
+    void preReleaseOnObtainError(JcloudsLocation location, @Nullable JcloudsMachineLocation machineLocation, Exception cause);
+
+    /**
+     * <p>
+     * Override to handle cleanup after failure to obtain a machine. Called after releasing the locations' underlying node.
+     * Could be called as a result of an {@link InterruptedException} in which case return as quickly as possible.
+     * <p>
+     * Will be skipped if {@link CloudLocationConfig#DESTROY_ON_FAILURE} is set to {@code false}.
+     */
+    void postReleaseOnObtainError(JcloudsLocation location, @Nullable JcloudsMachineLocation machineLocation, Exception cause);
 }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/LocationCustomizerDelegate.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/LocationCustomizerDelegate.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.brooklyn.api.location.MachineLocationCustomizer;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.javalang.Reflections;
+import org.apache.brooklyn.util.text.Strings;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.options.TemplateOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+
+public class LocationCustomizerDelegate implements JcloudsLocationCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(LocationCustomizerDelegate.class);
+
+    private Collection<JcloudsLocationCustomizer> customizers;
+    private Collection<MachineLocationCustomizer> machineCustomizers;
+
+    public static JcloudsLocationCustomizer newInstance(ManagementContext managementContext, ConfigBag setup) {
+        return new LocationCustomizerDelegate(managementContext, setup);
+    }
+
+    /** @deprecated since 0.11.0. Use {@link #newInstance(ManagementContext, ConfigBag)} instead. */
+    @Deprecated
+    public static JcloudsLocationCustomizer newInstance(Collection<JcloudsLocationCustomizer> customizers) {
+        return new LocationCustomizerDelegate(customizers);
+    }
+
+    private LocationCustomizerDelegate(ManagementContext mgmt, ConfigBag setup) {
+        this.customizers = getCustomizers(mgmt, setup);
+        this.machineCustomizers = getMachineCustomizers(mgmt, setup);
+    }
+
+    private LocationCustomizerDelegate(Collection<JcloudsLocationCustomizer> customizers) {
+        this.customizers = customizers;
+        this.machineCustomizers = ImmutableList.of();
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, TemplateBuilder templateBuilder) {
+        // Then apply any optional app-specific customization.
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            customizer.customize(location, computeService, templateBuilder);
+        }
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, Template template) {
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            customizer.customize(location, computeService, template);
+        }
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, TemplateOptions templateOptions) {
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            customizer.customize(location, computeService, templateOptions);
+        }
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, NodeMetadata node, ConfigBag setup) {
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            customizer.customize(location, node, setup);
+        }
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, ComputeService computeService, JcloudsMachineLocation machineLocation) {
+        // Apply any optional app-specific customization.
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
+            customizer.customize(location, computeService, machineLocation);
+        }
+        for (MachineLocationCustomizer customizer : machineCustomizers) {
+            LOG.debug("Customizing machine {}, using customizer {}", machineLocation, customizer);
+            customizer.customize(machineLocation);
+        }
+    }
+
+    @Override
+    public void preRelease(JcloudsMachineLocation machine) {
+        Exception tothrow = null;
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            try {
+                customizer.preRelease(machine);
+            } catch (Exception e) {
+                LOG.error("Problem invoking pre-release customizer "+customizer+" for machine "+machine+
+                    "; ignoring and continuing, "
+                    + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
+                if (tothrow==null) tothrow = e;
+            }
+        }
+        for (MachineLocationCustomizer customizer : machineCustomizers) {
+            try {
+                customizer.preRelease(machine);
+            } catch (Exception e) {
+                LOG.error("Problem invoking pre-release machine customizer "+customizer+" for machine "+machine+
+                    "; ignoring and continuing, "
+                    + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
+                if (tothrow==null) tothrow = e;
+            }
+        }
+        if (tothrow != null) {
+            throw Exceptions.propagate(tothrow);
+        }
+    }
+
+    @Override
+    public void postRelease(JcloudsMachineLocation machine) {
+        Exception tothrow = null;
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            try {
+                customizer.postRelease(machine);
+            } catch (Exception e) {
+                LOG.error("Problem invoking pre-release customizer "+customizer+" for machine "+machine+
+                    "; ignoring and continuing, "
+                    + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
+                if (tothrow==null) tothrow = e;
+            }
+        }
+        if (tothrow != null) {
+            throw Exceptions.propagate(tothrow);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public static Collection<JcloudsLocationCustomizer> getCustomizers(ManagementContext mgmt, ConfigBag setup) {
+        JcloudsLocationCustomizer customizer = setup.get(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZER);
+        Collection<JcloudsLocationCustomizer> customizers = setup.get(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS);
+        String customizerType = setup.get(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZER_TYPE);
+        String customizersSupplierType = setup.get(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZERS_SUPPLIER_TYPE);
+
+        ClassLoader catalogClassLoader = mgmt.getCatalogClassLoader();
+        List<JcloudsLocationCustomizer> result = new ArrayList<JcloudsLocationCustomizer>();
+        if (customizer != null) result.add(customizer);
+        if (customizers != null) result.addAll(customizers);
+        if (Strings.isNonBlank(customizerType)) {
+            Maybe<JcloudsLocationCustomizer> customizerByType = Reflections.invokeConstructorFromArgs(catalogClassLoader, JcloudsLocationCustomizer.class, customizerType, setup);
+            if (customizerByType.isPresent()) {
+                result.add(customizerByType.get());
+            } else {
+                customizerByType = Reflections.invokeConstructorFromArgs(catalogClassLoader, JcloudsLocationCustomizer.class, customizerType);
+                if (customizerByType.isPresent()) {
+                    result.add(customizerByType.get());
+                } else {
+                    throw new IllegalStateException("Failed to create JcloudsLocationCustomizer "+customizersSupplierType);
+                }
+            }
+        }
+        if (Strings.isNonBlank(customizersSupplierType)) {
+            Maybe<Supplier<Collection<JcloudsLocationCustomizer>>> supplier = Reflections.<Supplier<Collection<JcloudsLocationCustomizer>>>invokeConstructorFromArgsUntyped(catalogClassLoader, customizersSupplierType, setup);
+            if (supplier.isPresent()) {
+                result.addAll(supplier.get().get());
+            } else {
+                supplier = Reflections.<Supplier<Collection<JcloudsLocationCustomizer>>>invokeConstructorFromArgsUntyped(catalogClassLoader, customizersSupplierType);
+                if (supplier.isPresent()) {
+                    result.addAll(supplier.get().get());
+                } else {
+                    throw new IllegalStateException("Failed to create JcloudsLocationCustomizer supplier "+customizersSupplierType);
+                }
+            }
+        }
+        return result;
+    }
+
+    protected static Collection<MachineLocationCustomizer> getMachineCustomizers(ManagementContext mgmt, ConfigBag setup) {
+        Collection<MachineLocationCustomizer> customizers = setup.get(JcloudsLocationConfig.MACHINE_LOCATION_CUSTOMIZERS);
+        return (customizers == null ? ImmutableList.<MachineLocationCustomizer>of() : customizers);
+    }
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/LocationCustomizerDelegate.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/LocationCustomizerDelegate.java
@@ -154,6 +154,43 @@ public class LocationCustomizerDelegate implements JcloudsLocationCustomizer {
         }
     }
 
+    @Override
+    public void preReleaseOnObtainError(JcloudsLocation location, JcloudsMachineLocation machineLocation,
+            Exception cause) {
+        Exception tothrow = null;
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            try {
+                customizer.preReleaseOnObtainError(location, machineLocation, cause);
+            } catch (Exception e) {
+                LOG.error("Problem invoking customizer preReleaseOnObtainError for "+customizer+" for machine "+machineLocation+
+                    ", locaiton=" + location + "; ignoring and continuing, "
+                    + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
+                if (tothrow==null) tothrow = e;
+            }
+        }
+        if (tothrow != null) {
+            throw Exceptions.propagate(tothrow);
+        }
+    }
+
+    @Override
+    public void postReleaseOnObtainError(JcloudsLocation location, JcloudsMachineLocation machineLocation, Exception cause) {
+        Exception tothrow = null;
+        for (JcloudsLocationCustomizer customizer : customizers) {
+            try {
+                customizer.postReleaseOnObtainError(location, machineLocation, cause);
+            } catch (Exception e) {
+                LOG.error("Problem invoking customizer postReleaseOnObtainError for "+customizer+" for machine "+machineLocation+
+                    ", locaiton=" + location + "; ignoring and continuing, "
+                    + (tothrow==null ? "will throw subsequently" : "swallowing due to previous error")+": "+e, e);
+                if (tothrow==null) tothrow = e;
+            }
+        }
+        if (tothrow != null) {
+            throw Exceptions.propagate(tothrow);
+        }
+    }
+
     @SuppressWarnings("deprecation")
     public static Collection<JcloudsLocationCustomizer> getCustomizers(ManagementContext mgmt, ConfigBag setup) {
         JcloudsLocationCustomizer customizer = setup.get(JcloudsLocationConfig.JCLOUDS_LOCATION_CUSTOMIZER);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/BailOutJcloudsLocation.java
@@ -74,13 +74,13 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
     }
 
     @Override
-    public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
+    public Template buildTemplate(ComputeService computeService, ConfigBag config, JcloudsLocationCustomizer customizersDelegate) {
         lastConfigBag = config;
         if (getConfig(BUILD_TEMPLATE_INTERCEPTOR) != null) {
             getConfig(BUILD_TEMPLATE_INTERCEPTOR).apply(config);
         }
         if (Boolean.TRUE.equals(getConfig(BUILD_TEMPLATE))) {
-            template = super.buildTemplate(computeService, config, customizers);
+            template = super.buildTemplate(computeService, config, customizersDelegate);
         }
         throw new RuntimeException(BAIL_OUT_FOR_TESTING);
     }
@@ -150,9 +150,9 @@ public class BailOutJcloudsLocation extends JcloudsLocation {
     public static class CountingBailOutJcloudsLocation extends BailOutJcloudsLocation {
         int buildTemplateCount = 0;
         @Override
-        public Template buildTemplate(ComputeService computeService, ConfigBag config, Collection<JcloudsLocationCustomizer> customizers) {
+        public Template buildTemplate(ComputeService computeService, ConfigBag config, JcloudsLocationCustomizer customizersDelegate) {
             buildTemplateCount++;
-            return super.buildTemplate(computeService, config, customizers);
+            return super.buildTemplate(computeService, config, customizersDelegate);
         }
     }
 


### PR DESCRIPTION
Makes customizers aware of obtain failures in case they need to clean up.
Also wraps the customizer calls into a delegate.
