### PR TITLE
Adds getLastConstructorProps to RecordingWinRmTool

### DIFF
--- a/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
@@ -125,6 +125,10 @@ public class RecordingWinRmTool implements WinRmTool {
         return execs.get(execs.size()-1);
     }
 
+    public static Map<?,?> getLastConstructorProps() {
+        return constructorProps.get(constructorProps.size()-1);
+    }
+
     private final Map<?, ?> ownConstructorProps;
     
     public RecordingWinRmTool(Map<?,?> props) {


### PR DESCRIPTION
Adds `getLastConstructorProps()` to `RecordingWinRmTool`, in line with `RecordingSshTool`