### PR TITLE
use external config in examples

### DIFF
--- a/camp/camp-brooklyn/src/test/resources/java-web-app-and-db-with-function-2.yaml
+++ b/camp/camp-brooklyn/src/test/resources/java-web-app-and-db-with-function-2.yaml
@@ -19,7 +19,7 @@
 name: java-cluster-db-example
 location: localhost
 services:
-- serviceType: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+- type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   name: My Web
   brooklyn.config:
     wars.root: http://search.maven.org/remotecontent?filepath=io/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.6.0-M2/brooklyn-example-hello-world-sql-webapp-0.6.0-M2.war
@@ -29,13 +29,14 @@ services:
       brooklyn.example.db.url: 
         # alternate syntax
         $brooklyn:formatString:
-        - jdbc:%s%s?user=%s\&password=%s
+        - jdbc:%s%s?user=%s&password=%s
         - $brooklyn:component("db").attributeWhenReady("datastore.url")
         - visitors
         - brooklyn
-        - br00k11n
-- serviceType: org.apache.brooklyn.entity.database.mysql.MySqlNode
+        - $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
+- type: org.apache.brooklyn.entity.database.mysql.MySqlNode
   name: My DB
   id: db
   brooklyn.config:
+    creation.script.password: $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
     datastore.creation.script.url: classpath://visitors-creation-script.sql

--- a/camp/camp-brooklyn/src/test/resources/java-web-app-and-db-with-function.yaml
+++ b/camp/camp-brooklyn/src/test/resources/java-web-app-and-db-with-function.yaml
@@ -18,7 +18,7 @@
 #
 name: java-cluster-db-example
 services:
-- serviceType: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+- type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   name: My Web
   location: localhost
   brooklyn.config:
@@ -27,10 +27,11 @@ services:
     proxy.http.port: 9210+
     java.sysprops: 
       brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",
-         component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
-- serviceType: org.apache.brooklyn.entity.database.mysql.MySqlNode
+         component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", external("brooklyn-demo-sample", "hidden-brooklyn-password"))
+- type: org.apache.brooklyn.entity.database.mysql.MySqlNode
   id: db
   name: My DB
   location: localhost
   brooklyn.config:
+    creation.script.password: $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
     datastore.creation.script.url: classpath://visitors-creation-script.sql

--- a/camp/camp-brooklyn/src/test/resources/test-java-web-app-spec-and-db-with-function.yaml
+++ b/camp/camp-brooklyn/src/test/resources/test-java-web-app-spec-and-db-with-function.yaml
@@ -19,7 +19,7 @@
 name: java-cluster-db-example
 location: localhost
 services:
-- serviceType: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+- type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   name: My Web
   brooklyn.config:
     proxy.http.port: 9210+
@@ -31,9 +31,10 @@ services:
         wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
         java.sysprops: 
           brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s",
-             component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
-- serviceType: org.apache.brooklyn.entity.database.mysql.MySqlNode
+             component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password"))
+- type: org.apache.brooklyn.entity.database.mysql.MySqlNode
   id: db
   name: My DB
   brooklyn.config:
+    creation.script.password: $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
     datastore.creation.script.url: classpath://visitors-creation-script.sql

--- a/camp/camp-brooklyn/src/test/resources/visitors-creation-script.sql
+++ b/camp/camp-brooklyn/src/test/resources/visitors-creation-script.sql
@@ -19,17 +19,21 @@
 create database visitors;
 use visitors;
 
-# not necessary to create user if we grant (and not supported in some dialects)
-create user 'brooklyn' identified by 'br00k11n';
 
-grant usage on *.* to 'brooklyn'@'%' identified by 'br00k11n';
-
-# ''@localhost is sometimes set up, overriding brooklyn@'%', so do a second explicit grant
-grant usage on *.* to 'brooklyn'@'localhost' identified by 'br00k11n';
-
+# the below will create user (and note create user not supported in some dialects)
+grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]}';
 grant all privileges on visitors.* to 'brooklyn'@'%';
+# useful if sockets work also
+grant all privileges on visitors.* to 'brooklyn'@'localhost';
+
+# drop the anonymous users eg ''@'localhost' and sometimes other local hostnames
+# (necessary for same-host access as these are more restrictive rules that trump the wildcard above)
+delete from mysql.user where User='';
 
 flush privileges;
+
+
+# and now the table for visitors
 
 CREATE TABLE MESSAGES (
         id BIGINT NOT NULL AUTO_INCREMENT,

--- a/camp/camp-brooklyn/src/test/resources/visitors-creation-script.sql
+++ b/camp/camp-brooklyn/src/test/resources/visitors-creation-script.sql
@@ -21,7 +21,9 @@ use visitors;
 
 
 # the below will create user (and note create user not supported in some dialects)
-grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]}';
+# default password specified for compatibility with older blueprints that don't provide config;
+# if your blueprint sets the password it can be removed here
+grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]!"br00k11n"}';
 grant all privileges on visitors.* to 'brooklyn'@'%';
 # useful if sockets work also
 grant all privileges on visitors.* to 'brooklyn'@'localhost';

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
@@ -26,7 +26,9 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.external.ExternalConfigSupplier;
+import org.apache.brooklyn.core.config.external.InPlaceExternalConfigSupplier;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -46,18 +48,26 @@ public class BasicExternalConfigSupplierRegistry implements ExternalConfigSuppli
 
     private static final Logger LOG = LoggerFactory.getLogger(BasicExternalConfigSupplierRegistry.class);
 
