### PR TITLE
Fix JcloudsLocation config usage

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolver.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsByonLocationResolver.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 /**
@@ -155,7 +156,7 @@ public class JcloudsByonLocationResolver extends AbstractLocationResolver implem
                 for (Map<?,?> machineFlags : machinesFlags) {
                     try {
                         jcloudsLocation.config().putAll(machineFlags);
-                        JcloudsMachineLocation machine = jcloudsLocation.registerMachine(jcloudsLocation.config().getBag());
+                        JcloudsMachineLocation machine = jcloudsLocation.registerMachine(ImmutableMap.of());
                         result.add(machine);
                     } catch (NoMachinesAvailableException e) {
                         Map<?,?> sanitizedMachineFlags = Sanitizer.sanitize(machineFlags);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1772,11 +1772,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
     // ----------------- registering existing machines ------------------------
 
-    protected MachineLocation registerMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
+    protected JcloudsMachineLocation registerMachine(NodeMetadata metadata) throws NoMachinesAvailableException {
         return registerMachine(MutableMap.of(), metadata);
     }
 
-    protected MachineLocation registerMachine(Map<?, ?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
+    protected JcloudsMachineLocation registerMachine(Map<?, ?> flags, NodeMetadata metadata) throws NoMachinesAvailableException {
         ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
         if (!setup.containsKey("id")) setup.putStringKey("id", metadata.getId());
         setHostnameUpdatingCredentials(setup, metadata);
@@ -1793,7 +1793,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
      *   <li>userName: the username for sshing into the machine (for use if it is not a Windows system)
      * <ul>
      */
-    public JcloudsMachineLocation registerMachine(ConfigBag setup) throws NoMachinesAvailableException {
+    public JcloudsMachineLocation registerMachine(ConfigBag flags) throws NoMachinesAvailableException {
+        ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags.getAllConfig());
         NodeMetadata node = findNodeOrThrow(setup);
         return registerMachineLocation(setup, node);
     }
@@ -1871,9 +1872,8 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         return node;
     }
 
-    public MachineLocation registerMachine(Map<?,?> flags) throws NoMachinesAvailableException {
-        ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags);
-        return registerMachine(setup);
+    public JcloudsMachineLocation registerMachine(Map<?,?> flags) throws NoMachinesAvailableException {
+        return registerMachine(ConfigBag.newInstance(flags));
     }
 
     /**

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2456,7 +2456,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
                     if (success) {
                         credsSuccessful.set(machinesToTry.getRight());
 
-                        String verifyWindowsUp = getConfig(WinRmMachineLocation.WAIT_WINDOWS_TO_START);
+                        String verifyWindowsUp = setup.get(WinRmMachineLocation.WAIT_WINDOWS_TO_START);
                         if (Strings.isBlank(verifyWindowsUp) || verifyWindowsUp.equals("false")) {
                             return true;
                         }

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1784,12 +1784,24 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     /**
      * Brings an existing machine with the given details under management.
      * <p>
-     * Required fields are:
+     * The args passed in are used to match against an existing machine. The machines are listed
+     * (see @link #listMachines()}), and each is compared against the given args. There should
+     * be exactly one matching machine.
+     * <p>
+     * Arguments that can be used for matching are:
      * <ul>
-     *   <li>id: the jclouds VM id, e.g. "eu-west-1/i-5504f21d" (NB this is {@see JcloudsMachineLocation#getJcloudsId()} not #getId())
-     *   <li>hostname: the public hostname or IP of the machine, e.g. "ec2-176-34-93-58.eu-west-1.compute.amazonaws.com"
-     *   <li>userName: the username for sshing into the machine (for use if it is not a Windows system)
-     * <ul>
+     *   <li>{@code id}: the cloud provider's VM id, e.g. "eu-west-1/i-5504f21d" (NB this is 
+     *       {@see JcloudsMachineLocation#getJcloudsId()} not #getId())
+     *   <li>{@code hostname}: the public hostname or IP of the machine, 
+     *       e.g. "ec2-176-34-93-58.eu-west-1.compute.amazonaws.com"
+     * </ul>
+     * 
+     * Other config options can also be passed in, for subsequent usage of the machine. For example,
+     * {@code user} will deterine the username subsequently used for ssh or WinRM. See the standard
+     * config options of {@link JcloudsLocation}, {@link SshMachineLocation} and 
+     * {@link WinRmMachineLocation}.
+     * 
+     * @throws IllegalArgumentException if there is not exactly one match
      */
     public JcloudsMachineLocation registerMachine(ConfigBag flags) throws NoMachinesAvailableException {
         ConfigBag setup = ConfigBag.newInstanceExtending(config().getBag(), flags.getAllConfig());

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -1611,10 +1611,6 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         sshProps.put("port", hostAndPort.getPort());
         sshProps.put(AbstractLocation.TEMPORARY_LOCATION.getName(), true);
         sshProps.put(LocalLocationManager.CREATE_UNMANAGED.getName(), true);
-        String sshClass = config().get(SshMachineLocation.SSH_TOOL_CLASS);
-        if (Strings.isNonBlank(sshClass)) {
-            sshProps.put(SshMachineLocation.SSH_TOOL_CLASS.getName(), sshClass);
-        }
 
         sshProps.remove("id");
         sshProps.remove("password");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolverTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolverTest.java
@@ -55,7 +55,8 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
                 .portForwardSshOverride(HostAndPort.fromParts("10.1.1.4", 4361))
                 .build();
         DefaultConnectivityResolver customizer = new DefaultConnectivityResolver();
-        ManagementAddressResolveResult result = customizer.resolve(jcloudsLocation, newNodeMetadata(), ConfigBag.newInstance(), options);
+        ConfigBag configBag = jcloudsLocation.config().getBag();
+        ManagementAddressResolveResult result = customizer.resolve(jcloudsLocation, newNodeMetadata(), configBag, options);
         assertEquals(result.hostAndPort().getHostText(), "10.1.1.4");
         assertEquals(result.hostAndPort().getPort(), 4361);
     }
