### PR TITLE
Rename to AbstractRebindHistoricTest

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/AbstractRebindHistoricTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/AbstractRebindHistoricTest.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.util.stream.Streams;
 
 import java.io.File;
 
-public abstract class RebindAbstractCommandFeedTest extends RebindTestFixtureWithApp {
+public abstract class AbstractRebindHistoricTest extends RebindTestFixtureWithApp {
 
     @Override
     protected TestApplication rebind() throws Exception {
@@ -53,7 +53,12 @@ public abstract class RebindAbstractCommandFeedTest extends RebindTestFixtureWit
     protected File getPersistanceFile(BrooklynObjectType type, String id) {
         String dir;
         switch (type) {
+            case ENTITY: dir = "entities"; break;
+            case LOCATION: dir = "locations"; break;
+            case POLICY: dir = "policies"; break;
+            case ENRICHER: dir = "enrichers"; break;
             case FEED: dir = "feeds"; break;
+            case CATALOG_ITEM: dir = "catalog"; break;
             default: throw new UnsupportedOperationException("type="+type);
         }
         return new File(mementoDir, Os.mergePaths(dir, id));

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshFeedTest.java
@@ -22,7 +22,7 @@ import org.apache.brooklyn.api.objs.BrooklynObjectType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class RebindHistoricSshFeedTest extends RebindAbstractCommandFeedTest {
+public class RebindHistoricSshFeedTest extends AbstractRebindHistoricTest {
     @Override
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWindowsPerformanceCounterFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWindowsPerformanceCounterFeedTest.java
@@ -19,10 +19,10 @@
 package org.apache.brooklyn.feed.windows;
 
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
-import org.apache.brooklyn.core.mgmt.rebind.RebindAbstractCommandFeedTest;
+import org.apache.brooklyn.core.mgmt.rebind.AbstractRebindHistoricTest;
 import org.testng.annotations.Test;
 
-public class RebindWindowsPerformanceCounterFeedTest extends RebindAbstractCommandFeedTest {
+public class RebindWindowsPerformanceCounterFeedTest extends AbstractRebindHistoricTest {
 
     @Test
     public void testWindowsPerformanceCounterFeed_2017_06() throws Exception {

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWinrmCmdFeedTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/RebindWinrmCmdFeedTest.java
@@ -19,10 +19,10 @@
 package org.apache.brooklyn.feed.windows;
 
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
-import org.apache.brooklyn.core.mgmt.rebind.RebindAbstractCommandFeedTest;
+import org.apache.brooklyn.core.mgmt.rebind.AbstractRebindHistoricTest;
 import org.testng.annotations.Test;
 
-public class RebindWinrmCmdFeedTest extends RebindAbstractCommandFeedTest {
+public class RebindWinrmCmdFeedTest extends AbstractRebindHistoricTest {
 
     @Test
     public void testWinrmCmdFeed_2017_04() throws Exception {


### PR DESCRIPTION
(from RebindAbstractCommandFeedTest), and support `getPersistanceFile` for more types