### PR TITLE
Change SetFromFlag tests

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySetFromFlagTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySetFromFlagTest.java
@@ -24,94 +24,11 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.location.PortRange;
-import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
-import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.flags.SetFromFlag;
-import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-
 public class EntitySetFromFlagTest extends BrooklynAppUnitTestSupport {
-
-    @Test
-    public void testSetFromFlagUsingFieldName() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("str1", "myval"));
-        assertEquals(entity.str1, "myval");
-    }
-    
-    @Test
-    public void testSetFromFlagUsingOverridenName() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("altStr2", "myval"));
-        assertEquals(entity.str2, "myval");
-    }
-    
-    @Test
-    public void testSetFromFlagWhenNoDefaultIsNull() {
-        MyEntity entity = newDeproxiedEntity();
-        assertEquals(entity.str1, null);
-    }
-    
-    @Test
-    public void testSetFromFlagUsesDefault() {
-        MyEntity entity = newDeproxiedEntity();
-        assertEquals(entity.str3, "default str3");
-    }
-    
-    @Test
-    public void testSetFromFlagOverridingDefault() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("str3", "overridden str3"));
-        assertEquals(entity.str3, "overridden str3");
-    }
-
-    @Test
-    public void testSetFromFlagCastsPrimitives() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("double1", 1f));
-        assertEquals(entity.double1, 1d);
-    }
-
-    @Test
-    public void testSetFromFlagCastsDefault() {
-        MyEntity entity = newDeproxiedEntity();
-        assertEquals(entity.byte1, (byte)1);
-        assertEquals(entity.short1, (short)2);
-        assertEquals(entity.int1, 3);
-        assertEquals(entity.long1, 4l);
-        assertEquals(entity.float1, 5f);
-        assertEquals(entity.double1, 6d);
-         assertEquals(entity.char1, 'a');
-        assertEquals(entity.bool1, true);
-        
-        assertEquals(entity.byte2, Byte.valueOf((byte)1));
-        assertEquals(entity.short2, Short.valueOf((short)2));
-        assertEquals(entity.int2, Integer.valueOf(3));
-        assertEquals(entity.long2, Long.valueOf(4l));
-        assertEquals(entity.float2, Float.valueOf(5f));
-        assertEquals(entity.double2, Double.valueOf(6d));
-        assertEquals(entity.char2, Character.valueOf('a'));
-        assertEquals(entity.bool2, Boolean.TRUE);
-    }
-    
-    @Test
-    public void testSetFromFlagCoercesDefaultToPortRange() {
-        MyEntity entity = newDeproxiedEntity();
-        assertEquals(entity.portRange1, PortRanges.fromInteger(1234));
-    }
-    
-    @Test
-    public void testSetFromFlagCoercesStringValueToPortRange() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("portRange1", "1-3"));
-        assertEquals(entity.portRange1, new PortRanges.LinearPortRange(1, 3));
-    }
-    
-    @Test
-    public void testSetFromFlagCoercesStringValueToInt() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("int1", "123"));
-        assertEquals(entity.int1, 123);
-    }
 
     @Test
     public void testSetIconUrl() {
@@ -119,31 +36,6 @@ public class EntitySetFromFlagTest extends BrooklynAppUnitTestSupport {
         assertEquals(entity.getIconUrl(), "/img/myicon.gif");
     }
 
-    @Test
-    public void testFailsFastOnInvalidCoercion() {
-        try {
-            newDeproxiedEntity(MutableMap.of("int1", "thisisnotanint"));
-            Asserts.shouldHaveFailedPreviously();
-        } catch (Exception e) {
-            if (Exceptions.getFirstThrowableOfType(e, IllegalArgumentException.class) == null) {
-                throw e;
-            }
-        }
-    }
-    
-    @Test
-    public void testSetFromFlagWithFieldThatIsExplicitySet() {
-        MyEntity entity = newDeproxiedEntity(MutableMap.of("str4", "myval"));
-        assertEquals(entity.str4, "myval");
-        
-        MyEntity entity2 = newDeproxiedEntity();
-        assertEquals(entity2.str4, "explicit str4");
-    }
-    
-    private MyEntity newDeproxiedEntity() {
-        return newDeproxiedEntity(ImmutableMap.of());
-    }
-    
     private MyEntity newDeproxiedEntity(Map<?, ?> config) {
         Entity result = app.addChild(EntitySpec.create(Entity.class).impl(MyEntity.class)
                 .configure(config));
@@ -151,68 +43,5 @@ public class EntitySetFromFlagTest extends BrooklynAppUnitTestSupport {
     }
     
     public static class MyEntity extends AbstractEntity {
-
-        @SetFromFlag(defaultVal="1234")
-        PortRange portRange1;
-
-        @SetFromFlag
-        String str1;
-        
-        @SetFromFlag("altStr2")
-        String str2;
-        
-        @SetFromFlag(defaultVal="default str3")
-        String str3;
-
-        @SetFromFlag
-        String str4 = "explicit str4";
-        
-        @SetFromFlag(defaultVal="1")
-        byte byte1;
-
-        @SetFromFlag(defaultVal="2")
-        short short1;
-
-        @SetFromFlag(defaultVal="3")
-        int int1;
-
-        @SetFromFlag(defaultVal="4")
-        long long1;
-
-        @SetFromFlag(defaultVal="5")
-        float float1;
-
-        @SetFromFlag(defaultVal="6")
-        double double1;
-
-        @SetFromFlag(defaultVal="a")
-        char char1;
-
-        @SetFromFlag(defaultVal="true")
-        boolean bool1;
-
-        @SetFromFlag(defaultVal="1")
-        Byte byte2;
-
-        @SetFromFlag(defaultVal="2")
-        Short short2;
-
-        @SetFromFlag(defaultVal="3")
-        Integer int2;
-
-        @SetFromFlag(defaultVal="4")
-        Long long2;
-
-        @SetFromFlag(defaultVal="5")
-        Float float2;
-
-        @SetFromFlag(defaultVal="6")
-        Double double2;
-
-        @SetFromFlag(defaultVal="a")
-        Character char2;
-
-        @SetFromFlag(defaultVal="true")
-        Boolean bool2;
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/PolicySetFromFlagTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/PolicySetFromFlagTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.entity;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.location.PortRanges;
+import org.apache.brooklyn.core.policy.AbstractPolicy;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class PolicySetFromFlagTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testSetFromFlagUsingFieldName() {
+        MyPolicy policy = newPolicy(MutableMap.of("str1", "myval"));
+        assertEquals(policy.str1, "myval");
+    }
+    
+    @Test
+    public void testSetFromFlagUsingOverridenName() {
+        MyPolicy policy = newPolicy(MutableMap.of("altStr2", "myval"));
+        assertEquals(policy.str2, "myval");
+    }
+    
+    @Test
+    public void testSetFromFlagWhenNoDefaultIsNull() {
+        MyPolicy policy = newPolicy();
+        assertEquals(policy.str1, null);
+    }
+    
+    @Test
+    public void testSetFromFlagUsesDefault() {
+        MyPolicy policy = newPolicy();
+        assertEquals(policy.str3, "default str3");
+    }
+    
+    @Test
+    public void testSetFromFlagOverridingDefault() {
+        MyPolicy policy = newPolicy(MutableMap.of("str3", "overridden str3"));
+        assertEquals(policy.str3, "overridden str3");
+    }
+
+    @Test
+    public void testSetFromFlagCastsPrimitives() {
+        MyPolicy policy = newPolicy(MutableMap.of("double1", 1f));
+        assertEquals(policy.double1, 1d);
+    }
+
+    @Test
+    public void testSetFromFlagCastsDefault() {
+        MyPolicy policy = newPolicy();
+        assertEquals(policy.byte1, (byte)1);
+        assertEquals(policy.short1, (short)2);
+        assertEquals(policy.int1, 3);
+        assertEquals(policy.long1, 4l);
+        assertEquals(policy.float1, 5f);
+        assertEquals(policy.double1, 6d);
+         assertEquals(policy.char1, 'a');
+        assertEquals(policy.bool1, true);
+        
+        assertEquals(policy.byte2, Byte.valueOf((byte)1));
+        assertEquals(policy.short2, Short.valueOf((short)2));
+        assertEquals(policy.int2, Integer.valueOf(3));
+        assertEquals(policy.long2, Long.valueOf(4l));
+        assertEquals(policy.float2, Float.valueOf(5f));
+        assertEquals(policy.double2, Double.valueOf(6d));
+        assertEquals(policy.char2, Character.valueOf('a'));
+        assertEquals(policy.bool2, Boolean.TRUE);
+    }
+    
+    @Test
+    public void testSetFromFlagCoercesDefaultToPortRange() {
+        MyPolicy policy = newPolicy();
+        assertEquals(policy.portRange1, PortRanges.fromInteger(1234));
+    }
+    
+    @Test
+    public void testSetFromFlagCoercesStringValueToPortRange() {
+        MyPolicy policy = newPolicy(MutableMap.of("portRange1", "1-3"));
+        assertEquals(policy.portRange1, new PortRanges.LinearPortRange(1, 3));
+    }
+    
+    @Test
+    public void testSetFromFlagCoercesStringValueToInt() {
+        MyPolicy policy = newPolicy(MutableMap.of("int1", "123"));
+        assertEquals(policy.int1, 123);
+    }
+
+    @Test
+    public void testFailsFastOnInvalidCoercion() {
+        try {
+            newPolicy(MutableMap.of("int1", "thisisnotanint"));
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception e) {
+            if (Exceptions.getFirstThrowableOfType(e, IllegalArgumentException.class) == null) {
+                throw e;
+            }
+        }
+    }
+    
+    @Test
+    public void testSetFromFlagWithFieldThatIsExplicitySet() {
+        MyPolicy policy = newPolicy(MutableMap.of("str4", "myval"));
+        assertEquals(policy.str4, "myval");
+        
+        MyPolicy policy2 = newPolicy();
+        assertEquals(policy2.str4, "explicit str4");
+    }
+    
+    private MyPolicy newPolicy() {
+        return newPolicy(ImmutableMap.of());
+    }
+    
+    private MyPolicy newPolicy(Map<?, ?> config) {
+        return app.policies().add(PolicySpec.create(MyPolicy.class)
+                .configure(config));
+    }
+    
+    public static class MyPolicy extends AbstractPolicy {
+
+        @SetFromFlag(defaultVal="1234")
+        PortRange portRange1;
+
+        @SetFromFlag
+        String str1;
+        
+        @SetFromFlag("altStr2")
+        String str2;
+        
+        @SetFromFlag(defaultVal="default str3")
+        String str3;
+
+        @SetFromFlag
+        String str4 = "explicit str4";
+        
+        @SetFromFlag(defaultVal="1")
+        byte byte1;
+
+        @SetFromFlag(defaultVal="2")
+        short short1;
+
+        @SetFromFlag(defaultVal="3")
+        int int1;
+
+        @SetFromFlag(defaultVal="4")
+        long long1;
+
+        @SetFromFlag(defaultVal="5")
+        float float1;
+
+        @SetFromFlag(defaultVal="6")
+        double double1;
+
+        @SetFromFlag(defaultVal="a")
+        char char1;
+
+        @SetFromFlag(defaultVal="true")
+        boolean bool1;
+
+        @SetFromFlag(defaultVal="1")
+        Byte byte2;
+
+        @SetFromFlag(defaultVal="2")
+        Short short2;
+
+        @SetFromFlag(defaultVal="3")
+        Integer int2;
+
+        @SetFromFlag(defaultVal="4")
+        Long long2;
+
+        @SetFromFlag(defaultVal="5")
+        Float float2;
+
+        @SetFromFlag(defaultVal="6")
+        Double double2;
+
+        @SetFromFlag(defaultVal="a")
+        Character char2;
+
+        @SetFromFlag(defaultVal="true")
+        Boolean bool2;
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubContainerLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/clocker/StubContainerLocation.java
@@ -28,12 +28,9 @@ public class StubContainerLocation extends SshMachineLocation implements Dynamic
     @SetFromFlag("machine")
     private SshMachineLocation machine;
 
-    @SetFromFlag("owner")
-    private StubContainer owner;
-
     @Override
     public StubContainer getOwner() {
-        return owner;
+        return (StubContainer) config().get(OWNER);
     }
 
     public SshMachineLocation getMachine() {


### PR DESCRIPTION
This PR just changes tests, to stop testing things that we shouldn't support!

We should stop supporting `@SetFromFlag` on entity fields. It's been discouraged for a long time, and is a bad idea - one should use config keys and sensors instead! Unfortunately it's not as easy to tell people to not use it on policies, enrichers and locations - those don't have sensors!

In a subsequent PR, I'm going to add support for `deprecatedNames` on `ConfigKey`. Removing the need to support `@SetFromFlag` on entity fields will allow config code to be made simpler longer term.

Here, I change the `EntitySetFromFlagTest` (which uses `@SetFromFlag` on fields) to be `PolicySetFromFlagTest`.

This PR also changes `StubContainerLocation` (which is a test class) to remove the field `@SetFromFlag("owner") private StubContainer owner`. There is a config key on its super type `DynamicLocation.OWNER` that has the name "owner". Two reasons to change this:
1. we shouldn't support `@SetFromFlag` on entity fields.
2. people shouldn't rely on using a duplicate name of a config key and a field (or on two different config keys, or whatever). That's mad! The semantics of what it would mean if you subsequent change one of the values is unclear (e.g. does it impact the other config key).