### PR TITLE
Adds HttpFeed.preemptiveBasicAuth

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
@@ -242,8 +242,15 @@ public class HttpFeed extends AbstractFeed {
                     throw new IllegalArgumentException("Must not enable preemptiveBasicAuth when there are no credentials, in feed for "+baseUri);
                 }
                 String username = checkNotNull(creds.getUserPrincipal().getName(), "username");
+                if (username == null) {
+                    throw new IllegalArgumentException("Must not enable preemptiveBasicAuth when username is null, in feed for "+baseUri);
+                }
+                if (username.contains(":")) {
+                    throw new IllegalArgumentException("Username must not contain colon when preemptiveBasicAuth is enabled, in feed for "+baseUri);
+                }
+                
                 String password = creds.getPassword();
-                String toencode = username + (password == null ? "" : ":"+password);
+                String toencode = username + ":" + (password == null ? "" : password);
                 String headerVal = "Basic " + BaseEncoding.base64().encode((toencode).getBytes(StandardCharsets.UTF_8));
                 
                 return ImmutableMap.<String,String>builder()

--- a/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedIntegrationTest.java
@@ -99,6 +99,15 @@ public class HttpFeedIntegrationTest extends BrooklynAppUnitTestSupport {
 
     @Test(groups = {"Integration"})
     public void testPollsAndParsesHttpGetResponseWithBasicAuthentication() throws Exception {
+        runPollsAndParsesHttpGetResponseWithBasicAuthentication(false);
+    }
+    
+    @Test(groups = {"Integration"})
+    public void testPollsAndParsesHttpGetResponseWithPreemptiveBasicAuthentication() throws Exception {
+        runPollsAndParsesHttpGetResponseWithBasicAuthentication(true);
+    }
+    
+    protected void runPollsAndParsesHttpGetResponseWithBasicAuthentication(boolean preemptiveBasicAuth) throws Exception {
         final String username = "brooklyn";
         final String password = "hunter2";
         httpService = new HttpService(PortRanges.fromString("9000+"))
@@ -111,6 +120,7 @@ public class HttpFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                 .entity(entity)
                 .baseUri(baseUrl)
                 .credentials(username, password)
+                .preemptiveBasicAuth(preemptiveBasicAuth)
                 .poll(new HttpPollConfig<Integer>(SENSOR_INT)
                         .period(100)
                         .onSuccess(HttpValueFunctions.responseCode()))

--- a/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/http/HttpFeedTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -30,6 +31,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.EntityInternal.FeedSupport;
@@ -42,8 +44,8 @@ import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
-import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.guava.Functionals;
+import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -59,7 +61,9 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
 import com.google.mockwebserver.MockResponse;
+import com.google.mockwebserver.RecordedRequest;
 import com.google.mockwebserver.SocketPolicy;
 
 public class HttpFeedTest extends BrooklynAppUnitTestSupport {
@@ -360,7 +364,90 @@ public class HttpFeedTest extends BrooklynAppUnitTestSupport {
         
         server.shutdown();
     }
+    
+    @Test
+    public void testPreemptiveBasicAuth() throws Exception {
+        final String username = "brooklyn";
+        final String password = "hunter2";
 
+        feed = HttpFeed.builder()
+                .entity(entity)
+                .baseUrl(server.getUrl("/"))
+                .credentials(username, password)
+                .preemptiveBasicAuth(true)
+                .poll(new HttpPollConfig<Integer>(SENSOR_INT)
+                        .period(100)
+                        .onSuccess(HttpValueFunctions.responseCode())
+                        .onException(Functions.constant(-1)))
+                .build();
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
+        RecordedRequest req = server.takeRequest();
+        String headerVal = req.getHeader("Authorization");
+        String expectedVal = getBasicAuthHeaderVal(username, password);
+        assertEquals(headerVal, expectedVal);
+    }
+
+    @Test
+    public void testPreemptiveBasicAuthFailsIfNoCredentials() throws Exception {
+        try {
+            feed = HttpFeed.builder()
+                    .entity(entity)
+                    .baseUrl(new URL("http://shouldNeverBeCalled.org"))
+                    .preemptiveBasicAuth(true)
+                    .poll(new HttpPollConfig<Integer>(SENSOR_INT)
+                            .period(100)
+                            .onSuccess(HttpValueFunctions.responseCode())
+                            .onException(Functions.constant(-1)))
+                    .build();
+            Asserts.shouldHaveFailedPreviously();
+        } catch (IllegalArgumentException e) {
+            Asserts.expectedFailureContains(e, "Must not enable preemptiveBasicAuth when there are no credentials");
+        }
+    }
+
+    // Expected behaviour of o.a.http.client is that it first sends the request without credentials,
+    // and then when given a challenge for basic-auth it re-sends the request with the basic-auth header.
+    @Test
+    public void testNonPreemptiveBasicAuth() throws Exception {
+        final String username = "brooklyn";
+        final String password = "hunter2";
+        
+        if (server != null) server.shutdown();
+        server = BetterMockWebServer.newInstanceLocalhost();
+        server.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .addHeader("WWW-Authenticate", "Basic"));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("Hello World"));
+        server.play();
+
+        feed = HttpFeed.builder()
+                .entity(entity)
+                .baseUrl(server.getUrl("/"))
+                .credentials(username, password)
+                .poll(new HttpPollConfig<Integer>(SENSOR_INT)
+                        .period(Duration.ONE_MINUTE) // so only dealing with first request
+                        .onSuccess(HttpValueFunctions.responseCode())
+                        .onException(Functions.constant(-1)))
+                .build();
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_INT, 200);
+        RecordedRequest req = server.takeRequest();
+        assertEquals(req.getHeader("Authorization"), null);
+        
+        RecordedRequest req2 = server.takeRequest();
+        String headerVal = req2.getHeader("Authorization");
+        String expected = getBasicAuthHeaderVal(username, password);
+        assertEquals(headerVal, expected);
+    }
+
+    public static String getBasicAuthHeaderVal(String username, String password) {
+        String toencode = username + (password == null ? "" : ":"+password);
+        return "Basic " + BaseEncoding.base64().encode((toencode).getBytes(StandardCharsets.UTF_8));
+    }
+    
     private void newMultiFeed(URL baseUrl) {
         feed = HttpFeed.builder()
                 .entity(entity)

--- a/utils/common/src/main/java/org/apache/brooklyn/test/http/RecordingHttpRequestHandler.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/http/RecordingHttpRequestHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.http;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.brooklyn.test.Asserts;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.testng.Assert;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+public class RecordingHttpRequestHandler implements HttpRequestHandler {
+    private final HttpRequestHandler delegate;
+
+    private final List<HttpRequest> requests = Lists.newCopyOnWriteArrayList();
+    
+    public RecordingHttpRequestHandler(HttpRequestHandler delegate) {
+        this.delegate = checkNotNull(delegate, "delegate");
+    }
+
+    @Override
+    public void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+        requests.add(request);
+        delegate.handle(request, response, context);
+    }
+
+    public void assertHasRequest(Predicate<? super HttpRequest> filter) {
+        for (HttpRequest req : requests) {
+            if (filter.apply(req)) {
+                return;
+            }
+        }
+        Assert.fail("No request matching filter "+ filter);
+    }
+
+    public void assertHasRequestEventually(Predicate<? super HttpRequest> filter) {
+        Asserts.succeedsEventually(new Runnable() {
+            @Override
+            public void run() {
+                assertHasRequest(filter);
+            }});
+    }
+    
+    public List<HttpRequest> getRequests(Predicate<? super HttpRequest> filter) {
+        return ImmutableList.copyOf(Iterables.filter(requests, filter));
+    }
+
+    public List<HttpRequest> getRequests() {
+        return ImmutableList.copyOf(requests);
+    }
+}

