### PR TITLE
BROOKLYN-440: ssh not use StreamGobbler for logging stdout

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
@@ -261,10 +261,14 @@ public class RecordingSshTool implements SshTool {
     protected void writeCustomResponseStreams(Map<String, ?> props, CustomResponse response) {
         try {
             if (Strings.isNonBlank(response.stdout) && props.get(SshTool.PROP_OUT_STREAM.getName()) != null) {
-                ((OutputStream)props.get(SshTool.PROP_OUT_STREAM.getName())).write(response.stdout.getBytes());
+                OutputStream out = (OutputStream)props.get(SshTool.PROP_OUT_STREAM.getName());
+                out.write(response.stdout.getBytes());
+                out.flush();
             }
             if (Strings.isNonBlank(response.stderr) && props.get(SshTool.PROP_ERR_STREAM.getName()) != null) {
-                ((OutputStream)props.get(SshTool.PROP_ERR_STREAM.getName())).write(response.stderr.getBytes());
+                OutputStream err = (OutputStream)props.get(SshTool.PROP_ERR_STREAM.getName());
+                err.write(response.stderr.getBytes());
+                err.flush();
             }
         } catch (IOException e) {
             Exceptions.propagate(e);

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -152,6 +152,14 @@ public class LogWatcher implements Closeable {
         assertFalse(events.isEmpty());
     }
 
+    public List<ILoggingEvent> assertHasEvent(final Predicate<? super ILoggingEvent> filter) {
+        synchronized (events) {
+            Iterable<ILoggingEvent> filtered = Iterables.filter(events, filter);
+            assertFalse(Iterables.isEmpty(filtered), "events="+events);
+            return ImmutableList.copyOf(filtered);
+        }
+    }
+
     public List<ILoggingEvent> assertHasEventEventually() {
         Asserts.succeedsEventually(new Runnable() {
             @Override
@@ -166,11 +174,7 @@ public class LogWatcher implements Closeable {
         Asserts.succeedsEventually(new Runnable() {
             @Override
             public void run() {
-                synchronized (events) {
-                    Iterable<ILoggingEvent> filtered = Iterables.filter(events, filter);
-                    assertFalse(Iterables.isEmpty(filtered));
-                    result.set(ImmutableList.copyOf(filtered));
-                }
+                result.set(assertHasEvent(filter));
             }});
         return result.get();
     }

--- a/utils/common/pom.xml
+++ b/utils/common/pom.xml
@@ -84,6 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.brooklyn</groupId>
             <artifactId>brooklyn-utils-test-support</artifactId>
             <version>${project.version}</version>

--- a/utils/common/src/main/java/org/apache/brooklyn/util/stream/LoggingOutputStream.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/stream/LoggingOutputStream.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.stream;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+
+/**
+ * Wraps another output stream, intercepting the writes to log it.
+ */
+public class LoggingOutputStream extends FilterOutputStream {
+
+    private static final OutputStream NOOP_OUTPUT_STREAM = new FilterOutputStream(null) {
+        @Override public void write(int b) throws IOException {
+        }
+        @Override public void flush() throws IOException {
+        }
+        @Override public void close() throws IOException {
+        }        
+    };
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static class Builder {
+        OutputStream out;
+        Logger log;
+        String logPrefix;
+        
+        public Builder outputStream(OutputStream val) {
+            this.out = val;
+            return this;
+        }
+        public Builder logger(Logger val) {
+            this.log = val;
+            return this;
+        }
+        public Builder logPrefix(String val) {
+            this.logPrefix = val;
+            return this;
+        }
+        public LoggingOutputStream build() {
+            return new LoggingOutputStream(this);
+        }
+    }
+    
+    protected final Logger log;
+    protected final String logPrefix;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final StringBuilder lineSoFar = new StringBuilder(16);
+
+    private LoggingOutputStream(Builder builder) {
+        super(builder.out != null ? builder.out : NOOP_OUTPUT_STREAM);
+        log = builder.log;
+        logPrefix = (builder.logPrefix != null) ? builder.logPrefix : "";
+      }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (running.get() && b >= 0) onChar(b);
+        out.write(b);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        try {
+            if (lineSoFar.length() > 0) {
+                onLine(lineSoFar.toString());
+                lineSoFar.setLength(0);
+            }
+        } finally {
+            super.flush();
+        }
+    }
+    
+    // Overriding close() because FilterOutputStream's close() method pre-JDK8 has bad behavior:
+    // it silently ignores any exception thrown by flush(). Instead, just close the delegate stream.
+    // It should flush itself if necessary.
+    @Override
+    public void close() throws IOException {
+        try {
+            onLine(lineSoFar.toString());
+            lineSoFar.setLength(0);
+        } finally {
+            out.close();
+            running.set(false);
+        }
+    }
+    
+    public void onChar(int c) {
+        if (c=='\n' || c=='\r') {
+            if (lineSoFar.length()>0)
+                //suppress blank lines, so that we can treat either newline char as a line separator
+                //(eg to show curl updates frequently)
+                onLine(lineSoFar.toString());
+            lineSoFar.setLength(0);
+        } else {
+            lineSoFar.append((char)c);
+        }
+    }
+    
+    public void onLine(String line) {
+        //right trim, in case there is \r or other funnies
+        while (line.length()>0 && Character.isWhitespace(line.charAt(line.length()-1)))
+            line = line.substring(0, line.length()-1);
+        //right trim, in case there is \r or other funnies
+        while (line.length()>0 && (line.charAt(0)=='\n' || line.charAt(0)=='\r'))
+            line = line.substring(1);
+        if (!line.isEmpty()) {
+            if (log!=null && log.isDebugEnabled()) log.debug(logPrefix+line);
+        }
+    }
+}

--- a/utils/common/src/main/java/org/apache/brooklyn/util/stream/StreamGobbler.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/stream/StreamGobbler.java
@@ -86,6 +86,8 @@ public class StreamGobbler extends Thread implements Closeable {
             onClose();
             //TODO parametrise log level, for this error, and for normal messages
             if (log!=null && log.isTraceEnabled()) log.trace(logPrefix+"exception reading from stream ("+e+")");
+        } finally {
+            if (out != null) out.flush();
         }
     }
     

--- a/utils/common/src/test/java/org/apache/brooklyn/util/stream/LoggingOutputStreamTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/stream/LoggingOutputStreamTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.stream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class LoggingOutputStreamTest {
+
+    private List<String> logs;
+    private Logger mockLogger;
+    
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        logs = new ArrayList<>();
+        mockLogger = Mockito.mock(Logger.class);
+        Mockito.when(mockLogger.isDebugEnabled()).thenReturn(true);
+        Mockito.doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+              Object[] args = invocation.getArguments();
+              logs.add((String)args[0]);
+              return null;
+            }
+        }).when(mockLogger).debug(Mockito.anyString());
+    }
+    
+    @Test
+    public void testCallsDelegateStream() throws Exception {
+        ByteArrayOutputStream delegate = new ByteArrayOutputStream();
+        LoggingOutputStream out = LoggingOutputStream.builder().outputStream(delegate).build();
+        out.write(new byte[] {1,2,3});
+        out.flush();
+        assertTrue(Arrays.equals(delegate.toByteArray(), new byte[] {1, 2, 3}));
+    }
+    
+    @Test
+    public void testNoopIfNoDelegateStream() throws Exception {
+        // Just checking that throws no exceptions
+        LoggingOutputStream out = LoggingOutputStream.builder().build();
+        out.write(new byte[] {1,2,3});
+        out.flush();
+    }
+    
+    @Test
+    public void testLogsLines() throws Exception {
+        LoggingOutputStream out = LoggingOutputStream.builder().logger(mockLogger).build();
+        out.write("line1\n".getBytes(StandardCharsets.UTF_8));
+        out.write("line2".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        
+        assertEquals(logs, ImmutableList.of("line1", "line2"));
+    }
+    
+    @Test
+    public void testLogsLinesWithPrefix() throws Exception {
+        LoggingOutputStream out = LoggingOutputStream.builder().logger(mockLogger).logPrefix("myprefix:").build();
+        out.write("line1\n".getBytes(StandardCharsets.UTF_8));
+        out.write("line2".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+        
+        assertEquals(logs, ImmutableList.of("myprefix:line1", "myprefix:line2"));
+    }
+}

--- a/utils/common/src/test/java/org/apache/brooklyn/util/stream/LoggingOutputStreamTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/stream/LoggingOutputStreamTest.java
@@ -91,4 +91,14 @@ public class LoggingOutputStreamTest {
         
         assertEquals(logs, ImmutableList.of("myprefix:line1", "myprefix:line2"));
     }
+    
+    @Test
+    public void testLogsUnicode() throws Exception {
+        LoggingOutputStream out = LoggingOutputStream.builder().logger(mockLogger).build();
+        String test = "Лорем.";
+        out.write((test+"\n").getBytes(StandardCharsets.UTF_8));
+        out.flush();
+
+        assertEquals(logs, ImmutableList.of(test));
+    }
 }


### PR DESCRIPTION
Improves thread usage when executing ssh remote commands. Simplifies the code to use a new `LoggingOutputStream`, rather than using the `StreamGobbler` thread.

@neykov I'd appreciate your thoughts. It only does the first part of https://issues.apache.org/jira/browse/BROOKLYN-440; it doesn't do your suggestion of having the single thread polling to see if the streams have any bytes available.