### PR TITLE
A default network is now created when deploying to Azure ARM

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -80,6 +80,7 @@ import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.jclouds.JcloudsBlobStoreBasedObjectStore;
 import org.apache.brooklyn.location.jclouds.api.JcloudsLocationPublic;
 import org.apache.brooklyn.location.jclouds.networking.JcloudsPortForwarderExtension;
+import org.apache.brooklyn.location.jclouds.networking.creator.DefaultAzureArmNetworkCreator;
 import org.apache.brooklyn.location.jclouds.templates.PortableTemplateBuilder;
 import org.apache.brooklyn.location.jclouds.templates.customize.TemplateBuilderCustomizer;
 import org.apache.brooklyn.location.jclouds.templates.customize.TemplateBuilderCustomizers;
@@ -667,6 +668,11 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             Template template;
 
             try {
+                // Create default network for Azure ARM if necessary
+                if ("azurecompute-arm".equals(this.getProvider())) {
+                    DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, setup);
+                }
+
                 // Setup the template
                 template = buildTemplate(computeService, setup, ImmutableList.of(customizersDelegate));
                 boolean expectWindows = isWindows(template, setup);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -670,7 +670,7 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             try {
                 // Create default network for Azure ARM if necessary
                 if ("azurecompute-arm".equals(this.getProvider())) {
-                    DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, setup);
+                    DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, setup);
                 }
 
                 // Setup the template

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
@@ -37,6 +37,9 @@ import org.jclouds.azurecompute.arm.domain.Subnet;
 import org.jclouds.azurecompute.arm.domain.VirtualNetwork;
 import org.jclouds.compute.ComputeService;
 
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
 public class DefaultAzureArmNetworkCreator {
@@ -47,23 +50,35 @@ public class DefaultAzureArmNetworkCreator {
     private static final String DEFAULT_NETWORK_NAME = "brooklyn-default-network";
     private static final String DEFAULT_SUBNET_NAME = "brooklyn-default-subnet";
 
-    private static final String defaultVnetAddressPrefix = "10.1.0.0/16";
-    private static final String defaultSubnetAddressPrefix = "10.1.0.0/24";
+    private static final String DEFAULT_VNET_ADDRESS_PREFIX = "10.1.0.0/16";
+    private static final String DEFAULT_SUBNET_ADDRESS_PREFIX = "10.1.0.0/24";
 
-    public static void createDefaultNetworkAndAddToTemplateOptions(ComputeService computeService, ConfigBag config) {
+    public static ConfigKey<Boolean> AZURE_ARM_DEFAULT_NETWORK_ENABLED = ConfigKeys.newBooleanConfigKey(
+            "azure.arm.default.network.enabled",
+            "When set to true, AMP will create a default network and subnet per Azure region and " +
+                    "deploy applications there (if no network configuration has been set for the application).",
+            true);
+
+    public static void createDefaultNetworkAndAddToTemplateOptionsIfRequired(ComputeService computeService, ConfigBag config) {
+        if (!config.get(AZURE_ARM_DEFAULT_NETWORK_ENABLED)) {
+            LOG.info("azure.arm.default.network.enabled is disabled, not creating default network");
+            return;
+        }
+
+
         Map<String, Object> templateOptions = config.get(TEMPLATE_OPTIONS);
 
         //Only create a default network if we haven't specified a network name (in template options or config) or ip options
         if (config.containsKey(NETWORK_NAME)) {
-            LOG.info("Network config specified when creating Azure location. Not creating default network");
+            LOG.info("Network config specified when provisioning Azure machine. Not creating default network");
             return;
         }
         if (templateOptions != null && (templateOptions.containsKey(NETWORK_NAME.getName()) || templateOptions.containsKey("ipOptions"))) {
-            LOG.info("Network config specified when creating Azure location. Not creating default network");
+            LOG.info("Network config specified when provisioning Azure machine. Not creating default network");
             return;
         }
 
-        LOG.info("Network config not specified when creating Azure location. Creating default network if doesn't exist");
+        LOG.info("Network config not specified when provisioning Azure machine. Creating default network if doesn't exist");
 
         AzureComputeApi api = computeService.getContext().unwrapApi(AzureComputeApi.class);
         String location = config.get(CLOUD_REGION_ID);
@@ -87,10 +102,10 @@ public class DefaultAzureArmNetworkCreator {
 
         //Setup properties for creating subnet/network
         Subnet subnet = Subnet.create(subnetName, null, null,
-                Subnet.SubnetProperties.builder().addressPrefix(defaultSubnetAddressPrefix).build());
+                Subnet.SubnetProperties.builder().addressPrefix(DEFAULT_SUBNET_ADDRESS_PREFIX).build());
 
         VirtualNetwork.VirtualNetworkProperties virtualNetworkProperties = VirtualNetwork.VirtualNetworkProperties
-                .builder().addressSpace(VirtualNetwork.AddressSpace.create(Arrays.asList(defaultVnetAddressPrefix)))
+                .builder().addressSpace(VirtualNetwork.AddressSpace.create(Arrays.asList(DEFAULT_VNET_ADDRESS_PREFIX)))
                 .subnets(Arrays.asList(subnet)).build();
 
         //Create network
@@ -103,19 +118,22 @@ public class DefaultAzureArmNetworkCreator {
     }
 
     private static void updateTemplateOptions(ConfigBag config, Subnet createdSubnet){
-        Map<String, Object> templateOptions = config.get(TEMPLATE_OPTIONS);
+        Map<String, Object> templateOptions;
 
-        if(templateOptions == null) {
+        if(config.containsKey(TEMPLATE_OPTIONS)) {
+            templateOptions = MutableMap.copyOf(config.get(TEMPLATE_OPTIONS));
+        } else {
             templateOptions = new HashMap<>();
-            config.put(TEMPLATE_OPTIONS, templateOptions);
         }
 
-        Map<String, Object> ipOptions = new HashMap<>();
-        ipOptions.put("allocateNewPublicIp", true); //JClouds will not provide a public IP unless we set this
-        ipOptions.put("subnet", createdSubnet.id());
-        templateOptions.put("ipOptions", ipOptions);
-    }
+        templateOptions.put("ipOptions", ImmutableMap.of(
+                "allocateNewPublicIp", true, //jclouds will not provide a public IP unless we set this
+                "subnet", createdSubnet.id()
+        ));
 
+        config.put(TEMPLATE_OPTIONS, templateOptions);
+
+    }
 
     private static void createResourceGroupIfNeeded(AzureComputeApi api, String resourceGroup, String location) {
         LOG.debug("using resource group [%s]", resourceGroup);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds.networking.creator;
+
+import static org.apache.brooklyn.core.location.cloud.CloudLocationConfig.CLOUD_REGION_ID;
+import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.NETWORK_NAME;
+import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.TEMPLATE_OPTIONS;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.jclouds.azurecompute.arm.AzureComputeApi;
+import org.jclouds.azurecompute.arm.domain.ResourceGroup;
+import org.jclouds.azurecompute.arm.domain.Subnet;
+import org.jclouds.azurecompute.arm.domain.VirtualNetwork;
+import org.jclouds.compute.ComputeService;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+
+public class DefaultAzureArmNetworkCreator {
+
+    public static final Logger LOG = LoggerFactory.getLogger(DefaultAzureArmNetworkCreator.class);
+
+    private static final String DEFAULT_RESOURCE_GROUP = "brooklyn-default-resource-group";
+    private static final String DEFAULT_NETWORK_NAME = "brooklyn-default-network";
+    private static final String DEFAULT_SUBNET_NAME = "brooklyn-default-subnet";
+
+    private static final String defaultVnetAddressPrefix = "10.1.0.0/16";
+    private static final String defaultSubnetAddressPrefix = "10.1.0.0/24";
+
+    public static void createDefaultNetworkAndAddToTemplateOptions(ComputeService computeService, ConfigBag config) {
+        Map<String, Object> templateOptions = config.get(TEMPLATE_OPTIONS);
+
+        //Only create a default network if we haven't specified a network name (in template options or config) or ip options
+        if (config.containsKey(NETWORK_NAME)) {
+            LOG.info("Network config specified when creating Azure location. Not creating default network");
+            return;
+        }
+        if (templateOptions != null && (templateOptions.containsKey(NETWORK_NAME.getName()) || templateOptions.containsKey("ipOptions"))) {
+            LOG.info("Network config specified when creating Azure location. Not creating default network");
+            return;
+        }
+
+        LOG.info("Network config not specified when creating Azure location. Creating default network if doesn't exist");
+
+        AzureComputeApi api = computeService.getContext().unwrapApi(AzureComputeApi.class);
+        String location = config.get(CLOUD_REGION_ID);
+
+        String resourceGroupName = DEFAULT_RESOURCE_GROUP  + "-" + location;
+        String vnetName = DEFAULT_NETWORK_NAME + "-" + location;
+        String subnetName = DEFAULT_SUBNET_NAME + "-" + location;
+
+        //Check if default already exists
+        Subnet preexistingSubnet = api.getSubnetApi(resourceGroupName, vnetName).get(subnetName);
+        if(preexistingSubnet != null){
+            LOG.info("Default Azure network and subnet already created, "+vnetName);
+            updateTemplateOptions(config, preexistingSubnet);
+            return;
+        }
+
+
+        LOG.info("Network config not specified when creating Azure location and default network/subnet does not exists. Creating");
+
+        createResourceGroupIfNeeded(api, resourceGroupName, location);
+
+        //Setup properties for creating subnet/network
+        Subnet subnet = Subnet.create(subnetName, null, null,
+                Subnet.SubnetProperties.builder().addressPrefix(defaultSubnetAddressPrefix).build());
+
+        VirtualNetwork.VirtualNetworkProperties virtualNetworkProperties = VirtualNetwork.VirtualNetworkProperties
+                .builder().addressSpace(VirtualNetwork.AddressSpace.create(Arrays.asList(defaultVnetAddressPrefix)))
+                .subnets(Arrays.asList(subnet)).build();
+
+        //Create network
+        api.getVirtualNetworkApi(resourceGroupName).createOrUpdate(vnetName, location, virtualNetworkProperties);
+        Subnet createdSubnet = api.getSubnetApi(resourceGroupName, vnetName).get(subnetName);
+
+        //Add config
+        updateTemplateOptions(config, createdSubnet);
+
+    }
+
+    private static void updateTemplateOptions(ConfigBag config, Subnet createdSubnet){
+        Map<String, Object> templateOptions = config.get(TEMPLATE_OPTIONS);
+
+        if(templateOptions == null) {
+            templateOptions = new HashMap<>();
+            config.put(TEMPLATE_OPTIONS, templateOptions);
+        }
+
+        Map<String, Object> ipOptions = new HashMap<>();
+        ipOptions.put("allocateNewPublicIp", true); //JClouds will not provide a public IP unless we set this
+        ipOptions.put("subnet", createdSubnet.id());
+        templateOptions.put("ipOptions", ipOptions);
+    }
+
+
+    private static void createResourceGroupIfNeeded(AzureComputeApi api, String resourceGroup, String location) {
+        LOG.debug("using resource group [%s]", resourceGroup);
+        ResourceGroup rg = api.getResourceGroupApi().get(resourceGroup);
+        if (rg == null) {
+            LOG.debug("resource group [%s] does not exist. Creating!", resourceGroup);
+            api.getResourceGroupApi().create(resourceGroup, location,
+                    ImmutableMap.of("description", "brooklyn default resource group"));
+        }
+    }
+}

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.location.jclouds.networking.creator;
 import static org.apache.brooklyn.core.location.cloud.CloudLocationConfig.CLOUD_REGION_ID;
 import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.NETWORK_NAME;
 import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.TEMPLATE_OPTIONS;
+import static org.apache.brooklyn.location.jclouds.networking.creator.DefaultAzureArmNetworkCreator.AZURE_ARM_DEFAULT_NETWORK_ENABLED;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,7 +80,7 @@ public class DefaultAzureArmNetworkCreatorTest {
         when(subnet.id()).thenReturn(TEST_SUBNET_ID);
 
         //Test
-        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //verify
         verify(subnetApi).get(TEST_SUBNET_NAME);
@@ -111,7 +112,7 @@ public class DefaultAzureArmNetworkCreatorTest {
 
 
         //Test
-        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //verify
         verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
@@ -136,7 +137,7 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         Map<String, Object> configCopy = configBag.getAllConfig();
 
-        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //Ensure nothing changed, and no calls were made to the compute service
         assertEquals(configCopy, configBag.getAllConfig());
@@ -154,7 +155,7 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         Map<String, Object> configCopy = configBag.getAllConfig();
 
-        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //Ensure nothing changed, and no calls were made to the compute service
         assertEquals(configCopy, configBag.getAllConfig());
@@ -172,7 +173,22 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         Map<String, Object> configCopy = configBag.getAllConfig();
 
-        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
+
+        //Ensure nothing changed, and no calls were made to the compute service
+        assertEquals(configCopy, configBag.getAllConfig());
+        Mockito.verifyZeroInteractions(computeService);
+    }
+
+    @Test
+    public void testConfigDisabled() {
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+        configBag.put(AZURE_ARM_DEFAULT_NETWORK_ENABLED, false);
+
+        Map<String, Object> configCopy = configBag.getAllConfig();
+
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //Ensure nothing changed, and no calls were made to the compute service
         assertEquals(configCopy, configBag.getAllConfig());

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.jclouds.networking.creator;
+
+import static org.apache.brooklyn.core.location.cloud.CloudLocationConfig.CLOUD_REGION_ID;
+import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.NETWORK_NAME;
+import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic.TEMPLATE_OPTIONS;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import org.jclouds.azurecompute.arm.AzureComputeApi;
+import org.jclouds.azurecompute.arm.domain.Subnet;
+import org.jclouds.azurecompute.arm.features.ResourceGroupApi;
+import org.jclouds.azurecompute.arm.features.SubnetApi;
+import org.jclouds.azurecompute.arm.features.VirtualNetworkApi;
+import org.jclouds.compute.ComputeService;
+
+import org.apache.brooklyn.util.core.config.ConfigBag;
+
+public class DefaultAzureArmNetworkCreatorTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) ComputeService computeService;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) AzureComputeApi azureComputeApi;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) ResourceGroupApi resourceGroupApi;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) VirtualNetworkApi virtualNetworkApi;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS) SubnetApi subnetApi;
+
+    @Mock Subnet subnet;
+
+    final String TEST_RESOURCE_GROUP = "brooklyn-default-resource-group-test-loc";
+    final String TEST_NETWORK_NAME = "brooklyn-default-network-test-loc";
+    final String TEST_SUBNET_NAME = "brooklyn-default-subnet-test-loc";
+    final String TEST_SUBNET_ID = "/test/resource/id";
+    final String TEST_LOCATION = "test-loc";
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testPreExisting() {
+        //Setup config bag
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+
+        //Setup mocks
+        when(computeService.getContext().unwrapApi(AzureComputeApi.class)).thenReturn(azureComputeApi);
+        when(azureComputeApi.getSubnetApi(TEST_RESOURCE_GROUP, TEST_NETWORK_NAME)).thenReturn(subnetApi);
+        when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(subnet);
+        when(subnet.id()).thenReturn(TEST_SUBNET_ID);
+
+        //Test
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+
+        //verify
+        verify(subnetApi).get(TEST_SUBNET_NAME);
+        verify(subnet).id();
+        verify(azureComputeApi).getSubnetApi(TEST_RESOURCE_GROUP, TEST_NETWORK_NAME);
+
+        Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
+        Map<String, Object> ipOptions = (Map<String, Object>)templateOptions.get("ipOptions");
+        assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
+        assertEquals(ipOptions.get("allocateNewPublicIp"), true);
+    }
+
+    @Test
+    public void testVanilla() {
+        //Setup config bag
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+
+        //Setup mocks
+        when(computeService.getContext().unwrapApi(AzureComputeApi.class)).thenReturn(azureComputeApi);
+        when(azureComputeApi.getSubnetApi(TEST_RESOURCE_GROUP, TEST_NETWORK_NAME)).thenReturn(subnetApi);
+        when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
+        when(subnet.id()).thenReturn(TEST_SUBNET_ID);
+
+        when(azureComputeApi.getResourceGroupApi()).thenReturn(resourceGroupApi);
+        when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(null);
+
+        when(azureComputeApi.getVirtualNetworkApi(TEST_RESOURCE_GROUP)).thenReturn(virtualNetworkApi);
+
+
+        //Test
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+
+        //verify
+        verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
+        verify(subnet).id();
+        verify(azureComputeApi, times(2)).getSubnetApi(TEST_RESOURCE_GROUP, TEST_NETWORK_NAME);
+
+        verify(azureComputeApi, times(2)).getResourceGroupApi();
+        verify(resourceGroupApi).get(TEST_RESOURCE_GROUP);
+        verify(azureComputeApi).getVirtualNetworkApi(TEST_RESOURCE_GROUP);
+
+        Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
+        Map<String, Object> ipOptions = (Map<String, Object>)templateOptions.get("ipOptions");
+        assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
+        assertEquals(ipOptions.get("allocateNewPublicIp"), true);
+    }
+
+    @Test
+    public void testNetworkInConfig() {
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+        configBag.put(NETWORK_NAME, TEST_NETWORK_NAME);
+
+        Map<String, Object> configCopy = configBag.getAllConfig();
+
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+
+        //Ensure nothing changed, and no calls were made to the compute service
+        assertEquals(configCopy, configBag.getAllConfig());
+        Mockito.verifyZeroInteractions(computeService);
+    }
+
+    @Test
+    public void testNetworkInTemplate() {
+        HashMap<String, Object> templateOptions = new HashMap<>();
+        templateOptions.put(NETWORK_NAME.getName(), TEST_NETWORK_NAME);
+
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+        configBag.put(TEMPLATE_OPTIONS, templateOptions);
+
+        Map<String, Object> configCopy = configBag.getAllConfig();
+
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+
+        //Ensure nothing changed, and no calls were made to the compute service
+        assertEquals(configCopy, configBag.getAllConfig());
+        Mockito.verifyZeroInteractions(computeService);
+    }
+
+    @Test
+    public void testIpOptionsInTemplate() {
+        HashMap<String, Object> templateOptions = new HashMap<>();
+        templateOptions.put("ipOptions", TEST_NETWORK_NAME);
+
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+        configBag.put(TEMPLATE_OPTIONS, templateOptions);
+
+        Map<String, Object> configCopy = configBag.getAllConfig();
+
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptions(computeService, configBag);
+
+        //Ensure nothing changed, and no calls were made to the compute service
+        assertEquals(configCopy, configBag.getAllConfig());
+        Mockito.verifyZeroInteractions(computeService);
+    }
+}


### PR DESCRIPTION
In an upcoming release of JClouds, support for Azure ARM will be added. The JClouds code for Azure ARM will place each created VM into a network based on it's group ID. As we do not use the concept of a group ID in Brooklyn, this means that each VM deployed by Brooklyn is deployed in it's own subnet. 

For most other clouds, a sensible default network is provided by the cloud. As such a Brooklyn user can be assured that if he deploys a blueprint with multiple VMs, they can reach each other on the private IPs that are provided. Unless we create a default network in Azure, those blueprints will not be portable and a user will have to manually create a network first. I believe that it is confusing for a user to have the clouds act differently on networking, which is an essential part of Brooklyn.

A few things to mention:
*) The default network/subnet is only created when needed
*) The default network/subnet is created per region
*) It is never cleaned up or deleted

--------------------------------------------------------------------
As a side note, I discovered this as AMP, which is a downstream project of Brooklyn, pulled in and was using Azure ARM support from JClouds. An older version of the JClouds code created the default network, but was recently removed meaning a regression in AMP. The code which I have added to create a default network is based on the JClouds code.
