### PR TITLE
Modify jcloudsLocation.releaseNode

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -522,7 +522,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
     @Override
     public void killMachine(String cloudServiceId) {
-        getComputeService().destroyNode(cloudServiceId);
+        // FIXME revert to computeService.destroyNode(cloudServiceId); once JCLOUDS-1332 gets fixed
+        Set<? extends NodeMetadata> destroyed = getComputeService().destroyNodesMatching(withIds(cloudServiceId));
+        LOG.debug("Destroyed nodes %s%n", destroyed);
     }
 
     @Override

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvis;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 import static org.apache.brooklyn.util.ssh.BashCommands.sbinPath;
+import static org.jclouds.compute.predicates.NodePredicates.*;
 import static org.jclouds.util.Throwables2.getFirstThrowableOfType;
 
 import java.io.ByteArrayOutputStream;
@@ -145,6 +146,7 @@ import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.domain.TemplateBuilder;
 import org.jclouds.compute.options.TemplateOptions;
+import org.jclouds.compute.predicates.NodePredicates;
 import org.jclouds.domain.Credentials;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.domain.LoginCredentials;
@@ -2183,10 +2185,13 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
     }
 
     protected void releaseNode(String instanceId) {
-        ComputeService computeService = null;
+        ComputeService computeService;
         try {
             computeService = getComputeService(config().getBag());
-            computeService.destroyNode(instanceId);
+            // FIXME revert to computeService.destroyNode(instanceId); once JCLOUDS-1332 gets fixed
+            Set<? extends NodeMetadata> destroyed = computeService.destroyNodesMatching(withIds(instanceId));
+            LOG.debug("Destroyed nodes %s%n", destroyed);
+
         } finally {
         /*
             // we don't close the compute service; this means if we provision add'l it is fast;

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/StubbedComputeServiceRegistry.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/StubbedComputeServiceRegistry.java
@@ -37,16 +37,18 @@ import org.jclouds.domain.LoginCredentials;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class StubbedComputeServiceRegistry implements ComputeServiceRegistry {
 
-    public static interface NodeCreator {
-        public Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException;
-        public void destroyNode(String id);
-        public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<? super NodeMetadata> filter);
-        public NodeMetadata getCreatedNode(String nodeId);
+    public interface NodeCreator {
+        Set<? extends NodeMetadata> createNodesInGroup(String group, int count, Template template) throws RunNodesException;
+        void destroyNode(String id);
+        Set<? extends NodeMetadata> destroyNodesMatching(Predicate<? super NodeMetadata> filter);
+        Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<? super NodeMetadata> filter);
+        NodeMetadata getCreatedNode(String nodeId);
     }
 
     public static abstract class AbstractNodeCreator implements NodeCreator {
@@ -67,6 +69,14 @@ public class StubbedComputeServiceRegistry implements ComputeServiceRegistry {
         public void destroyNode(String id) {
             destroyed.add(id);
         }
+
+        @Override
+        public Set<? extends NodeMetadata> destroyNodesMatching(Predicate<? super NodeMetadata> filter) {
+            NodeMetadata only = Iterables.get(created, 0);
+            destroyed.add(only.getId());
+            return ImmutableSet.of(only);
+        }
+        
         @Override
         public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<? super NodeMetadata> filter) {
             return ImmutableSet.of();
@@ -169,6 +179,12 @@ public class StubbedComputeServiceRegistry implements ComputeServiceRegistry {
         public void destroyNode(String id) {
             nodeCreator.destroyNode(id);
         }
+
+        @Override
+        public Set<? extends NodeMetadata> destroyNodesMatching(Predicate<? super NodeMetadata> filter) {
+            return nodeCreator.destroyNodesMatching(filter);
+        }
+
         @Override
         public Set<? extends NodeMetadata> listNodesDetailsMatching(Predicate<? super NodeMetadata> filter) {
             return nodeCreator.listNodesDetailsMatching(filter);


### PR DESCRIPTION
Workaround waiting for a fix for https://issues.apache.org/jira/browse/JCLOUDS-1332

Uses `destroyNodesMatchingId` instead of `destroyNode` as it consistently invokes `cleanUpIncidentalResourcesOfDeadNodes`