### PR TITLE
Azure ARM default network fixes from PR suggestions

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
@@ -45,6 +45,8 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.time.CountdownTimer;
+import org.apache.brooklyn.util.time.Duration;
 
 public class DefaultAzureArmNetworkCreator {
 
@@ -53,6 +55,9 @@ public class DefaultAzureArmNetworkCreator {
     private static final String DEFAULT_RESOURCE_GROUP_PREFIX = "brooklyn-default-resource-group";
     private static final String DEFAULT_NETWORK_NAME_PREFIX = "brooklyn-default-network";
     private static final String DEFAULT_SUBNET_NAME_PREFIX = "brooklyn-default-subnet";
+
+    private static final String PROVISIONING_STATE_UPDATING = "Updating";
+    private static final String PROVISIONING_STATE_SUCCEEDED = "Succeeded";
 
     private static final String DEFAULT_VNET_ADDRESS_PREFIX = "10.1.0.0/16";
     private static final String DEFAULT_SUBNET_ADDRESS_PREFIX = "10.1.0.0/24";
@@ -130,6 +135,24 @@ public class DefaultAzureArmNetworkCreator {
 
         //Get created subnet
         Subnet createdSubnet = api.getSubnetApi(resourceGroupName, vnetName).get(subnetName);
+
+        //Wait until subnet is created
+        CountdownTimer timeout = CountdownTimer.newInstanceStarted(Duration.minutes(new Integer(20)));
+        while (PROVISIONING_STATE_UPDATING.equals(createdSubnet.properties().provisioningState())) {
+            if (timeout.isExpired()) {
+                throw new IllegalStateException("Creating subnet " + subnetName + " stuck in the updating state, aborting.");
+            }
+            LOG.debug("Created subnet {} is still in updating state, waiting for it to complete", createdSubnet);
+            Duration.sleep(Duration.ONE_SECOND);
+            createdSubnet = api.getSubnetApi(resourceGroupName, vnetName).get(subnetName);
+        }
+
+        String lastProvisioningState = createdSubnet.properties().provisioningState();
+        if (!lastProvisioningState.equals(PROVISIONING_STATE_SUCCEEDED)) {
+            LOG.debug("Created subnet {} in wrong state, expected state {} but found {}", new Object[] {subnetName, PROVISIONING_STATE_SUCCEEDED, lastProvisioningState});
+            throw new IllegalStateException("Created subnet " + subnetName + " in wrong state, expected state " + PROVISIONING_STATE_SUCCEEDED +
+                    " but found " + lastProvisioningState );
+        }
 
         //Add config
         updateTemplateOptions(config, createdSubnet);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
@@ -24,6 +24,7 @@ import static org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPubl
 import static org.apache.brooklyn.location.jclouds.networking.creator.DefaultAzureArmNetworkCreator.AZURE_ARM_DEFAULT_NETWORK_ENABLED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,7 +64,7 @@ public class DefaultAzureArmNetworkCreatorTest {
     @Mock VirtualNetwork virtualNetwork;
 
     @Mock ResourceGroup resourceGroup;
-    @Mock Subnet subnet;
+    @Mock(answer = org.mockito.Answers.RETURNS_DEEP_STUBS) Subnet subnet;
 
     final String TEST_LOCATION = "test-loc";
     final String TEST_RESOURCE_GROUP = "brooklyn-default-resource-group-" + TEST_LOCATION;
@@ -128,16 +129,17 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         //Setup mocks
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
-
         when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(null);
+        when(subnet.properties().provisioningState()).thenReturn("Updating").thenReturn("Succeeded");
+
 
 
         //Test
         DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //verify calls made
-        verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
         verify(subnet).id();
+        verify(subnetApi, atLeast(2)).get(TEST_SUBNET_NAME);
 
         verify(resourceGroupApi).get(TEST_RESOURCE_GROUP);
         verify(resourceGroupApi).create(eq(TEST_RESOURCE_GROUP), eq(TEST_LOCATION), any());
@@ -162,13 +164,13 @@ public class DefaultAzureArmNetworkCreatorTest {
         //Setup mocks
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
         when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(resourceGroup);
-
+        when(subnet.properties().provisioningState()).thenReturn("Updating").thenReturn("Succeeded");
 
         //Test
         DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //verify
-        verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
+        verify(subnetApi, atLeast(2)).get(TEST_SUBNET_NAME);
         verify(subnet).id();
 
         verify(resourceGroupApi).get(TEST_RESOURCE_GROUP);
@@ -195,14 +197,14 @@ public class DefaultAzureArmNetworkCreatorTest {
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
         when(virtualNetworkApi.get(TEST_NETWORK_NAME)).thenReturn(virtualNetwork);
         when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(resourceGroup);
-
+        when(subnet.properties().provisioningState()).thenReturn("Updating").thenReturn("Succeeded");
 
         //Test
         DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
 
         //verify
-        verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
         verify(subnetApi).createOrUpdate(eq(TEST_SUBNET_NAME), any());
+        verify(subnetApi, atLeast(2)).get(TEST_SUBNET_NAME);
         verify(subnet).id();
 
         verify(resourceGroupApi).get(TEST_RESOURCE_GROUP);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreatorTest.java
@@ -31,12 +31,14 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.jclouds.azurecompute.arm.AzureComputeApi;
 import org.jclouds.azurecompute.arm.domain.ResourceGroup;
 import org.jclouds.azurecompute.arm.domain.Subnet;
+import org.jclouds.azurecompute.arm.domain.VirtualNetwork;
 import org.jclouds.azurecompute.arm.features.ResourceGroupApi;
 import org.jclouds.azurecompute.arm.features.SubnetApi;
 import org.jclouds.azurecompute.arm.features.VirtualNetworkApi;
@@ -58,6 +60,7 @@ public class DefaultAzureArmNetworkCreatorTest {
     @Mock ResourceGroupApi resourceGroupApi;
     @Mock VirtualNetworkApi virtualNetworkApi;
     @Mock SubnetApi subnetApi;
+    @Mock VirtualNetwork virtualNetwork;
 
     @Mock ResourceGroup resourceGroup;
     @Mock Subnet subnet;
@@ -89,7 +92,6 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         //Setup mocks
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(subnet);
-        
 
         //Test
         DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
@@ -100,7 +102,7 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         //verify templateOptions updated to include defaults
         Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
-        Map<?, ?> ipOptions = (Map<?, ?>)templateOptions.get("ipOptions");
+        Map<String, Object> ipOptions = (Map<String, Object>) ((List)templateOptions.get("ipOptions")).iterator().next();
         assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
         assertEquals(ipOptions.get("allocateNewPublicIp"), true);
     }
@@ -121,9 +123,9 @@ public class DefaultAzureArmNetworkCreatorTest {
     protected ConfigBag runVanilla(Map<?, ?> additionalConfig) throws Exception {
         //Setup config bag
         ConfigBag configBag = ConfigBag.newInstance();
-        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
         configBag.putAll(additionalConfig);
-        
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+
         //Setup mocks
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
 
@@ -144,7 +146,7 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         //verify templateOptions updated to include defaults
         Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
-        Map<?, ?> ipOptions = (Map<?, ?>)templateOptions.get("ipOptions");
+        Map<String, Object> ipOptions = (Map<String, Object>) ((List)templateOptions.get("ipOptions")).iterator().next();
         assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
         assertEquals(ipOptions.get("allocateNewPublicIp"), true);
         
@@ -156,10 +158,9 @@ public class DefaultAzureArmNetworkCreatorTest {
         //Setup config bag
         ConfigBag configBag = ConfigBag.newInstance();
         configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
-        
+
         //Setup mocks
         when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
-
         when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(resourceGroup);
 
 
@@ -177,7 +178,41 @@ public class DefaultAzureArmNetworkCreatorTest {
 
         //verify templateOptions updated to include defaults
         Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
-        Map<?, ?> ipOptions = (Map<?, ?>)templateOptions.get("ipOptions");
+        Map<String, Object> ipOptions = (Map<String, Object>) ((List)templateOptions.get("ipOptions")).iterator().next();
+        assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
+        assertEquals(ipOptions.get("allocateNewPublicIp"), true);
+    }
+
+
+
+    @Test
+    public void testVanillaWhereExistingNetworkButNoSubnet() throws Exception {
+        //Setup config bag
+        ConfigBag configBag = ConfigBag.newInstance();
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
+
+        //Setup mocks
+        when(subnetApi.get(TEST_SUBNET_NAME)).thenReturn(null).thenReturn(subnet); //null first time, subnet next
+        when(virtualNetworkApi.get(TEST_NETWORK_NAME)).thenReturn(virtualNetwork);
+        when(resourceGroupApi.get(TEST_RESOURCE_GROUP)).thenReturn(resourceGroup);
+
+
+        //Test
+        DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);
+
+        //verify
+        verify(subnetApi, times(2)).get(TEST_SUBNET_NAME);
+        verify(subnetApi).createOrUpdate(eq(TEST_SUBNET_NAME), any());
+        verify(subnet).id();
+
+        verify(resourceGroupApi).get(TEST_RESOURCE_GROUP);
+        verify(resourceGroupApi, never()).create(any(), any(), any());
+
+        verify(virtualNetworkApi, never()).createOrUpdate(any(), any(), any());
+
+        //verify templateOptions updated to include defaults
+        Map<String, Object> templateOptions = configBag.get(TEMPLATE_OPTIONS);
+        Map<String, Object> ipOptions = (Map<String, Object>) ((List)templateOptions.get("ipOptions")).iterator().next();
         assertEquals(ipOptions.get("subnet"), TEST_SUBNET_ID);
         assertEquals(ipOptions.get("allocateNewPublicIp"), true);
     }
@@ -188,19 +223,19 @@ public class DefaultAzureArmNetworkCreatorTest {
         configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
         configBag.put(NETWORK_NAME, TEST_NETWORK_NAME);
 
-        runAssertingNoIteractions(configBag);
+        runAssertingNoInteractions(configBag);
     }
 
     @Test
     public void testNetworkInTemplate() throws Exception {
         HashMap<String, Object> templateOptions = new HashMap<>();
-        templateOptions.put(NETWORK_NAME.getName(), TEST_NETWORK_NAME);
+        templateOptions.put("networks", TEST_NETWORK_NAME);
 
         ConfigBag configBag = ConfigBag.newInstance();
-        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
         configBag.put(TEMPLATE_OPTIONS, templateOptions);
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
 
-        runAssertingNoIteractions(configBag);
+        runAssertingNoInteractions(configBag);
     }
 
     @Test
@@ -209,22 +244,29 @@ public class DefaultAzureArmNetworkCreatorTest {
         templateOptions.put("ipOptions", TEST_NETWORK_NAME);
 
         ConfigBag configBag = ConfigBag.newInstance();
-        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
         configBag.put(TEMPLATE_OPTIONS, templateOptions);
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
 
-        runAssertingNoIteractions(configBag);
+        runAssertingNoInteractions(configBag);
     }
 
     @Test
     public void testConfigDisabled() throws Exception {
         ConfigBag configBag = ConfigBag.newInstance();
-        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
         configBag.put(AZURE_ARM_DEFAULT_NETWORK_ENABLED, false);
+        configBag.put(CLOUD_REGION_ID, TEST_LOCATION);
 
-        runAssertingNoIteractions(configBag);
+        runAssertingNoInteractions(configBag);
+    }
+
+    @Test
+    public void testNoRegion() throws Exception {
+        ConfigBag configBag = ConfigBag.newInstance();
+
+        runAssertingNoInteractions(configBag);
     }
     
-    protected void runAssertingNoIteractions(ConfigBag configBag) throws Exception {
+    protected void runAssertingNoInteractions(ConfigBag configBag) throws Exception {
         Map<String, Object> configCopy = configBag.getAllConfig();
 
         DefaultAzureArmNetworkCreator.createDefaultNetworkAndAddToTemplateOptionsIfRequired(computeService, configBag);


### PR DESCRIPTION
Important Note: Azure ARM doesn't currently work with the master of Brooklyn. Currently, after a Azure ARM VM is created, JClouds attempts to list all of the nodes in the resource group but cannot parse the result due to a missing property (vhd for DataDisk). I have tested with the latest JClouds code in master and we do not have this issue. 

However, we are currently on the latest released version of JClouds (2.0.1) and we cannot pull in the code in mater until there is another JClouds release. As such, the code that has been written for default network has been written against the code in JClouds master and will work when we upgrade to the next version of JClouds. If you need working Azure ARM support, and default networking build JClouds master locally, and build brooklyn against it.

---------------------

Various fixes:
- IpOptions were being added incorrectly to templateOptions. They were being set as a map, when they should have been a list of maps
- When checking templateOptions for existing config, look for 'networks' rather than NETWORK_NAME config (which resolves to 'networkName'). Still use NETWORK_NAME config when checking in brooklyn config
- Check that a region has been set in brooklyn config (config.get(CLOUD_REGION_ID)) if not, don't try and create a default network. It was suggested that I could move the default network creation to later in JCloudsLocation after the templateOptions have been built. This would mean that a default region would have been added to the templateOptions if none was specified in config. I attempted to implement this, but ran into an issue. The AzureTemplateOptions in JClouds 2.0.1 is different to the AzureTemplateOptions in JClouds master. As such, it is not possible to amend the AzureTemplateOptions from Brooklyn code, as we would not be able to modify the ipOptions (a concept that only exists in JClouds master). As such, I have put the null check in for the time being. After the next JClouds release, I will come back and fix this
- Check for the situation where a default network exists, but a default subnet does not. In this situation create a default subnet only

------------------------------

@neykov pointed out there could be issues if we are trying to create multiple VM's at the same time due to the these VMs all trying to create the default network/subnet. I have investigated and I don't think this will be an issue. The default network creation is done in the obtainOnce method of JCloudsLocation. If there were a situation where multiple VMs tried to create the network at the same time, then all but one would fail. Brooklyn will by default will then attempt to get a VM again, and this time it will succeed. To test this theory I spooled up three AMPs, and at the same time kicked off a deployment of 5 VMs on each AMP (15 total) to try and force this situation. Only 3/15 came up correctly, but the failures were quota issues which means they got passed network creation.