### PR TITLE
Getting the correct value for WinRmMachineLocation.USE_HTTPS_WINRM

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -766,7 +766,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
             if (windows) {
                 int newLoginPort = node.getLoginPort() == 22
-                        ? (getConfig(WinRmMachineLocation.USE_HTTPS_WINRM) ? 5986 : 5985)
+                        ? (setup.get(WinRmMachineLocation.USE_HTTPS_WINRM) ? 5986 : 5985)
                         : node.getLoginPort();
                 String newLoginUser = "root".equals(node.getCredentials().getUser())
                         ? "Administrator"


### PR DESCRIPTION
- the config still doesn't contain the correct value for
  USE_HTTPS_WINRM, when it is set via provisioning.properties