+    public static final String DEMO_SAMPLE_PROVIDER = "brooklyn-demo-sample";
+    public static final String DEMO_SAMPLE_PROVIDER_PASSWORD_KEY = "hidden-brooklyn-password";
+    public static final String DEMO_SAMPLE_PROVIDER_PASSWORD_VALUE = "br00k11n";
+    
     private final Map<String, ExternalConfigSupplier> providersByName = Maps.newLinkedHashMap();
     private final Object providersMapMutex = new Object();
 
     public BasicExternalConfigSupplierRegistry(ManagementContext mgmt) {
+        addProvider(DEMO_SAMPLE_PROVIDER, new InPlaceExternalConfigSupplier(mgmt, DEMO_SAMPLE_PROVIDER,
+            MutableMap.of(DEMO_SAMPLE_PROVIDER_PASSWORD_KEY, DEMO_SAMPLE_PROVIDER_PASSWORD_VALUE)));
         updateFromBrooklynProperties(mgmt);
     }
 
     @Override
     public void addProvider(String name, ExternalConfigSupplier supplier) {
         synchronized (providersMapMutex) {
-            if (providersByName.containsKey(name))
+            if (providersByName.containsKey(name) && !DEMO_SAMPLE_PROVIDER.equals(name)) {
+                // allow demo to be overridden
                 throw new IllegalArgumentException("Provider already registered with name '" + name + "'");
+            }
             providersByName.put(name, supplier);
         }
         LOG.info("Added external config supplier named '" + name + "': " + supplier);

--- a/launcher/src/test/resources/java-web-app-and-db-with-function.yaml
+++ b/launcher/src/test/resources/java-web-app-and-db-with-function.yaml
@@ -27,10 +27,11 @@ services:
     proxy.http.port: 9210+
     java.sysprops: 
       brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s",
-         component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")
+         component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password"))
 - serviceType: org.apache.brooklyn.entity.database.mysql.MySqlNode
   id: db
   name: My DB
   location: localhost
   brooklyn.config:
+    creation.script.password: $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
     creationScriptUrl: classpath://visitors-creation-script.sql

--- a/launcher/src/test/resources/visitors-creation-script.sql
+++ b/launcher/src/test/resources/visitors-creation-script.sql
@@ -19,17 +19,21 @@
 create database visitors;
 use visitors;
 
-# not necessary to create user if we grant (and not supported in some dialects)
-# create user 'brooklyn' identified by 'br00k11n';
 
-grant usage on *.* to 'brooklyn'@'%' identified by 'br00k11n';
-
-# ''@localhost is sometimes set up, overriding brooklyn@'%', so do a second explicit grant
-grant usage on *.* to 'brooklyn'@'localhost' identified by 'br00k11n';
-
+# the below will create user (and note create user not supported in some dialects)
+grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]}';
 grant all privileges on visitors.* to 'brooklyn'@'%';
+# useful if sockets work also
+grant all privileges on visitors.* to 'brooklyn'@'localhost';
+
+# drop the anonymous users eg ''@'localhost' and sometimes other local hostnames
+# (necessary for same-host access as these are more restrictive rules that trump the wildcard above)
+delete from mysql.user where User='';
 
 flush privileges;
+
+
+# and now the table for visitors
 
 CREATE TABLE MESSAGES (
         id BIGINT NOT NULL AUTO_INCREMENT,

--- a/launcher/src/test/resources/visitors-creation-script.sql
+++ b/launcher/src/test/resources/visitors-creation-script.sql
@@ -21,7 +21,9 @@ use visitors;
 
 
 # the below will create user (and note create user not supported in some dialects)
-grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]}';
+# default password specified for compatibility with older blueprints that don't provide config;
+# if your blueprint sets the password it can be removed here
+grant usage on *.* to 'brooklyn'@'%' identified by '${config["creation.script.password"]!"br00k11n"}';
 grant all privileges on visitors.* to 'brooklyn'@'%';
 # useful if sockets work also
 grant all privileges on visitors.* to 'brooklyn'@'localhost';

--- a/locations/container/src/test/resources/generic-application.tests.bom
+++ b/locations/container/src/test/resources/generic-application.tests.bom
@@ -78,7 +78,7 @@ brooklyn.catalog:
                     - $brooklyn:config("db.url")
                     - "visitors"
                     - "brooklyn"
-                    - "br00k11n"
+                    - $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
             brooklyn.enrichers:
               - type: org.apache.brooklyn.core.network.OnPublicNetworkEnricher
                 brooklyn.config:
@@ -123,6 +123,8 @@ brooklyn.catalog:
         provisioning.properties:
           osFamily: centos
           osVersionRegex: 7
+        creation.script.password: $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password")
+        # config above won't actually be used until link below updated to 0.12 or later (but values are the same so will be fine)
         datastore.creation.script.url:
           "https://raw.githubusercontent.com/apache/brooklyn-library/0.11.x/examples/simple-web-cluster/src/main/resources/visitors-creation-script.sql"
       brooklyn.enrichers:


### PR DESCRIPTION
some of our tests and examples used plain-text passwords, and this has caused some alarm when people have seen them.  we can say "you can use external but we haven't" though isn't it better if our message is "you *should* use external just like we've shown" ?

this sets up a pre-defined external provider called
`brooklyn-demo-sample` which defines `hidden-brooklyn-password` as `br00k11n`.
it can be overridden; PR to follow for docs to explain this.

i think examples elsewhere should be updated to use this wherever a plaintext password is encoded in a blueprint for anything other than the simplest teaching example (clearly caveated and linking to the docs).  i'll do the rest of the stock brooklyn ones shortly.