### PR TITLE
Add ConfigKey builders

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -73,6 +73,10 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         return new ConcreteBuilder<T>().type(type).name(name);
     }
 
+    public static <T> Builder<T,?> builder(String newName, ConfigKey<T> key) {
+        return new ConcreteBuilder<T>(newName, key);
+    }
+
     public static <T> Builder<T,?> builder(ConfigKey<T> key) {
         return new ConcreteBuilder<T>(key);
     }
@@ -82,6 +86,9 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         }
         public ConcreteBuilder(TypeToken<T> type, String name) {
             super(type, name);
+        }
+        public ConcreteBuilder(String newName, ConfigKey<T> key) {
+            super(newName, key);
         }
         public ConcreteBuilder(ConfigKey<T> key) {
             super(key);
@@ -113,8 +120,11 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
             this(TypeToken.of(type), name);
         }
         public Builder(ConfigKey<T> key) {
+            this(key.getName(), key);
+        }
+        public Builder(String newName, ConfigKey<T> key) {
             this.type = checkNotNull(key.getTypeToken(), "type");
-            this.name = checkNotNull(key.getName(), "name");
+            this.name = checkNotNull(newName, "name");
             description(key.getDescription());
             defaultValue(key.getDefaultValue());
             reconfigurable(key.isReconfigurable());
@@ -243,7 +253,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
         this.description = builder.description;
         this.defaultValue = builder.defaultValue;
         this.reconfigurable = builder.reconfigurable;
-        this.parentInheritance = builder.runtimeInheritance;
+        this.runtimeInheritance = builder.runtimeInheritance;
         this.typeInheritance = builder.typeInheritance;
         // Note: it's intentionally possible to have default values that are not valid
         // per the configured constraint. If validity were checked here any class that

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigKeys.java
@@ -161,8 +161,17 @@ public class ConfigKeys {
         return new PortAttributeSensorAndConfigKey(parent, defaultValue);
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> ConfigKey<T> newConfigKeyRenamed(String newName, ConfigKey<T> key) {
-        return new BasicConfigKey<T>(key.getTypeToken(), newName, key.getDescription(), key.getDefaultValue());
+        if (key instanceof MapConfigKey) {
+            return (ConfigKey<T>) new MapConfigKey.Builder<>(newName, (MapConfigKey<?>)key).build();
+        } else if (key instanceof SetConfigKey) {
+            return (ConfigKey<T>) new SetConfigKey.Builder<>(newName, (SetConfigKey<?>)key).build();
+        } else if (key instanceof ListConfigKey) {
+            return (ConfigKey<T>) new ListConfigKey.Builder<>(newName, (ListConfigKey<?>)key).build();
+        } else {
+            return BasicConfigKey.builder(newName, key).build();
+        }
     }
 
     public static <T> ConfigKey<T> newConfigKeyWithPrefix(String prefix, ConfigKey<T> key) {

--- a/core/src/main/java/org/apache/brooklyn/core/config/ListConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ListConfigKey.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.config;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +31,8 @@ import org.apache.brooklyn.core.internal.storage.impl.ConcurrentMapAcceptingNull
 import org.apache.brooklyn.util.collections.MutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.TypeToken;
 
 /** A config key representing a list of values. 
  * If a value is set on this key, it is _added_ to the list.
@@ -53,12 +57,59 @@ import org.slf4j.LoggerFactory;
  */
 //TODO Create interface
 @Deprecated
-public class ListConfigKey<V> extends AbstractCollectionConfigKey<List<? extends V>,List<Object>,V> {
+public class ListConfigKey<V> extends AbstractCollectionConfigKey<List<V>,List<Object>,V> {
 
     private static final long serialVersionUID = 751024268729803210L;
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(ListConfigKey.class);
     
+    public static class Builder<V> extends BasicConfigKey.Builder<List<V>,Builder<V>> {
+        protected Class<V> subType;
+        
+        public Builder(TypeToken<V> subType, String name) {
+            super(new TypeToken<List<V>>() {}, name);
+            this.subType = (Class<V>) subType.getRawType();
+        }
+        public Builder(Class<V> subType, String name) {
+            super(new TypeToken<List<V>>() {}, name);
+            this.subType = checkNotNull(subType, "subType");
+        }
+        public Builder(ListConfigKey<V> key) {
+            this(key.getName(), key);
+        }
+        public Builder(String newName, ListConfigKey<V> key) {
+            super(newName, key);
+            subType = key.subType;
+        }
+        @Override
+        public Builder<V> self() {
+            return this;
+        }
+        @Override
+        @Deprecated
+        public Builder<V> name(String val) {
+            throw new UnsupportedOperationException("Builder must be constructed with name");
+        }
+        @Override
+        @Deprecated
+        public Builder<V> type(Class<List<V>> val) {
+            throw new UnsupportedOperationException("Builder must be constructed with type");
+        }
+        @Override
+        @Deprecated
+        public Builder<V> type(TypeToken<List<V>> val) {
+            throw new UnsupportedOperationException("Builder must be constructed with type");
+        }
+        @Override
+        public ListConfigKey<V> build() {
+            return new ListConfigKey<V>(this);
+        }
+    }
+
+    public ListConfigKey(Builder<V> builder) {
+        super(builder, builder.subType);
+    }
+
     public ListConfigKey(Class<V> subType, String name) {
         this(subType, name, name, null);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/config/MapConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/MapConfigKey.java
@@ -77,13 +77,11 @@ public class MapConfigKey<V> extends AbstractStructuredConfigKey<Map<String,V>,M
             this.subType = checkNotNull(subType, "subType");
         }
         public Builder(MapConfigKey<V> key) {
-            super(checkNotNull(key.getTypeToken(), "type"), checkNotNull(key.getName(), "name"));
-            description(key.getDescription());
-            defaultValue(key.getDefaultValue());
-            reconfigurable(key.isReconfigurable());
-            runtimeInheritance(key.getParentInheritance());
-            typeInheritance(key.getTypeInheritance());
-            constraint(key.getConstraint());
+            this(key.getName(), key);
+        }
+        public Builder(String newName, MapConfigKey<V> key) {
+            super(newName, key);
+            subType = key.subType;
         }
         @Override
         public Builder<V> self() {
@@ -108,30 +106,10 @@ public class MapConfigKey<V> extends AbstractStructuredConfigKey<Map<String,V>,M
         public MapConfigKey<V> build() {
             return new MapConfigKey<V>(this);
         }
-        
-        @Override
-        public String getName() {
-            return name;
-        }
-        @Override
-        public String getDescription() {
-            return description;
-        }
     }
 
     protected MapConfigKey(Builder<V> builder) {
-        super((Class)Map.class,
-                checkNotNull(builder.subType, "subType"),
-                checkNotNull(builder.name, "name"),
-                builder.description,
-                builder.defaultValue);
-        this.reconfigurable = builder.reconfigurable;
-        this.runtimeInheritance = builder.runtimeInheritance;
-        this.typeInheritance = builder.typeInheritance;
-        // Note: it's intentionally possible to have default values that are not valid
-        // per the configured constraint. If validity were checked here any class that
-        // contained a weirdly-defined config key would fail to initialise.
-        this.constraint = checkNotNull(builder.constraint, "constraint");
+        super(builder, builder.subType);
     }
 
     public MapConfigKey(Class<V> subType, String name) {

--- a/core/src/main/java/org/apache/brooklyn/core/config/SetConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/SetConfigKey.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.config;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -28,6 +30,8 @@ import org.apache.brooklyn.core.config.internal.AbstractCollectionConfigKey;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.TypeToken;
 
 /** A config key representing a set of values. 
  * If a value is set using this *typed* key, it is _added_ to the set
@@ -44,11 +48,58 @@ import org.slf4j.LoggerFactory;
  * Specific values can be added in a replaceable way by referring to a subkey.
  */
 //TODO Create interface
-public class SetConfigKey<V> extends AbstractCollectionConfigKey<Set<? extends V>, Set<Object>, V> {
+public class SetConfigKey<V> extends AbstractCollectionConfigKey<Set<V>, Set<Object>, V> {
 
     private static final long serialVersionUID = 751024268729803210L;
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(SetConfigKey.class);
+
+    public static class Builder<V> extends BasicConfigKey.Builder<Set<V>,Builder<V>> {
+        protected Class<V> subType;
+        
+        public Builder(TypeToken<V> subType, String name) {
+            super(new TypeToken<Set<V>>() {}, name);
+            this.subType = (Class<V>) subType.getRawType();
+        }
+        public Builder(Class<V> subType, String name) {
+            super(new TypeToken<Set<V>>() {}, name);
+            this.subType = checkNotNull(subType, "subType");
+        }
+        public Builder(SetConfigKey<V> key) {
+            this(key.getName(), key);
+        }
+        public Builder(String newName, SetConfigKey<V> key) {
+            super(newName, key);
+            subType = key.subType;
+        }
+        @Override
+        public Builder<V> self() {
+            return this;
+        }
+        @Override
+        @Deprecated
+        public Builder<V> name(String val) {
+            throw new UnsupportedOperationException("Builder must be constructed with name");
+        }
+        @Override
+        @Deprecated
+        public Builder<V> type(Class<Set<V>> val) {
+            throw new UnsupportedOperationException("Builder must be constructed with type");
+        }
+        @Override
+        @Deprecated
+        public Builder<V> type(TypeToken<Set<V>> val) {
+            throw new UnsupportedOperationException("Builder must be constructed with type");
+        }
+        @Override
+        public SetConfigKey<V> build() {
+            return new SetConfigKey<V>(this);
+        }
+    }
+
+    public SetConfigKey(Builder<V> builder) {
+        super(builder, builder.subType);
+    }
 
     public SetConfigKey(Class<V> subType, String name) {
         this(subType, name, name, null);
@@ -60,7 +111,7 @@ public class SetConfigKey<V> extends AbstractCollectionConfigKey<Set<? extends V
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public SetConfigKey(Class<V> subType, String name, String description, Set<? extends V> defaultValue) {
-        super((Class)Set.class, subType, name, description, defaultValue);
+        super((Class)Set.class, subType, name, description, (Set) defaultValue);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractCollectionConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractCollectionConfigKey.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.config.SubElementConfigKey;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.text.Identifiers;
@@ -38,7 +39,11 @@ public abstract class AbstractCollectionConfigKey<T, RawT extends Collection<Obj
     private static final long serialVersionUID = 8225955960120637643L;
     private static final Logger log = LoggerFactory.getLogger(AbstractCollectionConfigKey.class);
     
-    public AbstractCollectionConfigKey(Class<T> type, Class<V> subType, String name, String description, T defaultValue) {
+    protected AbstractCollectionConfigKey(BasicConfigKey.Builder<T,?> builder, Class<V> subType) {
+        super(builder, subType);
+    }
+
+    protected AbstractCollectionConfigKey(Class<T> type, Class<V> subType, String name, String description, T defaultValue) {
         super(type, subType, name, description, defaultValue);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractStructuredConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractStructuredConfigKey.java
@@ -36,6 +36,11 @@ public abstract class AbstractStructuredConfigKey<T,RawT,V> extends BasicConfigK
 
     protected final Class<V> subType;
 
+    protected AbstractStructuredConfigKey(BasicConfigKey.Builder<T,?> builder, Class<V> subType) {
+        super(builder);
+        this.subType = subType;
+    }
+
     public AbstractStructuredConfigKey(Class<T> type, Class<V> subType, String name, String description, T defaultValue) {
         super(type, name, description, defaultValue);
         this.subType = subType;

--- a/core/src/test/java/org/apache/brooklyn/core/config/MapConfigKeyAndFriendsMoreTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/MapConfigKeyAndFriendsMoreTest.java
@@ -18,9 +18,14 @@
  */
 package org.apache.brooklyn.core.config;
 
+import static org.testng.Assert.assertEquals;
+
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.config.ConfigKeys.InheritanceContext;
 import org.apache.brooklyn.core.config.ListConfigKey.ListModifications;
 import org.apache.brooklyn.core.config.MapConfigKey.MapModifications;
 import org.apache.brooklyn.core.config.SetConfigKey.SetModifications;
@@ -36,6 +41,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -59,6 +66,75 @@ public class MapConfigKeyAndFriendsMoreTest extends BrooklynAppUnitTestSupport {
     public void setUp() throws Exception {
         super.setUp();
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+    }
+    
+    @Test
+    public void testMapConfigKeyBuilder() throws Exception {
+        Map<String, String> defaultVal = ImmutableMap.of("defaultKey", "defaultVal");
+        Predicate<Object> constraint = Predicates.instanceOf(Map.class);
+        
+        MapConfigKey<String> key = new MapConfigKey.Builder<>(String.class, "myname")
+                .description("my description")
+                .defaultValue(defaultVal)
+                .constraint(constraint)
+                .reconfigurable(true)
+                .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+                .typeInheritance(BasicConfigInheritance.OVERWRITE)
+                .build();
+        
+        assertEquals(key.getName(), "myname");
+        assertEquals(key.getDescription(), "my description");
+        assertEquals(key.getDefaultValue(), defaultVal);
+        assertEquals(key.getConstraint(), constraint);
+        assertEquals(key.isReconfigurable(), true);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.RUNTIME_MANAGEMENT), BasicConfigInheritance.NEVER_INHERITED);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.TYPE_DEFINITION), BasicConfigInheritance.OVERWRITE);
+    }
+
+    @Test
+    public void testSetConfigKeyBuilder() throws Exception {
+        Set<String> defaultVal = ImmutableSet.of("defaultVal");
+        Predicate<Object> constraint = Predicates.instanceOf(Set.class);
+        
+        SetConfigKey<String> key = new SetConfigKey.Builder<>(String.class, "myname")
+                .description("my description")
+                .defaultValue(defaultVal)
+                .constraint(constraint)
+                .reconfigurable(true)
+                .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+                .typeInheritance(BasicConfigInheritance.OVERWRITE)
+                .build();
+        
+        assertEquals(key.getName(), "myname");
+        assertEquals(key.getDescription(), "my description");
+        assertEquals(key.getDefaultValue(), defaultVal);
+        assertEquals(key.getConstraint(), constraint);
+        assertEquals(key.isReconfigurable(), true);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.RUNTIME_MANAGEMENT), BasicConfigInheritance.NEVER_INHERITED);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.TYPE_DEFINITION), BasicConfigInheritance.OVERWRITE);
+    }
+
+    @Test
+    public void testListConfigKeyBuilder() throws Exception {
+        List<String> defaultVal = ImmutableList.of("defaultVal");
+        Predicate<Object> constraint = Predicates.instanceOf(List.class);
+        
+        ListConfigKey<String> key = new ListConfigKey.Builder<>(String.class, "myname")
+                .description("my description")
+                .defaultValue(defaultVal)
+                .constraint(constraint)
+                .reconfigurable(true)
+                .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+                .typeInheritance(BasicConfigInheritance.OVERWRITE)
+                .build();
+        
+        assertEquals(key.getName(), "myname");
+        assertEquals(key.getDescription(), "my description");
+        assertEquals(key.getDefaultValue(), defaultVal);
+        assertEquals(key.getConstraint(), constraint);
+        assertEquals(key.isReconfigurable(), true);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.RUNTIME_MANAGEMENT), BasicConfigInheritance.NEVER_INHERITED);
+        assertEquals(key.getInheritanceByContext(InheritanceContext.TYPE_DEFINITION), BasicConfigInheritance.OVERWRITE);
     }
 
     public void testMapModUsage() throws Exception {


### PR DESCRIPTION
This change is motivated by (and is is preparation for) supporting deprecated names for`ConfigKey`s.