### PR TITLE
Restore HTTP annotations to deprecated API methods

### DIFF
--- a/karaf/itests/pom.xml
+++ b/karaf/itests/pom.xml
@@ -73,13 +73,6 @@
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-karaf</artifactId>
-            <version>${pax.exam.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-junit4</artifactId>
             <version>${pax.exam.version}</version>
             <scope>test</scope>

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ActivityApi.java
@@ -72,10 +72,16 @@ public interface ActivityApi {
             @QueryParam("limit") @DefaultValue("200") int limit,
             @ApiParam(value = "Max depth to traverse, or -1 for all (default)", required = false) 
             @QueryParam("maxDepth") @DefaultValue("-1") int maxDepth);
-    
+
     /** @deprecated since 0.12.0 use {@link #getAllChildrenAsMap(String, int, int)} with depth -1 */
+    @GET
+    @Path("/{task}/children/recurse/deprecated")
+    @ApiOperation(
+            value = "Fetch all child tasks details as Map<String,TaskSummary> map key == Task ID",
+            response = Map.class)
     @Deprecated
-    public Map<String,TaskSummary> getAllChildrenAsMap(String taskId);
+    public Map<String,TaskSummary> getAllChildrenAsMap(
+            @ApiParam(value = "Task ID", required = true) @PathParam("task") String taskId);
 
     @GET
     @Path("/{task}/stream/{streamId}")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
@@ -117,11 +117,17 @@ public interface EntityApi {
             @ApiParam(value = "Whether to include subtasks recursively across different entities (default false)", required = false)
             @QueryParam("recurse") @DefaultValue("false") Boolean recurse);
 
-    /** @deprecated since 0.12.0 use {@link #listTasks(String, String, Integer, Boolean)} */
+    /** @deprecated since 0.12.0 use {@link #listTasks(String, String, int, Boolean)} */
+    @GET
+    @Path("/{entity}/activities/deprecated")
+    @ApiOperation(value = "Fetch list of tasks for this entity")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Could not find application or entity")
+    })
     @Deprecated
     public List<TaskSummary> listTasks(
-        String applicationId,
-        String entityId);
+            @ApiParam(value = "Application ID or name", required = true) @PathParam("application") String applicationId,
+            @ApiParam(value = "Entity ID or name", required = true) @PathParam("entity") String entityId);
         
     @GET
     @Path("/{entity}/activities/{task}")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LocationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LocationApi.java
@@ -49,7 +49,7 @@ import io.swagger.annotations.ApiParam;
 public interface LocationApi {
 
     /**
-     * @deprecated since 0.7.0; use {@link CatalogApi#listLocations(String, String)}
+     * @deprecated since 0.7.0; use {@link CatalogApi#listLocations}
      */
     @GET
     @ApiOperation(value = "Fetch the list of location definitions",


### PR DESCRIPTION
The missing annotations mean that brooklyn-client is unable to proxy the affected classes (since Resteasy expects to work with every method), and by extension that every build of the project fails. I think the simplest way to solve this is to expose the deprecated methods at `.../deprecated`.