@@ -72,7 +73,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
                 .userCredentials(credential)
                 .build();
         DefaultConnectivityResolver customizer = new DefaultConnectivityResolver();
-        ConfigBag configBag = ConfigBag.newInstance();
+        ConfigBag configBag = jcloudsLocation.config().getBag();
         ManagementAddressResolveResult result = customizer.resolve(
                 jcloudsLocation, newNodeMetadata(), configBag, options);
         assertEquals(result.hostAndPort().getHostText(), expectedHostname);
@@ -91,7 +92,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
         });
         initNodeCreatorAndJcloudsLocation(newNodeCreator(), ImmutableMap.of());
         DefaultConnectivityResolver customizer = new DefaultConnectivityResolver();
-        final ConfigBag config = ConfigBag.newInstance(ImmutableMap.of(
+        final ConfigBag config = ConfigBag.newInstanceExtending(jcloudsLocation.config().getBag(), ImmutableMap.of(
                 JcloudsLocationConfig.WAIT_FOR_SSHABLE, "1ms",
                 JcloudsLocationConfig.POLL_FOR_FIRST_REACHABLE_ADDRESS, "1ms"));
         assertTrue(customizer.checkCredential(
@@ -114,7 +115,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
         });
         initNodeCreatorAndJcloudsLocation(newNodeCreator(), ImmutableMap.of());
         DefaultConnectivityResolver customizer = new DefaultConnectivityResolver();
-        final ConfigBag config = ConfigBag.newInstance(ImmutableMap.of(
+        final ConfigBag config = ConfigBag.newInstanceExtending(jcloudsLocation.config().getBag(), ImmutableMap.of(
                 JcloudsLocationConfig.WAIT_FOR_WINRM_AVAILABLE, "1ms",
                 JcloudsLocationConfig.POLL_FOR_FIRST_REACHABLE_ADDRESS, "1ms"));
         assertTrue(customizer.checkCredential(
@@ -146,7 +147,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
                 return new RecordingSshTool.CustomResponse(exitCode, "", "");
             }
         });
-        ConfigBag config = ConfigBag.newInstance(ImmutableMap.of(
+        ConfigBag config = ConfigBag.newInstanceExtending(jcloudsLocation.config().getBag(), ImmutableMap.of(
                 JcloudsLocationConfig.LOOKUP_AWS_HOSTNAME, false,
                 JcloudsLocationConfig.WAIT_FOR_SSHABLE, "1ms",
                 JcloudsLocationConfig.POLL_FOR_FIRST_REACHABLE_ADDRESS, "1ms",
@@ -194,7 +195,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
                 JcloudsLocationConfig.CONNECTIVITY_RESOLVER, customizer));
 
         ConnectivityResolverOptions options = newResolveOptionsForIps(reachableIps, Duration.millis(100)).build();
-        ConfigBag configBag = ConfigBag.newInstance();
+        ConfigBag configBag = jcloudsLocation.config().getBag();
 
         ManagementAddressResolveResult result = customizer.resolve(jcloudsLocation, newNodeMetadata(), configBag, options);
         assertEquals(result.hostAndPort().getHostText(), expectedIp);
@@ -223,7 +224,7 @@ public class DefaultConnectivityResolverTest extends AbstractJcloudsStubbedUnitT
                 JcloudsLocationConfig.CONNECTIVITY_RESOLVER, customizer));
 
         ConnectivityResolverOptions options = newResolveOptionsForIps(reachableIps, Duration.ONE_MILLISECOND).build();
-        ConfigBag configBag = ConfigBag.newInstance();
+        ConfigBag configBag = jcloudsLocation.config().getBag();
         customizer.resolve(jcloudsLocation, newNodeMetadata(), configBag, options);
     }
 


### PR DESCRIPTION
Ensure we use the `ConfigBag` that we pass into the methods (rather than `location.config().get(...)`) because the ConfigBag will contain the union of the location's config along with any overrides/additions that were passed in to methods like `obtain()` (e.g. via an entity's `provisioning.properties`).

See individual commits for details.

Much longer term, all this config usage is a bit worrying! For an entity, there is special config lookup so that it correctly handles inherited config etc. For locations, we don't have runtime-management inheritance (which is a relief!) so things are a lot simpler. But the big code differences between Location and Entity are worrying.