### PR TITLE
Makes core-tests.jar installable in the catalog, add metadata

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -58,6 +58,7 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.AggregateClassLoader;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.javalang.LoadedClassLoader;
+import org.apache.brooklyn.util.osgi.OsgiUtils;
 import org.apache.brooklyn.util.osgi.VersionedName;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
@@ -446,7 +447,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (Strings.isBlank(version)) {
             throw new IllegalStateException("Catalog BOM must define version if bundle is defined");
         }
-        return new VersionedName(bundle, Version.valueOf(version));
+        return new VersionedName(bundle, Version.valueOf(OsgiUtils.toOsgiVersion(version)));
     }
 
     private void collectCatalogItems(String yaml, List<CatalogItemDtoAbstract<?, ?>> result, Map<?, ?> parentMeta) {

--- a/core/src/test/resources/catalog.bom
+++ b/core/src/test/resources/catalog.bom
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+  bundle: org.apache.brooklyn.core-tests
+  version: "0.12.0-SNAPSHOT" # BROOKLYN_VERSION


### PR DESCRIPTION
Fixes CatalogDtoTest.testCatalogLookup which installs the jar even though it's not a proper osgi bundle.

https://builds.apache.org/view/B/view/Brooklyn/job/brooklyn-integration-tests/73/testngreports/org.apache.brooklyn.core.catalog.internal/CatalogDtoTest/testCatalogLookup/