### PR TITLE
BROOKLYN-120: fix NPE in /v1/server/up/extended

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -129,7 +129,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
     private static final Logger LOG = LoggerFactory.getLogger(HighAvailabilityManagerImpl.class);
 
     private final ManagementContextInternal managementContext;
-    private volatile String ownNodeId;
+    private final String ownNodeId;
     private volatile ManagementPlaneSyncRecordPersister persister;
     private volatile PromotionListener promotionListener;
     private volatile MasterChooser masterChooser = new AlphabeticMasterChooser();
@@ -163,6 +163,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
 
     public HighAvailabilityManagerImpl(ManagementContextInternal managementContext) {
         this.managementContext = managementContext;
+        ownNodeId = managementContext.getManagementNodeId();
         startTimeUtc = localTickerUtc.read();
     }
 
@@ -242,7 +243,6 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
     @Override
     public void disabled() {
         disabled = true;
-        ownNodeId = managementContext.getManagementNodeId();
         // this is notionally the master, just not running; see javadoc for more info
         stop(ManagementNodeState.MASTER);
         
@@ -276,7 +276,6 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             }
         }
         
-        ownNodeId = managementContext.getManagementNodeId();
         // TODO Small race in that we first check, and then we'll do checkMaster() on first poll,
         // so another node could have already become master or terminated in that window.
         ManagementPlaneSyncRecord planeRec = loadManagementPlaneSyncRecord(false);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -80,6 +80,7 @@ import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Reflections;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,6 +133,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     }
 
     private final AtomicLong totalEffectorInvocationCount = new AtomicLong();
+    private final String managementNodeId;
 
     protected DeferredBrooklynProperties configMap;
     protected Scratchpad scratchpad;
@@ -163,6 +165,8 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     protected CatalogInitialization catalogInitialization;
 
     public AbstractManagementContext(BrooklynProperties brooklynProperties) {
+        this.managementNodeId = Strings.makeRandomId(8);
+
         this.configMap = new DeferredBrooklynProperties(brooklynProperties, this);
         this.scratchpad = new BasicScratchpad();
         this.entityDriverManager = new BasicEntityDriverManager();
@@ -200,6 +204,11 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         return startupComplete;
     }
 
+    @Override
+    public String getManagementNodeId() {
+        return managementNodeId;
+    }
+    
     @Override
     public BrooklynStorage getStorage() {
         return storage;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalManagementContext.java
@@ -127,9 +127,8 @@ public class LocalManagementContext extends AbstractManagementContext {
         return closed;
     }
 
-    private AtomicBoolean terminated = new AtomicBoolean(false);
+    private final AtomicBoolean terminated = new AtomicBoolean(false);
     private String managementPlaneId;
-    private String managementNodeId;
     private BasicExecutionManager execution;
     private SubscriptionManager subscriptions;
     private LocalEntityManager entityManager;
@@ -172,7 +171,6 @@ public class LocalManagementContext extends AbstractManagementContext {
         
         checkNotNull(configMap, "brooklynProperties");
         
-        this.managementNodeId = Strings.makeRandomId(8);
         this.builder = builder;
         this.brooklynAdditionalProperties = brooklynAdditionalProperties;
         if (brooklynAdditionalProperties != null)
@@ -206,22 +204,17 @@ public class LocalManagementContext extends AbstractManagementContext {
     
     public void setManagementPlaneId(String newPlaneId) {
         if (managementPlaneId != null && !managementPlaneId.equals(newPlaneId)) {
-            log.warn("Management plane ID at {} {} changed from {} to {} (can happen on concurrent startup of multiple nodes)", new Object[] { managementNodeId, getHighAvailabilityManager().getNodeState(), managementPlaneId, newPlaneId });
-            log.debug("Management plane ID at {} {} changed from {} to {} (can happen on concurrent startup of multiple nodes)", new Object[] {managementNodeId, getHighAvailabilityManager().getNodeState(), managementPlaneId, newPlaneId, new RuntimeException("Stack trace for setManagementPlaneId")});
+            log.warn("Management plane ID at {} {} changed from {} to {} (can happen on concurrent startup of multiple nodes)", new Object[] { getManagementNodeId(), getHighAvailabilityManager().getNodeState(), managementPlaneId, newPlaneId });
+            log.debug("Management plane ID at {} {} changed from {} to {} (can happen on concurrent startup of multiple nodes)", new Object[] {getManagementNodeId(), getHighAvailabilityManager().getNodeState(), managementPlaneId, newPlaneId, new RuntimeException("Stack trace for setManagementPlaneId")});
         }
         this.managementPlaneId = newPlaneId;
     }
 
     public void generateManagementPlaneId() {
         if (this.managementPlaneId != null) {
-            throw new IllegalStateException("Request to generate a management plane ID for node "+managementNodeId+" but one already exists (" + managementPlaneId + ")");
+            throw new IllegalStateException("Request to generate a management plane ID for node "+getManagementNodeId()+" but one already exists (" + managementPlaneId + ")");
         }
         this.managementPlaneId = Strings.makeRandomId(8);
-    }
-    
-    @Override
-    public String getManagementNodeId() {
-        return managementNodeId;
     }
     
     @Override


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BROOKLYN-120

Moves the setting of `managementContext.managementNodeId` from `LocalManagementContext` constructor into `AbstractManagementContext` constructor, to ensure it's set early enough!