### PR TITLE
Support DSL in template options

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsCustomizerInstantiationYamlDslTest.java
@@ -24,7 +24,10 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
@@ -48,6 +51,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 /**
@@ -141,6 +145,7 @@ public class JcloudsCustomizerInstantiationYamlDslTest extends AbstractJcloudsSt
         assertEquals(expected.size(), 0);
     }
 
+
     public static class RecordingLocationCustomizer extends BasicJcloudsLocationCustomizer {
 
         public static final List<CallParams> calls = Lists.newCopyOnWriteArrayList();
@@ -154,7 +159,17 @@ public class JcloudsCustomizerInstantiationYamlDslTest extends AbstractJcloudsSt
         public void setEnabled(Boolean val) {
             this.enabled = val;
         }
-        
+
+        public static TemplateOptions findTemplateOptionsInCustomizerArgs() {
+            for (CallParams call : calls) {
+                Optional<?> templateOptions = Iterables.tryFind(call.args, Predicates.instanceOf(TemplateOptions.class));
+                if (templateOptions.isPresent()) {
+                    return (TemplateOptions) templateOptions.get();
+                }
+            }
+            throw new NoSuchElementException();
+        }
+
         @Override
         public void customize(JcloudsLocation location, ComputeService computeService, TemplateBuilder templateBuilder) {
             if (Boolean.TRUE.equals(enabled)) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlAwsTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlAwsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.apache.brooklyn.camp.brooklyn.JcloudsCustomizerInstantiationYamlDslTest
+    .RecordingLocationCustomizer.findTemplateOptionsInCustomizerArgs;
+import static org.apache.brooklyn.test.LogWatcher.EventPredicates.containsMessage;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.camp.brooklyn.JcloudsCustomizerInstantiationYamlDslTest.RecordingLocationCustomizer;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.entity.machine.MachineEntity;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.location.jclouds.templates.customize.TemplateOptionsOption;
+import org.apache.brooklyn.test.LogWatcher;
+import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests that jcouds TemplateOptions are constructed properly from yaml blueprints.
+ */
+@Test
+public class JcloudsTemplateOptionsYamlAwsTest extends AbstractJcloudsStubYamlTest {
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        RecordingLocationCustomizer.clear();
+        super.setUp();
+    }
+
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            RecordingLocationCustomizer.clear();
+        }
+    }
+    
+    @Override
+    protected String getLocationSpec() {
+        return "jclouds:aws-ec2:us-east-1";
+    }
+
+    @Test
+    public void testDslCanBeUsedInTemplateOptions() throws Exception {
+
+        String subnetValue = "subnet-123456";
+
+        String yaml = Joiner.on("\n").join(
+            "location: " + LOCATION_CATALOG_ID,
+            "services:",
+            "  - type: " + BasicEntity.class.getName(),
+            "    id: ent1",
+            "    brooklyn.config:",
+            "      subnet.value: " + subnetValue,
+            "  - type: " + MachineEntity.class.getName(),
+            "    brooklyn.config:",
+            "      onbox.base.dir.skipResolution: true",
+            "      sshMonitoring.enabled: false",
+            "      metrics.usage.retrieve: false",
+            "      enabled: true",
+            "      provisioning.properties:",
+            "        templateOptions:",
+            "          subnetId: $brooklyn:entity(\"ent1\").config(\"subnet.value\")",
+            "        customizer:",
+            "          $brooklyn:object:",
+            "            type: " + RecordingLocationCustomizer.class.getName(),
+            "            object.fields:",
+            "              enabled: $brooklyn:config(\"enabled\")");
+
+        final String ignoreOption = "Ignoring request to set template option";
+
+        final LogWatcher watcher = new LogWatcher(
+            ImmutableList.of(LoggerFactory.getLogger(TemplateOptionsOption.class).getName()),
+            ch.qos.logback.classic.Level.WARN,
+            Predicates.and(containsMessage(ignoreOption), containsMessage("subnetId")));
+
+        watcher.start();
+        try {
+            EntitySpec<?> spec = managementContext.getTypeRegistry().createSpecFromPlan(
+                CampTypePlanTransformer.FORMAT, yaml,
+                RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+            Entity app = managementContext.getEntityManager().createEntity(spec);
+
+            app.invoke(Startable.START, ImmutableMap.<String, Object>of()).get();
+
+            assertTrue(watcher.getEvents().isEmpty(), ignoreOption);
+
+            AWSEC2TemplateOptions options = (AWSEC2TemplateOptions) findTemplateOptionsInCustomizerArgs();
+            assertEquals(options.getSubnetId(), subnetValue);
+        } finally {
+            watcher.close();
+        }
+
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.brooklyn.camp.brooklyn;
 
+import static org.apache.brooklyn.camp.brooklyn.JcloudsCustomizerInstantiationYamlDslTest
+    .RecordingLocationCustomizer.findTemplateOptionsInCustomizerArgs;
 import static org.testng.Assert.assertEquals;
-
-import java.util.NoSuchElementException;
 
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
@@ -30,7 +30,6 @@ import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.entity.machine.MachineEntity;
-import org.jclouds.compute.options.TemplateOptions;
 import org.jclouds.googlecomputeengine.compute.options.GoogleComputeEngineTemplateOptions;
 import org.jclouds.googlecomputeengine.domain.Instance.ServiceAccount;
 import org.testng.annotations.AfterMethod;
@@ -38,11 +37,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 
 /**
  * Tests that jcouds TemplateOptions are constructed properly from yaml blueprints.
@@ -96,23 +92,17 @@ public class JcloudsTemplateOptionsYamlTest extends AbstractJcloudsStubYamlTest 
                 "          object.fields:",
                 "            enabled: $brooklyn:config(\"enabled\")");
 
-        EntitySpec<?> spec = managementContext.getTypeRegistry().createSpecFromPlan(CampTypePlanTransformer.FORMAT, yaml, RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
+        EntitySpec<?> spec = managementContext.getTypeRegistry().createSpecFromPlan(
+            CampTypePlanTransformer.FORMAT, yaml,
+            RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
         Entity app = managementContext.getEntityManager().createEntity(spec);
 
         app.invoke(Startable.START, ImmutableMap.<String, Object>of()).get();
 
-        GoogleComputeEngineTemplateOptions options = (GoogleComputeEngineTemplateOptions) findTemplateOptionsInCustomizerArgs();
+        GoogleComputeEngineTemplateOptions options =
+            (GoogleComputeEngineTemplateOptions) findTemplateOptionsInCustomizerArgs();
         assertEquals(options.serviceAccounts(), ImmutableList.of(
                 ServiceAccount.create("myemail", ImmutableList.of("myscope1", "myscope2"))));
     }
-    
-    private TemplateOptions findTemplateOptionsInCustomizerArgs() {
-        for (RecordingLocationCustomizer.CallParams call : RecordingLocationCustomizer.calls) {
-            Optional<?> templateOptions = Iterables.tryFind(call.args, Predicates.instanceOf(TemplateOptions.class));
-            if (templateOptions.isPresent()) {
-                return (TemplateOptions) templateOptions.get();
-            }
-        }
-        throw new NoSuchElementException();
-    }
+
 }


### PR DESCRIPTION
At the moment it's not possible to specify DSL in template options - for example you can't do 

      - type: some-type-publishing-subnet-id
        id: ent1

      - type: some-service
        id: service
        brooklyn.config:
          provisioning.properties:
            templateOptions:
              subnetId: $brooklyn:entity("ent1").attributeWhenReady("subnet.id")

see new test [here](https://github.com/geomacy/brooklyn-server/commit/d2f5bf9e0a5038208ff98aedb16795c217d01fc7#diff-99cb6184bb386646b61f6678346ec63bR75).

This adds support in `TemplateOptionsOption` for resolving the values supplied for the options. This allows the approach in the blueprint above to be used.