### PR TITLE
Fix SoftwareProcessEntityFeedRebindTest

### DIFF
--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityFeedRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessEntityFeedRebindTest.java
@@ -38,7 +38,6 @@ import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityRebindTest.MyProvisioningLocation;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessEntityTest.SimulatedDriver;
 import org.apache.brooklyn.feed.function.FunctionFeed;
@@ -107,7 +106,7 @@ public class SoftwareProcessEntityFeedRebindTest extends RebindTestFixtureWithAp
         for (Entity child : origApp.getChildren()) {
             EntityAsserts.assertAttributeEquals(child, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
             EntityAsserts.assertAttributeEquals(child, Attributes.SERVICE_UP, Boolean.TRUE);
-            EntityAsserts.assertAttributeEquals(child, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, Boolean.TRUE);
+            EntityAsserts.assertAttributeEqualsEventually(child, SoftwareProcess.SERVICE_PROCESS_IS_RUNNING, Boolean.TRUE);
         }
 
         LOG.info("Rebinding "+numEntities+" entities");


### PR DESCRIPTION
The test `testFeedsDoNotPollUntilManaged` failed in jenkins (see https://github.com/apache/brooklyn-server/pull/726#issuecomment-307579748) with the failure:
```
java.lang.AssertionError: entity=MyServiceWithFeedsImpl{id=ghzmpwboh4}; attribute=Sensor: service.process.isRunning (java.lang.Boolean) expected [true] but found [null]
	at org.apache.brooklyn.entity.software.base.SoftwareProcessEntityFeedRebindTest.runFeedsDoNotPollUntilManaged(SoftwareProcessEntityFeedRebindTest.java:110)
	at org.apache.brooklyn.entity.software.base.SoftwareProcessEntityFeedRebindTest.testFeedsDoNotPollUntilManaged(SoftwareProcessEntityFeedRebindTest.java:68)
```

The problem is that the sensor `SERVICE_PROCESS_IS_RUNNING` is set asynchronously -
 in `MyServiceWithFeeds.connectSensors`, it calls `connectServiceUpIsRunning`, which sets up a feed to poll the driver's `isRunning`. We therefore need to to use `assertAttributeEqualsEventually`, rather than `assertAttributeEquals`.

This isn't a problem in normal production usage because the default behaviour of `SoftwareProcess` is to block until `driver.isRunning()` returns true. The fact the sensor isn't populated with true until a fraction of a second later isn't an issue.