### PR TITLE
Adds JcloudsLocationCustomizer hook to allow node / config configuration

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/SshTool.java
@@ -86,6 +86,10 @@ public interface SshTool extends ShellTool {
     public static final ConfigKey<Long> PROP_LAST_MODIFICATION_DATE = newConfigKey("lastModificationDate", "Last-modification-date to be set on files copied/created (should be UTC/1000, ie seconds since 1970; default 0 usually means current)", 0L);
     public static final ConfigKey<Long> PROP_LAST_ACCESS_DATE = newConfigKey("lastAccessDate", "Last-access-date to be set on files copied/created (should be UTC/1000, ie seconds since 1970; default 0 usually means lastModificationDate)", 0L);
     public static final ConfigKey<Integer> PROP_OWNER_UID = newConfigKey("ownerUid", "Default owner UID (not username) for files created on remote machine; default is unset", -1);
+
+    ConfigKey<String> ADDITIONAL_CONNECTION_METADATA = newStringConfigKey("additional.connection.metadata",
+            "Can be used to pass additional custom data to the SshTool, which is especially useful " +
+                    "if writing a bespoke tool implementation");
     
     // TODO remove unnecessary "public static final" modifiers
     

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BasicJcloudsLocationCustomizer.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.objs.BasicConfigurableObject;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.options.TemplateOptions;
@@ -100,6 +101,11 @@ public class BasicJcloudsLocationCustomizer extends BasicConfigurableObject impl
 
     @Override
     public void customize(JcloudsLocation location, ComputeService computeService, TemplateOptions templateOptions) {
+        // no-op
+    }
+
+    @Override
+    public void customize(JcloudsLocation location, NodeMetadata node, ConfigBag setup) {
         // no-op
     }
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -756,6 +756,10 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             if (node == null)
                 throw new IllegalStateException("No nodes returned by jclouds create-nodes in " + getCreationString(setup));
 
+            for (JcloudsLocationCustomizer customizer : customizers) {
+                customizer.customize(this, node, setup);
+            }
+
             boolean windows = isWindows(node, setup);
 
             if (windows) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocationCustomizer.java
@@ -18,7 +18,9 @@
  */
 package org.apache.brooklyn.location.jclouds;
 
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.options.TemplateOptions;
@@ -60,6 +62,13 @@ public interface JcloudsLocationCustomizer {
      * be used by {@link JcloudsLocation} to obtain machines.
      */
     void customize(JcloudsLocation location, ComputeService computeService, TemplateOptions templateOptions);
+
+
+    /**
+     * Override to configure the {@link NodeMetadata}, and {@link ConfigBag} that will be used when
+     * connecting to the machine.
+     */
+    void customize(JcloudsLocation location, NodeMetadata node, ConfigBag setup);
 
     /**
      * Override to configure the given machine once it has been created and started by Jclouds.

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -86,6 +86,10 @@ public interface WinRmTool {
             "Size of file chunks (in bytes) to be used when copying a file to the remote server", 
             1024);
 
+    ConfigKey<String> ADDITIONAL_CONNECTION_METADATA = newStringConfigKey("additional.connection.metadata",
+            "Can be used to pass additional custom data to the WinrmTool, which is especially useful " +
+                    "if writing a bespoke tool implementation");
+
     /**
      * @deprecated since 0.9.0; use {@link #executeCommand(List)} to avoid ambiguity between native command and power shell.
      */


### PR DESCRIPTION
Adds JcloudsLocationCustomizer hook to allow node / config configuration which can be used by a customizer to configure the ssh / winrm config tool with runtime data such as machineid