### PR TITLE
Allow catalog item to be force-updated via query string flag on the REST API

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -67,7 +67,7 @@ public interface CatalogApi {
             @ApiResponse(code = 400, message = "Error processing the given YAML"),
             @ApiResponse(code = 201, message = "Catalog items added successfully")
     })
-    public Response create(String yaml);
+    public Response create(String yaml, @QueryParam("forceUpdate") @DefaultValue("false") boolean forceUpdate);
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON, "application/x-yaml",
@@ -85,7 +85,9 @@ public interface CatalogApi {
     })
     public Response createFromYaml(
             @ApiParam(name = "yaml", value = "YAML descriptor of catalog item", required = true)
-            @Valid String yaml);
+            @Valid String yaml,
+            @QueryParam("forceUpdate") @DefaultValue("false")
+            boolean forceUpdate);
 
     @Beta
     /* TODO the polymorphic return type dependent on 'detail' is ugly, 
@@ -118,7 +120,9 @@ public interface CatalogApi {
             byte[] archive,
             @ApiParam(name="detail", value="Provide a wrapping details map", required=false)
             @QueryParam("detail") @DefaultValue("false")
-            boolean detail);
+            boolean detail,
+            @QueryParam("forceUpdate") @DefaultValue("false")
+            boolean forceUpdate);
 
     @Beta
     @POST
@@ -140,7 +144,9 @@ public interface CatalogApi {
                     name = "item",
                     value = "Item to install, as JAR/ZIP or Catalog YAML (autodetected)",
                     required = true)
-                    byte[] item);
+                    byte[] item,
+            @QueryParam("forceUpdate") @DefaultValue("false")
+                    boolean forceUpdate);
     
     @DELETE
     @Path("/applications/{symbolicName}/{version}")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/CatalogApi.java
@@ -67,7 +67,9 @@ public interface CatalogApi {
             @ApiResponse(code = 400, message = "Error processing the given YAML"),
             @ApiResponse(code = 201, message = "Catalog items added successfully")
     })
-    public Response create(String yaml, @QueryParam("forceUpdate") @DefaultValue("false") boolean forceUpdate);
+    public Response create(String yaml,
+            @ApiParam(name="forceUpdate", value="Force update of catalog item (overwriting existing catalog items with same name and version)")
+            @QueryParam("forceUpdate") @DefaultValue("false") boolean forceUpdate);
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON, "application/x-yaml",
@@ -86,6 +88,7 @@ public interface CatalogApi {
     public Response createFromYaml(
             @ApiParam(name = "yaml", value = "YAML descriptor of catalog item", required = true)
             @Valid String yaml,
+            @ApiParam(name="forceUpdate", value="Force update of catalog item (overwriting existing catalog items with same name and version)")
             @QueryParam("forceUpdate") @DefaultValue("false")
             boolean forceUpdate);
 
@@ -121,6 +124,7 @@ public interface CatalogApi {
             @ApiParam(name="detail", value="Provide a wrapping details map", required=false)
             @QueryParam("detail") @DefaultValue("false")
             boolean detail,
+            @ApiParam(name="forceUpdate", value="Force update of catalog item (overwriting existing catalog items with same name and version)")
             @QueryParam("forceUpdate") @DefaultValue("false")
             boolean forceUpdate);
 
@@ -145,6 +149,7 @@ public interface CatalogApi {
                     value = "Item to install, as JAR/ZIP or Catalog YAML (autodetected)",
                     required = true)
                     byte[] item,
+            @ApiParam(name="forceUpdate", value="Force update of catalog item (overwriting existing catalog items with same name and version)")
             @QueryParam("forceUpdate") @DefaultValue("false")
                     boolean forceUpdate);
     

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
@@ -1069,4 +1069,175 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         assertEquals(applications.size(), 1);
         assertEquals(applications.get(0).getVersion(), TEST_VERSION);
     }
+
+    @Test
+    public void testForceUpdateForYAML() {
+        String symbolicName = "force.update.catalog.application.id";
+        String itemType = "template";
+        String initialName = "My Catalog App";
+        String initialDescription = "My description";
+        String updatedName = initialName + " 2";
+        String updatedDescription = initialDescription + " 2";
+
+        String initialYaml = Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  id: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  itemType: " + itemType,
+                "  name: " + initialName,
+                "  description: " + initialDescription,
+                "  icon_url: classpath:///bridge-small.png",
+                "  version: " + TEST_VERSION,
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity");
+        String updatedYaml = Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  id: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  itemType: " + itemType,
+                "  name: " + updatedName,
+                "  description: " + updatedDescription,
+                "  icon_url: classpath:///bridge-small.png",
+                "  version: " + TEST_VERSION,
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity");
+
+        client().path("/catalog").post(initialYaml);
+
+        CatalogItemSummary initialApplication = client().path("/catalog/applications/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(initialApplication.getName(), initialName);
+        assertEquals(initialApplication.getDescription(), initialDescription);
+
+        Response invalidResponse = client().path("/catalog").post(updatedYaml);
+
+        assertEquals(invalidResponse.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+        Response validResponse = client().path("/catalog").query("forceUpdate", true).post(updatedYaml);
+
+        assertEquals(validResponse.getStatus(), Response.Status.CREATED.getStatusCode());
+
+        CatalogItemSummary application = client().path("/catalog/applications/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(application.getName(), updatedName);
+        assertEquals(application.getDescription(), updatedDescription);
+    }
+
+    @Test
+    public void testForceUpdateForZip() throws Exception {
+        final String symbolicName = "force.update.zip.catalog.application.id";
+        final String initialName = "My Catalog App";
+        final String initialDescription = "My Description";
+        final String updatedName = initialName + " 2";
+        final String updatedDescription = initialDescription  +" 2";
+
+        File initialZip = createZip(ImmutableMap.<String, String>of("catalog.bom", Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  bundle: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  id: " + symbolicName,
+                "  itemType: entity",
+                "  name: " + initialName,
+                "  description: " + initialDescription,
+                "  icon_url: classpath:/org/apache/brooklyn/test/osgi/entities/icon.gif",
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity")));
+        File updatedZip = createZip(ImmutableMap.<String, String>of("catalog.bom", Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  bundle: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  id: " + symbolicName,
+                "  itemType: entity",
+                "  name: " + updatedName,
+                "  description: " + updatedDescription,
+                "  icon_url: classpath:/org/apache/brooklyn/test/osgi/entities/icon.gif",
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity")));
+
+        client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-zip")
+                .post(Streams.readFully(new FileInputStream(initialZip)));
+
+        CatalogItemSummary initialEntity = client().path("/catalog/entities/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(initialEntity.getName(), initialName);
+        assertEquals(initialEntity.getDescription(), initialDescription);
+
+        Response invalidResponse = client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-zip")
+                .post(Streams.readFully(new FileInputStream(updatedZip)));
+
+        assertEquals(invalidResponse.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+        Response validResponse = client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-zip")
+                .query("forceUpdate", true)
+                .post(Streams.readFully(new FileInputStream(updatedZip)));
+
+        assertEquals(validResponse.getStatus(), Response.Status.CREATED.getStatusCode());
+
+        CatalogItemSummary entity = client().path("/catalog/entities/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(entity.getName(), updatedName);
+        assertEquals(entity.getDescription(), updatedDescription);
+    }
+
+    @Test
+    public void testForceUpdateForJar() throws Exception {
+        final String symbolicName = "force.update.jar.catalog.application.id";
+        final String initialName = "My Catalog App";
+        final String initialDescription = "My Description";
+        final String updatedName = initialName + " 2";
+        final String updatedDescription = initialDescription  +" 2";
+
+        File initialJar = createJar(ImmutableMap.<String, String>of("catalog.bom", Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  bundle: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  id: " + symbolicName,
+                "  itemType: entity",
+                "  name: " + initialName,
+                "  description: " + initialDescription,
+                "  icon_url: classpath:/org/apache/brooklyn/test/osgi/entities/icon.gif",
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity")));
+        File updatedJar = createJar(ImmutableMap.<String, String>of("catalog.bom", Joiner.on("\n").join(
+                "brooklyn.catalog:",
+                "  bundle: " + symbolicName,
+                "  version: " + TEST_VERSION,
+                "  id: " + symbolicName,
+                "  itemType: entity",
+                "  name: " + updatedName,
+                "  description: " + updatedDescription,
+                "  icon_url: classpath:/org/apache/brooklyn/test/osgi/entities/icon.gif",
+                "  item:",
+                "    type: org.apache.brooklyn.core.test.entity.TestEntity")));
+
+        client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-jar")
+                .post(Streams.readFully(new FileInputStream(initialJar)));
+
+        CatalogItemSummary initialEntity = client().path("/catalog/entities/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(initialEntity.getName(), initialName);
+        assertEquals(initialEntity.getDescription(), initialDescription);
+
+        Response invalidResponse = client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-jar")
+                .post(Streams.readFully(new FileInputStream(updatedJar)));
+
+        assertEquals(invalidResponse.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+        Response validResponse = client().path("/catalog")
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-jar")
+                .query("forceUpdate", true)
+                .post(Streams.readFully(new FileInputStream(updatedJar)));
+
+        assertEquals(validResponse.getStatus(), Response.Status.CREATED.getStatusCode());
+
+        CatalogItemSummary entity = client().path("/catalog/entities/" + symbolicName + "/" + TEST_VERSION)
+                .get(CatalogItemSummary.class);
+        assertEquals(entity.getName(), updatedName);
+        assertEquals(entity.getDescription(), updatedDescription);
+    }
 }


### PR DESCRIPTION
# Issue

When `POST`ing a catalog item (YAML file) with an ID and version that already exists, the REST API returns a `400` with a message inviting the user to use a `forceUpdate` flag if one wishes to. However, this flag is only available internally and not exposed to the REST API.

Another issue is that under the same condition for ZIP/JAR archives, the `OsgiArchiveInstaller` silently ignores the update and therefore, the REST API returns a `201` even though it has done anything.

# Fix

This fixes both above issues by:
- exposing a `forceUpdate` flag on the REST API for `/v1/catalog`
- checking the result code from `OsgiArchiveInstaller.install()` method and throws the same error message inviting the user to use the `forceUpdate` flag