### PR TITLE
Switch to Java 8

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -571,10 +571,11 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         }
 
         /** used if yaml specifies a parameter, but possibly incomplete, and a spec supertype has a parameter */
+        @SuppressWarnings("unchecked")
         SpecParameter<?> resolveWithAncestor(SpecParameter<?> ancestor) {
             if (ancestor==null) return new BasicSpecParameter<>(getLabel(), isPinned(), getConfigKey(), getSensor());
 
-            return new BasicSpecParameter<>(
+            return new BasicSpecParameter(
                     hasLabelSet ? getLabel() : ancestor.getLabel(), 
                     hasPinnedSet ? isPinned() : ancestor.isPinned(), 
                     resolveWithAncestorConfigKey(ancestor.getConfigKey()), 

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
@@ -72,7 +72,7 @@ public class BasicExecutionContext extends AbstractExecutionContext {
     /**
      * Supported flags are {@code tag} and {@code tags}
      * 
-     * @see ExecutionManager#submit(Map, Task)
+     * @see ExecutionManager#submit(Map, TaskAdaptable)
      */
     public BasicExecutionContext(Map<?, ?> flags, ExecutionManager executionManager) {
         this.executionManager = executionManager;
@@ -213,16 +213,13 @@ public class BasicExecutionContext extends AbstractExecutionContext {
             } else {
                 // as above, but here we are definitely not a child (what we are submitting isn't even a task)
                 // (will only come here if properties defines tags including a target entity, which probably never happens) 
-                submit(Tasks.<T>builder().displayName("Cross-context execution").dynamic(true).body(new Callable<T>() {
-                    @Override
-                    public T call() {
-                        if (task instanceof Callable) {
-                            return DynamicTasks.queue( Tasks.<T>builder().dynamic(false).body((Callable<T>)task).build() ).getUnchecked();
-                        } else if (task instanceof Runnable) {
-                            return DynamicTasks.queue( Tasks.<T>builder().dynamic(false).body((Runnable)task).build() ).getUnchecked();
-                        } else {
-                            throw new IllegalArgumentException("Unhandled task type: "+task+"; type="+(task!=null ? task.getClass() : "null"));
-                        }
+                submit(Tasks.<T>builder().displayName("Cross-context execution").dynamic(true).body(() -> {
+                    if (task instanceof Callable) {
+                        return DynamicTasks.queue( Tasks.<T>builder().dynamic(false).body((Callable<T>)task).build() ).getUnchecked();
+                    } else if (task instanceof Runnable) {
+                        return DynamicTasks.queue( Tasks.<T>builder().dynamic(false).body((Runnable)task).build() ).getUnchecked();
+                    } else {
+                        throw new IllegalArgumentException("Unhandled task type: "+task+"; type="+(task!=null ? task.getClass() : "null"));
                     }
                 }).build());
             }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -886,7 +886,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.13</version>
+                <version>2.17</version>
                 <executions>
                     <execution>
                         <id>verify-style</id>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
 
         <!-- Compilation -->
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/GroovJavaMethodsTest.java
+++ b/utils/groovy/src/test/java/org/apache/brooklyn/util/groovy/GroovJavaMethodsTest.java
@@ -67,8 +67,8 @@ public class GroovJavaMethodsTest {
         assertEquals(elvis("string1", "string2"), "string1");
         assertEquals(elvis(null, "string2"), "string2");
         assertEquals(elvis("", "string2"), "string2");
-        assertEquals(elvis(1, 2), 1);
-        assertEquals(elvis(0, 2), 2);
+        assertEquals((int)elvis(1, 2), 1);
+        assertEquals((int)elvis(0, 2), 2);
         assertEquals(elvis(singletonList, differentList), singletonList);
         assertEquals(elvis(emptyList, differentList), differentList);
         assertEquals(elvis(gstring, "other"), gstringVal);


### PR DESCRIPTION
This updates the Java version to `1.8` and makes a couple of changes to get Brooklyn to build again.  

For demonstration purposes I've switched a `new Callable ...` in 
[BasicExecutionContext.java](https://github.com/apache/brooklyn-server/compare/master...geomacy:switch-to-java-8?expand=1#diff-1876d3c7b9d3cc5d485f7469b403e281R216) to use a Java 8 lambda expression, really just to prove that it is Java 8! (This was useful as it showed we needed to update the Checkstyle plugin to a level that works with 8).   

I've tested that Brooklyn runs in both classic and Karaf launchers, and can successfully deploy a basic server and a couple of apps from Brooklyn Central, (a three tier app and `brooklyn-etcd`). 

There's a matching update to `brooklyn-ui`, https://github.com/apache/brooklyn-ui/pull/44.


