### PR TITLE
Update jclouds to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
         <!-- Dependency Versions -->
-        <jclouds.version>2.0.1</jclouds.version> <!-- JCLOUDS_VERSION -->
+        <jclouds.version>2.0.2</jclouds.version> <!-- JCLOUDS_VERSION -->
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.6.6</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->


### PR DESCRIPTION
`azurecompute-arm` has changed considerably since `2.0.1`. `jclouds-labs` providers usually backport all master changes to iterate quickly, free to break backwards compatibility.
Notably `templateOptions` has completely different fields.  
Also https://github.com/jclouds/jclouds/pull/1113 is included, fixing edge cases with Amazon security groups.