### PR TITLE
Fix feature install bundle version issue

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -1364,7 +1364,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             log.debug("Wrapping supplied BOM as "+vn);
             Manifest mf = new Manifest();
             mf.getMainAttributes().putValue(Constants.BUNDLE_SYMBOLICNAME, vn.getSymbolicName());
-            mf.getMainAttributes().putValue(Constants.BUNDLE_VERSION, vn.getOsgiVersionString() );
+            mf.getMainAttributes().putValue(Constants.BUNDLE_VERSION, vn.getOsgiVersionString());
+            mf.getMainAttributes().putValue(Constants.BUNDLE_MANIFESTVERSION, "2");
             mf.getMainAttributes().putValue(Attributes.Name.MANIFEST_VERSION.toString(), OSGI_MANIFEST_VERSION_VALUE);
             mf.getMainAttributes().putValue(BROOKLYN_WRAPPED_BOM_BUNDLE, Boolean.TRUE.toString());
             

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
@@ -227,10 +227,10 @@ class OsgiArchiveInstaller {
             manifestNeedsUpdating = true;
         }
         if (!matchSetOrFail("MANIFEST.MF in archive", discoveredManifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME),
-                discoveredManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION) )) {
+                discoveredManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION))) {
             manifestNeedsUpdating = true;                
             discoveredManifest.getMainAttributes().putValue(Constants.BUNDLE_SYMBOLICNAME, inferredMetadata.getSymbolicName());
-            discoveredManifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, inferredMetadata.getOsgiVersionString() );
+            discoveredManifest.getMainAttributes().putValue(Constants.BUNDLE_VERSION, inferredMetadata.getOsgiVersionString());
         }
         if (Strings.isBlank(inferredMetadata.getSymbolicName())) {
             throw new IllegalArgumentException("Missing bundle symbolic name in BOM or MANIFEST");


### PR DESCRIPTION
Fixes issue with installing bundles, causing the following error:
```
karaf@brooklyn()> feature:install -r jclouds-api-route53
Error executing command: Unable to build resource for brooklyn:fo9y9ghsab: Unsupported 'Bundle-ManifestVersion' value: 1
```
Sets `Bundle-ManifestVersion` to 2 for Brooklyn generated bundles.