### PR TITLE
Disabled AUTO_WRAP_CATALOG_YAML_AS_BUNDLE

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -128,7 +128,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     /** Header on bundle indicating it is a wrapped BOM with no other resources */
     public static final String BROOKLYN_WRAPPED_BOM_BUNDLE = "Brooklyn-Wrapped-BOM";
     @VisibleForTesting
-    public static final boolean AUTO_WRAP_CATALOG_YAML_AS_BUNDLE = true;
+    public static final boolean AUTO_WRAP_CATALOG_YAML_AS_BUNDLE = false;
     
     private static final Logger log = LoggerFactory.getLogger(BasicBrooklynCatalog.class);
 


### PR DESCRIPTION
There is currently a bug in brooklyn-server surrounding auto wrap. Under certain conditions, templates which have been added to brooklyn are not able to be deployed. 

I am still investigating the issue, but have raised a PR to open a discussion about turning off temporarily whilst we investigate the issue.