### PR TITLE
Use PolicySpec instead of policy constructor

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
@@ -24,7 +24,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
+import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
+import org.apache.brooklyn.core.objs.BrooklynObjectInternal.ConfigurationSupportInternal;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -141,6 +143,13 @@ public abstract class BrooklynYamlTypeInstantiator {
                 result = Reflections.invokeConstructorFromArgs(type);
                 if (result.isPresent()) 
                     return result.get();
+            } else if (Configurable.class.isAssignableFrom(type)) {
+                result = Reflections.invokeConstructorFromArgs(type);
+                if (result.isPresent()) {
+                    ConfigurationSupportInternal configSupport = (ConfigurationSupportInternal) ((Configurable)result.get()).config();
+                    configSupport.putAll(cfg);
+                    return result.get();
+                }
             }
             
             throw new IllegalStateException("No known mechanism for constructing type "+type+" in "+factory.contextForLogging);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractMembershipTrackingPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractMembershipTrackingPolicy.java
@@ -68,10 +68,6 @@ public abstract class AbstractMembershipTrackingPolicy extends AbstractPolicy {
 
     private ConcurrentMap<String,Map<Sensor<Object>, Object>> entitySensorCache = new ConcurrentHashMap<String, Map<Sensor<Object>, Object>>();
     
-    public AbstractMembershipTrackingPolicy(Map<?,?> flags) {
-        super(flags);
-    }
-    
     public AbstractMembershipTrackingPolicy() {
         super();
     }

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
+import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
@@ -44,7 +45,7 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
     private SimulatedLocation loc;
     private TestEntity entity;
     private TestEntity otherEntity;
-    private AbstractPolicy policy;
+    private MyPolicy policy;
     private RecordingSensorEventListener<Object> listener;
     
     @BeforeMethod(alwaysRun=true)
@@ -55,8 +56,7 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
         entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         otherEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         listener = new RecordingSensorEventListener<>();
-        policy = new AbstractPolicy() {};
-        entity.policies().add(policy);
+        policy = entity.policies().add(PolicySpec.create(MyPolicy.class));
         app.start(ImmutableList.of(loc));
     }
 
@@ -149,5 +149,8 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
             @Override public void run() {
                 assertEquals(listener.getEvents(), ImmutableList.of());
             }});
