### PR TITLE
Remove `org.ow2.asm` (already included in Karaf)

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -143,7 +143,6 @@
         <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml.jackson.version}</bundle>
         <bundle dependency="true">mvn:net.minidev/json-smart/${jsonSmart.version}</bundle>
         <bundle dependency="true">mvn:net.minidev/accessors-smart/${minidev.accessors-smart.version}</bundle>
-        <bundle dependency="true">mvn:org.ow2.asm/asm/${ow2.asm.version}</bundle>
         <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>


### PR DESCRIPTION
I added this in https://github.com/apache/brooklyn-server/pull/784, but turns out that broke karaf!

Including `org.ow2.asm:5.0.4` breaks things badly:

```
Caused by: java.lang.ClassNotFoundException: org.objectweb.asm.commons.AdviceAdapter not found by org.apache.aries.proxy.impl [20]
```

`org.ow2.asm.all:5.0.2` is already included in karaf; we'll just rely on that instead:
```
ASM all classes with debug info (49)
------------------------------------
Bnd-LastModified = 1398065775616
Created-By = 1.8.0 (Oracle Corporation)
Implementation-Title = ASM all classes
Implementation-Vendor = France Telecom R&D
Implementation-Version = 5.0.2
Manifest-Version = 1.0
Tool = Bnd-1.50.0

Bundle-DocURL = http://asm.objectweb.org
Bundle-ManifestVersion = 2
Bundle-Name = ASM all classes with debug info
Bundle-RequiredExecutionEnvironment = J2SE-1.3
Bundle-SymbolicName = org.objectweb.asm.all
Bundle-UpdateLocation = mvn:org.ow2.asm/asm-all/5.0.2
Bundle-Vendor = France Telecom R&D
Bundle-Version = 5.0.2

Export-Package = 
	org.objectweb.asm.signature;version=5.0.2,
	org.objectweb.asm.commons;uses:="org.objectweb.asm,org.objectweb.asm.tree,org.objectweb.asm.signature";version=5.0.2,
	org.objectweb.asm.util;uses:="org.objectweb.asm,org.objectweb.asm.tree.analysis,org.objectweb.asm.tree,org.objectweb.asm.signature";version=5.0.2,
	org.objectweb.asm.tree.analysis;uses:="org.objectweb.asm,org.objectweb.asm.tree";version=5.0.2,
	org.objectweb.asm;version=5.0.2,
	org.objectweb.asm.xml;uses:="org.xml.sax,org.objectweb.asm,org.xml.sax.helpers,org.xml.sax.ext,javax.xml.transform.sax,javax.xml.transform,javax.xml.transform.stream,org.objectweb.asm.util";version=5.0.2,
	org.objectweb.asm.tree;uses:=org.objectweb.asm;version=5.0.2
Import-Package = 
	javax.xml.transform;resolution:=optional,
	javax.xml.transform.sax;resolution:=optional,
	javax.xml.transform.stream;resolution:=optional,
	org.xml.sax;resolution:=optional,
	org.xml.sax.ext;resolution:=optional,
	org.xml.sax.helpers;resolution:=optional
```