### PR TITLE
Removes `FIRST` sensors on children

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
@@ -611,8 +611,20 @@ public class ServiceStateLogic {
             }
 
             return "Required entit"+Strings.ies(onesNotHealthy.size())+" not healthy: "+
-                (onesNotHealthy.size()>3 ? onesNotHealthy.get(0)+" and "+(onesNotHealthy.size()-1)+" others"
-                    : Strings.join(onesNotHealthy, ", "));
+                (onesNotHealthy.size()>3 ? nameOfEntity(onesNotHealthy.get(0))+" and "+(onesNotHealthy.size()-1)+" others"
+                    : Strings.join(nameOfEntity(onesNotHealthy), ", "));
+        }
+
+        private List<String> nameOfEntity(List<Entity> entities) {
+            List<String> result = MutableList.of();
+            for (Entity e: entities) result.add(nameOfEntity(e));
+            return result;
+        }
+
+        private String nameOfEntity(Entity entity) {
+            String name = entity.getDisplayName();
+            if (name.contains(entity.getId())) return name;
+            else return name + " ("+entity.getId()+")";
         }
 
         protected void updateMapSensor(AttributeSensor<Map<String, Object>> sensor, Object value) {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
@@ -50,11 +50,9 @@ public interface AbstractGroup extends Entity, Group, Changeable {
     AttributeSensor<Collection<Entity>> GROUP_MEMBERS = Sensors.newSensor(
             new TypeToken<Collection<Entity>>() { }, "group.members", "Members of the group");
 
-    // FIXME should definitely remove this, it is ambiguous if an entity is in multiple clusters.  also should be "is_first" or something to indicate boolean.
-    AttributeSensor<Boolean> FIRST_MEMBER = Sensors.newBooleanSensor(
-            "cluster.first", "Set on an entity if it is the first member of a cluster");
-
-    // FIXME can we remove this too?
+    /** @deprecated since 0.12.0 use AbstractGroup.getFirst(Group) if required,
+     * or better use an external enricher or policy to define the primary. */
+    @Deprecated
     AttributeSensor<Entity> FIRST = Sensors.newSensor(Entity.class,
             "cluster.first.entity", "The first member of the cluster");
 
@@ -87,4 +85,10 @@ public interface AbstractGroup extends Entity, Group, Changeable {
     // FIXME Do we really want this method? "setMembers" is a misleading name
     void setMembers(Collection<Entity> mm, Predicate<Entity> filter);
 
+    public static Entity getFirst(Group g) {
+        Collection<Entity> members = g.sensors().get(AbstractGroup.GROUP_MEMBERS);
+        if (!members.isEmpty()) return members.iterator().next();
+        return null;
+    }
+    
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroupImpl.java
@@ -107,16 +107,7 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
                 // FIXME do not set sensors on members; possibly we don't need FIRST at all, just look at the first in MEMBERS, and take care to guarantee order there
                 Entity first = getAttribute(FIRST);
                 if (first == null) {
-                    member.sensors().set(FIRST_MEMBER, true);
-                    member.sensors().set(FIRST, member);
                     sensors().set(FIRST, member);
-                } else {
-                    if (first.equals(member) || first.equals(member.getAttribute(FIRST))) {
-                        // do nothing (rebinding)
-                    } else {
-                        member.sensors().set(FIRST_MEMBER, false);
-                        member.sensors().set(FIRST, first);
-                    }
                 }
     
                 ((EntityInternal)member).groups().add((Group)getProxyIfAvailable());
@@ -165,10 +156,10 @@ public abstract class AbstractGroupImpl extends AbstractEntity implements Abstra
                     log.debug("Group {} lost member {}", this, member);
                     // TODO ideally the following are all synched
                     sensors().set(GROUP_SIZE, getCurrentSize());
-                    sensors().set(GROUP_MEMBERS, getMembers());
+                    Collection<Entity> membersNow = getMembers();
+                    sensors().set(GROUP_MEMBERS, membersNow);
                     if (member.equals(getAttribute(FIRST))) {
-                        // TODO should we elect a new FIRST ?  as is the *next* will become first.  could we do away with FIRST altogether?
-                        sensors().set(FIRST, null);
+                        sensors().set(FIRST, membersNow.isEmpty() ? null : membersNow.iterator().next());
                     }
                     // emit after the above so listeners can use getMembers() and getCurrentSize()
                     sensors().emit(MEMBER_REMOVED, member);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -847,7 +847,7 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
             if (entity instanceof Startable) {
                 // First members are used when subsequent members need some attributes from them
                 // before they start; make sure they're in the first batch.
-                boolean privileged = Boolean.TRUE.equals(entity.sensors().get(AbstractGroup.FIRST_MEMBER));
+                boolean privileged = entity.equals(AbstractGroup.getFirst(this));
                 Map<String, ?> args = ImmutableMap.of("locations", MutableList.builder().addIfNotNull(loc).buildImmutable());
                 Task<?> task = newThrottledEffectorTask(entity, Startable.START, args, privileged);
                 tasks.put(entity, task);

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -1255,7 +1255,7 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
         public void start(Collection<? extends Location> locs) {
             int count = config().get(COUNTER).incrementAndGet();
             try {
-                LOG.debug("{} starting (first={})", new Object[]{this, sensors().get(AbstractGroup.FIRST_MEMBER)});
+                LOG.debug("{} starting (members={})", new Object[]{this, getParent().sensors().get(AbstractGroup.GROUP_MEMBERS)});
                 config().get(START_LATCH);
                 // Throw if more than one entity is starting at the same time as this.
                 assertTrue(count <= config().get(MAX_CONCURRENCY), "expected " + count + " <= " + config().get(MAX_CONCURRENCY));

--- a/utils/common/src/main/java/org/apache/brooklyn/util/collections/QuorumCheck.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/collections/QuorumCheck.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.util.collections;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -112,7 +113,9 @@ public interface QuorumCheck {
          */
         @SuppressWarnings({ "rawtypes", "unchecked" })
         public static QuorumCheck newLinearRange(String range, String name) {
-            return LinearRangeQuorumCheck.of(name, (Iterable)Iterables.getOnlyElement( Yamls.parseAll(range) ));
+            Object input = Iterables.getOnlyElement( Yamls.parseAll(range) );
+            if (input instanceof Iterable) return LinearRangeQuorumCheck.of(name, (Iterable)input);
+            throw new IllegalArgumentException("Invalid input to linear range quorum check; should be a list of points (not '"+range+"')");
         }
         
         private static final List<QuorumCheck> NAMED_CHECKS = MutableList
@@ -126,7 +129,21 @@ public interface QuorumCheck {
                         return qc;
                 }
             }
-            return newLinearRange(nameOrRange);
+            // parse YAML
+            Object input = Iterables.getOnlyElement( Yamls.parseAll(nameOrRange) );
+            if (input instanceof Collection) return of((Collection<?>)input);
+            if (input instanceof Integer || input instanceof Long) return of((int)((Number)input));
+            // TODO also accept "50%", and "50%,1"
+            throw new IllegalArgumentException("Unknown quorum check format '"+input+"'");
+        }
+        
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        public static QuorumCheck of(Collection<?> pointsForLinearRange) {
+            return LinearRangeQuorumCheck.of(null, (Iterable)pointsForLinearRange);
+        }
+        
+        public static QuorumCheck of(Integer constant) {
+            return newInstance(constant, 0.0, constant>0);
         }
     }
     

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
@@ -257,6 +257,18 @@ public class CommonAdaptorTypeCoercions {
                 return QuorumChecks.of(input);
             }
         });
+        registerAdapter(Integer.class, QuorumCheck.class, new Function<Integer,QuorumCheck>() {
+            @Override
+            public QuorumCheck apply(final Integer input) {
+                return QuorumChecks.of(input);
+            }
+        });
+        registerAdapter(Collection.class, QuorumCheck.class, new Function<Collection,QuorumCheck>() {
+            @Override
+            public QuorumCheck apply(final Collection input) {
+                return QuorumChecks.of(input);
+            }
+        });
         registerAdapter(String.class, TimeZone.class, new Function<String,TimeZone>() {
             @Override
             public TimeZone apply(final String input) {

--- a/utils/common/src/test/java/org/apache/brooklyn/util/collections/QuorumChecksTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/collections/QuorumChecksTest.java
@@ -99,7 +99,11 @@ public class QuorumChecksTest {
         Assert.assertTrue(q.isQuorate(31, 300));
     }
     
-    
-    
-    
+    @Test
+    public void testConstantQuorum() {
+        QuorumCheck q = QuorumChecks.of("2");
+        Assert.assertTrue(q.isQuorate(2, 2));
+        Assert.assertTrue(q.isQuorate(2, 10));
+        Assert.assertFalse(q.isQuorate(1, 1));
+    }     
 }


### PR DESCRIPTION
They were buggy and could deadlock -- and I think fundamentally flawed (as comments there suggested).

@grkvlt I think you added these; can you check that the workarounds suggested in the last commit is sufficient?

There are a few other minor tidies also.