### PR TITLE
Remove GroovyJavaMethods.* usage

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
@@ -52,7 +53,6 @@ import org.apache.brooklyn.util.core.task.TaskTags;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.xstream.ObjectWithDefaultStringImplConverter;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.groovy.GroovyJavaMethods;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -489,7 +489,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                 targetSensor = Sensors.newSensor(Object.class, sensorNameS);
             }
             Object result = targetEntity.sensors().get(targetSensor);
-            return GroovyJavaMethods.truth(result) ? Maybe.of(result) : ImmediateValueNotAvailableException.newAbsentWithExceptionSupplier();
+            return JavaGroovyEquivalents.groovyTruth(result) ? Maybe.of(result) : ImmediateValueNotAvailableException.newAbsentWithExceptionSupplier();
         }
 
         @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -48,6 +48,7 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -116,7 +117,7 @@ public class DependentConfiguration {
      * @see #attributeWhenReady(Entity, AttributeSensor, Predicate)
      */
     public static <T> Task<T> attributeWhenReady(Entity source, AttributeSensor<T> sensor) {
-        return attributeWhenReady(source, sensor, GroovyJavaMethods.truthPredicate());
+        return attributeWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
     }
     
     /**
@@ -124,7 +125,7 @@ public class DependentConfiguration {
      */
     @Deprecated
     public static <T> Task<T> attributeWhenReady(Entity source, AttributeSensor<T> sensor, Closure<Boolean> ready) {
-        Predicate<Object> readyPredicate = (ready != null) ? GroovyJavaMethods.<Object>predicateFromClosure(ready) : GroovyJavaMethods.truthPredicate();
+        Predicate<Object> readyPredicate = (ready != null) ? GroovyJavaMethods.<Object>predicateFromClosure(ready) : JavaGroovyEquivalents.groovyTruthPredicate();
         return attributeWhenReady(source, sensor, readyPredicate);
     }
     
@@ -143,7 +144,7 @@ public class DependentConfiguration {
      */
     @Deprecated
     public static <T,V> Task<V> attributePostProcessedWhenReady(Entity source, AttributeSensor<T> sensor, Closure<Boolean> ready, Closure<V> postProcess) {
-        Predicate<? super T> readyPredicate = (ready != null) ? GroovyJavaMethods.predicateFromClosure(ready) : GroovyJavaMethods.truthPredicate();
+        Predicate<? super T> readyPredicate = (ready != null) ? GroovyJavaMethods.predicateFromClosure(ready) : JavaGroovyEquivalents.groovyTruthPredicate();
         Function<? super T, V> postProcessFunction = GroovyJavaMethods.<T,V>functionFromClosure(postProcess);
         return attributePostProcessedWhenReady(source, sensor, readyPredicate, postProcessFunction);
     }
@@ -153,15 +154,15 @@ public class DependentConfiguration {
      */
     @Deprecated
     public static <T,V> Task<V> attributePostProcessedWhenReady(Entity source, AttributeSensor<T> sensor, Closure<V> postProcess) {
-        return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), GroovyJavaMethods.<T,V>functionFromClosure(postProcess));
+        return attributePostProcessedWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate(), GroovyJavaMethods.<T,V>functionFromClosure(postProcess));
     }
 
     public static <T> Task<T> valueWhenAttributeReady(Entity source, AttributeSensor<T> sensor, T value) {
-        return DependentConfiguration.<T,T>attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), Functions.constant(value));
+        return DependentConfiguration.<T,T>attributePostProcessedWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate(), Functions.constant(value));
     }
 
     public static <T,V> Task<V> valueWhenAttributeReady(Entity source, AttributeSensor<T> sensor, Function<? super T,V> valueProvider) {
-        return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), valueProvider);
+        return attributePostProcessedWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate(), valueProvider);
     }
     
     /**
@@ -169,7 +170,7 @@ public class DependentConfiguration {
      */
     @Deprecated
     public static <T,V> Task<V> valueWhenAttributeReady(Entity source, AttributeSensor<T> sensor, Closure<V> valueProvider) {
-        return attributePostProcessedWhenReady(source, sensor, GroovyJavaMethods.truthPredicate(), valueProvider);
+        return attributePostProcessedWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate(), valueProvider);
     }
     
     /**
@@ -267,7 +268,7 @@ public class DependentConfiguration {
         
         protected boolean ready(T value) {
             if (ready!=null) return ready.apply(value);
-            return GroovyJavaMethods.truth(value);
+            return JavaGroovyEquivalents.groovyTruth(value);
         }
         
         @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -771,7 +772,7 @@ public class DependentConfiguration {
     /** returns a task for parallel execution returning a list of values for the given sensor for the given entity list,
      * optionally when the values satisfy a given readiness predicate (defaulting to groovy truth if not supplied) */
     public static <T> Task<List<T>> listAttributesWhenReady(AttributeSensor<T> sensor, Iterable<Entity> entities) {
-        return listAttributesWhenReady(sensor, entities, GroovyJavaMethods.truthPredicate());
+        return listAttributesWhenReady(sensor, entities, JavaGroovyEquivalents.groovyTruthPredicate());
     }
 
     /**
@@ -779,14 +780,14 @@ public class DependentConfiguration {
      */
     @Deprecated
     public static <T> Task<List<T>> listAttributesWhenReady(AttributeSensor<T> sensor, Iterable<Entity> entities, Closure<Boolean> readiness) {
-        Predicate<Object> readinessPredicate = (readiness != null) ? GroovyJavaMethods.<Object>predicateFromClosure(readiness) : GroovyJavaMethods.truthPredicate();
+        Predicate<Object> readinessPredicate = (readiness != null) ? GroovyJavaMethods.<Object>predicateFromClosure(readiness) : JavaGroovyEquivalents.groovyTruthPredicate();
         return listAttributesWhenReady(sensor, entities, readinessPredicate);
     }
     
     /** returns a task for parallel execution returning a list of values of the given sensor list on the given entity, 
      * optionally when the values satisfy a given readiness predicate (defaulting to groovy truth if not supplied) */    
     public static <T> Task<List<T>> listAttributesWhenReady(final AttributeSensor<T> sensor, Iterable<Entity> entities, Predicate<? super T> readiness) {
-        if (readiness == null) readiness = GroovyJavaMethods.truthPredicate();
+        if (readiness == null) readiness = JavaGroovyEquivalents.groovyTruthPredicate();
         return builder().attributeWhenReadyFromMultiple(entities, sensor, readiness).build();
     }
 
