### PR TITLE
Revert PolicyConfigResource changes from the REST API response fix.

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/PolicyConfigResource.java
@@ -66,7 +66,7 @@ public class PolicyConfigResource extends AbstractBrooklynRestResource implement
             ((BrooklynObjectInternal)policy).config().getInternalConfigMap().getAllConfigInheritedRawValuesIgnoringErrors() ).getAllConfig();
         Map<String, Object> result = Maps.newLinkedHashMap();
         for (Map.Entry<String, Object> ek : source.entrySet()) {
-            result.put(ek.getKey(), WebResourceUtils.getValueForDisplay(mapper(), getStringValueForDisplay(brooklyn(), policy, ek.getValue()), true, true));
+            result.put(ek.getKey(), getStringValueForDisplay(brooklyn(), policy, ek.getValue()));
         }
         return result;
     }
@@ -77,7 +77,7 @@ public class PolicyConfigResource extends AbstractBrooklynRestResource implement
         ConfigKey<?> ck = policy.getPolicyType().getConfigKey(configKeyName);
         if (ck == null) throw WebResourceUtils.notFound("Cannot find config key '%s' in policy '%s' of entity '%s'", configKeyName, policy, entityToken);
 
-        return (String) WebResourceUtils.getValueForDisplay(mapper(), getStringValueForDisplay(brooklyn(), policy, policy.getConfig(ck)), true, true);
+        return getStringValueForDisplay(brooklyn(), policy, policy.getConfig(ck));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
@@ -110,7 +110,7 @@ public class PolicyResourceTest extends BrooklynRestResourceTest {
     @Test
     public void testGetDefaultValue() throws Exception {
         String configName = RestMockSimplePolicy.SAMPLE_CONFIG.getName();
-        String expectedVal = (String) WebResourceUtils.getValueForDisplay(mapper(), RestMockSimplePolicy.SAMPLE_CONFIG.getDefaultValue(), true, true);
+        String expectedVal = RestMockSimplePolicy.SAMPLE_CONFIG.getDefaultValue();
         
         String configVal = client().path(ENDPOINT + policyId + "/config/" + configName)
                 .get(String.class);
@@ -130,7 +130,7 @@ public class PolicyResourceTest extends BrooklynRestResourceTest {
     @Test(dependsOnMethods = "testReconfigureConfig")
     public void testGetConfigValue() throws Exception {
         String configName = RestMockSimplePolicy.SAMPLE_CONFIG.getName();
-        String expectedVal = (String) WebResourceUtils.getValueForDisplay(mapper(), "newval", true, true);
+        String expectedVal = "newval";
         
         Map<String, Object> allState = client().path(ENDPOINT + policyId + "/config/current-state")
                 .get(new GenericType<Map<String, Object>>() {});


### PR DESCRIPTION
Those changes require more careful testing and updates.
We need to revert them from master and reopen in a separate PR.