### PR TITLE
Update maven-compiler-plugin to 3.6.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -547,7 +547,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>


### PR DESCRIPTION
I think since we upgrade java it will be useful to have later maven-compiler-plugin.
If you approve this change, I will do the same PR for brooklyn-ui and brooklyn-dist.