### PR TITLE
Freemarker DSL

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -798,6 +798,10 @@ public class BrooklynDslCommon {
         }
     }
 
+    public static Object template(Object template) {
+        return new DslComponent(Scope.THIS, "").template(template);
+    }
+
     public static class Functions {
         @DslAccessible
         public static Object regexReplacement(final Object pattern, final Object replacement) {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -802,6 +802,10 @@ public class BrooklynDslCommon {
         return new DslComponent(Scope.THIS, "").template(template);
     }
 
+    public static Object template(Object template, Map<? ,?> substitutions) {
+        return new DslComponent(Scope.THIS, "").template(template, substitutions);
+    }
+
     public static class Functions {
         @DslAccessible
         public static Object regexReplacement(final Object pattern, final Object replacement) {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
 
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -744,14 +745,24 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         return new DslTemplate(this, template);
     }
 
+    public Object template(Object template, Map<?, ?> substitutions) {
+        return new DslTemplate(this, template, substitutions);
+    }
+
     protected final static class DslTemplate extends BrooklynDslDeferredSupplier<Object> {
         private static final long serialVersionUID = -585564936781673667L;
         private DslComponent component;
         private Object template;
+        private Map<?, ?> substitutions;
 
         public DslTemplate(DslComponent component, Object template) {
+            this(component, template, ImmutableMap.of());
+        }
+
+        public DslTemplate(DslComponent component, Object template, Map<?, ?> substitutions) {
             this.component = component;
             this.template = template;
+            this.substitutions = substitutions;
         }
         
         private String resolveTemplate(boolean immediately) {
@@ -766,17 +777,29 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                 .description("Resolving template from " + template)
                 .get();
         }
+        
+        @SuppressWarnings("unchecked")
+        private Map<String, ?> resolveSubstitutions(boolean immediately) {
+            return (Map<String, ?>) Tasks.resolving(substitutions)
+                    .as(Object.class)
+                    .context(findExecutionContext(this))
+                    .immediately(immediately)
+                    .deep(true)
+                    .description("Resolving substitutions " + substitutions + " for template " + template)
+                    .get();
+        }
 
         @Override
         public Maybe<Object> getImmediately() {
             String resolvedTemplate = resolveTemplate(true);
+            Map<String, ?> resolvedSubstitutions = resolveSubstitutions(true);
 
             Maybe<Entity> targetEntityMaybe = component.getImmediately();
             if (targetEntityMaybe.isAbsent()) return ImmediateValueNotAvailableException.newAbsentWrapping("Target entity is not available: "+component, targetEntityMaybe);
             Entity targetEntity = targetEntityMaybe.get();
 
             String evaluatedTemplate = TemplateProcessor.processTemplateContents(
-                    resolvedTemplate, (EntityInternal)targetEntity, ImmutableMap.<String, Object>of());
+                    resolvedTemplate, (EntityInternal)targetEntity, resolvedSubstitutions);
             return Maybe.of(evaluatedTemplate);
         }
 
@@ -786,8 +809,9 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                 @Override
                 public Object call() throws Exception {
                     Entity targetEntity = component.get();
+                    Map<String, ?> resolvedSubstitutions = resolveSubstitutions(false);
                     return TemplateProcessor.processTemplateContents(
-                            resolveTemplate(false), (EntityInternal)targetEntity, ImmutableMap.<String, Object>of());
+                            resolveTemplate(false), (EntityInternal)targetEntity, resolvedSubstitutions);
                 }
             }).build();
         }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ha.MementoCopyMode;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoRawData;
@@ -617,6 +618,23 @@ public class DslAndRebindYamlTest extends AbstractYamlRebindTest {
         testEntity.sensors().set(TestEntity.NAME, "somefooname");
         AttributeSensor<String> transformedSensor = Sensors.newStringSensor("test.name.transformed");
         EntityAsserts.assertAttributeEqualsEventually(testEntity, transformedSensor, "somebarname");
+    }
+
+    @Test
+    public void testDslTemplateRebind() throws Exception {
+        Entity testEntity = entityWithTemplatedString();
+        Application app2 = rebind(testEntity.getApplication());
+        Entity e2 = Iterables.getOnlyElement(app2.getChildren());
+
+        Assert.assertEquals(getConfigInTask(e2, TestEntity.CONF_NAME), "hello world");
+    }
+
+    protected Entity entityWithTemplatedString() throws Exception {
+        return setupAndCheckTestEntityInBasicYamlWith(
+                "  id: x",
+                "  brooklyn.config:",
+                "    test.sourceName: hello world",
+                "    test.confName: $brooklyn:template(\"${config['test.sourceName']}\")");
     }
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
@@ -38,14 +38,12 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
@@ -801,6 +799,21 @@ public class DslYamlTest extends AbstractYamlTest {
                 "    test.sourceName: hello world",
                 "    dest: $brooklyn:template(\"${config['test.sourceName']}\")");
         assertEquals(getConfigEventually(app, DEST), "hello world");
+    }
+
+    @Test
+    public void testDslTemplateSubstitutions() throws Exception {
+        final Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicApplication.class.getName(),
+                "  brooklyn.config:",
+                "    test.sourceName: hello world",
+                "    test.substituteValue: and all",
+                "    dest: ",
+                "      $brooklyn:template:",
+                "      - ${config['test.sourceName']} ${key}",
+                "      - $brooklyn:literal(\"key\"): $brooklyn:config(\"test.substituteValue\")");
+        assertEquals(getConfigEventually(app, DEST), "hello world and all");
     }
 
     @Test


### PR DESCRIPTION
Provides `$brooklyn:template(...)` evaluated against the context entity as a freemarker template.
The main advantage of the new DSL is that it's now possible to do simple expressions in YAML - both logical or algebraic.

Re-implements the most useful parts of #392 for easier merge.

I think providing a shortcut for the expression as `$brooklyn:"some template"` will be useful as well, but will get this to the mailing list for discussion.