+    }
+    
+    public static class MyPolicy extends AbstractPolicy {
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicyTypeTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicyTypeTest.java
@@ -20,28 +20,26 @@ package org.apache.brooklyn.core.policy.basic;
 
 import static org.testng.Assert.assertEquals;
 
+import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.policy.PolicyType;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
-import org.testng.annotations.AfterMethod;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-public class PolicyTypeTest {
+public class PolicyTypeTest extends BrooklynAppUnitTestSupport {
     private MyPolicy policy;
     
     @BeforeMethod(alwaysRun=true)
-    public void setUpTestEntity() throws Exception{
-        policy = new MyPolicy();
+    @Override
+    public void setUp() throws Exception{
+        super.setUp();
+        policy = app.policies().add(PolicySpec.create(MyPolicy.class));
     }
 
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        // nothing to tear down; no management context not started
-    }
-    
     @Test
     public void testGetConfig() throws Exception {
         PolicyType policyType = policy.getPolicyType();

--- a/core/src/test/java/org/apache/brooklyn/core/test/policy/TestPolicy.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/policy/TestPolicy.java
@@ -43,13 +43,8 @@ public class TestPolicy extends AbstractPolicy {
         .build();
     
     public TestPolicy() {
-        this(Collections.emptyMap());
     }
     
-    public TestPolicy(Map<?, ?> properties) {
-        super(properties);
-    }
-
     public Map<?, ?> getLeftoverProperties() {
         return Collections.unmodifiableMap(leftoverProperties);
     }

--- a/core/src/test/java/org/apache/brooklyn/entity/group/MembershipTrackingPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/MembershipTrackingPolicyTest.java
@@ -149,9 +149,9 @@ public class MembershipTrackingPolicyTest extends BrooklynAppUnitTestSupport {
     
     @Test
     public void testDeprecatedSetGroupWorks() throws Exception {
-        RecordingMembershipTrackingPolicy policy2 = new RecordingMembershipTrackingPolicy(MutableMap.of("sensorsToTrack", ImmutableSet.of(TestEntity.NAME)));
-        group.policies().add(policy2);
-        policy2.setGroup(group);
+        RecordingMembershipTrackingPolicy policy2 = group.policies().add(PolicySpec.create(RecordingMembershipTrackingPolicy.class)
+                .configure(RecordingMembershipTrackingPolicy.GROUP, group)
+                .configure("sensorsToTrack", ImmutableSet.of(TestEntity.NAME)));
 
         TestEntity e1 = createAndManageChildOf(group);
         e1.sensors().set(TestEntity.NAME, "myname");
@@ -255,14 +255,8 @@ public class MembershipTrackingPolicyTest extends BrooklynAppUnitTestSupport {
     public static class RecordingMembershipTrackingPolicy extends AbstractMembershipTrackingPolicy {
         final List<Record> records = new CopyOnWriteArrayList<Record>();
 
-        public RecordingMembershipTrackingPolicy() {
-            super();
-        }
+        public RecordingMembershipTrackingPolicy() {}
         
-        public RecordingMembershipTrackingPolicy(MutableMap<String, ?> flags) {
-            super(flags);
-        }
-
         @Override protected void onEntityChange(Entity member) {
             records.add(Record.newChanged(member));
         }

--- a/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicy.java
@@ -187,6 +187,10 @@ public class AutoScalerPolicy extends AbstractPolicy {
         public Builder maxReachedNotificationDelay(Duration val) {
             this.maxReachedNotificationDelay = val; return this;
         }
+        /**
+         * @deprecated since 0.12.0; use {@link #buildSpec()}, or use {@link PolicySpec} directly
+         */
+        @Deprecated
         public AutoScalerPolicy build() {
             return new AutoScalerPolicy(toFlags());
         }
@@ -455,13 +459,16 @@ public class AutoScalerPolicy extends AbstractPolicy {
     };
 
     public AutoScalerPolicy() {
-        this(MutableMap.<String,Object>of());
     }
     
+    /**
+     * @deprecated since 0.12.0; use {@link PolicySpec}
+     */
+    @Deprecated
     public AutoScalerPolicy(Map<String,?> props) {
         super(props);
     }
-
+    
     @Override
     public void init() {
         doInit();

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
@@ -23,11 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -47,9 +44,10 @@ import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.entity.group.StopFailedRuntimeException;
 import org.apache.brooklyn.policy.ha.HASensors.FailureDescriptor;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Ticker;
 import com.google.common.collect.Lists;
@@ -97,22 +95,8 @@ public class ServiceReplacer extends AbstractPolicy {
     protected final List<Long> consecutiveReplacementFailureTimes = Lists.newCopyOnWriteArrayList();
     
     public ServiceReplacer() {
-        this(new ConfigBag());
     }
     
-    public ServiceReplacer(Map<String,?> flags) {
-        this(new ConfigBag().putAll(flags));
-    }
-    
-    public ServiceReplacer(ConfigBag configBag) {
-        // TODO hierarchy should use ConfigBag, and not change flags
-        super(configBag.getAllConfigMutable());
-    }
-    
-    public ServiceReplacer(Sensor<?> failureSensorToMonitor) {
-        this(new ConfigBag().configure(FAILURE_SENSOR_TO_MONITOR, failureSensorToMonitor));
-    }
-
     @Override
     public void setEntity(final EntityLocal entity) {
         checkArgument(entity instanceof MemberReplaceable, "ServiceReplacer must take a MemberReplaceable, not %s", entity);

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
@@ -18,11 +18,8 @@
  */
 package org.apache.brooklyn.policy.ha;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.Sensor;
@@ -39,11 +36,12 @@ import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.policy.ha.HASensors.FailureDescriptor;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
@@ -80,23 +78,10 @@ public class ServiceRestarter extends AbstractPolicy {
     protected final AtomicReference<Long> lastFailureTime = new AtomicReference<Long>();
 
     public ServiceRestarter() {
-        this(new ConfigBag());
+        super();
+        if (uniqueTag == null) uniqueTag = JavaClassNames.simpleClassName(getClass())+":"+getConfig(FAILURE_SENSOR_TO_MONITOR).getName();
     }
     
-    public ServiceRestarter(Map<String,?> flags) {
-        this(new ConfigBag().putAll(flags));
-    }
-    
-    public ServiceRestarter(ConfigBag configBag) {
-        // TODO hierarchy should use ConfigBag, and not change flags
-        super(configBag.getAllConfigMutable());
-        uniqueTag = JavaClassNames.simpleClassName(getClass())+":"+getConfig(FAILURE_SENSOR_TO_MONITOR).getName();
-    }
-    
-    public ServiceRestarter(Sensor<?> failureSensorToMonitor) {
-        this(new ConfigBag().configure(FAILURE_SENSOR_TO_MONITOR, failureSensorToMonitor));
-    }
-
     @Override
     public void setEntity(final EntityLocal entity) {
         Preconditions.checkArgument(entity instanceof Startable, "Restarter must take a Startable, not "+entity);

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyMetricTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyMetricTest.java
@@ -69,8 +69,11 @@ public class AutoScalerPolicyMetricTest {
     public void testIncrementsSizeIffUpperBoundExceeded() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         tc.sensors().set(MY_ATTRIBUTE, 100);
         Asserts.succeedsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), currentSizeAsserter(tc, 1));
@@ -83,8 +86,11 @@ public class AutoScalerPolicyMetricTest {
     public void testDecrementsSizeIffLowerBoundExceeded() {
         tc.resize(2);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         tc.sensors().set(MY_ATTRIBUTE, 50);
         Asserts.succeedsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), currentSizeAsserter(tc, 2));
@@ -97,8 +103,11 @@ public class AutoScalerPolicyMetricTest {
     public void testIncrementsSizeInProportionToMetric() {
         tc.resize(5);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
         
         // workload 200 so requires doubling size to 10 to handle: (200*5)/100 = 10
         tc.sensors().set(MY_ATTRIBUTE, 200);
@@ -113,8 +122,11 @@ public class AutoScalerPolicyMetricTest {
     public void testDecrementsSizeInProportionToMetric() {
         tc.resize(5);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
         
         // workload can be handled by 4 servers, within its valid range: (49*5)/50 = 4.9
         tc.sensors().set(MY_ATTRIBUTE, 49);
@@ -132,11 +144,12 @@ public class AutoScalerPolicyMetricTest {
     public void testObeysMinAndMaxSize() {
         tc.resize(4);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
                 .minPoolSize(2).maxPoolSize(6)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         // Decreases to min-size only
         tc.sensors().set(MY_ATTRIBUTE, 0);
@@ -159,12 +172,13 @@ public class AutoScalerPolicyMetricTest {
                     maxReachedEvents.add(event.getValue());
                 }});
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
+        tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
                 .maxPoolSize(6)
                 .maxSizeReachedSensor(maxSizeReachedSensor)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         // workload can be handled by 6 servers, so no need to notify: 6 <= (100*6)/50
         tc.sensors().set(MY_ATTRIBUTE, 600);
@@ -196,8 +210,11 @@ public class AutoScalerPolicyMetricTest {
     public void testDestructionState() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         policy.destroy();
         assertTrue(policy.isDestroyed());
@@ -212,8 +229,11 @@ public class AutoScalerPolicyMetricTest {
     
     @Test
     public void testSuspendState() {
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
         
         policy.suspend();
         assertFalse(policy.isRunning());
@@ -228,8 +248,11 @@ public class AutoScalerPolicyMetricTest {
     public void testPostSuspendActions() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         policy.suspend();
         
@@ -241,8 +264,11 @@ public class AutoScalerPolicyMetricTest {
     public void testPostResumeActions() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE).metricLowerBound(50).metricUpperBound(100).build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
         
         policy.suspend();
         policy.resume();
@@ -256,13 +282,12 @@ public class AutoScalerPolicyMetricTest {
         
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder()
+        tc.policies().add(AutoScalerPolicy.builder()
                 .metric(TestEntity.SEQUENCE)
                 .entityWithMetric(entityWithMetric)
                 .metricLowerBound(50)
                 .metricUpperBound(100)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         // First confirm that tc is not being listened to for this entity
         tc.sensors().set(TestEntity.SEQUENCE, 101);

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyReconfigurationTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyReconfigurationTest.java
@@ -58,11 +58,12 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testIncreaseMinPoolSizeCausesImmediateGrowth() {
         tc.resize(2);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
                 .minPoolSize(2)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.MIN_POOL_SIZE, 3);
         
@@ -73,11 +74,10 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testDecreaseMinPoolSizeAllowsSubsequentShrink() {
         tc.resize(4);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder().metric(MY_ATTRIBUTE)
                 .metricLowerBound(50).metricUpperBound(100)
                 .minPoolSize(2)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
         
         // 25*4 = 100 -> 2 nodes at 50 each
         tc.sensors().set(MY_ATTRIBUTE, 25);
@@ -93,11 +93,10 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testDecreaseMaxPoolSizeCausesImmediateShrink() {
         tc.resize(6);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder().metric(MY_ATTRIBUTE)
                 .metricLowerBound(50).metricUpperBound(100)
                 .maxPoolSize(6)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.MAX_POOL_SIZE, 4);
         
@@ -108,11 +107,11 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testIncreaseMaxPoolSizeAllowsSubsequentGrowth() {
         tc.resize(3);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
                 .metricLowerBound(50).metricUpperBound(100)
                 .maxPoolSize(6)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         // 200*3 = 600 -> 6 nodes at 100 each
         tc.sensors().set(MY_ATTRIBUTE, 200);
@@ -129,10 +128,11 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testReconfigureMetricLowerBound() {
         tc.resize(2);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
-                .build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.METRIC_LOWER_BOUND, 51);
 
@@ -144,10 +144,11 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testReconfigureMetricUpperBound() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
-                .build();
-        tc.policies().add(policy);
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.METRIC_UPPER_BOUND, 99);
 
@@ -159,11 +160,12 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testReconfigureResizeUpStabilizationDelay() {
         tc.resize(1);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
                 .resizeUpStabilizationDelay(Duration.TWO_MINUTES)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.RESIZE_UP_STABILIZATION_DELAY, Duration.ZERO);
 
@@ -175,11 +177,12 @@ public class AutoScalerPolicyReconfigurationTest {
     public void testReconfigureResizeDownStabilizationDelay() {
         tc.resize(2);
         
-        AutoScalerPolicy policy = new AutoScalerPolicy.Builder().metric(MY_ATTRIBUTE)
-                .metricLowerBound(50).metricUpperBound(100)
+        AutoScalerPolicy policy = tc.policies().add(AutoScalerPolicy.builder()
+                .metric(MY_ATTRIBUTE)
+                .metricLowerBound(50)
+                .metricUpperBound(100)
                 .resizeDownStabilizationDelay(Duration.TWO_MINUTES)
-                .build();
-        tc.policies().add(policy);
+                .buildSpec());
 
         policy.config().set(AutoScalerPolicy.RESIZE_DOWN_STABILIZATION_DELAY, Duration.ZERO);
 

--- a/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceReplacerTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceReplacerTest.java
@@ -103,8 +103,8 @@ public class ServiceReplacerTest {
                 .configure(DynamicCluster.INITIAL_SIZE, 3));
         app.start(ImmutableList.<Location>of(loc));
 
-        ServiceReplacer policy = new ServiceReplacer(new ConfigBag().configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
-        cluster.policies().add(policy);
+        cluster.policies().add(PolicySpec.create(ServiceReplacer.class)
+                .configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
 
         final Set<Entity> initialMembers = ImmutableSet.copyOf(cluster.getMembers());
         final TestEntity e1 = (TestEntity) Iterables.get(initialMembers, 1);
@@ -150,8 +150,8 @@ public class ServiceReplacerTest {
         
         log.info("started "+app+" for "+JavaClassNames.niceClassAndMethod());
         
-        ServiceReplacer policy = new ServiceReplacer(new ConfigBag().configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
-        cluster.policies().add(policy);
+        cluster.policies().add(PolicySpec.create(ServiceReplacer.class)
+                .configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
         
         final Set<Entity> initialMembers = ImmutableSet.copyOf(cluster.getMembers());
         final TestEntity e1 = (TestEntity) Iterables.get(initialMembers, 0);
@@ -200,10 +200,9 @@ public class ServiceReplacerTest {
                 .configure(DynamicCluster.QUARANTINE_FAILED_ENTITIES, true));
         app.start(ImmutableList.<Location>of(loc));
         
-        ServiceReplacer policy = new ServiceReplacer(new ConfigBag()
+        cluster.policies().add(PolicySpec.create(ServiceReplacer.class)
                 .configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED)
                 .configure(ServiceReplacer.SET_ON_FIRE_ON_FAILURE, false));
-        cluster.policies().add(policy);
         
         final Set<Entity> initialMembers = ImmutableSet.copyOf(cluster.getMembers());
         final TestEntity e1 = (TestEntity) Iterables.get(initialMembers, 0);
@@ -289,10 +288,9 @@ public class ServiceReplacerTest {
                 .configure(DynamicCluster.QUARANTINE_FAILED_ENTITIES, true));
         app.start(ImmutableList.<Location>of(loc));
         
-        ServiceReplacer policy = new ServiceReplacer(new ConfigBag()
+        cluster.policies().add(PolicySpec.create(ServiceReplacer.class)
                 .configure(ServiceReplacer.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED)
                 .configure(ServiceReplacer.FAIL_ON_NUM_RECURRING_FAILURES, 3));
-        cluster.policies().add(policy);
 
         final Set<Entity> initialMembers = ImmutableSet.copyOf(cluster.getMembers());
         for (int i = 0; i < 5; i++) {

--- a/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceRestarterTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/ha/ServiceRestarterTest.java
@@ -71,8 +71,8 @@ public class ServiceRestarterTest extends BrooklynAppUnitTestSupport {
     
     @Test
     public void testRestartsOnFailure() throws Exception {
-        policy = new ServiceRestarter(new ConfigBag().configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
-        e1.policies().add(policy);
+        policy = e1.policies().add(PolicySpec.create(ServiceRestarter.class)
+                .configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
         
         e1.sensors().emit(HASensors.ENTITY_FAILED, new FailureDescriptor(e1, "simulate failure"));
         
@@ -84,8 +84,8 @@ public class ServiceRestarterTest extends BrooklynAppUnitTestSupport {
     
     @Test(groups="Integration") // Has a 1 second wait
     public void testDoesNotRestartsWhenHealthy() throws Exception {
-        policy = new ServiceRestarter(new ConfigBag().configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
-        e1.policies().add(policy);
+        policy = e1.policies().add(PolicySpec.create(ServiceRestarter.class)
+                .configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
         
         e1.sensors().emit(HASensors.ENTITY_RECOVERED, new FailureDescriptor(e1, "not a failure"));
         
@@ -101,8 +101,8 @@ public class ServiceRestarterTest extends BrooklynAppUnitTestSupport {
                 .configure(FailingEntity.FAIL_ON_RESTART, true));
         app.subscriptions().subscribe(e2, ServiceRestarter.ENTITY_RESTART_FAILED, eventListener);
 
-        policy = new ServiceRestarter(new ConfigBag().configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
-        e2.policies().add(policy);
+        policy = e2.policies().add(PolicySpec.create(ServiceRestarter.class)
+                .configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED));
 
         e2.sensors().emit(HASensors.ENTITY_FAILED, new FailureDescriptor(e2, "simulate failure"));
         
@@ -123,10 +123,9 @@ public class ServiceRestarterTest extends BrooklynAppUnitTestSupport {
                 .configure(FailingEntity.FAIL_ON_RESTART, true));
         app.subscriptions().subscribe(e2, ServiceRestarter.ENTITY_RESTART_FAILED, eventListener);
 
-        policy = new ServiceRestarter(new ConfigBag()
+        policy = e2.policies().add(PolicySpec.create(ServiceRestarter.class)
                 .configure(ServiceRestarter.FAILURE_SENSOR_TO_MONITOR, HASensors.ENTITY_FAILED)
                 .configure(ServiceRestarter.SET_ON_FIRE_ON_FAILURE, false));
-        e2.policies().add(policy);
 
         e2.sensors().emit(HASensors.ENTITY_FAILED, new FailureDescriptor(e2, "simulate failure"));
         

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimplePolicy.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimplePolicy.java
@@ -18,8 +18,6 @@
  */
 package org.apache.brooklyn.rest.testing.mocks;
 
-import java.util.Map;
-
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
@@ -34,11 +32,6 @@ public class RestMockSimplePolicy extends AbstractPolicy {
 
     public RestMockSimplePolicy() {
         super();
-    }
-
-    @SuppressWarnings("rawtypes")
-    public RestMockSimplePolicy(Map flags) {
-        super(flags);
     }
 
     @SetFromFlag("sampleConfig")

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtilsTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/util/BrooklynRestResourceUtilsTest.java
@@ -204,10 +204,6 @@ public class BrooklynRestResourceUtilsTest {
     }
     
     public static class MyPolicy extends AbstractPolicy {
-        public MyPolicy() {
-        }
-        public MyPolicy(Map<String, ?> flags) {
-            super(flags);
-        }
+        public MyPolicy() {}
     }
 }


### PR DESCRIPTION
Changes (mostly test) code to use `PolicySpec` to create policies, rather than calling the policy's constructor. There are two big reasons for doing this:
1. the `PolicySpec` approach is the same as is used by yaml blueprints - by using/testing in this way, we are more confident that we'll be able to do the same in yaml blueprints.
2. we want to simplify our code - reducing the number of ways a policy/enricher/location/entity can be created and configured will give us some simplification.