### PR TITLE
Improve localhost detection and webserver binding

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -177,7 +177,7 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
         for (int i=0; i<size; i++) {
             Map<Object,Object> flags2 = MutableMap.<Object,Object>builder()
                     .putAll(flags)
-                    .put("address", elvis(address, Networking.getLocalHost()))
+                    .put("address", elvis(address, getLocalhostInetAddress()))
                     .build();
             
             // copy inherited keys for ssh; 
@@ -309,17 +309,17 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
         @Override
         public LocalhostMachine configure(Map<?,?> properties) {
             if (address==null || !properties.containsKey("address"))
-                address = Networking.getLocalHost();
+                address = getLocalhostInetAddress();
             super.configure(properties);
             return this;
         }
         @Override
         public String getSubnetHostname() {
-           return Networking.getLocalHost().getHostName();
+           return Networking.getReachableLocalHost().getHostName();
         }
         @Override
         public String getSubnetIp() {
-            return Networking.getLocalHost().getHostAddress();
+            return Networking.getReachableLocalHost().getHostAddress();
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -198,12 +198,15 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
        }
     }
 
-    public static synchronized boolean obtainSpecificPort(InetAddress localAddress, int portNumber) {
+    public static boolean obtainSpecificPort(InetAddress localAddress, int portNumber) {
+        return obtainSpecificPort(localAddress, portNumber, false);
+    }
+    public static synchronized boolean obtainSpecificPort(InetAddress localAddress, int portNumber, Boolean reuseAddr) {
         if (portsInUse.contains(portNumber)) {
             return false;
         } else {
             //see if it is available?
-            if (!checkPortAvailable(localAddress, portNumber)) {
+            if (!checkPortAvailable(localAddress, portNumber, reuseAddr)) {
                 return false;
             }
             portsInUse.add(portNumber);
@@ -212,18 +215,27 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
     }
     /** checks the actual availability of the port on localhost, ie by binding to it; cf {@link Networking#isPortAvailable(int)} */
     public static boolean checkPortAvailable(InetAddress localAddress, int portNumber) {
+        return checkPortAvailable(localAddress, portNumber, false);
+    }
+    public static boolean checkPortAvailable(InetAddress localAddress, int portNumber, Boolean reuseAddr) {
         if (portNumber<1024) {
             if (LOG.isDebugEnabled()) LOG.debug("Skipping system availability check for privileged localhost port "+portNumber);
             return true;
         }
-        return Networking.isPortAvailable(localAddress, portNumber);
+        return Networking.isPortAvailable(localAddress, portNumber, reuseAddr);
     }
     public static int obtainPort(PortRange range) {
-        return obtainPort(getLocalhostInetAddress(), range);
+        return obtainPort(range, false);
+    }
+    public static int obtainPort(PortRange range, Boolean reuseAddr) {    
+        return obtainPort(getLocalhostInetAddress(), range, reuseAddr);
     }
     public static int obtainPort(InetAddress localAddress, PortRange range) {
+        return obtainPort(localAddress, range, false);
+    }
+    public static int obtainPort(InetAddress localAddress, PortRange range, Boolean reuseAddr) {
         for (int p: range)
-            if (obtainSpecificPort(localAddress, p)) return p;
+            if (obtainSpecificPort(localAddress, p, reuseAddr)) return p;
         if (LOG.isDebugEnabled()) LOG.debug("unable to find port in {} on {}; returning -1", range, localAddress);
         return -1;
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
@@ -44,9 +44,9 @@ public class BrooklynNetworkUtils {
      * {@link BrooklynServiceAttributes#LOCALHOST_IP_ADDRESS}
      * if set to prevent default selection when needed,
      * otherwise finding the first bindable/reachable NIC from a system lookup which usually
-     * prefers non-loopback devices (but use the system property if if needed) */
+     * prefers IPv4 then non-loopback devices (but use the system property if if needed) */
     public static InetAddress getLocalhostInetAddress() {
         return TypeCoercions.coerce(JavaGroovyEquivalents.elvis(BrooklynServiceAttributes.LOCALHOST_IP_ADDRESS.getValue(),
-                Networking.getLocalHost(true, false, true, 500)), InetAddress.class);
+                Networking.getLocalHost(true, false, true, true, 500)), InetAddress.class);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
@@ -42,6 +42,6 @@ public class BrooklynNetworkUtils {
     /** returns a IP address for localhost paying attention to a system property to prevent lookup in some cases */
     public static InetAddress getLocalhostInetAddress() {
         return TypeCoercions.coerce(JavaGroovyEquivalents.elvis(BrooklynServiceAttributes.LOCALHOST_IP_ADDRESS.getValue(),
-                Networking.getLocalHost()), InetAddress.class);
+                Networking.getReachableLocalHost()), InetAddress.class);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/BrooklynNetworkUtils.java
@@ -39,9 +39,14 @@ public class BrooklynNetworkUtils {
         return LocalhostExternalIpLoader.getLocalhostIpQuicklyOrDefault();
     }
 
-    /** returns a IP address for localhost paying attention to a system property to prevent lookup in some cases */
+    /** returns an IP address for localhost,
+     * paying attention to system property 
+     * {@link BrooklynServiceAttributes#LOCALHOST_IP_ADDRESS}
+     * if set to prevent default selection when needed,
+     * otherwise finding the first bindable/reachable NIC from a system lookup which usually
+     * prefers non-loopback devices (but use the system property if if needed) */
     public static InetAddress getLocalhostInetAddress() {
         return TypeCoercions.coerce(JavaGroovyEquivalents.elvis(BrooklynServiceAttributes.LOCALHOST_IP_ADDRESS.getValue(),
-                Networking.getReachableLocalHost()), InetAddress.class);
+                Networking.getLocalHost(true, false, true, 500)), InetAddress.class);
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
@@ -51,7 +51,7 @@ public class SimulatedLocation extends AbstractLocation implements MachineProvis
 
     private static final InetAddress address;
     static {
-        address = Networking.getLocalHost();
+        address = Networking.getReachableLocalHost();
     }
 
     Iterable<Integer> permittedPorts = PortRanges.fromString("1+");

--- a/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocationTest.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.core.location.geo.HostGeoInfo;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.BrooklynNetworkUtils;
 import org.apache.brooklyn.util.net.Networking;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +77,7 @@ public class LocalhostMachineProvisioningLocationTest extends BrooklynMgmtUnitTe
         LocalhostMachineProvisioningLocation provisioner = mgmt.getLocationManager().createLocation(LocationSpec.create(LocalhostMachineProvisioningLocation.class));
         SshMachineLocation machine = provisioner.obtain();
         assertNotNull(machine);
-        assertEquals(machine.getAddress(), Networking.getLocalHost());
+        assertEquals(machine.getAddress(), BrooklynNetworkUtils.getLocalhostInetAddress());
     }
 
     @Test
@@ -98,12 +99,12 @@ public class LocalhostMachineProvisioningLocationTest extends BrooklynMgmtUnitTe
         // first machine
         SshMachineLocation first = provisioner.obtain();
         assertNotNull(first);
-        assertEquals(first.getAddress(), Networking.getLocalHost());
+        assertEquals(first.getAddress(), Networking.getReachableLocalHost());
 
         // second machine
         SshMachineLocation second = provisioner.obtain();
         assertNotNull(second);
-        assertEquals(second.getAddress(), Networking.getLocalHost());
+        assertEquals(second.getAddress(), Networking.getReachableLocalHost());
 
         // third machine - fails
         try {

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
@@ -87,7 +87,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
     @Override
     protected SshMachineLocation newHost() {
         return mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", Networking.getLocalHost()));
+                .configure("address", Networking.getReachableLocalHost()));
     }
 
     // Overridden just to make it integration (because `newHost()` returns a real ssh'ing host)
@@ -222,7 +222,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
     // For issue #230
     @Test(groups = "Integration")
     public void testOverridingPropertyOnExec() throws Exception {
-        SshMachineLocation host = new SshMachineLocation(MutableMap.of("address", Networking.getLocalHost(), "sshPrivateKeyData", "wrongdata"));
+        SshMachineLocation host = new SshMachineLocation(MutableMap.of("address", Networking.getReachableLocalHost(), "sshPrivateKeyData", "wrongdata"));
         
         OutputStream outStream = new ByteArrayOutputStream();
         String expectedName = Os.user();
@@ -234,7 +234,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
 
     @Test(groups = "Integration", expectedExceptions={IllegalStateException.class, SshException.class})
     public void testSshRunWithInvalidUserFails() throws Exception {
-        SshMachineLocation badHost = new SshMachineLocation(MutableMap.of("user", "doesnotexist", "address", Networking.getLocalHost()));
+        SshMachineLocation badHost = new SshMachineLocation(MutableMap.of("user", "doesnotexist", "address", Networking.getReachableLocalHost()));
         badHost.execScript("mysummary", ImmutableList.of("whoami; exit"));
     }
     

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationPerformanceTest.java
@@ -111,7 +111,7 @@ public class SshMachineLocationPerformanceTest {
     public void testConsecutiveSmallCommandsWithDifferentProperties() throws Exception {
         final Map<String, ?> emptyProperties = Collections.emptyMap();
         final Map<String, ?> customProperties = MutableMap.of(
-                "address", Networking.getLocalHost(),
+                "address", Networking.getReachableLocalHost(),
                 SshTool.PROP_SESSION_TIMEOUT.getName(), 20000,
                 SshTool.PROP_CONNECT_TIMEOUT.getName(), 50000,
                 SshTool.PROP_SCRIPT_HEADER.getName(), "#!/bin/bash");

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationReuseIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationReuseIntegrationTest.java
@@ -102,7 +102,7 @@ public class SshMachineLocationReuseIntegrationTest {
     public void setUp() throws Exception {
         managementContext = new LocalManagementContext();
         host = managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", Networking.getLocalHost())
+                .configure("address", Networking.getReachableLocalHost())
                 .configure(SshMachineLocation.SSH_TOOL_CLASS, RecordingSshjTool.class.getName()));
     }
 
@@ -163,7 +163,7 @@ public class SshMachineLocationReuseIntegrationTest {
 
     public Map<String, Object> customSshConfigKeys() throws UnknownHostException {
         return MutableMap.<String, Object>of(
-                "address", Networking.getLocalHost(),
+                "address", Networking.getReachableLocalHost(),
                 SshTool.PROP_SESSION_TIMEOUT.getName(), 20000,
                 SshTool.PROP_CONNECT_TIMEOUT.getName(), 50000,
                 SshTool.PROP_SCRIPT_HEADER.getName(), "#!/bin/bash");

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -196,7 +196,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testConfigurePrivateAddresses() throws Exception {
         SshMachineLocation host2 = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", Networking.getLocalHost())
+                .configure("address", Networking.getReachableLocalHost())
                 .configure(SshMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of("1.2.3.4"))
                 .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true));
 
@@ -211,7 +211,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testGetMachineIsInessentialOnFailure() throws Exception {
         SshMachineLocation host2 = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
-                .configure("address", Networking.getLocalHost())
+                .configure("address", Networking.getReachableLocalHost())
                 .configure(SshMachineLocation.SSH_TOOL_CLASS, FailingSshTool.class.getName()));
 
         final Effector<MachineDetails> GET_MACHINE_DETAILS = Effectors.effector(MachineDetails.class, "getMachineDetails")
@@ -314,7 +314,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
     
     @Test
     public void testObtainPortDoesNotUsePreReservedPorts() {
-        host = new SshMachineLocation(MutableMap.of("address", Networking.getLocalHost(), "usedPorts", ImmutableSet.of(8000)));
+        host = new SshMachineLocation(MutableMap.of("address", Networking.getReachableLocalHost(), "usedPorts", ImmutableSet.of(8000)));
         assertEquals(host.obtainPort(PortRanges.fromString("8000")), -1);
         assertEquals(host.obtainPort(PortRanges.fromString("8000+")), 8001);
     }

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -38,25 +38,25 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.security.auth.spi.LoginModule;
 
-import com.google.common.collect.ImmutableList;
-import org.apache.brooklyn.core.BrooklynFeatureEnablement;
-import org.apache.brooklyn.rest.NopSecurityHandler;
 import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.internal.BrooklynInitialization;
 import org.apache.brooklyn.core.location.PortRanges;
+import org.apache.brooklyn.core.mgmt.ShutdownHandler;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.server.BrooklynServerPaths;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
 import org.apache.brooklyn.launcher.config.CustomResourceLocator;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.rest.NopSecurityHandler;
 import org.apache.brooklyn.rest.RestApiSetup;
+import org.apache.brooklyn.rest.filter.CorsImplSupplierFilter;
 import org.apache.brooklyn.rest.filter.CsrfTokenFilter;
 import org.apache.brooklyn.rest.filter.EntitlementContextFilter;
-import org.apache.brooklyn.rest.filter.CorsImplSupplierFilter;
 import org.apache.brooklyn.rest.filter.HaHotCheckResourceFilter;
 import org.apache.brooklyn.rest.filter.LoggingFilter;
 import org.apache.brooklyn.rest.filter.NoCacheFilter;
@@ -66,7 +66,6 @@ import org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule;
 import org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule.RolePrincipal;
 import org.apache.brooklyn.rest.security.jaas.JaasUtils;
 import org.apache.brooklyn.rest.util.ManagementContextProvider;
-import org.apache.brooklyn.core.mgmt.ShutdownHandler;
 import org.apache.brooklyn.rest.util.ShutdownHandlerProvider;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.BrooklynNetworkUtils;
@@ -80,6 +79,7 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.javalang.Threads;
 import org.apache.brooklyn.util.logging.LoggingSetup;
+import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Identifiers;
@@ -104,6 +104,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
 /**
@@ -386,8 +387,10 @@ public class BrooklynWebServer {
             if (portRange==null) {
                 portRange = getHttpsEnabled() ? httpsPort : httpPort;
             }
-            actualPort = LocalhostMachineProvisioningLocation.obtainPort(getAddress(), portRange,
-                // allow reuse-addr so we prefer to bind to lower-numbered ports even if they are in time-wait state
+            actualPort = LocalhostMachineProvisioningLocation.obtainPort( 
+                shouldBindToAll() ? Networking.ANY_NIC : getAddress(), portRange,
+                // allow reuse-addr so we prefer to bind to lower-numbered ports even if they are in time-wait state;
+                // also allows if specific NIC specified, we can bind to it even if something else is using 0.0.0.0
                 true);
             if (actualPort == -1) 
                 throw new IllegalStateException("Unable to provision port for web console (wanted "+portRange+")");

--- a/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
+++ b/launcher/src/main/java/org/apache/brooklyn/launcher/BrooklynWebServer.java
@@ -386,7 +386,9 @@ public class BrooklynWebServer {
             if (portRange==null) {
                 portRange = getHttpsEnabled() ? httpsPort : httpPort;
             }
-            actualPort = LocalhostMachineProvisioningLocation.obtainPort(getAddress(), portRange);
+            actualPort = LocalhostMachineProvisioningLocation.obtainPort(getAddress(), portRange,
+                // allow reuse-addr so we prefer to bind to lower-numbered ports even if they are in time-wait state
+                true);
             if (actualPort == -1) 
                 throw new IllegalStateException("Unable to provision port for web console (wanted "+portRange+")");
         }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/core/mgmt/usage/JcloudsLocationUsageTrackingTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/test/core/mgmt/usage/JcloudsLocationUsageTrackingTest.java
@@ -110,7 +110,7 @@ public class JcloudsLocationUsageTrackingTest extends AbstractJcloudsStubbedLive
         entity = app.createAndManageChild(EntitySpec.create(SoftwareProcessEntityTest.MyService.class));
         
         serverSocket = new ServerSocket();
-        serverSocket.bind(new InetSocketAddress(Networking.getLocalHost(), 0), 0);
+        serverSocket.bind(new InetSocketAddress(Networking.getReachableLocalHost(), 0), 0);
     }
 
     @AfterMethod(alwaysRun=true)

--- a/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/WinRmMachineLocationTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/location/winrm/WinRmMachineLocationTest.java
@@ -34,7 +34,7 @@ public class WinRmMachineLocationTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testConfigurePrivateAddresses() throws Exception {
         WinRmMachineLocation host = mgmt.getLocationManager().createLocation(LocationSpec.create(WinRmMachineLocation.class)
-                .configure("address", Networking.getLocalHost())
+                .configure("address", Networking.getReachableLocalHost())
                 .configure(WinRmMachineLocation.PRIVATE_ADDRESSES, ImmutableList.of("1.2.3.4"))
                 .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true));
 

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestEndpointReachableTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestEndpointReachableTest.java
@@ -227,7 +227,7 @@ public class TestEndpointReachableTest extends BrooklynAppUnitTestSupport {
     }
 
     protected ServerSocket openServerPort() throws IOException {
-        InetAddress localAddress = Networking.getLocalHost();
+        InetAddress localAddress = Networking.getReachableLocalHost();
         return new ServerSocket(0, 1024, localAddress);
     }
 
@@ -235,7 +235,7 @@ public class TestEndpointReachableTest extends BrooklynAppUnitTestSupport {
         int startPort = 58767;
         int endPort = 60000;
         int port = startPort;
-        InetAddress localAddress = Networking.getLocalHost();
+        InetAddress localAddress = Networking.getReachableLocalHost();
         do {
             if (Networking.isPortAvailable(localAddress, port)) {
                 return HostAndPort.fromParts(localAddress.getHostAddress(), port);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/net/Networking.java
@@ -107,7 +107,10 @@ public class Networking {
             //192.168.0.1:X which explains the above comment (nginx sets SO_REUSEADDR as well). Moreover there
             //is no TIME_WAIT for listening sockets without any connections so why enable it at all.
             //Alex - TIME_WAIT sticks around for a while (30s or so) if a java process dies while it has
-            //connections; if we want things to aggressively try to take a port, they should use reuse-addr
+            //connections; if we want things to aggressively try to take a port, they should use reuse-addr,
+            //but probably testing against ANY_NIC unless they want to trump things listening on all interfaces.
+            //(isPortAvailable(ANY_NIC) will say false if any NIC is using it, 
+            //but isPortAvailable(SPECIFIC) may say true even if there is an ANY_NIC binding, when reuseAddr is true)
             ServerSocket ss = null;
             DatagramSocket ds = null;
             try {

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/NetworkingUtilsTest.java
@@ -171,34 +171,56 @@ public class NetworkingUtilsTest {
             fail("This test requires that at least some ports near "+port+"+ not be in use.");
     }
 
+    private int findPort() {
+        for (int port = 58767; port < 60000; port++) {
+            if (Networking.isPortAvailable(port)) {
+                return port;
+            }
+        }
+        throw Asserts.fail("This test requires that at least one port a little bit under port 60000 not be in use.");
+    }
+    
     @Test
     public void testIsPortAvailableReportsFalseWhenPortIsInUse() throws Exception {
-        int port = 58767;
-        ServerSocket ss = null;
-        do {
-            port ++;
-            if (Networking.isPortAvailable(port)) {
-                try {
-                    ss = new ServerSocket(port);
-                    log.info("acquired port on "+port+" for test "+JavaClassNames.niceClassAndMethod());
-                    assertFalse(Networking.isPortAvailable(port), "port mistakenly reported as available");
-                } finally {
-                    if (ss != null) {
-                        ss.close();
-                    }
-                }
-            }
-            // repeat until we can get a port
-        } while (ss == null && port < 60000);
-        Assert.assertNotNull(ss, "could not get a port");
-        
+        int port = findPort();
+        try (ServerSocket ss = new ServerSocket(port)) {
+            log.info("acquired port on "+port+" for test "+JavaClassNames.niceClassAndMethod());
+            assertFalse(Networking.isPortAvailable(port), "port mistakenly reported as available");
+        }
+        // above will close, so below succeeds
+          
         final int portF = port;
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
                 assertTrue(Networking.isPortAvailable(portF), "port "+portF+" not made available afterwards");
             }});
     }
-
+    
+    @Test
+    public void testPortNotAvailableOnAnyNicWithReuseAddressWhenBoundToAnyNic() throws Exception {
+        int port = findPort();
+        try (ServerSocket ss = new ServerSocket()) {
+            ss.setReuseAddress(true);
+            ss.bind(new InetSocketAddress(Networking.ANY_NIC, port));
+            log.info("acquired port on "+port+" for test "+JavaClassNames.niceClassAndMethod());
+            assertFalse(Networking.isPortAvailable(Networking.ANY_NIC, port, true), "port mistakenly reported as available");
+            // a specific NIC *will* be available
+            //assertFalse(Networking.isPortAvailable(Networking.LOOPBACK, port, true), "port mistakenly reported as available");
+        }
+    }
+    
+    @Test
+    public void testPortNotAvailableOnAnyNicOrLoopbackWithReuseAddressWhenBoundToLoopback() throws Exception {
+        int port = findPort();
+        try (ServerSocket ss = new ServerSocket()) {
+            ss.setReuseAddress(true);
+            ss.bind(new InetSocketAddress(Networking.LOOPBACK, port));
+            log.info("acquired port on "+port+" for test "+JavaClassNames.niceClassAndMethod());
+            assertFalse(Networking.isPortAvailable(Networking.LOOPBACK, port, true), "port mistakenly reported as available");
+            assertFalse(Networking.isPortAvailable(Networking.ANY_NIC, port, true), "port mistakenly reported as available");
+        }
+    }
+    
     @Test
     public void testIsPortAvailableReportsPromptly() throws Exception {
         // repeat until we can get an available port

--- a/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/net/ReachableSocketFinderTest.java
@@ -173,7 +173,7 @@ public class ReachableSocketFinderTest {
     @Test(groups="Integration")
     public void testFailsIfRealSocketUnreachable() throws Exception {
         ReachableSocketFinder realFinder = new ReachableSocketFinder();
-        HostAndPort wrongAddr = HostAndPort.fromParts(Networking.getLocalHost().getHostAddress(), findAvailablePort());
+        HostAndPort wrongAddr = HostAndPort.fromParts(Networking.getReachableLocalHost().getHostAddress(), findAvailablePort());
         
         try {
             HostAndPort result = realFinder.findOpenSocketOnNode(ImmutableList.of(wrongAddr), Duration.FIVE_SECONDS);


### PR DESCRIPTION
Fixes two annoying network issues:

* Sometimes when disconnected Brooklyn detects a non-usable NIC address as localhost and things like SSH fail subsequently
* If start-use-stop-immediately_restart brooklyn, it will normally take a different port eg 8082 because the first one eg 8081 will be in `TIME_WAIT` state.  Allow webserver to `REUSE_ADDR` so it takes the same port in this case.  Minor but hits me a lot when I'm testing!