### PR TITLE
HttpRequestSensor: handling non-json

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AggregatorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AggregatorYamlTest.java
@@ -184,6 +184,36 @@ public class AggregatorYamlTest extends AbstractYamlTest {
     }
     
     @Test
+    public void testListExcludesBlank() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicApplication.class.getName(),
+                "  brooklyn.children:",
+                "    - type: " + TestEntity.class.getName(),
+                "    - type: " + TestEntity.class.getName(),
+                "  brooklyn.enrichers:",
+                "    - type: " + Aggregator.class.getName(),
+                "      brooklyn.config:",
+                "        "+Aggregator.SOURCE_SENSOR.getName()+": myVal",
+                "        "+Aggregator.TARGET_SENSOR.getName()+": myResult",
+                "        "+Aggregator.EXCLUDE_BLANK.getName()+": true",
+                "        "+Aggregator.TRANSFORMATION_UNTYPED.getName()+": list");
+        Entity child1 = Iterables.get(app.getChildren(), 0);
+        Entity child2 = Iterables.get(app.getChildren(), 1);
+
+        EntityAsserts.assertAttributeEqualsEventually(app, myResult, ImmutableList.of());
+
+        child1.sensors().set(myVal, "val1");
+        EntityAsserts.assertAttributeEqualsEventually(app, myResult, ImmutableList.of("val1"));
+        
+        child2.sensors().set(myVal, "val2");
+        EntityAsserts.assertAttributeEqualsEventually(app, myResult, ImmutableList.of("val1", "val2"));
+        
+        child1.sensors().set(myVal, null);
+        EntityAsserts.assertAttributeEqualsEventually(app, myResult, MutableList.of("val2"));
+    }
+    
+    @Test
     public void testFirst() throws Exception {
         Entity app = createAndStartApplication(
                 "services:",

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/PropagatorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/PropagatorYamlTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.enricher.stock.Propagator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+
+@Test
+public class PropagatorYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(PropagatorYamlTest.class);
+
+    AttributeSensor<String> mySourceSensor = Sensors.newStringSensor("mySource");
+    AttributeSensor<String> myTargetSensor = Sensors.newStringSensor("myTarget");
+
+    @Test
+    public void testPropagateSensorMapping() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + TestEntity.class.getName(),
+                "  brooklyn.enrichers:",
+                "    - type: " + Propagator.class.getName(),
+                "      brooklyn.config:",
+                "        "+Propagator.PRODUCER.getName()+": $brooklyn:parent()",
+                "        "+Propagator.SENSOR_MAPPING.getName()+": ",
+                "          mySource: myTarget");
+        TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
+        
+        app.sensors().set(mySourceSensor, "myval");
+        EntityAsserts.assertAttributeEqualsEventually(entity, myTargetSensor, "myval");
+    }
+    
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
@@ -27,15 +27,20 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.effector.AddSensor;
 import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.ssh.SshCommandSensor;
 import org.apache.brooklyn.feed.http.HttpFeed;
 import org.apache.brooklyn.feed.http.HttpPollConfig;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.config.ResolvingConfigBag;
+import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.base.Supplier;
 
@@ -92,10 +97,18 @@ public final class HttpRequestSensor<T> extends AddSensor<T> {
         final Map<String, String> headers = EntityInitializers.resolve(allConfig, HEADERS);
         final Boolean preemptiveBasicAuth = EntityInitializers.resolve(allConfig, PREEMPTIVE_BASIC_AUTH);
         
+        Function<? super HttpToolResponse, T> successFunction;
+        if (Strings.isBlank(jsonPath)) {
+            // TODO Should also coerce to type `allConfig.get(SENSOR_TYPE)` (would need to class-load that, using the entity's context)
+            successFunction = (Function) HttpValueFunctions.stringContentsFunction();
+        } else {
+            successFunction = HttpValueFunctions.<T>jsonContentsFromPath(jsonPath);
+        }
+        
         HttpPollConfig<T> pollConfig = new HttpPollConfig<T>(sensor)
                 .checkSuccess(HttpValueFunctions.responseCodeEquals(200))
                 .onFailureOrException(Functions.constant((T) null))
-                .onSuccess(HttpValueFunctions.<T>jsonContentsFromPath(jsonPath))
+                .onSuccess(successFunction)
                 .period(period);
 
         HttpFeed.Builder httpRequestBuilder = HttpFeed.builder().entity(entity)

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
@@ -80,7 +80,8 @@ public abstract class AbstractAggregator<T,U> extends AbstractEnricher implement
     public static final ConfigKey<Boolean> EXCLUDE_BLANK = ConfigKeys.newBooleanConfigKey(
             "enricher.aggregator.excludeBlank",
             "Whether explicit nulls or blank strings should be excluded (default false); " +
-                    "may only apply if no value filter set", false);
+                    "may only apply if no value filter set", 
+            false);
 
     protected Entity producer;
     protected Sensor<U> targetSensor;

--- a/core/src/main/java/org/apache/brooklyn/feed/http/JsonFunctions.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/http/JsonFunctions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.feed.http;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -309,7 +311,7 @@ public class JsonFunctions {
         private final String path;
 
         public GetPath(String path) {
-            this.path = path;
+            this.path = checkNotNull(path, "path");
         }
         @SuppressWarnings("unchecked")
         @Override public T apply(JsonElement input) {


### PR DESCRIPTION
Previously the `HttpRequestSensor` failed if no `jsonPath: ` is suppiled in the yaml. I've added a failing test, but not worked specifically on that. It doesn't pick up the default value of `$`.

Added support for setting `jsonPath` to blank, so that it just takes the pure-string value (i.e. no json parsing).

Also added a few more (unrelated!) tests.