### PR TITLE
Adds patent pom relative path to `brooklyn-locations-container`

### DIFF
--- a/locations/container/pom.xml
+++ b/locations/container/pom.xml
@@ -28,6 +28,7 @@
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-parent</artifactId>
         <version>0.12.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 
     <properties>


### PR DESCRIPTION
Without this the build will fail when preforming a release