### PR TITLE
Adds method to reset the shutdown flag within BrooklynShutdownHooks

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynShutdownHooks.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynShutdownHooks.java
@@ -18,11 +18,8 @@
  */
 package org.apache.brooklyn.core.mgmt.internal;
 
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -40,8 +37,10 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BrooklynShutdownHooks {
 
@@ -97,6 +96,17 @@ public class BrooklynShutdownHooks {
             
         } catch (Exception e) {
             throw Exceptions.propagate(e);
+        }
+    }
+
+    public static void resetShutdownFlag() {
+        try {
+            semaphore.acquire();
+            isShutDown.compareAndSet(true, false);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Could not reset shutdown flag", e);
+        } finally {
+            semaphore.release();
         }
     }
 

--- a/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiLauncher.java
+++ b/karaf/init/src/main/java/org/apache/brooklyn/launcher/osgi/OsgiLauncher.java
@@ -20,6 +20,7 @@ import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.core.BrooklynVersionService;
 import org.apache.brooklyn.core.catalog.internal.CatalogInitialization;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.BrooklynShutdownHooks;
 import org.apache.brooklyn.core.mgmt.persist.PersistMode;
 import org.apache.brooklyn.launcher.common.BasicLauncher;
 import org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelper;
@@ -96,6 +97,7 @@ public class OsgiLauncher extends BasicLauncher<OsgiLauncher> {
     // init-method can't find the start method for some reason, provide an alternative
     public void init() {
         synchronized (reloadLock) {
+            BrooklynShutdownHooks.resetShutdownFlag();
             LOG.debug("OsgiLauncher init");
             catalogInitialization(new CatalogInitialization(String.format("file:%s", defaultCatalogLocation), false, null, false));
             start();


### PR DESCRIPTION
Under karaf if you restarted the brooklyn-init bundle
either manually or due to a re-wire the management context would not
restart (requiring you to resart karaf). This change allows the OSGi
launcher to reset the shutdown flag enabling bundle / management context restart

See [BROOKLYN-522](https://issues.apache.org/jira/browse/BROOKLYN-522)