### PR TITLE
Cache the default region in location config

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -675,6 +675,14 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
                 // Setup the template
                 template = buildTemplate(computeService, setup, ImmutableList.of(customizersDelegate));
+
+                // If region is not set on the location by the user get the default from jclouds and cache the value.
+                // Makes it easier for code to keep track of what region the location deploys to (for example customizers).
+                if (Strings.isEmpty(setup.get(CLOUD_REGION_ID))) {
+                    setup.put(CLOUD_REGION_ID, template.getLocation().getId());
+                    config().set(CLOUD_REGION_ID, template.getLocation().getId());
+                }
+
                 boolean expectWindows = isWindows(template, setup);
                 if (!options.skipJcloudsSshing()) {
                     if (expectWindows) {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocationStubbedTest.java
@@ -23,6 +23,7 @@ import static org.apache.brooklyn.util.core.internal.ssh.SshTool.ADDITIONAL_CONN
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.AbstractNodeCreator;
 import org.apache.brooklyn.location.jclouds.StubbedComputeServiceRegistry.NodeCreator;
+import org.apache.brooklyn.location.jclouds.api.JcloudsLocationConfigPublic;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.test.Asserts;
@@ -226,4 +228,14 @@ public class JcloudsSshMachineLocationStubbedTest extends AbstractJcloudsStubbed
         assertTrue(calledPreRelease.get(), "preReleaseOnObtainError not called on failed onObtain");
         assertFalse(calledPostRelease.get(), "postReleaseOnObtainError not to be called on failed onObtain when destroyOnFailure=false");
     }
+
+    @Test
+    public void testRegionCachedFromJcloudsDefault() throws Exception {
+        privateAddresses = ImmutableList.of();
+        jcloudsLocation.config().removeKey(JcloudsLocationConfigPublic.CLOUD_REGION_ID);
+        JcloudsSshMachineLocation machine = obtainMachine();
+        assertEquals(jcloudsLocation.config().get(JcloudsLocationConfigPublic.CLOUD_REGION_ID), "us-east-1");
+        assertEquals(machine.config().get(JcloudsLocationConfigPublic.CLOUD_REGION_ID), "us-east-1");
+    }
+    
 }


### PR DESCRIPTION
The default region is expensive to retrieve when one is not set by the user. Very often it needs expensive clouds calls (e.x. retrieve list of images).
Cache the value so it can easily be used by code that needs it. It can be used by customizers in starting from `customizer(template)` step or any other code after the first `obtain` call.