--- a/utils/common/src/main/java/org/apache/brooklyn/test/http/RecordingHttpRequestHandler.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/http/RecordingHttpRequestHandler.java
@@ -29,7 +29,6 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestHandler;
-import org.testng.Assert;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -57,7 +56,7 @@ public class RecordingHttpRequestHandler implements HttpRequestHandler {
                 return;
             }
         }
-        Assert.fail("No request matching filter "+ filter);
+        Asserts.fail("No request matching filter "+ filter);
     }
 
     public void assertHasRequestEventually(Predicate<? super HttpRequest> filter) {


### PR DESCRIPTION
For a description of pre-emptive basic auth, see https://hc.apache.org/httpcomponents-client-ga/tutorial/html/authentication.html (section 4.6. Preemptive authentication). As is described in that link, pre-emptive basic auth should be used with caution!

However, if you really do need to use basic auth then some servers don't send back the right challenge-response in the headers of the 401 response. For example, this seems to be the case with CouchDB!

We've seen in some downstream project people working around it by auto-generating the basic-auth header, and configuring the `HttpRequestSensor` accordingly. That is a bad pattern! (e.g. we lose the fact that this is a credential, so would never be able to use externalised configuration to ensure the passwords are not logged or written to persisted state).

This PR will allow those users to delete a bunch of lines of ugly yaml configuration from their blueprints. It will also help people knocking together a proof of concept - they can use `preemptiveBaicAuth` while they ask the people responsible for the servers to fix it properly!