### PR TITLE
REST API returns plane-id

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -85,6 +85,11 @@ public interface ServerApi {
     public VersionSummary getVersion();
 
     @GET
+    @Path("/planeid")
+    @ApiOperation(value = "Return the plane id (an identifier that is stable across restarts and HA failovers)")
+    public String getPlaneId();
+
+    @GET
     @Path("/up")
     @ApiOperation(value = "Returns whether this server is up - fully started, and not stopping, though it may have errors")
     public boolean isUp();

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
@@ -101,20 +101,27 @@ public class HighAvailabilitySummary implements Serializable {
         }
     }
 
+    private final String planeId;
     private final String ownId;
     private final String masterId;
     private final Map<String, HaNodeSummary> nodes;
     private final Map<String, URI> links;
 
     public HighAvailabilitySummary(
+            @JsonProperty("planeId") String planeId,
             @JsonProperty("ownId") String ownId,
             @JsonProperty("masterId") String masterId,
             @JsonProperty("nodes") Map<String, HaNodeSummary> nodes,
             @JsonProperty("links") Map<String, URI> links) {
+        this.planeId = planeId;
         this.ownId = ownId;
         this.masterId = masterId;
         this.nodes = (nodes == null) ? ImmutableMap.<String, HaNodeSummary>of() : nodes;
         this.links = (links == null) ? ImmutableMap.<String, URI>of() : ImmutableMap.copyOf(links);
+    }
+
+    public String getPlaneId() {
+        return planeId;
     }
 
     public String getOwnId() {
@@ -138,7 +145,8 @@ public class HighAvailabilitySummary implements Serializable {
         if (this == o) return true;
         if (!(o instanceof HighAvailabilitySummary)) return false;
         HighAvailabilitySummary that = (HighAvailabilitySummary) o;
-        return Objects.equals(ownId, that.ownId) &&
+        return Objects.equals(planeId, that.planeId) &&
+                Objects.equals(ownId, that.ownId) &&
                 Objects.equals(masterId, that.masterId) &&
                 Objects.equals(nodes, that.nodes) &&
                 Objects.equals(links, that.links);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -346,6 +346,16 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
     }
 
     @Override
+    public String getPlaneId() {
+        if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SERVER_STATUS, null))
+            throw WebResourceUtils.forbidden("User '%s' is not authorized for this operation", Entitlements.getEntitlementContext().user());
+
+        Maybe<ManagementContext> mm = mgmtMaybe();
+        Maybe<String> result = (mm.isPresent()) ? mm.get().getManagementPlaneIdMaybe() : Maybe.absent();
+        return result.isPresent() ? result.get() : "";
+    }
+
+    @Override
     public boolean isUp() {
         if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SERVER_STATUS, null))
             throw WebResourceUtils.forbidden("User '%s' is not authorized for this operation", Entitlements.getEntitlementContext().user());

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/HighAvailabilityTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/HighAvailabilityTransformer.java
@@ -40,7 +40,7 @@ public class HighAvailabilityTransformer {
         // TODO What links?
         ImmutableMap.Builder<String, URI> lb = ImmutableMap.<String, URI>builder();
 
-        return new HighAvailabilitySummary(ownNodeId, memento.getMasterNodeId(), nodes, lb.build());
+        return new HighAvailabilitySummary(memento.getPlaneId(), ownNodeId, memento.getMasterNodeId(), nodes, lb.build());
     }
 
     public static HaNodeSummary haNodeSummary(ManagementNodeSyncRecord memento) {

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
@@ -59,6 +59,12 @@ public class ServerResourceTest extends BrooklynRestResourceTest {
     }
 
     @Test
+    public void testGetPlaneId() throws Exception {
+        String planeId = client().path("/server/planeid").get(String.class);
+        assertEquals(planeId, manager.getManagementPlaneIdMaybe().get());
+    }
+
+    @Test
     public void testGetStatus() throws Exception {
         ManagementNodeState nodeState = client().path("/server/ha/state").get(ManagementNodeState.class);
         assertEquals(nodeState.name(), "MASTER");

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ServerResourceTest.java
@@ -77,7 +77,9 @@ public class ServerResourceTest extends BrooklynRestResourceTest {
         HighAvailabilitySummary summary = client().path("/server/ha/states").get(HighAvailabilitySummary.class);
         log.info("HA summary is: "+summary);
         
+        String planeId = getManagementContext().getManagementPlaneIdMaybe().get();
         String ownNodeId = getManagementContext().getManagementNodeId();
+        assertEquals(summary.getPlaneId(), planeId);
         assertEquals(summary.getOwnId(), ownNodeId);
         assertEquals(summary.getMasterId(), ownNodeId);
         assertEquals(summary.getNodes().keySet(), ImmutableSet.of(ownNodeId));

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -146,6 +146,8 @@ public abstract class BrooklynRestApiTest {
                 manager = new LocalManagementContextForTests();
             }
             manager.getHighAvailabilityManager().disabled();
+            ((LocalManagementContext)manager).generateManagementPlaneId();
+
             BasicLocationRegistry.addNamedLocationLocalhost(manager);
             
             new BrooklynCampPlatformLauncherNoServer()


### PR DESCRIPTION
This is useful for systems that use/manage Brooklyn - they want to know the stable id of that Brooklyn server, which will be the same after restarts or after HA failovers.