### PR TITLE
Fix REST API response of methods with String return type

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
@@ -75,6 +75,7 @@ public interface ActivityApi {
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Could not find task or stream")
     })
+    @Produces(MediaType.TEXT_PLAIN)
     public String stream(
             @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId,
             @ApiParam(value = "Stream ID", required = true) @PathParam("streamId") String streamId);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
@@ -77,7 +77,7 @@ public class PolicyConfigResource extends AbstractBrooklynRestResource implement
         ConfigKey<?> ck = policy.getPolicyType().getConfigKey(configKeyName);
         if (ck == null) throw WebResourceUtils.notFound("Cannot find config key '%s' in policy '%s' of entity '%s'", configKeyName, policy, entityToken);
 
-        return getStringValueForDisplay(brooklyn(), policy, policy.getConfig(ck));
+        return (String) WebResourceUtils.getValueForDisplay(mapper(), getStringValueForDisplay(brooklyn(), policy, policy.getConfig(ck)), true, true);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
@@ -66,7 +66,7 @@ public class PolicyConfigResource extends AbstractBrooklynRestResource implement
             ((BrooklynObjectInternal)policy).config().getInternalConfigMap().getAllConfigInheritedRawValuesIgnoringErrors() ).getAllConfig();
         Map<String, Object> result = Maps.newLinkedHashMap();
         for (Map.Entry<String, Object> ek : source.entrySet()) {
-            result.put(ek.getKey(), getStringValueForDisplay(brooklyn(), policy, ek.getValue()));
+            result.put(ek.getKey(), WebResourceUtils.getValueForDisplay(mapper(), getStringValueForDisplay(brooklyn(), policy, ek.getValue()), true, true));
         }
         return result;
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -383,7 +383,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
             throw WebResourceUtils.forbidden("User '%s' is not authorized for this operation", Entitlements.getEntitlementContext().user());
         }
         ConfigKey<String> config = ConfigKeys.newStringConfigKey(configKey);
-        return mgmt().getConfig().getConfig(config);
+        return (String) WebResourceUtils.getValueForDisplay(mapper(), mgmt().getConfig().getConfig(config), true, true);
     }
 
     @Override
@@ -446,7 +446,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
         request.getSession();
         EntitlementContext entitlementContext = Entitlements.getEntitlementContext();
         if (entitlementContext!=null && entitlementContext.user()!=null){
-            return entitlementContext.user();
+            return (String) WebResourceUtils.getValueForDisplay(mapper(), entitlementContext.user(), true, true);
         } else {
             return null; //User can be null if no authentication was requested
         }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -109,7 +110,7 @@ public class PolicyResourceTest extends BrooklynRestResourceTest {
     @Test
     public void testGetDefaultValue() throws Exception {
         String configName = RestMockSimplePolicy.SAMPLE_CONFIG.getName();
-        String expectedVal = RestMockSimplePolicy.SAMPLE_CONFIG.getDefaultValue();
+        String expectedVal = (String) WebResourceUtils.getValueForDisplay(mapper(), RestMockSimplePolicy.SAMPLE_CONFIG.getDefaultValue(), true, true);
         
         String configVal = client().path(ENDPOINT + policyId + "/config/" + configName)
                 .get(String.class);

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
@@ -130,7 +130,7 @@ public class PolicyResourceTest extends BrooklynRestResourceTest {
     @Test(dependsOnMethods = "testReconfigureConfig")
     public void testGetConfigValue() throws Exception {
         String configName = RestMockSimplePolicy.SAMPLE_CONFIG.getName();
-        String expectedVal = "newval";
+        String expectedVal = (String) WebResourceUtils.getValueForDisplay(mapper(), "newval", true, true);
         
         Map<String, Object> allState = client().path(ENDPOINT + policyId + "/config/current-state")
                 .get(new GenericType<Map<String, Object>>() {});

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
@@ -99,7 +99,7 @@ public class ServerResourceTest extends BrooklynRestResourceTest {
     void testGetConfig() throws Exception {
         ((ManagementContextInternal)getManagementContext()).getBrooklynProperties().put("foo.bar.baz", "quux");
         try {
-            assertEquals(client().path("/server/config/foo.bar.baz").get(String.class), "quux");
+            assertEquals(client().path("/server/config/foo.bar.baz").get(String.class), "\"quux\"");
         } finally {
             ((ManagementContextInternal)getManagementContext()).getBrooklynProperties().remove("foo.bar.baz");
         }


### PR DESCRIPTION
Using the REST API from the GUI used to return `"error": "no response from server"` and return code 0 for methods that return String.
The problem was that the received response was not in json format, while the expected response content type is `application/json`.
