### PR TITLE
Delete use of entity constructors

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.entity.group;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -62,14 +61,6 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
     private static final Logger log = LoggerFactory.getLogger(AbstractGroupImpl.class);
 
     private Set<Entity> members = Sets.newLinkedHashSet();
-
-    public AbstractGroupImpl() {
-    }
-
-    @Deprecated
-    public AbstractGroupImpl(@SuppressWarnings("rawtypes") Map flags, Entity parent) {
-        super(flags, parent);
-    }
 
     @Override
     public void setManagementContext(ManagementContextInternal managementContext) {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.entity.group;
 
 import java.util.Collection;
-import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -52,13 +51,6 @@ public class DynamicGroupImpl extends AbstractGroupImpl implements DynamicGroup 
     protected final Object memberChangeMutex = new Object();
 
     private volatile MyEntitySetChangeListener setChangeListener = null;
-
-    public DynamicGroupImpl() { }
-
-    @Deprecated
-    public DynamicGroupImpl(@SuppressWarnings("rawtypes") Map flags, Entity parent) {
-        super(flags, parent);
-    }
 
     @Override
     public void init() {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/AttributeTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/AttributeTest.java
@@ -21,46 +21,47 @@ package org.apache.brooklyn.core.entity;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class AttributeTest {
+public class AttributeTest extends BrooklynAppUnitTestSupport {
     static AttributeSensor<String> COLOR = new BasicAttributeSensor<String>(String.class, "my.color");
 
-    TestEntityImpl e;
+    TestEntity entity;
+    TestEntityImpl entityImpl;
     
     @BeforeMethod(alwaysRun=true)
+    @Override
     public void setUp() throws Exception {
-        e = new TestEntityImpl();
-    }
-
-    @AfterMethod(alwaysRun = true)
-    public void tearDown(){
-        // nothing to tear down; entity was not managed (i.e. had no management context)
+        super.setUp();
+        entity = app.addChild(EntitySpec.create(TestEntity.class));
+        entityImpl = (TestEntityImpl) Entities.deproxy(entity);
     }
 
     @Test
     public void canGetAndSetAttribute() {
-        e.sensors().set(COLOR, "red");
-        assertEquals(e.getAttribute(COLOR), "red");
+        entity.sensors().set(COLOR, "red");
+        assertEquals(entity.getAttribute(COLOR), "red");
     }
     
     @Test
     public void missingAttributeIsNull() {
-        assertEquals(e.getAttribute(COLOR), null);
+        assertEquals(entity.getAttribute(COLOR), null);
     }
     
     @Test
     public void canGetAttributeByNameParts() {
         // Initially null
-        assertNull(e.getAttributeByNameParts(COLOR.getNameParts()));
+        assertNull(entityImpl.getAttributeByNameParts(COLOR.getNameParts()));
         
         // Once set, returns val
-        e.sensors().set(COLOR, "red");
-        assertEquals(e.getAttributeByNameParts(COLOR.getNameParts()), "red");
+        entity.sensors().set(COLOR, "red");
+        assertEquals(entityImpl.getAttributeByNameParts(COLOR.getNameParts()), "red");
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
@@ -149,7 +149,7 @@ public class EntitySpecTest extends BrooklynAppUnitTestSupport {
 
     @Test
     public void testCallsConfigureAfterConstruction() throws Exception {
-        AbstractEntityLegacyTest.MyEntity entity = app.createAndManageChild(EntitySpec.create(AbstractEntityLegacyTest.MyEntity.class));
+        TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
 
         assertEquals(entity.getConfigureCount(), 1);
         assertEquals(entity.getConfigureDuringConstructionCount(), 0);

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityTypeTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityTypeTest.java
@@ -47,14 +47,6 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -69,6 +61,13 @@ import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 
 public class EntityTypeTest extends BrooklynAppUnitTestSupport {
     private static final AttributeSensor<String> TEST_SENSOR = Sensors.newStringSensor("test.sensor");
@@ -152,29 +151,24 @@ public class EntityTypeTest extends BrooklynAppUnitTestSupport {
 
     @Test
     public void testCustomSimpleName() throws Exception {
-        class CustomTypeNamedEntity extends AbstractEntity {
-            private final String typeName;
-            @SuppressWarnings("deprecation")
-            CustomTypeNamedEntity(Entity parent, String typeName) {
-                super(parent);
-                this.typeName = typeName;
-            }
-            @Override protected String getEntityTypeName() {
-                return typeName;
-            }
-        }
-        
-        CustomTypeNamedEntity entity2 = new CustomTypeNamedEntity(app, "a.b.with space");
-        Entities.manage(entity2);
+        CustomTypeNamedEntity.typeName = "a.b.with space";
+        Entity entity2 = app.addChild(EntitySpec.create(Entity.class).impl(CustomTypeNamedEntity.class));
         assertEquals(entity2.getEntityType().getSimpleName(), "with_space");
         
-        CustomTypeNamedEntity entity3 = new CustomTypeNamedEntity(app, "a.b.with$dollar");
-        Entities.manage(entity3);
+        CustomTypeNamedEntity.typeName = "a.b.with$dollar";
+        Entity entity3 = app.addChild(EntitySpec.create(Entity.class).impl(CustomTypeNamedEntity.class));
         assertEquals(entity3.getEntityType().getSimpleName(), "with_dollar");
         
-        CustomTypeNamedEntity entity4 = new CustomTypeNamedEntity(app, "a.nothingafterdot.");
-        Entities.manage(entity4);
+        CustomTypeNamedEntity.typeName = "a.nothingafterdot.";
+        Entity entity4 = app.addChild(EntitySpec.create(Entity.class).impl(CustomTypeNamedEntity.class));
         assertEquals(entity4.getEntityType().getSimpleName(), "a.nothingafterdot.");
+    }
+    public static class CustomTypeNamedEntity extends AbstractEntity {
+        static volatile String typeName;
+        
+        @Override protected String getEntityTypeName() {
+            return typeName;
+        }
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/entity/OwnedChildrenDeprecatedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/OwnedChildrenDeprecatedTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.entity;
+
+import static org.apache.brooklyn.test.Asserts.assertEqualsIgnoringOrder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class OwnedChildrenDeprecatedTest extends BrooklynAppUnitTestSupport {
+
+    // Tests that the deprecated "owner" still works
+    @Test
+    public void testSetOwnerInConstructorMap() {
+        Entity e = new AbstractEntity(MutableMap.of("owner", app)) {};
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+        assertEquals(e.getApplication(), app);
+    }
+    
+    // Tests that the deprecated constructor still works
+    @Test
+    public void testSetParentInConstructorArgument() {
+        Entity e = new AbstractEntity(app) {};
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+        assertEquals(e.getApplication(), app);
+    }
+    
+    // Tests with deprecated constructor usage
+    @Test
+    public void testSetParentWhenMatchesParentSetInConstructor() {
+        Entity e = new AbstractEntity(app) {};
+        e.setParent(app);
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+    }
+    
+    // Tests with deprecated constructor usage
+    @Test
+    public void testSetParentWhenDiffersFromParentSetInConstructor() {
+        Entity e = new AbstractEntity(app) {};
+        Entity e2 = new AbstractEntity() {};
+        try {
+            e.setParent(e2);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception uoe = Exceptions.getFirstThrowableOfType(ex, UnsupportedOperationException.class);
+            if (uoe == null || !uoe.toString().contains("Cannot change parent")) {
+                throw ex;
+            }
+        }
+    }
+    
+    // Tests deprecated setParent still works - should be set through EntitySpec or addChild
+    @Test
+    public void testSetParentInSetterMethod() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        e.setParent(app);
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+        assertEquals(e.getApplication(), app);
+    }
+
+    // Tests with deprecated setParent(Entity)
+    @Test
+    public void testSetParentWhenMatchesParentSetInSpec() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class).parent(app));
+        e.setParent(app);
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+    }
+    
+    // Tests with deprecated setParent(Entity)
+    @Test
+    public void testSetParentWhenDiffersFromParentSetInSpec() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class).parent(app));
+        Entity e2 = mgmt.getEntityManager().createEntity(EntitySpec.create(TestApplication.class));
+        try {
+            e.setParent(e2);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception uoe = Exceptions.getFirstThrowableOfType(ex, UnsupportedOperationException.class);
+            if (uoe == null || !uoe.toString().contains("Cannot change parent")) {
+                throw ex;
+            }
+        }
+    }
+    
+    // Tests deprecated addChild still works - users should instead set it through EntitySpec (or {@code addChild(EntitySpec)})
+    @Test
+    public void testAddChild() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        app.addChild(e);
+        
+        assertEquals(e.getParent(), app);
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of(e));
+        assertEquals(e.getApplication(), app);
+    }
+    
+
+    
+    @Test(enabled = false) // FIXME fails currently
+    public void testRemoveChild() {
+        Entity e = app.addChild(EntitySpec.create(TestEntity.class));
+        app.removeChild(e);
+        
+        assertEqualsIgnoringOrder(app.getChildren(), ImmutableList.of());
+        assertEquals(e.getParent(), null);
+    }
+    
+    @Test
+    public void testParentalLoopForbiddenViaAddChild() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        Entity e2 = e.addChild(EntitySpec.create(TestEntity.class));
+        try {
+            e2.addChild(e);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception cause = Exceptions.getFirstThrowableOfType(ex, IllegalStateException.class);
+            if (cause == null || !cause.toString().contains("loop detected trying to add child")) {
+                throw ex;
+            }
+        }
+        assertEqualsIgnoringOrder(e.getChildren(), ImmutableList.of(e2));
+        assertEqualsIgnoringOrder(e2.getChildren(), ImmutableList.of());
+        assertEquals(e.getParent(), null);
+        assertEquals(e2.getParent(), e);
+    }
+    
+    @Test
+    public void testParentalLoopForbiddenViaSetParent() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        Entity e2 = e.addChild(EntitySpec.create(TestEntity.class));
+        try {
+            e.setParent(e2);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception cause = Exceptions.getFirstThrowableOfType(ex, IllegalStateException.class);
+            if (cause == null || !cause.toString().contains("loop detected trying to set parent")) {
+                throw ex;
+            }
+        }
+        assertEqualsIgnoringOrder(e.getChildren(), ImmutableList.of(e2));
+        assertEqualsIgnoringOrder(e2.getChildren(), ImmutableList.of());
+        assertEquals(e.getParent(), null);
+        assertEquals(e2.getParent(), e);
+    }
+    
+    @Test
+    public void testChildingOneselfForbidden() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        try {
+            e.addChild(e);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception cause = Exceptions.getFirstThrowableOfType(ex, IllegalStateException.class);
+            if (cause == null || !cause.toString().contains("cannot own itself")) {
+                throw ex;
+            }
+        }
+        
+        assertNull(e.getParent());
+        assertEquals(e.getChildren(), ImmutableList.of());
+    }
+    
+    @Test
+    public void testParentingOneselfForbidden() {
+        Entity e = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class));
+        try {
+            e.setParent(e);
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception ex) {
+            Exception cause = Exceptions.getFirstThrowableOfType(ex, IllegalStateException.class);
+            if (cause == null || !cause.toString().contains("cannot own itself")) {
+                throw ex;
+            }
+        }
+        
+        assertNull(e.getParent());
+        assertEquals(e.getChildren(), ImmutableList.of());
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/entity/drivers/BasicEntityDriverManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/drivers/BasicEntityDriverManagerTest.java
@@ -20,53 +20,50 @@ package org.apache.brooklyn.core.entity.drivers;
 
 import static org.testng.Assert.assertTrue;
 
