### PR TITLE
[BROOKLYN-516] Persist feed of WindowsPerformanceCounterSensors initializer

### DIFF
--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
@@ -83,6 +83,6 @@ public class WindowsPerformanceCounterSensors implements EntityInitializer {
             }
             builder.addSensor(sensorConfig.get("counter"), Sensors.newSensor(clazz, name, sensorConfig.get("description")));
         }
-        builder.build();
+        entity.addFeed(builder.build());
     }
 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -44,12 +44,13 @@ import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.feed.AbstractFeed;
 import org.apache.brooklyn.core.feed.PollHandler;
 import org.apache.brooklyn.core.feed.Poller;
+import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -230,6 +231,10 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
         @Override
         @SuppressWarnings("unchecked")
         public T call() throws Exception {
+            Maybe<WinRmMachineLocation> machineLocationMaybe = Machines.findUniqueMachineLocation(entity.getLocations(), WinRmMachineLocation.class);
+            if (machineLocationMaybe.isAbsent()) {
+                return null;
+            }
             WinRmMachineLocation machine = EffectorTasks.getMachine(entity, WinRmMachineLocation.class);
             WinRmToolResponse response = machine.executePsScript(command);
             return (T)response;
@@ -282,7 +287,7 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
             // TODO not just using statusCode; also looking at absence of stderr.
             // Status code is (empirically) unreliable: it returns 0 sometimes even when failed 
             // (but never returns non-zero on success).
-            if (val.getStatusCode() != 0) return false;
+            if (val == null || val.getStatusCode() != 0) return false;
             String stderr = val.getStdErr();
             if (stderr == null || stderr.length() != 0) return false;
             String out = val.getStdOut();
@@ -323,6 +328,10 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
 
         @Override
         public void onFailure(WinRmToolResponse val) {
+            if (val == null) {
+                log.trace("Windows Performance Counter not executed since there is still now WinRmMachineLocation");
+                return;
+            }
             log.error("Windows Performance Counter query did not respond as expected. exitcode={} stdout={} stderr={}",
                     new Object[]{val.getStatusCode(), val.getStdOut(), val.getStdErr()});
             for (WindowsPerformanceCounterPollConfig<?> config : polls) {

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWindowsPerformanceCounterFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWindowsPerformanceCounterFeedTest.java
@@ -22,17 +22,17 @@ import org.apache.brooklyn.api.objs.BrooklynObjectType;
 import org.apache.brooklyn.core.mgmt.rebind.RebindAbstractCommandFeedTest;
 import org.testng.annotations.Test;
 
-public class RebindWinrmCmdFeedTest extends RebindAbstractCommandFeedTest {
+public class RebindWindowsPerformanceCounterFeedTest extends RebindAbstractCommandFeedTest {
 
     @Test
-    public void testWinrmCmdFeed_2017_04() throws Exception {
-        addMemento(BrooklynObjectType.FEED, "winrm-cmd-feed", "a8pno3muco");
+    public void testWindowsPerformanceCounterFeed_2017_06() throws Exception {
+        addMemento(BrooklynObjectType.FEED, "windows-performance-counter-feed", "tu4kk0xvf8");
         rebind();
     }
 
     @Test
-    public void testWinrmCmdFeed_2017_04_withoutBundlePrefixes() throws Exception {
-        addMemento(BrooklynObjectType.FEED, "winrm-cmd-feed-no-bundle-prefixes", "akc24nlh2k");
+    public void testWindowsPerformanceCounterFeed_2017_06_withoutBundlePrefixes() throws Exception {
+        addMemento(BrooklynObjectType.FEED, "windows-performance-counter-feed-no-bundle-prefixies", "ueauyeu41d");
         rebind();
     }
 }

--- a/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/windows-performance-counter-feed-no-bundle-prefixies-ueauyeu41d
+++ b/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/windows-performance-counter-feed-no-bundle-prefixies-ueauyeu41d
@@ -1,0 +1,61 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<feed>
+  <brooklynVersion>0.12.0-SNAPSHOT</brooklynVersion>
+  <type>org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed</type>
+  <id>ueauyeu41d</id>
+  <displayName>org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed</displayName>
+  <searchPath class="ImmutableList"/>
+  <tags>
+    <string>WindowsPerformanceCounterFeed[WindowsPerformanceCounterPollConfig[\Processor Information(_total....../f3c25627</string>
+  </tags>
+  <uniqueTag>WindowsPerformanceCounterFeed[WindowsPerformanceCounterPollConfig[\Processor Information(_total....../f3c25627</uniqueTag>
+  <config>
+    <polls>
+      <list>
+        <org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+          <sensor class="attributeSensor">
+            <type>java.lang.String</type>
+            <name>percent.processor.time</name>
+            <description>% Processor Time</description>
+            <persistence>REQUIRED</persistence>
+          </sensor>
+          <onsuccess class="com.google.common.base.Functions$IdentityFunction">INSTANCE</onsuccess>
+          <suppressDuplicates>false</suppressDuplicates>
+          <enabled>true</enabled>
+          <period>30000</period>
+          <performanceCounterName>\Processor Information(_total)\% Processor Time</performanceCounterName>
+        </org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+        <org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+          <sensor class="attributeSensor">
+            <type>java.lang.String</type>
+            <name>bytes.available</name>
+            <description>Bytes Available</description>
+            <persistence>REQUIRED</persistence>
+          </sensor>
+          <onsuccess class="com.google.common.base.Functions$IdentityFunction">INSTANCE</onsuccess>
+          <suppressDuplicates>false</suppressDuplicates>
+          <enabled>true</enabled>
+          <period>30000</period>
+          <performanceCounterName>\Memory\Available Bytes</performanceCounterName>
+        </org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+      </list>
+    </polls>
+  </config>
+</feed>

--- a/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/windows-performance-counter-feed-tu4kk0xvf8
+++ b/software/winrm/src/test/resources/org/apache/brooklyn/feed/windows/windows-performance-counter-feed-tu4kk0xvf8
@@ -1,0 +1,61 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<feed>
+  <brooklynVersion>0.12.0-SNAPSHOT</brooklynVersion>
+  <type>org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed</type>
+  <id>tu4kk0xvf8</id>
+  <displayName>org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed</displayName>
+  <searchPath class="ImmutableList"/>
+  <tags>
+    <string>WindowsPerformanceCounterFeed[WindowsPerformanceCounterPollConfig[\Processor Information(_total....../f3c25627</string>
+  </tags>
+  <uniqueTag>WindowsPerformanceCounterFeed[WindowsPerformanceCounterPollConfig[\Processor Information(_total....../f3c25627</uniqueTag>
+  <config>
+    <polls>
+      <list>
+        <org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+          <sensor class="attributeSensor">
+            <type>java.lang.String</type>
+            <name>percent.processor.time</name>
+            <description>% Processor Time</description>
+            <persistence>REQUIRED</persistence>
+          </sensor>
+          <onsuccess class="com.google.guava:com.google.common.base.Functions$IdentityFunction">INSTANCE</onsuccess>
+          <suppressDuplicates>false</suppressDuplicates>
+          <enabled>true</enabled>
+          <period>30000</period>
+          <performanceCounterName>\Processor Information(_total)\% Processor Time</performanceCounterName>
+        </org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+        <org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+          <sensor class="attributeSensor">
+            <type>java.lang.String</type>
+            <name>bytes.available</name>
+            <description>Bytes Available</description>
+            <persistence>REQUIRED</persistence>
+          </sensor>
+          <onsuccess class="com.google.guava:com.google.common.base.Functions$IdentityFunction">INSTANCE</onsuccess>
+          <suppressDuplicates>false</suppressDuplicates>
+          <enabled>true</enabled>
+          <period>30000</period>
+          <performanceCounterName>\Memory\Available Bytes</performanceCounterName>
+        </org.apache.brooklyn.software-winrm:org.apache.brooklyn.feed.windows.WindowsPerformanceCounterPollConfig>
+      </list>
+    </polls>
+  </config>
+</feed>


### PR DESCRIPTION
Also make WindowsPerformanceCounterFeed$GetPerformanceCountersJob to not throw 
exception when no machine is found.