### PR TITLE
Fix type-coercion to/from arrays

### DIFF
--- a/utils/common/pom.xml
+++ b/utils/common/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -1099,4 +1100,14 @@ public class Reflections {
         return hasSpecialSerializationMethods(type.getSuperclass());
     }
 
+    public static List<?> arrayToList(Object input) {
+        // We can't just use Arrays.asList(), because that would return a list containing the single
+        // value "input".
+        List<Object> result = new ArrayList<>();
+        int length = Array.getLength(input);
+        for (int i = 0; i < length; i++) {
+            result.add(Array.get(input, i));
+        }
+        return result;
+    }
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/ReflectionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/ReflectionsTest.java
@@ -172,6 +172,12 @@ public class ReflectionsTest {
         Assert.assertFalse(Reflections.invokeConstructorFromArgs(CI1.class, new Object[] {"wrong", "args"}).isPresent());
     }
 
+    @Test
+    public void testArrayToList() throws Exception {
+        assertEquals(Reflections.arrayToList(new String[] {"a", "b"}), ImmutableList.of("a", "b"));
+        assertEquals(Reflections.arrayToList((Object) new String[] {"a", "b"}), ImmutableList.of("a", "b"));
+    }
+    
     interface I { };
     interface J extends I { };
     interface K extends I, J { };

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
@@ -37,6 +37,7 @@ import java.util.TimeZone;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.text.StringPredicates;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -194,6 +195,57 @@ public class TypeCoercionsTest {
         UPPER,
         UPPER_WITH_UNDERSCORE,
         lower_with_underscore;
+    }
+    
+    @Test
+    public void testArrayToListCoercion() {
+        @SuppressWarnings("serial")
+        List<?> s = coerce(new String[] {"1", "2"}, new TypeToken<List<String>>() { });
+        Assert.assertEquals(s, ImmutableList.of("1", "2"));
+    }
+    
+    @Test
+    public void testArrayEntryCoercion() {
+        @SuppressWarnings("serial")
+        Integer[] val = coerce(new String[] {"1", "2"}, new TypeToken<Integer[]>() { });
+        Assert.assertTrue(Arrays.equals(val, new Integer[] {1, 2}), "val="+Arrays.toString(val)+" of type "+val.getClass());
+    }
+    
+    @Test
+    public void testArrayEntryInvalidCoercion() {
+        try {
+            @SuppressWarnings("serial")
+            Integer[] val = coerce(new String[] {"myWrongVal"}, new TypeToken<Integer[]>() { });
+            Asserts.shouldHaveFailedPreviously("val="+val);
+        } catch (ClassCoercionException e) {
+            Asserts.expectedFailureContains(e, "Cannot coerce", "myWrongVal", "to java.lang.Integer");
+        }
+    }
+    
+    @Test
+    public void testListToArrayInvalidCoercion() {
+        try {
+            @SuppressWarnings("serial")
+            Integer[] val = coerce(ImmutableList.of("myWrongVal"), new TypeToken<Integer[]>() { });
+            Asserts.shouldHaveFailedPreviously("val="+val);
+        } catch (ClassCoercionException e) {
+            Asserts.expectedFailureContains(e, "Cannot coerce", "myWrongVal", "to java.lang.Integer");
+        }
+    }
+    
+    @Test
+    public void testArrayMultiDimensionEntryCoercion() {
+        @SuppressWarnings("serial")
+        Integer[][] val = coerce(new String[][] {{"1", "2"}, {"3", "4"}}, new TypeToken<Integer[][]>() { });
+        Assert.assertTrue(EqualsBuilder.reflectionEquals(val, new Integer[][] {{1, 2}, {3, 4}}), 
+                "val="+Arrays.toString(val)+" of type "+val.getClass());
+    }
+    
+    @Test
+    public void testArrayEntryToListCoercion() {
+        @SuppressWarnings("serial")
+        List<?> s = coerce(new String[] {"1", "2"}, new TypeToken<List<Integer>>() { });
+        Assert.assertEquals(s, ImmutableList.of(1, 2));
     }
     
     @Test


### PR DESCRIPTION
Motivated by investigating the list->iterable coercion problems (see https://github.com/apache/brooklyn-server/pull/698), I also added tests and fixed the casting to/from arrays.