-import org.apache.brooklyn.api.entity.drivers.DriverDependentEntity;
-import org.apache.brooklyn.core.entity.drivers.BasicEntityDriverManager;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.entity.drivers.ReflectiveEntityDriverFactoryTest.MyDriver;
 import org.apache.brooklyn.core.entity.drivers.ReflectiveEntityDriverFactoryTest.MyDriverDependentEntity;
 import org.apache.brooklyn.core.entity.drivers.ReflectiveEntityDriverFactoryTest.MySshDriver;
 import org.apache.brooklyn.core.entity.drivers.RegistryEntityDriverFactoryTest.MyOtherSshDriver;
 import org.apache.brooklyn.core.location.SimulatedLocation;
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.util.collections.MutableMap;
 
-public class BasicEntityDriverManagerTest {
+public class BasicEntityDriverManagerTest extends BrooklynAppUnitTestSupport {
 
     private BasicEntityDriverManager manager;
     private SshMachineLocation sshLocation;
     private SimulatedLocation simulatedLocation;
-
-    @BeforeMethod
-    public void setUp() throws Exception {
-        manager = new BasicEntityDriverManager();
-        sshLocation = new SshMachineLocation(MutableMap.of("address", "localhost"));
-        simulatedLocation = new SimulatedLocation();
-    }
-
-    @AfterMethod
-    public void tearDown(){
-        // nothing to tear down; no management context created
-    }
+    private MyDriverDependentEntity entity;
     
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        manager = new BasicEntityDriverManager();
+        sshLocation = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+                .configure("address", "localhost"));
+        simulatedLocation = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
+        entity = app.addChild(EntitySpec.create(MyDriverDependentEntity.class)
+                .configure(MyDriverDependentEntity.DRIVER_CLASS, MyDriver.class));
+    }
+
     @Test
     public void testPrefersRegisteredDriver() throws Exception {
-        DriverDependentEntity<MyDriver> entity = new MyDriverDependentEntity<MyDriver>(MyDriver.class);
         manager.registerDriver(MyDriver.class, SshMachineLocation.class, MyOtherSshDriver.class);
         assertTrue(manager.build(entity, sshLocation) instanceof MyOtherSshDriver);
     }
     
     @Test
     public void testFallsBackToReflectiveDriver() throws Exception {
-        DriverDependentEntity<MyDriver> entity = new MyDriverDependentEntity<MyDriver>(MyDriver.class);
         assertTrue(manager.build(entity, sshLocation) instanceof MySshDriver);
     }
     
     @Test
     public void testRespectsLocationWhenDecidingOnDriver() throws Exception {
-        DriverDependentEntity<MyDriver> entity = new MyDriverDependentEntity<MyDriver>(MyDriver.class);
         manager.registerDriver(MyDriver.class, SimulatedLocation.class, MyOtherSshDriver.class);
         assertTrue(manager.build(entity, simulatedLocation) instanceof MyOtherSshDriver);
         assertTrue(manager.build(entity, sshLocation) instanceof MySshDriver);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiStandaloneTest.java
@@ -170,7 +170,7 @@ public class OsgiStandaloneTest extends OsgiTestBase {
     public void testLoadOsgiBundleDependencies() throws Exception {
         Bundle bundle = installFromClasspath(BROOKLYN_TEST_OSGI_ENTITIES_PATH);
         Assert.assertNotNull(bundle);
-        Class<?> aClass = bundle.loadClass("org.apache.brooklyn.test.osgi.entities.SimpleApplicationImpl");
+        Class<?> aClass = bundle.loadClass("org.apache.brooklyn.test.osgi.entities.SimpleObject");
         Object aInst = aClass.newInstance();
         Assert.assertNotNull(aInst);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogItemTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindCatalogItemTest.java
@@ -298,6 +298,7 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
         final String tag = "tag1";
         origItem.tags().addTag(tag);
         assertTrue(origItem.tags().containsTag(tag));
+        origManagementContext.getCatalog().persist(origItem);
 
         rebindAndAssertCatalogsAreEqual();
 
@@ -352,7 +353,9 @@ public class RebindCatalogItemTest extends RebindTestFixtureWithApp {
         
         item.setDeprecated(true);
         catalog.persist(item);
+        
         rebindAndAssertCatalogsAreEqual();
+        
         RegisteredType catalogItemAfterRebind = newManagementContext.getTypeRegistry().get("rebind-yaml-catalog-item-test", TEST_VERSION);
         assertTrue(catalogItemAfterRebind.isDeprecated(), "Expected item to be deprecated");
     }

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
@@ -112,6 +112,10 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
 
     public Map<?,?> getConfigureProperties();
 
+    public int getConfigureCount();
+    
+    public int getConfigureDuringConstructionCount();
+    
     public int getSequenceValue();
 
     public void setSequenceValue(int value);

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
@@ -63,9 +63,6 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     public TestEntityImpl() {
         super();
     }
-    public TestEntityImpl(Map properties) {
-        this(properties, null);
-    }
     public TestEntityImpl(Entity parent) {
         this(MutableMap.of(), parent);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
@@ -58,6 +58,8 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     protected AtomicInteger counter = new AtomicInteger(0);
     protected Map<?,?> constructorProperties;
     protected Map<?,?> configureProperties;
+    protected int configureCount;
+    protected int configureDuringConstructionCount;
     protected List<String> callHistory = Collections.synchronizedList(Lists.<String>newArrayList());
 
     public TestEntityImpl() {
@@ -69,11 +71,13 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     public TestEntityImpl(Map properties, Entity parent) {
         super(properties, parent);
         this.constructorProperties = properties;
+        this.configureDuringConstructionCount = configureCount;
     }
     
     @Override
     public AbstractEntity configure(Map flags) {
         this.configureProperties = flags;
+        configureCount++;
         return super.configure(flags);
     }
     
@@ -132,6 +136,16 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
         return configureProperties;
     }
     
+    @Override
+    public int getConfigureCount() {
+        return configureCount;
+    }
+
+    @Override
+    public int getConfigureDuringConstructionCount() {
+        return configureDuringConstructionCount;
+    }
+
     @Override
     public synchronized int getSequenceValue() {
         return sequenceValue;

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricherTest.java
@@ -24,22 +24,16 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
-import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.sensor.BasicSensorEvent;
-import org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher;
-import org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher.ConfidenceQualifiedNumber;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.util.time.Duration;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class YamlRollingTimeWindowMeanEnricherTest {
-    
-    AbstractApplication app;
+public class YamlRollingTimeWindowMeanEnricherTest extends BrooklynAppUnitTestSupport {
     
     BasicEntity producer;
 
@@ -55,10 +49,10 @@ public class YamlRollingTimeWindowMeanEnricherTest {
     SubscriptionContext subscription;
     
     @SuppressWarnings("unchecked")
-    @BeforeMethod
-    public void before() {
-        app = new AbstractApplication() {};
-        Entities.startManagement(app);
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         producer = app.addChild(EntitySpec.create(BasicEntity.class));
 
         intSensor = new BasicAttributeSensor<Integer>(Integer.class, "int sensor");
@@ -77,11 +71,6 @@ public class YamlRollingTimeWindowMeanEnricherTest {
                 .configure(YamlRollingTimeWindowMeanEnricher.WINDOW_DURATION, timePeriod));
     }
 
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (app != null) Entities.destroyAll(app.getManagementContext());
-    }
-        
     @Test
     public void testDefaultAverageWhenEmpty() {
         ConfidenceQualifiedNumber average = averager.getAverage(0, 0);

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/LocallyResizableEntity.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/LocallyResizableEntity.java
@@ -21,52 +21,23 @@ package org.apache.brooklyn.policy.autoscaling;
 import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.trait.Resizable;
-import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestCluster;
-
-import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 
 /**
  * Test class for providing a Resizable LocallyManagedEntity for policy testing
  * It is hooked up to a TestCluster that can be used to make assertions against
  */
-public class LocallyResizableEntity extends AbstractEntity implements Resizable {
-    List<Integer> sizes = Lists.newArrayList();
-    TestCluster cluster;
-    long resizeSleepTime = 0;
+@ImplementedBy(LocallyResizableEntityImpl.class)
+public interface LocallyResizableEntity extends Entity, Resizable {
+    ConfigKey<TestCluster> TEST_CLUSTER = ConfigKeys.newConfigKey(
+            TestCluster.class,
+            "testCluster");
     
-    public LocallyResizableEntity (TestCluster tc) {
-        this(null, tc);
-    }
-    @SuppressWarnings("deprecation")
-    public LocallyResizableEntity (Entity parent, TestCluster tc) {
-        super(parent);
-        this.cluster = tc;
-        sensors().set(Startable.SERVICE_UP, true);
-    }
+    void setResizeSleepTime(long val);
     
-    @Override
-    public Integer resize(Integer newSize) {
-        try {
-            Thread.sleep(resizeSleepTime);
-            sizes.add(newSize); 
-            return cluster.resize(newSize);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw Throwables.propagate(e);
-        }
-    }
-    
-    @Override
-    public Integer getCurrentSize() {
-        return cluster.getCurrentSize();
-    }
-    
-    @Override
-    public String toString() {
-        return getDisplayName();
-    }
+    List<Integer> getSizes();
 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/LocallyResizableEntityImpl.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/LocallyResizableEntityImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.policy.autoscaling;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.test.entity.TestCluster;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+public class LocallyResizableEntityImpl extends AbstractEntity implements LocallyResizableEntity {
+    List<Integer> sizes = Lists.newArrayList();
+    TestCluster cluster;
+    long resizeSleepTime = 0;
+
+    @Override
+    public void init() {
+        super.init();
+        this.cluster = checkNotNull(config().get(TEST_CLUSTER), "testCluster");
+        sensors().set(Startable.SERVICE_UP, true);
+    }
+    
+    @Override
+    public void setResizeSleepTime(long val) {
+        resizeSleepTime = val;
+    }
+    
+    @Override
+    public List<Integer> getSizes() {
+        return ImmutableList.copyOf(sizes);
+    }
+    
+    @Override
+    public Integer resize(Integer newSize) {
+        try {
+            Thread.sleep(resizeSleepTime);
+            sizes.add(newSize); 
+            return cluster.resize(newSize);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw Throwables.propagate(e);
+        }
+    }
+    
+    @Override
+    public Integer getCurrentSize() {
+        return cluster.getCurrentSize();
+    }
+    
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+}

--- a/policy/src/test/java/org/apache/brooklyn/policy/enricher/DeltaEnrichersTests.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/enricher/DeltaEnrichersTests.java
@@ -20,43 +20,33 @@ package org.apache.brooklyn.policy.enricher;
 
 import static org.testng.Assert.assertEquals;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.SubscriptionContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
-import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.AbstractEntity;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
 
-public class DeltaEnrichersTests {
+public class DeltaEnrichersTests extends BrooklynAppUnitTestSupport {
     
-    AbstractApplication app;
-    
-    EntityLocal producer;
+    Entity producer;
 
     Sensor<Integer> intSensor;
     Sensor<Double> avgSensor;
     SubscriptionContext subscription;
     
-    @BeforeMethod
-    public void before() {
-        app = new AbstractApplication() {};
-        producer = new AbstractEntity(app) {};
-        producer.setParent(app);
-        Entities.startManagement(app);
-
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        producer = app.addChild(EntitySpec.create(TestEntity.class));
         intSensor = new BasicAttributeSensor<Integer>(Integer.class, "int sensor");
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (app != null) Entities.destroyAll(app.getManagementContext());
     }
 
     @Test
@@ -83,15 +73,16 @@ public class DeltaEnrichersTests {
             TimeWeightedDeltaEnricher.<Integer>getPerSecondDeltaEnricher(producer, intSensor, deltaSensor);
         producer.enrichers().add(delta);
         
-        delta.onEvent(intSensor.newEvent(producer, 0), 0);
-        assertEquals(producer.getAttribute(deltaSensor), null);
+        // Don't start with timestamp=0: that may be treated special 
         delta.onEvent(intSensor.newEvent(producer, 0), 1000);
+        assertEquals(producer.getAttribute(deltaSensor), null);
+        delta.onEvent(intSensor.newEvent(producer, 0), 2000);
         assertEquals(producer.getAttribute(deltaSensor), 0d);
-        delta.onEvent(intSensor.newEvent(producer, 1), 2000);
+        delta.onEvent(intSensor.newEvent(producer, 1), 3000);
         assertEquals(producer.getAttribute(deltaSensor), 1d);
-        delta.onEvent(intSensor.newEvent(producer, 3), 3000);
+        delta.onEvent(intSensor.newEvent(producer, 3), 4000);
         assertEquals(producer.getAttribute(deltaSensor), 2d);
-        delta.onEvent(intSensor.newEvent(producer, 8), 4000);
+        delta.onEvent(intSensor.newEvent(producer, 8), 5000);
         assertEquals(producer.getAttribute(deltaSensor), 5d);
     }
     
@@ -102,16 +93,16 @@ public class DeltaEnrichersTests {
             TimeWeightedDeltaEnricher.<Integer>getPerSecondDeltaEnricher(producer, intSensor, deltaSensor);
         producer.enrichers().add(delta);
         
-        delta.onEvent(intSensor.newEvent(producer, 0), 0);
-        delta.onEvent(intSensor.newEvent(producer, 0), 2000);
+        delta.onEvent(intSensor.newEvent(producer, 0), 1000);
+        delta.onEvent(intSensor.newEvent(producer, 0), 3000);
         assertEquals(producer.getAttribute(deltaSensor), 0d);
-        delta.onEvent(intSensor.newEvent(producer, 3), 5000);
+        delta.onEvent(intSensor.newEvent(producer, 3), 6000);
         assertEquals(producer.getAttribute(deltaSensor), 1d);
-        delta.onEvent(intSensor.newEvent(producer, 7), 7000);
+        delta.onEvent(intSensor.newEvent(producer, 7), 8000);
         assertEquals(producer.getAttribute(deltaSensor), 2d);
-        delta.onEvent(intSensor.newEvent(producer, 12), 7500);
+        delta.onEvent(intSensor.newEvent(producer, 12), 8500);
         assertEquals(producer.getAttribute(deltaSensor), 10d);
-        delta.onEvent(intSensor.newEvent(producer, 15), 9500);
+        delta.onEvent(intSensor.newEvent(producer, 15), 10500);
         assertEquals(producer.getAttribute(deltaSensor), 1.5d);
     }
 
@@ -121,10 +112,10 @@ public class DeltaEnrichersTests {
         TimeWeightedDeltaEnricher<Integer> delta = new TimeWeightedDeltaEnricher<Integer>(producer, intSensor, deltaSensor, 1000, new AddConstant(123d));
         producer.enrichers().add(delta);
         
-        delta.onEvent(intSensor.newEvent(producer, 0), 0);
         delta.onEvent(intSensor.newEvent(producer, 0), 1000);
+        delta.onEvent(intSensor.newEvent(producer, 0), 2000);
         assertEquals(producer.getAttribute(deltaSensor), 123+0d);
-        delta.onEvent(intSensor.newEvent(producer, 1), 2000);
+        delta.onEvent(intSensor.newEvent(producer, 1), 3000);
         assertEquals(producer.getAttribute(deltaSensor), 123+1d);
     }
 

--- a/policy/src/test/java/org/apache/brooklyn/policy/enricher/RollingMeanEnricherTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/enricher/RollingMeanEnricherTest.java
@@ -20,22 +20,19 @@ package org.apache.brooklyn.policy.enricher;
 
 import static org.testng.Assert.assertEquals;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
-import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.AbstractEntity;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class RollingMeanEnricherTest {
+public class RollingMeanEnricherTest extends BrooklynAppUnitTestSupport {
     
-    AbstractApplication app;
-    
-    EntityLocal producer;
+    Entity producer;
 
     Sensor<Integer> intSensor;
     AttributeSensor<Integer> deltaSensor;
@@ -43,11 +40,10 @@ public class RollingMeanEnricherTest {
     RollingMeanEnricher<Integer> averager;
 
     @BeforeMethod(alwaysRun=true)
-    public void before() {
-        app = new AbstractApplication() {};
-        producer = new AbstractEntity(app) {};
-        producer.setParent(app);
-        Entities.startManagement(app);
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        producer = app.addChild(EntitySpec.create(TestEntity.class));
 
         intSensor = new BasicAttributeSensor<Integer>(Integer.class, "int sensor");
         deltaSensor = new BasicAttributeSensor<Integer>(Integer.class, "delta sensor");
@@ -56,11 +52,6 @@ public class RollingMeanEnricherTest {
         producer.enrichers().add(new DeltaEnricher<Integer>(producer, intSensor, deltaSensor));
         averager = new RollingMeanEnricher<Integer>(producer, deltaSensor, avgSensor, 4);
         producer.enrichers().add(averager);
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (app != null) Entities.destroyAll(app.getManagementContext());
     }
 
     @Test

--- a/policy/src/test/java/org/apache/brooklyn/policy/enricher/RollingTimeWindowMeanEnricherTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/enricher/RollingTimeWindowMeanEnricherTest.java
@@ -20,24 +20,21 @@ package org.apache.brooklyn.policy.enricher;
 
 import static org.testng.Assert.assertEquals;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
-import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.AbstractEntity;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher.ConfidenceQualifiedNumber;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @SuppressWarnings("deprecation")
-public class RollingTimeWindowMeanEnricherTest {
+public class RollingTimeWindowMeanEnricherTest extends BrooklynAppUnitTestSupport {
     
-    AbstractApplication app;
-    
-    EntityLocal producer;
+    Entity producer;
 
     Sensor<Integer> intSensor;
     AttributeSensor<Integer> deltaSensor;
@@ -48,11 +45,11 @@ public class RollingTimeWindowMeanEnricherTest {
 
     private final long timePeriod = 1000;
     
-    @BeforeMethod
-    public void before() {
-        app = new AbstractApplication() {};
-        producer = new AbstractEntity(app) {};
-        Entities.startManagement(app);
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        producer = app.addChild(EntitySpec.create(TestEntity.class));
 
         intSensor = new BasicAttributeSensor<Integer>(Integer.class, "int sensor");
         deltaSensor = new BasicAttributeSensor<Integer>(Integer.class, "delta sensor");
@@ -61,11 +58,6 @@ public class RollingTimeWindowMeanEnricherTest {
         producer.enrichers().add(new DeltaEnricher<Integer>(producer, intSensor, deltaSensor));
         averager = new RollingTimeWindowMeanEnricher<Integer>(producer, deltaSensor, avgSensor, timePeriod);
         producer.enrichers().add(averager);
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (app != null) Entities.destroyAll(app.getManagementContext());
     }
 
     @Test

--- a/policy/src/test/java/org/apache/brooklyn/policy/followthesun/FollowTheSunModelTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/followthesun/FollowTheSunModelTest.java
@@ -22,41 +22,48 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.core.location.SimulatedLocation;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.policy.loadbalancing.MockContainerEntity;
+import org.apache.brooklyn.policy.loadbalancing.MockItemEntity;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.core.location.SimulatedLocation;
-import org.apache.brooklyn.policy.loadbalancing.MockContainerEntity;
-import org.apache.brooklyn.policy.loadbalancing.MockContainerEntityImpl;
-import org.apache.brooklyn.policy.loadbalancing.MockItemEntity;
-import org.apache.brooklyn.policy.loadbalancing.MockItemEntityImpl;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class FollowTheSunModelTest {
+public class FollowTheSunModelTest extends BrooklynAppUnitTestSupport {
 
-    private Location loc1 = new SimulatedLocation(DefaultFollowTheSunModel.newHashMap("name","loc1"));
-    private Location loc2 = new SimulatedLocation(DefaultFollowTheSunModel.newHashMap("name","loc2"));
-    private MockContainerEntity container1 = new MockContainerEntityImpl();
-    private MockContainerEntity container2 = new MockContainerEntityImpl();
-    private MockItemEntity item1 = new MockItemEntityImpl();
-    private MockItemEntity item2 = new MockItemEntityImpl();
-    private MockItemEntity item3 = new MockItemEntityImpl();
+    private Location loc1;
+    private Location loc2;
+    private MockContainerEntity container1;
+    private MockContainerEntity container2;
+    private MockItemEntity item1;
+    private MockItemEntity item2;
+    private MockItemEntity item3;
     
     private DefaultFollowTheSunModel<MockContainerEntity, MockItemEntity> model;
 
     @BeforeMethod(alwaysRun=true)
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         model = new DefaultFollowTheSunModel<MockContainerEntity, MockItemEntity>("myname");
+        
+        loc1 = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class)
+                .configure("name","loc1"));
+        loc2 = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class)
+                .configure("name","loc2"));
+        container1 = app.addChild(EntitySpec.create(MockContainerEntity.class));
+        container2 = app.addChild(EntitySpec.create(MockContainerEntity.class));
+        item1 = app.addChild(EntitySpec.create(MockItemEntity.class));
+        item2 = app.addChild(EntitySpec.create(MockItemEntity.class));
+        item3 = app.addChild(EntitySpec.create(MockItemEntity.class));
     }
     
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        // noting to tear down; no management context created
-    }
-
     @Test
     public void testSimpleAddAndRemove() throws Exception {
         model.onContainerAdded(container1, loc1);

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/AbstractLoadBalancingPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/AbstractLoadBalancingPolicyTest.java
@@ -32,9 +32,9 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.group.DynamicGroup;
 import org.apache.brooklyn.test.Asserts;
@@ -53,7 +53,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-public class AbstractLoadBalancingPolicyTest {
+public abstract class AbstractLoadBalancingPolicyTest extends BrooklynAppUnitTestSupport {
     
     private static final Logger LOG = LoggerFactory.getLogger(AbstractLoadBalancingPolicyTest.class);
     
@@ -68,7 +68,6 @@ public class AbstractLoadBalancingPolicyTest {
     public static final ConfigKey<Double> LOW_THRESHOLD_CONFIG_KEY = new BasicConfigKey<Double>(Double.class, TEST_METRIC.getName()+".threshold.low", "desc", 0.0);
     public static final ConfigKey<Double> HIGH_THRESHOLD_CONFIG_KEY = new BasicConfigKey<Double>(Double.class, TEST_METRIC.getName()+".threshold.high", "desc", 0.0);
     
-    protected TestApplication app;
     protected SimulatedLocation loc;
     protected BalanceableWorkerPool pool;
     protected DefaultBalanceablePoolModel<Entity, Entity> model;
@@ -78,7 +77,9 @@ public class AbstractLoadBalancingPolicyTest {
     protected Random random = new Random();
     
     @BeforeMethod(alwaysRun=true)
-    public void before() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         LOG.debug("In AbstractLoadBalancingPolicyTest.before()");
         
         MockItemEntityImpl.totalMoveCount.set(0);
@@ -103,9 +104,13 @@ public class AbstractLoadBalancingPolicyTest {
     }
     
     @AfterMethod(alwaysRun=true)
-    public void after() {
-        if (policy != null) policy.destroy();
-        if (app != null) Entities.destroyAll(app.getManagementContext());
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            if (policy != null) policy.destroy();
+        } finally {
+            super.tearDown();
+        }
     }
     
     // Using this utility, as it gives more info about the workrates of all containers rather than just the one that differs    

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingModelTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingModelTest.java
@@ -22,33 +22,37 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Collections;
 
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class LoadBalancingModelTest {
+public class LoadBalancingModelTest extends BrooklynAppUnitTestSupport {
 
     private static final double PRECISION = 0.00001;
     
-    private MockContainerEntity container1 = new MockContainerEntityImpl();
-    private MockContainerEntity container2 = new MockContainerEntityImpl();
-    private MockItemEntity item1 = new MockItemEntityImpl();
-    private MockItemEntity item2 = new MockItemEntityImpl();
-    private MockItemEntity item3 = new MockItemEntityImpl();
+    private MockContainerEntity container1;
+    private MockContainerEntity container2;
+    private MockItemEntity item1;
+    private MockItemEntity item2;
+    private MockItemEntity item3;
     
     private DefaultBalanceablePoolModel<MockContainerEntity, MockItemEntity> model;
 
     @BeforeMethod(alwaysRun=true)
+    @Override
     public void setUp() throws Exception {
+        super.setUp();
         model = new DefaultBalanceablePoolModel<MockContainerEntity, MockItemEntity>("myname");
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        // nothing to tear down; no management context created
+        
+        container1 = app.addChild(EntitySpec.create(MockContainerEntity.class));
+        container2 = app.addChild(EntitySpec.create(MockContainerEntity.class));
+        item1 = app.addChild(EntitySpec.create(MockItemEntity.class));
+        item2 = app.addChild(EntitySpec.create(MockItemEntity.class));
+        item3 = app.addChild(EntitySpec.create(MockItemEntity.class));
     }
 
     @Test

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicyConcurrencyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicyConcurrencyTest.java
@@ -51,16 +51,16 @@ public class LoadBalancingPolicyConcurrencyTest extends AbstractLoadBalancingPol
 
     @BeforeMethod(alwaysRun=true)
     @Override
-    public void before() {
+    public void setUp() throws Exception {
         scheduledExecutor = Executors.newScheduledThreadPool(10);
-        super.before();
+        super.setUp();
     }
     
     @AfterMethod(alwaysRun=true)
     @Override
-    public void after() {
+    public void tearDown() throws Exception {
         if (scheduledExecutor != null) scheduledExecutor.shutdownNow();
-        super.after();
+        super.tearDown();
     }
     
     /**

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/MockItemEntityImpl.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/MockItemEntityImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +82,7 @@ public class MockItemEntityImpl extends AbstractEntity implements MockItemEntity
                 _lock.lock();
                 try {
                     if (stopped) throw new IllegalStateException("Item "+this+" is stopped; cannot move to "+destination);
-                    if (currentContainer != null) currentContainer.removeItem(MockItemEntityImpl.this);
+                    if (currentContainer != null && Entities.isManaged(currentContainer)) currentContainer.removeItem(MockItemEntityImpl.this);
                     currentContainer = destination;
                     destination.addItem(MockItemEntityImpl.this);
                     sensors().set(CONTAINER, currentContainer);
@@ -97,7 +98,7 @@ public class MockItemEntityImpl extends AbstractEntity implements MockItemEntity
         if (LOG.isDebugEnabled()) LOG.debug("Mocks: stopping item {} (was in container {})", this, currentContainer);
         _lock.lock();
         try {
-            if (currentContainer != null) currentContainer.removeItem(this);
+            if (currentContainer != null && Entities.isManaged(currentContainer)) currentContainer.removeItem(this);
             currentContainer = null;
             stopped = true;
         } finally {

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimpleEntity.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimpleEntity.java
@@ -18,9 +18,6 @@
  */
 package org.apache.brooklyn.rest.testing.mocks;
 
-import java.util.Map;
-
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
@@ -38,22 +35,6 @@ import org.slf4j.LoggerFactory;
 public class RestMockSimpleEntity extends SoftwareProcessImpl {
 
     private static final Logger log = LoggerFactory.getLogger(RestMockSimpleEntity.class);
-    
-    public RestMockSimpleEntity() {
-        super();
-    }
-
-    public RestMockSimpleEntity(Entity parent) {
-        super(parent);
-    }
-
-    public RestMockSimpleEntity(@SuppressWarnings("rawtypes") Map flags, Entity parent) {
-        super(flags, parent);
-    }
-
-    public RestMockSimpleEntity(@SuppressWarnings("rawtypes") Map flags) {
-        super(flags);
-    }
     
     @Override
     protected void connectSensors() {

--- a/server-cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
+++ b/server-cli/src/test/java/org/apache/brooklyn/cli/CliTest.java
@@ -41,8 +41,10 @@ import java.util.regex.Pattern;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.cli.AbstractMain.BrooklynCommand;
 import org.apache.brooklyn.cli.AbstractMain.BrooklynCommandCollectingArgs;
@@ -219,19 +221,19 @@ public class CliTest {
     @Test
     public void testStopAllApplications() throws Exception {
         LaunchCommand launchCommand = new Main.LaunchCommand();
-        ExampleApp app = new ExampleApp();
-        ManagementContext mgmt = null;
+        ManagementContext mgmt = LocalManagementContextForTests.newInstance();
+        
         try {
-            Entities.startManagement(app);
-            mgmt = app.getManagementContext();
-            app.start(ImmutableList.of(new SimulatedLocation()));
-            assertTrue(app.running);
+            StartableApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(StartableApplication.class).impl(ExampleApp.class));
+            ExampleApp appImpl = (ExampleApp) Entities.deproxy(app);
+            SimulatedLocation loc = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
+            app.start(ImmutableList.of(loc));
+            assertTrue(appImpl.running);
             
             launchCommand.stopAllApps(ImmutableList.of(app));
-            assertFalse(app.running);
+            assertFalse(appImpl.running);
         } finally {
             // Stopping the app will make app.getManagementContext return the "NonDeploymentManagementContext";
-            // hence we've retrieved it before calling stopAllApps()
             if (mgmt != null) Entities.destroyAll(mgmt);
         }
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -119,14 +119,6 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
 
     private HttpFeed httpFeed;
     
-    public BrooklynNodeImpl() {
-        super();
-    }
-
-    public BrooklynNodeImpl(Entity parent) {
-        super(parent);
-    }
-    
     @Override
     public Class<?> getDriverInterface() {
         return BrooklynNodeDriver.class;

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/VanillaJavaAppImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/VanillaJavaAppImpl.java
@@ -23,34 +23,24 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.feed.jmx.JmxFeed;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 public class VanillaJavaAppImpl extends SoftwareProcessImpl implements VanillaJavaApp {
 
+    private static final Logger log = LoggerFactory.getLogger(VanillaJavaApp.class);
+    
     static {
         JavaAppUtils.init();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(VanillaJavaApp.class);
 
     @SetFromFlag
     protected long jmxPollPeriod;
 
     protected JmxFeed jmxFeed;
-
-    public VanillaJavaAppImpl() {}
-
-    @VisibleForTesting
-    public VanillaJavaAppImpl(Map<?,?> properties, Entity parent) {
-        super(properties, parent);
-    }
 
     @Override
     public String getMainClass() { return getConfig(MAIN_CLASS); }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -89,19 +89,6 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
 
     protected boolean connectedSensors = false;
 
-    public SoftwareProcessImpl() {
-        super(MutableMap.of(), null);
-    }
-    public SoftwareProcessImpl(Entity parent) {
-        this(MutableMap.of(), parent);
-    }
-    public SoftwareProcessImpl(Map properties) {
-        this(properties, null);
-    }
-    public SoftwareProcessImpl(Map properties, Entity parent) {
-        super(properties, parent);
-    }
-
     protected void setProvisioningLocation(MachineProvisioningLocation val) {
         if (getAttribute(PROVISIONING_LOCATION) != null) throw new IllegalStateException("Cannot change provisioning location: existing="+getAttribute(PROVISIONING_LOCATION)+"; new="+val);
         sensors().set(PROVISIONING_LOCATION, val);

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityTest.java
@@ -92,7 +92,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 
-
 public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
 
     // NB: These tests don't actually require ssh to localhost -- only that 'localhost' resolves.
@@ -364,12 +363,12 @@ public class SoftwareProcessEntityTest extends BrooklynAppUnitTestSupport {
                     .configure(StopSoftwareParameters.STOP_MACHINE_MODE, stopMachineMode)));
         t1.asTask().get(10, TimeUnit.SECONDS);
 
-        if (MachineLifecycleEffectorTasksTest.canStop(stopProcessMode, isEntityStopped)) {
+        if (MachineLifecycleEffectorTasksTest.canStop(app, stopProcessMode, isEntityStopped)) {
             assertEquals(d.events, ImmutableList.of("stop"));
         } else {
             assertTrue(d.events.isEmpty());
         }
-        if (MachineLifecycleEffectorTasksTest.canStop(stopMachineMode, machine == null)) {
+        if (MachineLifecycleEffectorTasksTest.canStop(app, stopMachineMode, machine == null)) {
             assertTrue(entity.getLocations().isEmpty());
             assertTrue(l.getAvailable().contains(machine));
         } else {

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/StartStopSshDriverTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/lifecycle/StartStopSshDriverTest.java
@@ -31,13 +31,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.core.test.entity.TestApplicationImpl;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
+import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -47,7 +47,6 @@ import org.apache.brooklyn.util.core.internal.ssh.sshj.SshjTool;
 import org.apache.brooklyn.util.stream.StreamGobbler;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.location.ssh.SshMachineLocation;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
@@ -55,7 +54,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class StartStopSshDriverTest {
+public class StartStopSshDriverTest extends BrooklynAppUnitTestSupport {
 
     public class BasicStartStopSshDriver extends AbstractSoftwareProcessSshDriver {
         public BasicStartStopSshDriver(EntityLocal entity, SshMachineLocation machine) {
@@ -82,15 +81,13 @@ public class StartStopSshDriverTest {
         }
     }
 
-    private TestApplication app;
     private TestEntity entity;
     private SshMachineLocationWithSshTool sshMachineLocation;
     private AbstractSoftwareProcessSshDriver driver;
 
     @SuppressWarnings("rawtypes")
-    protected static class SshMachineLocationWithSshTool extends SshMachineLocation {
+    public static class SshMachineLocationWithSshTool extends SshMachineLocation {
         SshTool lastTool;
-        public SshMachineLocationWithSshTool(Map flags) { super(flags); }
 
         @Override
         public SshTool connectSsh(Map args) {
@@ -101,11 +98,12 @@ public class StartStopSshDriverTest {
     }
     
     @BeforeMethod(alwaysRun = true)
-    public void setUp() {
-        app = new TestApplicationImpl();
-        entity = new TestEntityImpl(app);
-        Entities.startManagement(app);
-        sshMachineLocation = new SshMachineLocationWithSshTool(ImmutableMap.of("address", "localhost"));
+    public void setUp() throws Exception {
+        super.setUp();
+        entity = app.addChild(EntitySpec.create(TestEntity.class));
+        
+        sshMachineLocation = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocationWithSshTool.class)
+                .configure("address", "localhost"));
         driver = new BasicStartStopSshDriver(entity, sshMachineLocation);
     }
     


### PR DESCRIPTION
Replaces code (in tests) that uses entity-constructors directly. Deletes a few entity constructors, now they are not used.

This code is a step towards deleting more code from `AbstractEntity` that handles entities being created directly via their constructors (deprecated since Brooklyn 0.5.0!). We first need our tests to not be relying on that.

Also please review https://github.com/apache/brooklyn-library/pull/110.