### PR TITLE
[BROOKLYN-515] WindowsPerformanceCounterSensors does not show values

### DIFF
--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.sensor.windows;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.Beta;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.reflect.TypeToken;
 
+@Beta
 public class WindowsPerformanceCounterSensors implements EntityInitializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsPerformanceCounterSensors.class);

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -191,6 +191,7 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
         }
         
         Iterable<String> allParams = ImmutableList.<String>builder()
+                .add("$ProgressPreference = \"SilentlyContinue\";")
                 .add("(Get-Counter")
                 .add("-Counter")
                 .add(JOINER_ON_COMMA.join(Iterables.transform(performanceCounterNames, QuoteStringFunction.INSTANCE)))


### PR DESCRIPTION
WindowsPerformanceCounterSensors does not show values on some deployments.