### PR TITLE
Test Framework TestNG runner

### DIFF
--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -90,6 +90,19 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-launcher</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-launcher</artifactId>
+            <version>${brooklyn.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkLiveTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkLiveTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework.live;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.location.BasicLocationDefinition;
+import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
+import org.apache.brooklyn.core.mgmt.EntityManagementUtils.CreationResult;
+import org.apache.brooklyn.launcher.SimpleYamlLauncherForTests;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.FluentIterable;
+
+public abstract class TestFrameworkLiveTest {
+    private static final Logger log = LoggerFactory.getLogger(TestFrameworkLiveTest.class);
+
+    private SimpleYamlLauncherForTests launcher;
+    private ManagementContext mgmt;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() {
+        launcher = new SimpleYamlLauncherForTests();
+        mgmt = launcher.getManagementContext();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        if (launcher != null) {
+            launcher.destroyAll();
+        }
+    }
+
+    @DataProvider
+    public abstract Object[][] tests();
+
+    @Test(dataProvider="tests", groups="Live")
+    public void runTestFrameworkTest(TestFrameworkRun testRun) {
+        for (Map.Entry<String, String> alias : testRun.locationAliases().entries()) {
+            mgmt.getLocationRegistry().updateDefinedLocation(
+                    new BasicLocationDefinition(alias.getValue(), alias.getValue(), alias.getKey(), null));
+        }
+
+        for (URL prereq : testRun.prerequisites()) {
+            addCatalogItems(prereq);
+        }
+        Collection<String> testIds = new ArrayList<>();
+        for (URL test : testRun.tests()) {
+            testIds.addAll(addCatalogItems(test));
+        }
+        Collection<CreationResult<? extends Application, Void>> tests = new ArrayList<>();
+        for (String testId : testIds) {
+            String testYaml = yaml(
+                    "location: " + testRun.location(),
+                    "services:",
+                    "- type: "+ testId);
+            CreationResult<? extends Application, Void> result = EntityManagementUtils.createStarting(mgmt, testYaml);
+            tests.add(result);
+        }
+        for (CreationResult<? extends Application, Void> t : tests) {
+            t.blockUntilComplete();
+        }
+        
+        boolean isInteractive = Boolean.getBoolean("test.framework.interactive");
+        if (isInteractive) {
+            boolean hasFailed = false;
+            for (CreationResult<? extends Application, Void> t : tests) {
+                hasFailed = hasFailed || t.task().isError();
+            }
+            if (hasFailed) {
+                log.error("The test failed, blocking until user unmanages all entities.");
+                while (!mgmt.getApplications().isEmpty()) {
+                    Duration.sleep(Duration.ONE_SECOND);
+                }
+            }
+        }
+
+        for (CreationResult<? extends Application, Void> t : tests) {
+            t.task().getUnchecked();
+        }
+    }
+
+    private String yaml(String... lines) {
+        return Joiner.on("\n").join(lines);
+    }
+
+    private Collection<String> addCatalogItems(URL url) {
+        try {
+            return addCatalogItems(Streams.readFullyStringAndClose(url.openStream()));
+        } catch (IOException e) {
+            throw Exceptions.propagate("Failed to load url " + url, e);
+        }
+    }
+
+    private Collection<String> addCatalogItems(String yaml) {
+        return FluentIterable.from(mgmt.getCatalog().addItems(yaml))
+                .transform(item -> item.getId())
+                .toList();
+    }
+}

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkRun.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkRun.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework.live;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.brooklyn.util.collections.MutableList;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+
+public class TestFrameworkRun {
+    public static class TestFrameworkRunBuilder {
+        private TestFrameworkRunBuilder() {}
+
+        private MutableList<URL> prerequisites = MutableList.of();
+        private MutableList<URL> tests = MutableList.of();
+        private String location;
+        private Multimap<String, String> locationAliases = ArrayListMultimap.create();
+
+        public TestFrameworkRunBuilder prerequisite(URL value) {
+            prerequisites.add(checkNotNull(value, "value"));
+            return this;
+        }
+        public TestFrameworkRunBuilder prerequisites() {
+            prerequisites.clear();
+            return this;
+        }
+        public TestFrameworkRunBuilder prerequisites(Iterable<URL> value) {
+            Iterables.addAll(prerequisites, checkNotNull(value, "value"));
+            return this;
+        }
+        public TestFrameworkRunBuilder test(URL value) {
+            tests.add(value);
+            return this;
+        }
+        public TestFrameworkRunBuilder tests() {
+            tests.clear();
+            return this;
+        }
+        public TestFrameworkRunBuilder tests(Iterable<URL> value) {
+            Iterables.addAll(tests, checkNotNull(value, "value"));
+            return this;
+        }
+        public TestFrameworkRunBuilder location(String value) {
+            location = checkNotNull(value, "value");
+            return this;
+        }
+        public TestFrameworkRunBuilder locationAlias(String location, String alias) {
+            locationAliases.put(
+                    checkNotNull(location, "location"),
+                    checkNotNull(alias, "alias"));
+            return this;
+        }
+        public TestFrameworkRunBuilder locationAliases() {
+            locationAliases.clear();
+            return this;
+        }
+        public TestFrameworkRunBuilder locationAliases(Map<String, String> aliases) {
+            checkNotNull(aliases, "aliases");
+            for (Entry<String, String> alias : aliases.entrySet()) {
+                locationAliases.put(alias.getKey(), alias.getValue());
+            }
+            return this;
+        }
+        public TestFrameworkRunBuilder locationAliases(Multimap<String, String> aliases) {
+            locationAliases.putAll(checkNotNull(aliases, "aliases"));
+            return this;
+        }
+        public TestFrameworkRun build() {
+            return new TestFrameworkRun(prerequisites.asImmutableCopy(),
+                    tests.asImmutableCopy(),
+                    location,
+                    locationAliases);
+        }
+    }
+
+    public static TestFrameworkRunBuilder builder() {
+        return new TestFrameworkRunBuilder();
+    }
+
+    private Collection<URL> prerequisites;
+    private Collection<URL> tests;
+    private String location;
+    private Multimap<String, String> locationAliases;
+
+    public TestFrameworkRun(Collection<URL> prerequisites,
+            Collection<URL> tests,
+            String location,
+            Multimap<String, String> locationAliases) {
+        this.prerequisites = prerequisites;
+        this.tests = tests;
+        this.location = location;
+        this.locationAliases = locationAliases;
+    }
+
+    public Collection<URL> prerequisites() {
+        return prerequisites;
+    }
+    public Collection<URL> tests() {
+        return tests;
+    }
+    public String location() {
+        return location;
+    }
+    public Multimap<String, String> locationAliases() {
+        return locationAliases;
+    }
+    
+    @Override
+    public String toString() {
+        return tests.toString() + "@" + location;
+    }
+}

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkSuiteBuilder.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/live/TestFrameworkSuiteBuilder.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework.live;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.brooklyn.test.framework.live.TestFrameworkRun.TestFrameworkRunBuilder;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+
+public class TestFrameworkSuiteBuilder {
+    private static final Logger log = LoggerFactory.getLogger(TestFrameworkSuiteBuilder.class);
+    
+    public static class TestFrameworkGroupBuilder {
+        private TestFrameworkSuiteBuilder testFrameworkSuiteBuilder;
+        private TestFrameworkGroupBuilder(TestFrameworkSuiteBuilder testFrameworkSuiteBuilder) {
+            this.testFrameworkSuiteBuilder = testFrameworkSuiteBuilder;
+        }
+
+        private MutableList<URL> prerequisites = MutableList.of();
+        private MutableList<URL> tests = MutableList.of();
+        private MutableList<String> clouds = MutableList.of();
+        private MutableList<String> distributions = MutableList.of();
+        private Multimap<String, String> locationAliases = ArrayListMultimap.create();
+        private MutableList<String> locations = MutableList.of();
+
+        /**
+         * Adds a resource reference to load generic catalog items from.
+         * @param value points to a generic catalog bom resource. Could
+         * be of any type, including locations.
+         */
+        public TestFrameworkGroupBuilder prerequisite(URL value) {
+            prerequisites.add(checkNotNull(value, "value"));
+            return this;
+        }
+        /**
+         * Adds a resource reference to load catalog items from
+         * @param resource points to a resource on the class path
+         *                 visible to the brooklyn-test-framework bundle.
+         */
+        // TODO Support for OSGi (pass in a class from the bundle?)
+        public TestFrameworkGroupBuilder prerequisiteResource(String resource) {
+            return prerequisite(getResourceUrl(resource));
+        }
+        /**
+         * Removes all previously added prerequisites.
+         */
+        public TestFrameworkGroupBuilder prerequisitesClear() {
+            prerequisites.clear();
+            return this;
+        }
+        /**
+         * Adds resource references to load catalog items from.
+         * @param value elements point to catalog bom resources.
+         */
+        public TestFrameworkGroupBuilder prerequisites(Iterable<URL> value) {
+            Iterables.addAll(prerequisites, checkNotNull(value, "value"));
+            return this;
+        }
+        /**
+         * Adds a resource reference to load test catalog items from.
+         * @param value points to a test catalog bom resource. The items
+         *              in the resource will be use to launch tests with.
+         *              This includes the catalog items from any included catalogs.
+         */
+        public TestFrameworkGroupBuilder test(URL value) {
+            tests.add(value);
+            return this;
+        }
+        /**
+         * Removes all previously added test resources.
+         */
+        public TestFrameworkGroupBuilder testsClear() {
+            tests.clear();
+            return this;
+        }
+        /**
+         * Adds resource references to load test catalog items from.
+         * @param value elements point to test catalog bom resources.
+         *              The catalog items in the resource will be use to launch tests with.
+         *              This includes the catalog items from any included catalogs.
+         */
+        public TestFrameworkGroupBuilder tests(Iterable<URL> value) {
+            Iterables.addAll(tests, checkNotNull(value, "value"));
+            return this;
+        }
+        /**
+         * Adds a resource reference to load test catalog items from.
+         * @param resource points to a test resource on the class path
+         *                 visible to the brooklyn-test-framework bundle.
+         */
+        // TODO Support for OSGi (pass in a class from the bundle?)
+        public TestFrameworkGroupBuilder testResource(String resource) {
+            return test(getResourceUrl(resource));
+        }
+        /**
+         * Adds a cloud to the testing matrix. Assumes location boms on disk
+         * follow the "cloud:distribution.bom" naming format.
+         */
+        public TestFrameworkGroupBuilder cloud(String value) {
+            clouds.add(value);
+            return this;
+        }
+        /**
+         * Removes all previously added clouds.
+         */
+        public TestFrameworkGroupBuilder clouds() {
+            clouds.clear();
+            return this;
+        }
+        /**
+         * Adds the clouds passed as argument to the testing matrix.
+         * Assumes location boms on disk follow the "cloud:distribution.bom" naming format.
+         */
+        public TestFrameworkGroupBuilder clouds(Iterable<String> value) {
+            Iterables.addAll(clouds, checkNotNull(value, "value"));
+            return this;
+        }
+        /**
+         * Adds a distribution to the testing matrix. Assumes location boms on disk
+         * follow the "cloud:distribution.bom" naming format.
+         */
+        public TestFrameworkGroupBuilder distribution(String value) {
+            distributions.add(value);
+            return this;
+        }
+        /**
+         * Removes all previously added distributions.
+         */
+        public TestFrameworkGroupBuilder distributionClear() {
+            distributions.clear();
+            return this;
+        }
+        /**
+         * Adds the distributions passed as an argument to the testing matrix.
+         * Assumes location boms on disk follow the "cloud:distribution.bom" naming format.
+         */
+        public TestFrameworkGroupBuilder distributions(Iterable<String> value) {
+            Iterables.addAll(distributions, checkNotNull(value, "value"));
+            return this;
+        }
+        /**
+         * Adds a location -> alias pair. When executing the test the location will
+         * be made available under the {@code alias} ID to the running test.
+         */
+        public TestFrameworkGroupBuilder locationAlias(String location, String alias) {
+            locationAliases.put(
+                    checkNotNull(location, "location"),
+                    checkNotNull(alias, "alias"));
+            return this;
+        }
+        /**
+         * Removes all previously added location->alias pairs.
+         */
+        public TestFrameworkGroupBuilder locationAliasesClear() {
+            locationAliases.clear();
+            return this;
+        }
+        /**
+         * Adds the location -> alias pairs. When executing the test the locations (the map keys)
+         * will be made available under the alias ID (the map values) to the running test.
+         */
+        public TestFrameworkGroupBuilder locationAliases(Map<String, String> aliases) {
+            checkNotNull(aliases, "aliases");
+            for (Entry<String, String> alias : aliases.entrySet()) {
+                locationAliases.put(alias.getKey(), alias.getValue());
+            }
+            return this;
+        }
+        /**
+         * Adds a location to execute the test against. Before
+         * starting a test run the code will load the
+         * location from the location.bom file if one exists.
+         */
+        public TestFrameworkGroupBuilder location(String value) {
+            locations.add(value);
+            return this;
+        }
+        /**
+         * Removes all previously added locations.
+         */
+        public TestFrameworkGroupBuilder locationsClear() {
+            locations.clear();
+            return this;
+        }
+        /**
+         * Adds locations to execute the test against (once per location).
+         * Before starting a test run the code will load the location
+         * from the location.bom file if one exists.
+         */
+        public TestFrameworkGroupBuilder locations(Iterable<String> value) {
+            Iterables.addAll(locations, value);
+            return this;
+        }
+
+        /**
+         * Creates a list of tests corresponding to the arguments passed to the
+         * builder. Adds the cartesion product of all cloud + distribution pairs, 
+         * concatenating them like "<cloud>:<distribution>" and adds the result
+         * to the test locations. For each resulting location adds an element to
+         * the returned list.
+         */
+        public Collection<TestFrameworkRun> build() {
+            MutableList<TestFrameworkRun> runs = MutableList.of();
+            Collection<String> allLocations = MutableList.of();
+            for (String cloud : clouds) {
+                for (String dist : distributions) {
+                    // TODO add a generic template for the location names to handle custom schemes.
+                    allLocations.add(dist + ":" + cloud);
+                }
+            }
+            allLocations.addAll(locations);
+            for (String location : allLocations) {
+                runs.add(TestFrameworkRun.builder()
+                    .prerequisites(getLocationResources(ImmutableList.of(location)))
+                    .prerequisites(getLocationResources(locationAliases.keySet()))
+                    .prerequisites(prerequisites)
+                    .tests(tests)
+                    // Handles locations with file names using ':' delimiter, but 
+                    // using '_' for the ID.
+                    // TODO add a generic file name -> ID transformer to handle custom schemes.
+                    .location(location.replace(":", "_"))
+                    // TODO Transform the aliases keys in a similar way to the locations
+                    .locationAliases(locationAliases)
+                    .build());
+            }
+            return runs.asImmutableCopy();
+        }
+
+        private URL getResourceUrl(String resource) {
+            checkNotNull(resource, "resource");
+            URL url = getClass().getClassLoader().getResource(resource);
+            checkNotNull(url, "resource url for " + resource);
+            return url;
+        }
+
+        private Collection<URL> getLocationResources(Collection<String> locations) {
+            if (testFrameworkSuiteBuilder.locationsFolder != null) {
+                MutableList<URL> resources = MutableList.of();
+                for (String location : locations) {
+                    File locationBom = new File(testFrameworkSuiteBuilder.locationsFolder, location + ".bom");
+                    if (locationBom.exists()) {
+                        try {
+                            resources.add(locationBom.toURI().toURL());
+                        } catch (MalformedURLException e) {
+                            throw new IllegalStateException("Could not conert the path " + locationBom.getAbsolutePath() + " to URL", e);
+                        }
+                    } else {
+                        log.info("Locationn file {} not found in {}. Assuming it's a location provided by the environment.",
+                                location, testFrameworkSuiteBuilder.locationsFolder);
+                    }
+                }
+                return resources.asImmutableCopy();
+            } else {
+                return ImmutableList.of();
+            }
+        }
+
+        public TestFrameworkSuiteBuilder add() {
+            testFrameworkSuiteBuilder.tests.addAll(build());
+            return testFrameworkSuiteBuilder;
+        }
+    }
+
+    private Collection<TestFrameworkRun> tests = MutableList.of();
+    private File locationsFolder;
+
+    public static TestFrameworkSuiteBuilder create() {
+        return new TestFrameworkSuiteBuilder();
+    }
+    
+    private TestFrameworkSuiteBuilder() {
+        String locations = System.getProperty("test.framework.locations");
+        if (locations != null) {
+            locationsFolder = new File(locations);
+        }
+    }
+    
+    /**
+     * Create a new test builder to describe a test run with.
+     * Add to the test suite with {@link TestFrameworkRunBuilder#add}.
+     */
+    public TestFrameworkGroupBuilder test() {
+        return new TestFrameworkGroupBuilder(this);
+    }
+    
+    /**
+     * Sets the folder to look for location boms in.
+     * Defaults to the "test.framework.locations" system property.
+     */
+    public TestFrameworkSuiteBuilder locationsFolder(File locationsFolder) {
+        this.locationsFolder = checkNotNull(locationsFolder, "locationsFolder");
+        return this;
+    }
+    
+    /**
+     * Sets the folder to look for location boms in.
+     * Defaults to the "test.framework.locations" system property.
+     */
+    public TestFrameworkSuiteBuilder locationsFolder(String locationsFolder) {
+        return locationsFolder(new File(checkNotNull(locationsFolder, "locationsFolder")));
+    }
+    
+    /**
+     * Returns the list of all tests created in the suite.
+     * To pause a test run on failure (don't tear down) specify
+     * "test.framework.interactive=true" as a system property.
+     */
+    public Collection<TestFrameworkRun> build() {
+        return ImmutableList.copyOf(tests);
+    }
+    
+    /**
+     * Same as {@link #build()} but returns a value suitable for a TestNG data provider.
+     */
+    public Object[][] buildProvider() {
+        Object[][] runs = new Object[tests.size()][];
+        int i = 0;
+        for (TestFrameworkRun test : tests) {
+            runs[i] = new Object[] {test};
+            i++;
+        }
+        return runs;
+    }
+}

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/yaml/SimpleTestFrameworkTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/yaml/SimpleTestFrameworkTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.framework.yaml;
+
+import org.apache.brooklyn.test.framework.live.TestFrameworkLiveTest;
+import org.apache.brooklyn.test.framework.live.TestFrameworkRun;
+import org.apache.brooklyn.test.framework.live.TestFrameworkSuiteBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SimpleTestFrameworkTest extends TestFrameworkLiveTest {
+
+    @DataProvider
+    @Override
+    public Object[][] tests() {
+        return TestFrameworkSuiteBuilder.create()
+            // Can be set on the command line with -Dtest.framework.locations=... to load locations used in the tests
+            // .locationsFolder("<path to>/locations")
+            .test()
+                .prerequisiteResource("test-framework-examples/simple-catalog.bom")
+                .prerequisiteResource("test-framework-examples/simple-catalog.locations.bom")
+                .testResource("test-framework-examples/simple-catalog.tests.bom")
+                .location("simple-entity-dummy")
+                .add()
+            .buildProvider();
+    }
+
+    // Set the system property "test.framework.interactive" to true to pause
+    // execution (don't tear down) on failure.
+    @Test(dataProvider="tests", groups="Integration")
+    public void runTestFrameworkTest(TestFrameworkRun testRun) {
+        super.runTestFrameworkTest(testRun);
+    }
+
+}

--- a/test-framework/src/test/resources/test-framework-examples/simple-catalog.bom
+++ b/test-framework/src/test/resources/test-framework-examples/simple-catalog.bom
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  id: simple-entity
+  version: "1.0"
+  itemType: entity
+  license: Apache-2.0
+  item:
+    brooklyn.config:
+      simple.confg: someValue
+    services:
+    - type: org.apache.brooklyn.entity.stock.BasicEntity
+      name: simple
+      brooklyn.initializers:
+      - type: org.apache.brooklyn.core.sensor.StaticSensor
+        brooklyn.config:
+          name: service.isUp
+          static.value: true
+          targetType: boolean

--- a/test-framework/src/test/resources/test-framework-examples/simple-catalog.locations.bom
+++ b/test-framework/src/test/resources/test-framework-examples/simple-catalog.locations.bom
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: "1.0"
+  itemType: location
+  items:
+  - id: simple-entity-dummy
+    item:
+      type: byon
+      brooklyn.config:
+        user: brooklyn
+        hosts:
+        - address: 127.0.0.1
+          privateAddresses: ["127.0.0.1"]
+          ssh: amp@127.0.0.1:22
+

--- a/test-framework/src/test/resources/test-framework-examples/simple-catalog.tests.bom
+++ b/test-framework/src/test/resources/test-framework-examples/simple-catalog.tests.bom
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  id: simple-entity-test
+  version: "1.0"
+  itemType: entity
+  name: Simple Entity Test
+  license: Apache-2.0
+  item:
+    type: org.apache.brooklyn.test.framework.TestCase
+    name: Simple Entity Tests
+    brooklyn.children:
+    - type: simple-entity
+      id: simple
+    - type: org.apache.brooklyn.test.framework.TestSensor
+      target: $brooklyn:entity("simple")
+      sensor: service.isUp
+      timeout: 10m
+      assert:
+      - equals: true


### PR DESCRIPTION
Useful for running the test framework tests as live tests on the project.

From the test included in the PR, example usage:
```
    TestFrameworkSuiteBuilder.create()
            .test()
                .prerequisiteResource("test-framework-examples/simple-catalog.bom")
                .prerequisiteResource("test-framework-examples/simple-catalog.locations.bom")
                .testResource("test-framework-examples/simple-catalog.tests.bom")
                .location("simple-entity-dummy")
                .add()
            .buildProvider();
```