### PR TITLE
fix npe that can occur with WinRM when no subnet IP

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsWinRmMachineLocation.java
@@ -275,7 +275,10 @@ public class JcloudsWinRmMachineLocation extends WinRmMachineLocation implements
         if (privateAddress.isPresent()) {
             return privateAddress.get();
         }
-        if (groovyTruth(node.getPublicAddresses())) {
+        if (groovyTruth(publicAddresses)) {
+            return publicAddresses.iterator().next();
+        }
+        if (node!=null && groovyTruth(node.getPublicAddresses())) {
             return node.getPublicAddresses().iterator().next();
         }
         return null;


### PR DESCRIPTION
do a better job of returning public IP but above all don't NPE