### PR TITLE
Upgrade json-path to 2.4.0 (from 2.0.0)

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/feed/http/JsonFunctionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/http/JsonFunctionsTest.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.jayway.jsonpath.PathNotFoundException;
@@ -118,6 +119,20 @@ public class JsonFunctionsTest {
     public void testGetPath2(){
         String obj = (String) JsonFunctions.getPath("$.europe.uk.edinburgh.lighting").apply(europeMap());
         Assert.assertEquals(obj, "dark");
+    }
+
+    @Test
+    public void testGetPathSizeOfMap(){
+        JsonElement json = JsonFunctions.asJson().apply("{\"mymap\": {\"k1\": \"v1\", \"k2\": \"v2\"}}");
+        Integer obj = (Integer) JsonFunctions.getPath("$.mymap.size()").apply(json);
+        Assert.assertEquals(obj, (Integer)2);
+    }
+
+    @Test
+    public void testGetPathSizeOfList(){
+        JsonElement json = JsonFunctions.asJson().apply("{\"mylist\": [\"a\", \"b\", \"c\"]}");
+        Integer obj = (Integer) JsonFunctions.getPath("$.mylist.size()").apply(json);
+        Assert.assertEquals(obj, (Integer)3);
     }
 
     @Test

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -142,7 +142,8 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml.jackson.version}</bundle>
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml.jackson.version}</bundle>
         <bundle dependency="true">mvn:net.minidev/json-smart/${jsonSmart.version}</bundle>
-        <bundle dependency="true">mvn:net.minidev/asm/${minidev.asm.version}</bundle>
+        <bundle dependency="true">mvn:net.minidev/accessors-smart/${minidev.accessors-smart.version}</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm/${ow2.asm.version}</bundle>
         <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -463,6 +463,33 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${jsonPath.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- Would otherwise pull in 1.7.25 (Brooklyn uses 1.6.6) -->
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- Would otherwise pull in 2.6.3 (Brooklyn uses 2.7.5) -->
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${jsonSmart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>accessors-smart</artifactId>
+                <version>${minidev.accessors-smart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${ow2.asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.maxmind.geoip2</groupId>
@@ -473,16 +500,6 @@
                 <groupId>jline</groupId>
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>${jsonSmart.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>asm</artifactId>
-                <version>${minidev.asm.version}</version>
             </dependency>
 
             <!-- JAX-RS dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <mockwebserver.version>20121111</mockwebserver.version>
         <freemarker.version>2.3.25-incubating</freemarker.version>
         <commons-io.version>2.4</commons-io.version>
-        <jsonPath.version>2.0.0</jsonPath.version>
+        <jsonPath.version>2.4.0</jsonPath.version>
         <commons-compress.version>1.4</commons-compress.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
@@ -183,8 +183,9 @@
         <log4j.version>1.2.17</log4j.version>
         <commons-logging.version>1.2</commons-logging.version>
         <jline.version>2.12</jline.version>
-        <jsonSmart.version>2.1.1</jsonSmart.version>
-        <minidev.asm.version>1.0.2</minidev.asm.version>
+        <jsonSmart.version>2.3</jsonSmart.version>
+        <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
+        <ow2.asm.version>5.0.4</ow2.asm.version>
         <commons-beanutils.version>1.9.1</commons-beanutils.version>
         <commons-collections.version>3.2.1</commons-collections.version>
         <javax.mail.version>1.4.4</javax.mail.version>


### PR DESCRIPTION
This supports `.size()`
Also fix the json-path dependency, to exclude conflicting versions.

The `.size()` is very useful for things like a CouchDB cluster - we can easily add a sensor that retrieves json for the members of the cluster. We'd also like a sensor for the size of that list (so we can check that all CouchDB nodes know about each other at startup).