@@ -849,7 +850,7 @@ public class DependentConfiguration {
          * optionally when the values satisfy a given readiness predicate (defaulting to groovy truth if not supplied) */ 
         @Beta
         public <T> MultiBuilder<T, T, List<T>> attributeWhenReadyFromMultiple(Iterable<? extends Entity> sources, AttributeSensor<T> sensor) {
-            return attributeWhenReadyFromMultiple(sources, sensor, GroovyJavaMethods.truthPredicate());
+            return attributeWhenReadyFromMultiple(sources, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
         }
         /** As {@link #attributeWhenReadyFromMultiple(Iterable, AttributeSensor)} with an explicit readiness test. */
         @Beta
@@ -918,7 +919,7 @@ public class DependentConfiguration {
             return (Builder<T,V2>) this;
         }
         public <T2> Builder<T,V> abortIf(Entity source, AttributeSensor<T2> sensor) {
-            return abortIf(source, sensor, GroovyJavaMethods.truthPredicate());
+            return abortIf(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
         }
         public <T2> Builder<T,V> abortIf(Entity source, AttributeSensor<T2> sensor, Predicate<? super T2> predicate) {
             abortSensorConditions.add(new AttributeAndSensorCondition<T2>(source, sensor, predicate));
@@ -1007,7 +1008,7 @@ public class DependentConfiguration {
         private void validate() {
             checkNotNull(source, "Entity source");
             checkNotNull(sensor, "Sensor");
-            if (readiness == null) readiness = GroovyJavaMethods.truthPredicate();
+            if (readiness == null) readiness = JavaGroovyEquivalents.groovyTruthPredicate();
             if (postProcess == null) postProcess = (Function) Functions.identity();
         }
     }
@@ -1030,7 +1031,7 @@ public class DependentConfiguration {
          * optionally when the values satisfy a given readiness predicate (defaulting to groovy truth if not supplied) */ 
         @Beta
         protected MultiBuilder(Iterable<? extends Entity> sources, AttributeSensor<T> sensor) {
-            this(sources, sensor, GroovyJavaMethods.truthPredicate());
+            this(sources, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
         }
         @Beta
         protected MultiBuilder(Iterable<? extends Entity> sources, AttributeSensor<T> sensor, Predicate<? super T> readiness) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.util.core.task;
 
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.asString;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvisString;
-import groovy.lang.Closure;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -44,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.groovy.GroovyJavaMethods;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -63,6 +63,8 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Callables;
 import com.google.common.util.concurrent.ExecutionList;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import groovy.lang.Closure;
 
 /**
  * The basic concrete implementation of a {@link Task} to be executed.
@@ -130,8 +132,13 @@ public class BasicTask<T> implements TaskInternal<T> {
         displayName = (d==null ? "" : d);
     }
 
-    public BasicTask(Runnable job) { this(GroovyJavaMethods.<T>callableFromRunnable(job)); }
-    public BasicTask(Map<?,?> flags, Runnable job) { this(flags, GroovyJavaMethods.<T>callableFromRunnable(job)); }
+    public BasicTask(Runnable job) {
+        this(JavaGroovyEquivalents.toCallable(job));
+    }
+    
+    public BasicTask(Map<?,?> flags, Runnable job) {
+        this(flags, JavaGroovyEquivalents.toCallable(job));
+    }
     
     /**
      * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.


### PR DESCRIPTION
Motivated by @duncangrant encountering more problems like that in https://issues.apache.org/jira/browse/BROOKLYN-449, but this time when it tried to call `DslComponent` which called `GroovyJavaMethods.truth`.

Now the only use of `GroovyJavaMethods` are:
* If we genuinely have a Groovy-specific object, such as a `Closure` 
* `AbstractAggregatingEnricher` constructor uses `GroovyJavaMethods.castToPredicate()` (but that code is all deprecated since 0.7.0, so should just be deleted - assuming it is never mentioned in anyone's persisted state?!)

---
These changes will change the semantics of our `attributeWhenReady` etc very slightly, for people taking advantage of the more unusual groovy'isms.

The difference between `GroovyJavaMethods.truth` and `JavaGroovyEquivalents.groovyTruth()` is that the former also handles "matchers" and classes with an asBoolean method (see http://groovy-lang.org/semantics.html#Groovy-Truth).

However, we deprecated all the groovy support in 0.11.0, so I think it's fine to make these changes now.