### PR TITLE
Fix generics usage (for compilation in Eclipse)

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/sensor/EnricherSpec.java
+++ b/api/src/main/java/org/apache/brooklyn/api/sensor/EnricherSpec.java
@@ -57,7 +57,7 @@ public class EnricherSpec<T extends Enricher> extends AbstractBrooklynObjectSpec
      * @param config The spec's configuration (see {@link EnricherSpec#configure(Map)}).
      * @param type   An {@link Enricher} class
      */
-    public static <T extends Enricher> EnricherSpec<T> create(Map<?,?> config, Class<? extends T> type) {
+    public static <T extends Enricher> EnricherSpec<T> create(Map<?,?> config, Class<T> type) {
         return EnricherSpec.create(type).configure(config);
     }
     

--- a/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/interpret/PlanInterpretationContext.java
+++ b/camp/camp-base/src/main/java/org/apache/brooklyn/camp/spi/resolve/interpret/PlanInterpretationContext.java
@@ -34,7 +34,7 @@ public class PlanInterpretationContext {
 
     public PlanInterpretationContext(Map<String,?> originalDeploymentPlan, List<PlanInterpreter> interpreters) {
         super();
-        this.originalDeploymentPlan = MutableMap.copyOf(originalDeploymentPlan).asUnmodifiable();
+        this.originalDeploymentPlan = MutableMap.<String, Object>copyOf(originalDeploymentPlan).asUnmodifiable();
         this.interpreters = ImmutableList.copyOf(interpreters);
         this.allInterpreter = new PlanInterpreter() {
             @Override

--- a/core/src/test/java/org/apache/brooklyn/core/network/OnPublicNetworkEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/network/OnPublicNetworkEnricherTest.java
@@ -362,7 +362,6 @@ public class OnPublicNetworkEnricherTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public <T> void testCoercesSensorName() throws Exception {
         AttributeSensor<String> sensor = Sensors.newStringSensor("mysensor");
 
@@ -370,9 +369,8 @@ public class OnPublicNetworkEnricherTest extends BrooklynAppUnitTestSupport {
         portForwardManager.associate("myPublicIp", HostAndPort.fromParts("mypublichost", 5678), machine, 1234);
         entity.addLocations(ImmutableList.of(machine));
         
-        // Ugly casting in java, but easy to get passed this when constructed from YAML
         entity.enrichers().add(EnricherSpec.create(OnPublicNetworkEnricher.class)
-                .configure(OnPublicNetworkEnricher.SENSORS, ((List)ImmutableList.of("mysensor"))));
+                .configure(OnPublicNetworkEnricher.SENSORS.getName(), ImmutableList.of("mysensor")));
 
         assertAttributeEqualsEventually("mysensor.mapped.public", "mypublichost:5678");
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -377,8 +377,8 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         //TODO These casts are not pretty, we could just provide separate get methods for the different types?
         //Or we could provide asEntity/asPolicy cast methods on the CataloItem doing a safety check internally
         @SuppressWarnings("unchecked")
-        CatalogItem<Entity, EntitySpec<?>> result =
-              (CatalogItem<Entity, EntitySpec<?>>) brooklyn().getCatalog().getCatalogItem(symbolicName, version);
+        CatalogItem<Entity, EntitySpec<? extends Entity>> result =
+              (CatalogItem<Entity, EntitySpec<? extends Entity>>) brooklyn().getCatalog().getCatalogItem(symbolicName, version);
 
         if (result==null) {
             throw WebResourceUtils.notFound("Entity with id '%s:%s' not found", symbolicName, version);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
@@ -242,15 +242,15 @@ public class Reflections {
     }
     /** @deprecated since 0.10.0 use {@link #invokeConstructorFromArgs(Class, Object...)} or one of the variants */ @Deprecated
     public static <T> Optional<T> invokeConstructorWithArgs(Class<? extends T> clazz, Object...argsArray) {
-        return invokeConstructorFromArgs(clazz, argsArray).toOptional();
+        return Reflections.<T>invokeConstructorFromArgs(clazz, argsArray).toOptional();
     }
     /** @deprecated since 0.10.0 use {@link #invokeConstructorFromArgs(Class, Object...)} or one of the variants */ @Deprecated
     public static <T> Optional<T> invokeConstructorWithArgs(Class<? extends T> clazz, Object[] argsArray, boolean setAccessible) {
-        return invokeConstructorFromArgs(clazz, argsArray, setAccessible).toOptional();
+        return Reflections.<T>invokeConstructorFromArgs(clazz, argsArray, setAccessible).toOptional();
     }
     /** @deprecated since 0.10.0 use {@link #invokeConstructorFromArgs(Class, Object...)} or one of the variants */ @Deprecated
     public static <T> Optional<T> invokeConstructorWithArgs(Reflections reflections, Class<? extends T> clazz, Object[] argsArray, boolean setAccessible) {
-        return invokeConstructorFromArgs(reflections, clazz, argsArray, setAccessible).toOptional();
+        return Reflections.<T>invokeConstructorFromArgs(reflections, clazz, argsArray, setAccessible).toOptional();
     }
     
     /** Finds and invokes a suitable constructor, supporting varargs and primitives, boxing and looking at compatible supertypes in the constructor's signature */


### PR DESCRIPTION
Fixes generics compilation errors that the Eclipse compiler reports, with Java 8 (in Eclipse 4.6.3).