### PR TITLE
Adds DynamicCluster.START_TIMEOUT

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
@@ -120,7 +120,7 @@ public class CatalogMakeOsgiBundleTest extends AbstractYamlTest {
                 "- type: " + "basic1";
         Entity app = createAndStartApplication(yaml);
         Entity basic1 = Iterables.getOnlyElement( app.getChildren() );
-        EntityAsserts.assertAttribute(basic1, Sensors.newStringSensor("a.sensor"), Predicates.equalTo("A"));
+        EntityAsserts.assertAttributeEqualsEventually(basic1, Sensors.newStringSensor("a.sensor"), "A");
         
         return basic1;
     }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.entity.group;
 
+import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +176,12 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
     @SetFromFlag("clusterMemberId")
     ConfigKey<Integer> CLUSTER_MEMBER_ID = ConfigKeys.newIntegerConfigKey(
             "cluster.member.id", "The unique ID number (sequential) of a member of a cluster");
+
+    ConfigKey<Duration> START_TIMEOUT = newConfigKey(
+            Duration.class,
+            "start.timeout", 
+            "Time to wait (after members' start() effectors return) for SERVICE_UP before failing (default is not to wait)",
+            null);
 
     @Beta
     @SetFromFlag("maxConcurrentChildCommands")


### PR DESCRIPTION
Similar to `SoftwareProcess`, this allows a dynamic cluster to wait for
`service.isUp` before returning from `start()`. It defaults to not waiting
(for backwards compatibility).

Previously, it would return as soon as all the initial member’s start()
effectors had finished executing.

---
Note that the new test `testReportsServiceUpAsSoonAsQuorumSize()` just demonstrates existing behaviour - this PR does not change that behaviour.