### PR TITLE
Adds BrooklynViewerLauncher (for tests)

### DIFF
--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -125,7 +125,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
     private Duration haHeartbeatTimeoutOverride = null;
     private Duration haHeartbeatPeriodOverride = null;
     
-    private boolean started;
+    protected boolean started;
     
     private BrooklynProperties.Factory.Builder brooklynPropertiesBuilder;
 

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynLauncher.java
@@ -74,6 +74,7 @@ import com.google.common.collect.Maps;
  *     .start();
  * 
  * Entities.dumpInfo(launcher.getApplications());
+ * }
  * </pre>
  */
 public class BrooklynLauncher extends BasicLauncher<BrooklynLauncher> {

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynViewerLauncher.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynViewerLauncher.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.launcher;
+
+/**
+ * A convenience for started the Brooklyn REST api and web-app in a test, so that one can visually
+ * inspect the app that the test creates. This is intended as a read-only view (but it has the real
+ * management context so one can perform actions through this UI).
+ * 
+ * An example of where this is very useful is when testing a blueprint where an effector hangs - 
+ * one can visually inspect the app, drilling into the activities view to see what it is doing
+ * and why it is blocked.
+ *   
+ * It must be configured with an existing {@link org.apache.brooklyn.api.mgmt.ManagementContext}.
+ * 
+ * Various other configuration options (e.g. {@link #application(String)) will be ignored.
+ * 
+ * Example usage is:
+ * <pre>
+ * {@code
+ * protected ManagementContext managementContext;
+ * protected BrooklynLauncher viewer;
+ * 
+ * public void setUp() throws Exception {
+ *     managementContext = ...
+ *     viewer = BrooklynViewerLauncher.newInstance()
+ *             .managementContext(managementContext)
+ *             .start();
+ * }
+ * 
+ * public void tearDown() throws Exception {
+ *     if (viewer != null) {
+ *         viewer.terminate();
+ *     }
+ *     ...
+ * }
+ * </pre>
+ */
+public class BrooklynViewerLauncher extends BrooklynLauncher {
+
+    public static BrooklynViewerLauncher newInstance() {
+        return new BrooklynViewerLauncher();
+    }
+
+    /**
+     * A cut-down start, which just does the web-apps (intended as a read-only view). It assumes 
+     * that a fully initialised management context will have been registered.
+     */
+    @Override
+    public BrooklynLauncher start() {
+        if (started) throw new IllegalStateException("Cannot start() or launch() multiple times");
+        started = true;
+
+        if (getManagementContext() == null || !getManagementContext().isRunning()) {
+            throw new IllegalStateException("Management context must be set, and running");
+        }
+        
+        startingUp();
+        markStartupComplete();
+        
+        initBrooklynNode();
+
+        return this;
+    }
+}

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/blueprints/AbstractBlueprintTest.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.launcher.BrooklynLauncher;
+import org.apache.brooklyn.launcher.BrooklynViewerLauncher;
 import org.apache.brooklyn.launcher.SimpleYamlLauncherForTests;
 import org.apache.brooklyn.launcher.camp.BrooklynCampPlatformLauncher;
 import org.apache.brooklyn.test.Asserts;
@@ -83,7 +84,7 @@ public abstract class AbstractBlueprintTest {
                 };
             }
         };
-        viewer = BrooklynLauncher.newInstance()
+        viewer = BrooklynViewerLauncher.newInstance()
                 .managementContext(mgmt)
                 .start();
     }


### PR DESCRIPTION
As per the javadoc:
```
/**
 * A convenience for started the Brooklyn REST api and web-app in a test, so that one can visually
 * inspect the app that the test creates. This is intended as a read-only view (but it has the real
 * management context so one can perform actions through this UI).
 * 
 * It expects to be configured with an existing {@link org.apache.brooklyn.api.mgmt.ManagementContext}.
 * 
 * Various other configuration options (e.g. {@link #application(String)) will be ignored.
 * 
 * An example of where this is very useful is when testing a blueprint where an effector hangs - 
 * one can visually inspect the app, drilling into the activities view to see what it is doing
 * and why it is blocked.
```

Note that `AbstractBlueprintTest` used to do this with `BrooklynLauncher`, but that is broken - that launcher also tries to set the `managementPlaneId` on the management context, but it's already set so it throws an exception.

My motivation for fixing + adding this is mostly for use in downstream projects. I want to run unit/integration tests that deploy + test some complicated blueprints. It's very useful to have this visualisation in such tests (particularly if it fails, and one places a breakpoint to see what activities have executed by that point).