### PR TITLE
Adds cluster.max.size to dynamic cluster

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -183,6 +183,8 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
             "Time to wait (after members' start() effectors return) for SERVICE_UP before failing (default is not to wait)",
             null);
 
+    ConfigKey<Integer> MAX_SIZE = ConfigKeys.newIntegerConfigKey("cluster.max.size", "Size after which it will throw InsufficientCapacityException", Integer.MAX_VALUE);
+
     @Beta
     @SetFromFlag("maxConcurrentChildCommands")
     ConfigKey<Integer> MAX_CONCURRENT_CHILD_COMMANDS = ConfigKeys.builder(Integer.class)

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -595,6 +595,10 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
     @Override
     public Integer resize(Integer desiredSize) {
         synchronized (mutex) {
+            Optional<Integer> optionalMaxSize = Optional.fromNullable(config().get(MAX_SIZE));
+            if (optionalMaxSize.isPresent() && desiredSize > optionalMaxSize.get()) {
+                throw new Resizable.InsufficientCapacityException("Desired cluster size " + desiredSize + " exceeds maximum size of " + optionalMaxSize.get());
+            }
             int originalSize = getCurrentSize();
             int delta = desiredSize - originalSize;
             if (delta != 0) {

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestClusterImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestClusterImpl.java
@@ -59,7 +59,7 @@ public class TestClusterImpl extends DynamicClusterImpl implements TestCluster {
     @Override
     public Integer resize(Integer desiredSize) {
         desiredSizeHistory.add(desiredSize);
-        int achievableSize = Math.min(desiredSize, getConfig(MAX_SIZE));
+        int achievableSize = Math.min(desiredSize, getConfig(TestCluster.MAX_SIZE));
         
         if (achievableSize != size) {
             this.sizeHistory.add(achievableSize);
@@ -67,7 +67,7 @@ public class TestClusterImpl extends DynamicClusterImpl implements TestCluster {
         }
         
         if (desiredSize > achievableSize) {
-            throw new InsufficientCapacityException("Simulating insufficient capacity (desiredSize="+desiredSize+"; maxSize="+getConfig(MAX_SIZE)+"; newSize="+size+")");
+            throw new InsufficientCapacityException("Simulating insufficient capacity (desiredSize="+desiredSize+"; maxSize="+getConfig(TestCluster.MAX_SIZE)+"; newSize="+size+")");
         }
 
         return size;


### PR DESCRIPTION
Adds cluster.max.size to dynamic cluster, and prevents the cluster from being manually increased beyond that size