### PR TITLE
BROOKLYN-528: same proxy class for all entities of type

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/ClassLoaderCache.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/ClassLoaderCache.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs.proxy;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.brooklyn.util.javalang.AggregateClassLoader;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+/**
+ * For getting/creating {@link AggregateClassLoader} for an entity proxy. The returned class loader
+ * can be used when calling {@link java.lang.reflect.Proxy#newProxyInstance(ClassLoader, Class[], java.lang.reflect.InvocationHandler)}.
+ * 
+ * The classloader is created with references to ClassLoaders for the given class and interfaces
+ * (including all super-classes and super-interfaces of those). Also see comment in
+ * {@link InternalEntityFactory#createEntityProxy(Iterable, org.apache.brooklyn.api.entity.Entity)}.
+ * 
+ * If a classloader has already been created for the given class+interfaces, then it guarantees
+ * to return that same classloader instance. This is very important when using {@code newProxyInstance}
+ * because if a different ClassLoader instance is used then it will reflectively create a new Proxy class.
+ * See https://issues.apache.org/jira/browse/BROOKLYN-528.
+ */
+class ClassLoaderCache {
+
+    // TODO Should TypesKey use WeakReferences for the classes (e.g. so that if bundle is unloaded, 
+    // karaf can eventually get rid of it)? But not as simple as that - the map's value 
+    // (the AggregateClassLoader) will also reference the class.
+
+    private final ConcurrentMap<TypesKey, AggregateClassLoader> cache = Maps.newConcurrentMap();
+    
+    public AggregateClassLoader getClassLoaderForProxy(Class<?> clazz, Set<Class<?>> interfaces) {
+        TypesKey typesKey = new TypesKey(clazz, interfaces);
+        AggregateClassLoader result = cache.get(typesKey);
+        if (result == null) {
+            result = newClassLoader(clazz, interfaces);
+            AggregateClassLoader oldVal = cache.putIfAbsent(typesKey, result);
+            if (oldVal != null) result = oldVal;
+        }
+        return result;
+    }
+    
+    private AggregateClassLoader newClassLoader(Class<?> clazz, Set<Class<?>> interfaces) {
+        Set<ClassLoader> loaders = Sets.newLinkedHashSet();
+        addClassLoaders(clazz, loaders);
+        for (Class<?> iface : interfaces) {
+            loaders.add(iface.getClassLoader());
+        }
+
+        AggregateClassLoader aggregateClassLoader =  AggregateClassLoader.newInstanceWithNoLoaders();
+        for (ClassLoader cl : loaders) {
+            aggregateClassLoader.addLast(cl);
+        }
+        
+        return aggregateClassLoader;
+    }
+    
+    private void addClassLoaders(Class<?> type, Set<ClassLoader> loaders) {
+        ClassLoader cl = type.getClassLoader();
+
+        //java.lang.Object.getClassLoader() == null
+        if (cl != null) {
+            loaders.add(cl);
+        }
+
+        Class<?> superType = type.getSuperclass();
+        if (superType != null) {
+            addClassLoaders(superType, loaders);
+        }
+        for (Class<?> iface : type.getInterfaces()) {
+            addClassLoaders(iface, loaders);
+        }
+    }
+    
+    /**
+     * Uses weak references for the class/interface references.
+     */
+    private static class TypesKey {
+        final Class<?> type;
+        final Set<Class<?>> interfaces;
+        
+        public TypesKey(Class<?> type, Set<Class<?>> interfaces) {
+            this.type = checkNotNull(type, "type");
+            this.interfaces = ImmutableSet.copyOf(checkNotNull(interfaces, "interfaces"));
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(type, interfaces);
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TypesKey)) return false;
+            TypesKey o = (TypesKey) obj;
+            return Objects.equal(type, o.type) && Objects.equal(interfaces, o.interfaces);
+        }
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/objs/proxy/ClassLoaderCacheTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/objs/proxy/ClassLoaderCacheTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs.proxy;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+import java.util.Set;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.test.entity.TestEntityImpl;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.entity.stock.BasicEntityImpl;
+import org.apache.brooklyn.util.javalang.AggregateClassLoader;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+
+public class ClassLoaderCacheTest {
+
+    private ClassLoaderCache cache;
+
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        cache = new ClassLoaderCache();
+    }
+    
+    @Test
+    public void testSameLoader() throws Exception {
+        Class<BasicEntityImpl> clazz = BasicEntityImpl.class;
+        ImmutableSet<Class<? extends Object>> interfaces = ImmutableSet.of(EntityProxy.class, Entity.class, EntityInternal.class, BasicEntity.class);
+        
+        AggregateClassLoader loader = cache.getClassLoaderForProxy(clazz, interfaces);
+        assertLoader(loader, Iterables.concat(ImmutableList.of(clazz), interfaces));
+        
+        AggregateClassLoader loader2 = cache.getClassLoaderForProxy(clazz, interfaces);
+        assertSame(loader, loader2);
+    }
+    
+    @Test
+    public void testDifferentLoader() throws Exception {
+        Class<BasicEntityImpl> clazz = BasicEntityImpl.class;
+        Set<Class<?>> interfaces = ImmutableSet.of(EntityProxy.class, Entity.class, EntityInternal.class, BasicEntity.class);
+        AggregateClassLoader loader = cache.getClassLoaderForProxy(clazz, interfaces);
+        assertLoader(loader, Iterables.concat(ImmutableList.of(clazz), interfaces));
+
+        Class<TestEntityImpl> clazz2 = TestEntityImpl.class;
+        Set<Class<?>> interfaces2 = ImmutableSet.of(EntityProxy.class, Entity.class, EntityInternal.class, TestEntity.class);
+        AggregateClassLoader loader2 = cache.getClassLoaderForProxy(clazz2, interfaces2);
+        assertLoader(loader2, Iterables.concat(ImmutableList.of(clazz2), interfaces2));
+        assertNotSame(loader, loader2);
+    }
+    
+    private void assertLoader(ClassLoader loader, Iterable<? extends Class<?>> clazzes) throws Exception {
+        assertNotNull(loader);
+        for (Class<?> clazz : clazzes) {
+            loader.loadClass(clazz.getName());
+        }
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/EntityPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/EntityPerformanceTest.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.performance.PerformanceTestDescriptor;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -67,6 +68,23 @@ public class EntityPerformanceTest extends AbstractPerformanceTest {
         return 1000;
     }
     
+     @Test(groups={"Integration", "Acceptance"})
+     public void testCreateAndDeleteApp() {
+         int numIterations = numIterations();
+         double minRatePerSec = 100 * PERFORMANCE_EXPECTATION;
+         
+         measure(PerformanceTestDescriptor.create()
+                 .summary("EntityPerformanceTest.testUpdateAttributeWhenNoListeners")
+                 .iterations(numIterations)
+                 .minAcceptablePerSecond(minRatePerSec)
+                 .job(new Runnable() {
+                     @Override
+                     public void run() {
+                         BasicApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+                         app.stop();
+                     }}));
+     }
+
     @Test(groups={"Integration", "Acceptance"})
     public void testUpdateAttributeWhenNoListeners() {
         int numIterations = numIterations();


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BROOKLYN-528

As well as fixing the space leak and decreasing the memory usage, this improves performance of entity creation from about 90 per second to about 230 per second (on my laptop).