### PR TITLE
Use MoreObjects.toStringHelper (deprecation warning)

### DIFF
--- a/camp/camp-server/src/main/java/org/apache/brooklyn/camp/server/dto/ApiErrorDto.java
+++ b/camp/camp-server/src/main/java/org/apache/brooklyn/camp/server/dto/ApiErrorDto.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.camp.server.dto;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
@@ -110,7 +111,7 @@ public class ApiErrorDto {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("message", message)
                 .add("details", details)
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleDto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleDto.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.catalog.internal;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -68,7 +69,7 @@ public class CatalogBundleDto implements CatalogBundle {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("symbolicName", symbolicName)
                 .add("version", version)
                 .add("url", url)

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogDto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogDto.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 
@@ -105,7 +105,7 @@ public class CatalogDto {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("name", name)
                 .add("id", id)

--- a/core/src/main/java/org/apache/brooklyn/core/config/external/UrlsExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/UrlsExternalConfigSupplier.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.util.core.ResourceUtils;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 
 
@@ -70,7 +70,7 @@ public class UrlsExternalConfigSupplier extends AbstractExternalConfigSupplier {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("name", getName()).toString();
+        return MoreObjects.toStringHelper(this).add("name", getName()).toString();
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/effector/BasicParameterType.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/BasicParameterType.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.effector.ParameterType;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 public class BasicParameterType<T> implements ParameterType<T> {
@@ -94,7 +95,7 @@ public class BasicParameterType<T> implements ParameterType<T> {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("name", name).add("description", description).add("type", getParameterClassName())
                 .add("defaultValue", defaultValue)
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAndAttribute.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAndAttribute.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 
@@ -84,7 +85,7 @@ public class EntityAndAttribute<T> implements Supplier<T> {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("entity", entity)
                 .add("attribute", attribute)
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadRequirement.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadRequirement.java
@@ -26,7 +26,7 @@ import org.apache.brooklyn.api.entity.drivers.EntityDriver;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolverManager.DownloadRequirement;
 import org.apache.brooklyn.util.collections.MutableMap;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 public class BasicDownloadRequirement implements DownloadRequirement {
@@ -80,6 +80,6 @@ public class BasicDownloadRequirement implements DownloadRequirement {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("driver", entityDriver).add("addon", addonName).omitNullValues().toString();
+        return MoreObjects.toStringHelper(this).add("driver", entityDriver).add("addon", addonName).omitNullValues().toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadResolver.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolver;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 public class BasicDownloadResolver implements DownloadResolver {
@@ -60,7 +60,7 @@ public class BasicDownloadResolver implements DownloadResolver {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("targets", targets).add("filename", filename)
+        return MoreObjects.toStringHelper(this).add("targets", targets).add("filename", filename)
                 .add("unpackDirName", unpackDirectoryName).omitNullValues().toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadTargets.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/BasicDownloadTargets.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolverManager.DownloadTargets;
 import org.apache.brooklyn.util.collections.MutableList;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -115,7 +115,7 @@ public class BasicDownloadTargets implements DownloadTargets {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("primaries", primaries).add("fallbacks", fallbacks)
+        return MoreObjects.toStringHelper(this).add("primaries", primaries).add("fallbacks", fallbacks)
                 .add("canContinueResolving", canContinueResolving).toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/DownloadSubstituters.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/drivers/downloads/DownloadSubstituters.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
@@ -166,7 +166,7 @@ public class DownloadSubstituters {
         }
         
         @Override public String toString() {
-            return Objects.toStringHelper(this).add("basevalue", basevalueProducer).add("subs", subsProducer).toString();
+            return MoreObjects.toStringHelper(this).add("basevalue", basevalueProducer).add("subs", subsProducer).toString();
         }
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/PolicyDescriptor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/PolicyDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.entity.lifecycle;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /** Emitted as part of {@link AbstractEntity#POLICY_ADDED} and {@link AbstractEntity#POLICY_REMOVED} */
@@ -63,6 +64,6 @@ public class PolicyDescriptor {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("id", id).add("type", type).add("name",  name).omitNullValues().toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("type", type).add("name",  name).omitNullValues().toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
@@ -37,7 +37,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 
 /** 
@@ -210,6 +210,6 @@ public class Poller<V> {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("entity", entity).toString();
+        return MoreObjects.toStringHelper(this).add("entity", entity).toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynProperties.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 
@@ -183,7 +183,7 @@ public interface BrooklynProperties extends StringConfigMap {
             @Override
             @SuppressWarnings("deprecation")
             public String toString() {
-                return Objects.toStringHelper(this)
+                return MoreObjects.toStringHelper(this)
                         .omitNullValues()
                         .add("originalProperties", originalProperties)
                         .add("defaultLocationMetadataUrl", defaultLocationMetadataUrl)

--- a/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/internal/BrooklynPropertiesImpl.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
@@ -192,7 +192,7 @@ public class BrooklynPropertiesImpl implements BrooklynProperties {
             @Override
             @SuppressWarnings("deprecation")
             public String toString() {
-                return Objects.toStringHelper(this)
+                return MoreObjects.toStringHelper(this)
                         .omitNullValues()
                         .add("originalProperties", originalProperties)
                         .add("defaultLocationMetadataUrl", defaultLocationMetadataUrl)

--- a/core/src/main/java/org/apache/brooklyn/core/location/AggregatingMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AggregatingMachineProvisioningLocation.java
@@ -32,7 +32,7 @@ import org.apache.brooklyn.api.location.NoMachinesAvailableException;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.stream.Streams;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -71,7 +71,7 @@ public class AggregatingMachineProvisioningLocation<T extends MachineLocation> e
     
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("id", getId()).add("name", getDisplayName())
                 .add("provisioners", provisioners)
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicHardwareDetails.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicHardwareDetails.java
@@ -20,9 +20,9 @@ package org.apache.brooklyn.core.location;
 
 import javax.annotation.concurrent.Immutable;
 
-import com.google.common.base.Objects;
-
 import org.apache.brooklyn.api.location.HardwareDetails;
+
+import com.google.common.base.MoreObjects;
 
 @Immutable
 public class BasicHardwareDetails implements HardwareDetails {
@@ -47,7 +47,7 @@ public class BasicHardwareDetails implements HardwareDetails {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(HardwareDetails.class)
+        return MoreObjects.toStringHelper(HardwareDetails.class)
                 .omitNullValues()
                 .add("cpuCount", cpuCount)
                 .add("ram", ram)

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineDetails.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineDetails.java
@@ -48,7 +48,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
@@ -82,7 +82,7 @@ public class BasicMachineDetails implements MachineDetails {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(MachineDetails.class)
+        return MoreObjects.toStringHelper(MachineDetails.class)
                 .add("os", osDetails)
                 .add("hardware", hardwareDetails)
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineMetadata.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineMetadata.java
@@ -18,9 +18,10 @@
  */
 package org.apache.brooklyn.core.location;
 
-import com.google.common.base.Objects;
-
 import org.apache.brooklyn.api.location.MachineManagementMixins;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class BasicMachineMetadata implements MachineManagementMixins.MachineMetadata {
 
@@ -83,7 +84,7 @@ public class BasicMachineMetadata implements MachineManagementMixins.MachineMeta
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("id", id).add("name", name).add("originalMetadata", originalMetadata).toString();
+        return MoreObjects.toStringHelper(this).add("id", id).add("name", name).add("originalMetadata", originalMetadata).toString();
     }
     
 }

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicOsDetails.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicOsDetails.java
@@ -23,9 +23,9 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import com.google.common.base.Objects;
-
 import org.apache.brooklyn.api.location.OsDetails;
+
+import com.google.common.base.MoreObjects;
 
 @Immutable
 public class BasicOsDetails implements OsDetails {
@@ -87,7 +87,7 @@ public class BasicOsDetails implements OsDetails {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(OsDetails.class)
+        return MoreObjects.toStringHelper(OsDetails.class)
                 .omitNullValues()
                 .add("name", name)
                 .add("version", version)

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortForwardManager.java
@@ -23,7 +23,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.net.HostAndPort;
 
@@ -85,7 +85,7 @@ public interface PortForwardManager extends Location {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("publicIpId", publicIpId)
                     .add("publicEndpoint", publicEndpoint)
                     .add("location", location)

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/PortMapping.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/PortMapping.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.api.location.Location;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.net.HostAndPort;
 
@@ -75,7 +76,7 @@ public class PortMapping {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("publicIpId", publicIpId+":"+publicPort)
                 .add("publicEndpoint", (publicEndpoint == null ? publicPort : publicEndpoint))
                 .add("targetLocation", target)

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/BasicEntitlementClassDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/BasicEntitlementClassDefinition.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.core.mgmt.entitlement;
 
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementClass;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.reflect.TypeToken;
 
 
@@ -51,6 +51,6 @@ public class BasicEntitlementClassDefinition<T> implements EntitlementClass<T> {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("identitifier", identifier).add("argumentType", argumentType).toString();
+        return MoreObjects.toStringHelper(this).add("identitifier", identifier).add("argumentType", argumentType).toString();
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/BasicManagementNodeSyncRecord.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/BasicManagementNodeSyncRecord.java
@@ -27,7 +27,7 @@ import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.util.time.Time;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents the state of a management node within the Brooklyn management plane
@@ -165,14 +165,14 @@ public class BasicManagementNodeSyncRecord implements ManagementNodeSyncRecord, 
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("nodeId", getNodeId())
                 .add("status", getStatus()).toString();
     }
     
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("brooklynVersion", getBrooklynVersion())
                 .add("nodeId", getNodeId())

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/ManagementPlaneSyncRecordImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/dto/ManagementPlaneSyncRecordImpl.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.api.mgmt.ha.ManagementNodeSyncRecord;
 import org.apache.brooklyn.api.mgmt.ha.ManagementPlaneSyncRecord;
 import org.apache.brooklyn.util.collections.MutableMap;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
@@ -97,7 +97,7 @@ public class ManagementPlaneSyncRecordImpl implements ManagementPlaneSyncRecord,
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("masterNodeId", masterNodeId)
                 .add("nodes", managementNodes.keySet())
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -75,7 +75,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -153,7 +153,7 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("entity", entity.getId()).add("mode", mode).toString();
+        return MoreObjects.toStringHelper(this).add("entity", entity.getId()).add("mode", mode).toString();
     }
     
     public void setMode(NonDeploymentManagementContextMode mode) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/FileBasedObjectStore.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -173,7 +173,7 @@ public class FileBasedObjectStore implements PersistenceObjectStore {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("basedir", basedir).toString();
+        return MoreObjects.toStringHelper(this).add("basedir", basedir).toString();
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/AbstractMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/AbstractMemento.java
@@ -27,14 +27,13 @@ import java.util.Set;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.Memento;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.config.Sanitizer;
+import org.apache.brooklyn.util.collections.MutableList;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import org.apache.brooklyn.util.collections.MutableList;
 
 public abstract class AbstractMemento implements Memento, Serializable {
 
@@ -201,7 +200,7 @@ public abstract class AbstractMemento implements Memento, Serializable {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("type", getType()).add("id", getId()).toString();
+        return MoreObjects.toStringHelper(this).add("type", getType()).add("id", getId()).toString();
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/usage/ApplicationUsage.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/usage/ApplicationUsage.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -80,7 +81,7 @@ public class ApplicationUsage {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).add("date", date).add("state", state).add("entitlementContext", user).toString();
+            return MoreObjects.toStringHelper(this).add("date", date).add("state", state).add("entitlementContext", user).toString();
         }
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -56,7 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -541,7 +541,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(getClass()).omitNullValues()
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
                 .add("name", name)
                 .add("uniqueTag", uniqueTag)
                 .add("running", isRunning())

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctType.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctType.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -101,7 +102,7 @@ public class AdjunctType implements Serializable {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(name)
+        return MoreObjects.toStringHelper(name)
                 .add("configKeys", configKeys)
                 .toString();
     }

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Enrichers.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Enrichers.java
@@ -40,9 +40,10 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
+
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
@@ -324,7 +325,7 @@ public class Enrichers {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("aggregating", aggregating)
                     .add("keySensor", keySensor)
@@ -426,7 +427,7 @@ public class Enrichers {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("combining", combining)
                     .add("publishing", publishing)
@@ -485,7 +486,7 @@ public class Enrichers {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("publishing", publishing)
                     .add("transforming", transforming)
@@ -569,7 +570,7 @@ public class Enrichers {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("fromEntity", fromEntity)
                     .add("fromEntitySupplier", fromEntitySupplier)
@@ -629,7 +630,7 @@ public class Enrichers {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("publishing", targetSensor)
                     .add("fromSensor", fromSensor)
@@ -705,7 +706,7 @@ public class Enrichers {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("publishing", publishing)
                     .add("transforming", transforming)

--- a/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/ProportionalZoneFailureDetector.java
@@ -21,7 +21,7 @@ package org.apache.brooklyn.entity.group.zoneaware;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.util.time.Duration;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Ticker;
 
 public class ProportionalZoneFailureDetector extends AbstractZoneFailureDetector {
@@ -60,7 +60,7 @@ public class ProportionalZoneFailureDetector extends AbstractZoneFailureDetector
 
     @Override
     public String toString(){
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("minDatapoints", minDatapoints)
                 .add("timeToConsider",  timeToConsider)
                 .add("maxProportionFailures", maxProportionFailures)

--- a/core/src/main/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/byon/FixedListMachineProvisioningLocation.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -200,7 +200,7 @@ implements MachineProvisioningLocation<T>, Closeable {
     
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("id", getId()).add("name", getDisplayName())
                 .add("machinesAvailable", getAvailable()).add("machinesInUse", getInUse())
                 .toString();

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -105,7 +105,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -950,7 +950,7 @@ public class SshMachineLocation extends AbstractLocation implements MachineLocat
 
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("id", getId()).add("name", getDisplayName())
                 .add("user", getUser()).add("address", getAddress()).add("port", getPort())
                 .add("parentLocation", getParent())

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/FlagUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/FlagUtils.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -211,7 +212,7 @@ public class FlagUtils {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).omitNullValues()
+            return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("flag", flagName)
                 .add("configKey", configKey)
                 .add("flagValue", flagValue.orNull())

--- a/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/sshj/SshjClientConnection.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/internal/ssh/sshj/SshjClientConnection.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.util.core.internal.ssh.SshAbstractTool.SshAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.net.HostAndPort;
 
@@ -269,7 +270,7 @@ public class SshjClientConnection implements SshAction<SSHClient> {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper("")
+        return MoreObjects.toStringHelper("")
                 .add("hostAndPort", hostAndPort)
                 .add("user", username)
                 .add("ssh", ssh != null ? ssh.hashCode() : null)

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/TaskInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/TaskInternal.java
@@ -29,7 +29,7 @@ import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.ExecutionList;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -156,7 +156,7 @@ public interface TaskInternal<T> extends Task<T> {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).add("interruptTask", allowedToInterruptTask)
+            return MoreObjects.toStringHelper(this).add("interruptTask", allowedToInterruptTask)
                 .add("interruptDependentSubmitted", allowedToInterruptDependentSubmittedTasks)
                 .add("interruptAllSubmitted", allowedToInterruptAllSubmittedTasks)
                 .toString();

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityAutomanagedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityAutomanagedTest.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.test.Asserts;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -299,7 +300,7 @@ public class EntityAutomanagedTest extends BrooklynAppUnitTestSupport {
             
             @Override
             public String toString() {
-                return Objects.toStringHelper(this).add("type", type).add("entity", entity).toString();
+                return MoreObjects.toStringHelper(this).add("type", type).add("entity", entity).toString();
             }
         }
         

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/EntityExecutionManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/EntityExecutionManagerTest.java
@@ -59,7 +59,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -445,7 +445,7 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
     }
 
     private String taskToVerboseString(Task<?> t) {
-        return Objects.toStringHelper(t)
+        return MoreObjects.toStringHelper(t)
                 .add("id", t.getId())
                 .add("displayName", t.getDisplayName())
                 .add("submitTime", t.getSubmitTimeUtc())

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/FlagUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/FlagUtilsTest.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -303,7 +304,7 @@ public class FlagUtilsTest {
         }
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).omitNullValues()
+            return MoreObjects.toStringHelper(this).omitNullValues()
                     .add("flag", flagName)
                     .add("configKey", configKey)
                     .add("flagValue", flagValue.orNull())

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -66,7 +67,7 @@ public class RecordingSshTool implements SshTool {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("constructorProps", constructorProps)
                     .add("props", props)
                     .add("commands", commands)
@@ -120,7 +121,7 @@ public class RecordingSshTool implements SshTool {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("summaryForLogging", summaryForLogging)
                     .add("commands", commands)
                     .add("env", env)

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStore.java
@@ -38,7 +38,7 @@ import org.apache.brooklyn.util.exceptions.FatalConfigurationRuntimeException;
 import org.apache.brooklyn.util.text.Strings;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 
@@ -186,7 +186,7 @@ public class JcloudsBlobStoreBasedObjectStore implements PersistenceObjectStore 
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("blobStoreContext", context)
                 .add("basedir", containerNameFirstPart)
                 .toString();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -160,6 +160,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
@@ -286,7 +287,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("id", getId()).add("name", getDisplayName()).add("identity", getIdentity())
                 .add("description", config().getLocalBag().getDescription()).add("provider", getProvider())
                 .add("region", getRegion()).add("endpoint", getEndpoint())

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
@@ -128,7 +128,7 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
     
     @Override
     public String toVerboseString() {
-        return Objects.toStringHelper(this).omitNullValues()
+        return MoreObjects.toStringHelper(this).omitNullValues()
                 .add("id", getId()).add("name", getDisplayName())
                 .add("user", getUser())
                 .add("address", getAddress())

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/RebindToMachinePredicate.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/RebindToMachinePredicate.java
@@ -23,7 +23,7 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.compute.domain.ComputeMetadata;
 import org.jclouds.compute.domain.NodeMetadata;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 
 /**
@@ -75,7 +75,7 @@ class RebindToMachinePredicate implements Predicate<ComputeMetadata> {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("id", rawId)
                 .add("hostname", rawHostname)

--- a/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/MaxPoolSizeReachedEvent.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/MaxPoolSizeReachedEvent.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.policy.autoscaling;
 
 import java.io.Serializable;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class MaxPoolSizeReachedEvent implements Serializable {
     private static final long serialVersionUID = 1602627701360505190L;
@@ -96,7 +96,7 @@ public class MaxPoolSizeReachedEvent implements Serializable {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("maxAllowed", maxAllowed).add("currentPoolSize", currentPoolSize)
+        return MoreObjects.toStringHelper(this).add("maxAllowed", maxAllowed).add("currentPoolSize", currentPoolSize)
                 .add("currentUnbounded", currentUnbounded).add("maxUnbounded", maxUnbounded)
                 .add("timeWindow", timeWindow).toString();
     }

--- a/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/SizeHistory.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/autoscaling/SizeHistory.java
@@ -25,7 +25,7 @@ import org.apache.brooklyn.util.collections.TimeWindowedList;
 import org.apache.brooklyn.util.collections.TimestampedValue;
 import org.apache.brooklyn.util.time.Duration;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Using a {@link TimeWindowedList}, tracks the recent history of values to allow a summary of 
@@ -61,7 +61,7 @@ public class SizeHistory {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).add("latest", latest).add("min", min).add("max", max)
+            return MoreObjects.toStringHelper(this).add("latest", latest).add("min", min).add("max", max)
                     .add("stableForGrowth", stableForGrowth).add("stableForShrinking", stableForShrinking).toString();
         }
     }

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/HASensors.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/HASensors.java
@@ -20,7 +20,7 @@ package org.apache.brooklyn.policy.ha;
 
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class HASensors {
 
@@ -56,7 +56,7 @@ public class HASensors {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this).add("component", component).add("description", description).toString();
+            return MoreObjects.toStringHelper(this).add("component", component).add("description", description).toString();
         }
     }
 }

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EffectorSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EffectorSummary.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
@@ -96,7 +97,7 @@ public class EffectorSummary implements HasName, Serializable {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .omitNullValues()
                     .add("name", name)
                     .add("type", type)

--- a/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
@@ -27,7 +27,7 @@ import java.util.Map.Entry;
 
 import org.apache.brooklyn.util.stream.Streams;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -59,7 +59,7 @@ public class RecordingWinRmTool implements WinRmTool {
         
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("type", type)
                     .add("constructorProps", constructorProps)
                     .add("commands", commands)

--- a/test-support/src/main/java/org/apache/brooklyn/test/performance/PerformanceTestDescriptor.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/performance/PerformanceTestDescriptor.java
@@ -29,7 +29,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.apache.commons.io.FileUtils;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * For building up a description of what to measure.
@@ -211,7 +211,7 @@ public class PerformanceTestDescriptor {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("summary", summary)
                 .add("duration", duration)

--- a/test-support/src/main/java/org/apache/brooklyn/test/performance/PerformanceTestResult.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/performance/PerformanceTestResult.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * The results of a performance test.
@@ -45,7 +45,7 @@ public class PerformanceTestResult {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .omitNullValues()
                 .add("summary", summary)
                 .add("duration", duration)

--- a/utils/common/src/main/java/org/apache/brooklyn/util/http/HttpToolResponse.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/http/HttpToolResponse.java
@@ -36,7 +36,7 @@ import org.apache.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -204,7 +204,7 @@ public class HttpToolResponse {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(getClass())
+        return MoreObjects.toStringHelper(getClass())
                 .add("responseCode", responseCode)
                 .toString();
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/pool/BasicPool.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/pool/BasicPool.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
@@ -100,7 +100,7 @@ public class BasicPool<T> implements Pool<T> {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this).add("name", name).toString();
+        return MoreObjects.toStringHelper(this).add("name", name).toString();
     }
     
     @Override

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/MemoryUsageTrackerTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/MemoryUsageTrackerTest.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Range;
 
 public class MemoryUsageTrackerTest {
@@ -139,7 +139,7 @@ public class MemoryUsageTrackerTest {
         }
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("total", Strings.makeSizeString(total))
                     .add("free", Strings.makeSizeString(free))
                     .add("used", Strings.makeSizeString(used))


### PR DESCRIPTION
Remove deprecation warnings by using `MoreObjects.toStringHelper`, rather than the deprecated guava `Objects.toStringHelper`.