### PR TITLE
[WIP] Adds ‘deploymentUid’

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -50,6 +50,11 @@ public class BrooklynConfigKeys {
     @Deprecated /** @deprecated since 0.7.0 use BrooklynServerConfig routines */
     public static final ConfigKey<String> BROOKLYN_DATA_DIR = BrooklynServerConfig.BROOKLYN_DATA_DIR;
 
+    public static final ConfigKey<String> DEPLOYMENT_UID = ConfigKeys.newStringConfigKey(
+            "org.apache.brooklyn.deploymentUid",
+            "An (optional) unique id for an application instance. If present, then no other app "
+                    + "can be deployed with that same deployment uid.");
+    
     public static final ConfigKey<String> ONBOX_BASE_DIR = newStringConfigKey("onbox.base.dir",
             "Default base directory on target machines where Brooklyn config data is stored; " +
             "default depends on the location, either ~/brooklyn-managed-processes or /tmp/brooklyn-${username} on localhost");

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/IdAlreadyExistsException.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/IdAlreadyExistsException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.internal;
+
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+
+/**
+ * Indicates that there is an id conflict (e.g. when creating an app using {@link BrooklynConfigKeys#DEPLOYMENT_UID}).
+ */
+public class IdAlreadyExistsException extends RuntimeException {
+
+    private static final long serialVersionUID = -602477310528752776L;
+
+    public IdAlreadyExistsException(String msg) {
+        super(msg);
+    }
+    
+    public IdAlreadyExistsException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -104,11 +104,8 @@ public interface ApplicationApi {
             @ApiResponse(code = 412, message = "Application already registered")
     })
     public Response createFromYaml(
-            @ApiParam(
-                    name = "applicationSpec",
-                    value = "App spec in CAMP YAML format",
-                    required = true)
-            String yaml);
+            @ApiParam(name = "applicationSpec", value = "App spec in CAMP YAML format", required = true) String yaml,
+            @ApiParam(value = "Unique deployment id", required = false) @QueryParam("deploymentUid") String deploymentUid);
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM, MediaType.TEXT_PLAIN})
@@ -124,8 +121,8 @@ public interface ApplicationApi {
             @ApiParam(
                     name = "applicationSpec",
                     value = "App spec in JSON, YAML, or other (auto-detected) format",
-                    required = true)
-            byte[] autodetectedInput);
+                    required = true) byte[] autodetectedInput,
+            @ApiParam(value = "Unique deployment id", required = false) @QueryParam("deploymentUid") String deploymentUid);
 
     @POST
     @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
@@ -142,7 +139,8 @@ public interface ApplicationApi {
                     name = "applicationSpec",
                     value = "App spec in form-encoded YAML, JSON, or other (auto-detected) format",
                     required = true)
-            @Valid String contents);
+            @Valid String contents,
+            @ApiParam(value = "Unique deployment id", required = false) @QueryParam("deploymentUid") String deploymentUid);
 
     @DELETE
     @Path("/{application}")

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestResourceTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,7 @@ import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.ApplicationSummary;
 import org.apache.brooklyn.rest.domain.Status;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.cxf.endpoint.Server;
@@ -160,6 +162,15 @@ public abstract class BrooklynRestResourceTest extends BrooklynRestApiTest {
 
     protected Status getApplicationStatus(URI uri) {
         return client().path(uri).get(ApplicationSummary.class).getStatus();
+    }
+
+    protected Map<?, ?> getApplicationConfig(URI appUri) {
+        // appUri in a format like "http://localhost:9998/applications/mwk66lso65/config/current-state"; 
+        // Will call /applications/{application}/entities/{entity}/config
+        String[] pathParts = appUri.getPath().split("/");
+        String appId = pathParts[pathParts.length-1];
+        URI configUri = URI.create(Urls.mergePaths(appUri.toString(), "/entities/", appId, "/config/current-state"));
+        return client().path(configUri).get(Map.class);
     }
 
     protected void waitForPageFoundResponse(final String resource, final Class<?> clazz) {


### PR DESCRIPTION
As discussed on the mailing list: https://lists.apache.org/thread.html/8eb58818d3ba50cfa5d5111363258cfe8529a76d17d45dc01823e0ba@%3Cdev.brooklyn.apache.org%3E

This PR adds support for deploying YAML apps via the rest api, to include `&deploymentUid=...`. This gets turned into a config key named `org.apache.brooklyn.deploymentUid` set on the app being deployed.

If there is already an app in existence with that deploymentUid, then the deployment fails (*before* creating the entity).

---
An alternative (simpler) implementation would be to allow the internal entity-id to be specified via such a query parameter. There is already code to fail-fast if an entity with a given id already exists.

However, we removed (the deprecated) support for supplying the entity id in the `EntitySpec`. We'd presumably have to add that back in (perhaps as "internal", somehow, rather than on the main `EntitySpec` class).