### PR TITLE
Added highlights to policy endpoint

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/PolicyMemento.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/PolicyMemento.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.api.mgmt.rebind.mementos;
 import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
+import org.apache.brooklyn.api.objs.HighlightTuple;
 
 /**
  * Represents the state of an policy, so that it can be reconstructed (e.g. after restarting brooklyn).
@@ -32,4 +33,6 @@ import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 public interface PolicyMemento extends Memento {
 
     Map<String, Object> getConfig();
+
+    Map<String, HighlightTuple> getHighlights();
 }

--- a/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.api.objs;
 
+import java.util.Map;
+
 import javax.annotation.Nullable;
 
 /**
@@ -50,4 +52,5 @@ public interface EntityAdjunct extends BrooklynObject {
      */
     @Nullable String getUniqueTag();
 
+    Map<String, HighlightTuple> getHighlights();
 }

--- a/api/src/main/java/org/apache/brooklyn/api/objs/HighlightTuple.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/HighlightTuple.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.api.objs;
+
+public class HighlightTuple {
+
+    private String description;
+    private long time;
+    private String taskId;
+
+    //required for JSON de-serialisation
+    private HighlightTuple(){
+
+    }
+
+    public HighlightTuple(String description, long time, String taskId) {
+        this.description = description;
+        this.time = time;
+        this.taskId = taskId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HighlightTuple that = (HighlightTuple) o;
+
+        if (time != that.time) return false;
+        if (description != null ? !description.equals(that.description) : that.description != null) return false;
+        return taskId != null ? taskId.equals(that.taskId) : that.taskId == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = description != null ? description.hashCode() : 0;
+        result = 31 * result + (int) (time ^ (time >>> 32));
+        result = 31 * result + (taskId != null ? taskId.hashCode() : 0);
+        return result;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -1228,6 +1228,7 @@ public abstract class RebindIteration {
                 policy = policyFactory.constructPolicy(policyClazz);
                 FlagUtils.setFieldsFromFlags(ImmutableMap.of("id", id), policy);
                 ((AbstractPolicy)policy).setManagementContext(managementContext);
+                ((AbstractPolicy)policy).setHighlights(memento.getHighlights());
 
             } else {
                 LOG.warn("Deprecated rebind of policy without no-arg constructor; " +

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicPolicyMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicPolicyMemento.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.rebind.mementos.PolicyMemento;
+import org.apache.brooklyn.api.objs.HighlightTuple;
 import org.apache.brooklyn.core.config.Sanitizer;
 
 import com.google.common.base.MoreObjects;
@@ -42,14 +43,19 @@ public class BasicPolicyMemento extends AbstractMemento implements PolicyMemento
 
     public static class Builder extends AbstractMemento.Builder<Builder> {
         protected Map<String,Object> config = Maps.newLinkedHashMap();
+        protected Map<String,HighlightTuple> highlights = Maps.newLinkedHashMap();
         
         public Builder from(PolicyMemento other) {
             super.from(other);
             config.putAll(other.getConfig());
+            highlights.putAll(other.getHighlights());
             return this;
         }
         public Builder config(Map<String,?> vals) {
             config.putAll(vals); return this;
+        }
+        public Builder highlights(Map<String,HighlightTuple> vals) {
+            highlights.putAll(vals); return this;
         }
         public PolicyMemento build() {
             return new BasicPolicyMemento(this);
@@ -58,6 +64,7 @@ public class BasicPolicyMemento extends AbstractMemento implements PolicyMemento
     
     private Map<String,Object> config;
     private Map<String, Object> fields;
+    private Map<String, HighlightTuple> highlights;
 
     @SuppressWarnings("unused") // For deserialisation
     private BasicPolicyMemento() {}
@@ -66,6 +73,7 @@ public class BasicPolicyMemento extends AbstractMemento implements PolicyMemento
     protected BasicPolicyMemento(Builder builder) {
         super(builder);
         config = toPersistedMap(builder.config);
+        highlights = toPersistedMap(builder.highlights);
     }
     
     @Deprecated
@@ -84,9 +92,14 @@ public class BasicPolicyMemento extends AbstractMemento implements PolicyMemento
     public Map<String, Object> getConfig() {
         return fromPersistedMap(config);
     }
-    
+
+    @Override
+    public Map<String, HighlightTuple> getHighlights() {
+        return highlights;
+    }
+
     @Override
     protected MoreObjects.ToStringHelper newVerboseStringHelper() {
-        return super.newVerboseStringHelper().add("config", Sanitizer.sanitize(getConfig()));
+        return super.newVerboseStringHelper().add("config", Sanitizer.sanitize(getConfig())).add("highlights", highlights);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementosGenerators.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementosGenerators.java
@@ -259,7 +259,9 @@ public class MementosGenerators {
             Object value = configValueToPersistable(entry.getValue(), policy, key.getName());
             builder.config.put(key.getName(), value); 
         }
-        
+
+        builder.highlights(policy.getHighlights());
+
         Map<String, Object> persistableFlags = MutableMap.<String, Object>builder()
                 .putAll(FlagUtils.getFieldsWithFlagsExcludingModifiers(policy, Modifier.STATIC ^ Modifier.TRANSIENT))
                 .remove("id")

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -23,6 +23,7 @@ import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -36,6 +37,7 @@ import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.api.objs.EntityAdjunct;
+import org.apache.brooklyn.api.objs.HighlightTuple;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
@@ -109,6 +111,13 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     @SetFromFlag(value="uniqueTag")
     protected String uniqueTag;
 
+    private Map<String, HighlightTuple> highlights = new HashMap<>();
+
+    public static String HIGHLIGHT_NAME_LAST_ACTION = "lastAction";
+    public static String HIGHLIGHT_NAME_LAST_CONFIRMATION= "lastConfirmation";
+    public static String HIGHLIGHT_NAME_LAST_VIOLATION= "lastViolation";
+    public static String HIGHLIGHT_NAME_TRIGGERS = "triggers";
+
     public AbstractEntityAdjunct() {
         this(Collections.emptyMap());
     }
@@ -126,6 +135,10 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
                 FlagUtils.checkRequiredFields(this);
             }
         }
+    }
+
+    protected void addHighlight(String name, HighlightTuple tuple) {
+        highlights.put(name, tuple);
     }
 
     /**
@@ -545,6 +558,23 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         }
         public void setUniqueTag(String uniqueTag) {
             AbstractEntityAdjunct.this.uniqueTag = uniqueTag;
+        }
+    }
+
+    @Override
+    public Map<String, HighlightTuple> getHighlights() {
+        HashMap<String, HighlightTuple> highlightsToReturn = new HashMap<>();
+        highlightsToReturn.putAll(highlights);
+        return highlightsToReturn;
+    }
+
+    /**
+     * Should only be used for rebind
+     * @param highlights
+     */
+    public void setHighlights(Map<String, HighlightTuple> highlights) {
+        if(highlights != null) {
+            this.highlights.putAll(highlights);
         }
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.Map;
 
+import org.apache.brooklyn.api.objs.HighlightTuple;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
@@ -70,6 +71,11 @@ public class BasicPolicyTest extends BrooklynAppUnitTestSupport {
             }
         }
 
+        //make visable for testing
+        @Override
+        protected void addHighlight(String name, HighlightTuple tuple) {
+            super.addHighlight(name, tuple);
+        }
     }
     
     @Test
@@ -106,4 +112,16 @@ public class BasicPolicyTest extends BrooklynAppUnitTestSupport {
         assertEquals(policy.getUniqueTag(), "x");
     }
 
+    @Test
+    public void testHighlights() throws Exception {
+        MyPolicy policy = new MyPolicy();
+
+        HighlightTuple highlight = new HighlightTuple("TEST_DESCRIPTION", 123L, "456");
+        policy.addHighlight("testHighlightName", highlight);
+
+        Map<String, HighlightTuple> highlights = policy.getHighlights();
+
+        assertEquals(1, highlights.size());
+        assertEquals(highlight, highlights.get("testHighlightName"));
+    }
 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
@@ -19,17 +19,22 @@
 package org.apache.brooklyn.policy.autoscaling;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.objs.HighlightTuple;
+import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
+import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestApplication;
@@ -105,6 +110,7 @@ public class AutoScalerPolicyRebindTest extends RebindTestFixtureWithApp {
         assertEquals(newPolicy.getConfig(AutoScalerPolicy.POOL_OK_SENSOR), POOL_OK_SENSOR);
         assertEquals(newPolicy.getConfig(AutoScalerPolicy.MAX_SIZE_REACHED_SENSOR), MAX_SIZE_REACHED_SENSOR);
         assertEquals(newPolicy.getConfig(AutoScalerPolicy.MAX_REACHED_NOTIFICATION_DELAY), Duration.of(7, TimeUnit.MILLISECONDS));
+        assertTrue(newPolicy.getHighlights().isEmpty());
     }
     
     @Test
@@ -130,5 +136,33 @@ public class AutoScalerPolicyRebindTest extends RebindTestFixtureWithApp {
         
         ((EntityInternal)newCluster).sensors().set(METRIC_SENSOR, 1);
         EntityAsserts.assertGroupSizeEqualsEventually(newCluster, 1);
+    }
+
+    @Test
+    public void testAutoScalerHighlightAfterRebind() throws Exception {
+        origCluster.start(ImmutableList.of(origLoc));
+        origCluster.policies().add(AutoScalerPolicy.builder()
+                .name("myname")
+                .metric(METRIC_SENSOR)
+                .entityWithMetric(origCluster)
+                .metricUpperBound(10)
+                .metricLowerBound(100)
+                .minPoolSize(1)
+                .maxPoolSize(3)
+                .buildSpec());
+
+        Map<String, HighlightTuple> highlights = new HashMap<>();
+        highlights.put("testNameTask",  new HighlightTuple("testDescription", 123L, "testTaskId"));
+
+
+        Policy originalPolicy = origCluster.policies().iterator().next();
+        ((AbstractEntityAdjunct)originalPolicy).setHighlights(highlights);
+
+        TestApplication newApp = rebind();
+
+        DynamicCluster newCluster = (DynamicCluster) Iterables.getOnlyElement(newApp.getChildren());
+        AutoScalerPolicy newPolicy = (AutoScalerPolicy) Iterables.getOnlyElement(newCluster.policies());
+
+        assertEquals(originalPolicy.getHighlights(), newPolicy.getHighlights());
     }
 }

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/PolicySummary.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.brooklyn.api.objs.HighlightTuple;
+
 public class PolicySummary implements HasName, HasId, Serializable {
 
     private static final long serialVersionUID = -5086680835225136768L;
@@ -37,18 +39,21 @@ public class PolicySummary implements HasName, HasId, Serializable {
     private final String catalogItemId;
     private final Status state;
     private final Map<String, URI> links;
+    private final Map<String, HighlightTuple> highlights;
 
     public PolicySummary(
             @JsonProperty("id") String id,
             @JsonProperty("name") String name,
             @JsonProperty("catalogItemId") String catalogItemId,
             @JsonProperty("state") Status state,
+            @JsonProperty("highlights") Map<String, HighlightTuple> highlights,
             @JsonProperty("links") Map<String, URI> links) {
         this.id = id;
         this.name = name;
         this.catalogItemId = catalogItemId;
         this.state = state;
         this.links = (links == null) ? ImmutableMap.<String, URI> of() : ImmutableMap.copyOf(links);
+        this.highlights = (highlights == null) ? ImmutableMap.of() : ImmutableMap.copyOf(highlights);
     }
 
     @Override
@@ -73,6 +78,10 @@ public class PolicySummary implements HasName, HasId, Serializable {
         return links;
     }
 
+    public Map<String, HighlightTuple> getHighlights() {
+        return highlights;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -82,12 +91,13 @@ public class PolicySummary implements HasName, HasId, Serializable {
                 Objects.equals(name, that.name) &&
                 Objects.equals(catalogItemId, that.catalogItemId) &&
                 state == that.state &&
-                Objects.equals(links, that.links);
+                Objects.equals(highlights, that.highlights) &&
+                Objects.equals(links, that.links) ;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, catalogItemId, state, links);
+        return Objects.hash(id, name, catalogItemId, state, highlights, links);
     }
 
     @Override
@@ -97,6 +107,7 @@ public class PolicySummary implements HasName, HasId, Serializable {
                 ", name='" + name + '\'' +
                 ", catalogItemId='" + catalogItemId + '\'' +
                 ", state=" + state +
+                ", highlights=" + highlights +
                 ", links=" + links +
                 '}';
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/PolicyTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/PolicyTransformer.java
@@ -65,7 +65,12 @@ public class PolicyTransformer {
                 .put("entity", entityUri)
                 .build();
 
-        return new PolicySummary(policy.getId(), policy.getDisplayName(), policy.getCatalogItemId(), ApplicationTransformer.statusFromLifecycle(Policies.getPolicyStatus(policy)), links);
+        return new PolicySummary(   policy.getId(),
+                                    policy.getDisplayName(),
+                                    policy.getCatalogItemId(),
+                                    ApplicationTransformer.statusFromLifecycle(Policies.getPolicyStatus(policy)),
+                                    policy.getHighlights(),
+                                    links);
     }
 
     public static PolicyConfigSummary policyConfigSummary(BrooklynRestResourceUtils utils, ApplicationSummary application, Entity entity, Policy policy, ConfigKey<?> config, UriBuilder ub) {

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/PolicyResourceTest.java
@@ -28,12 +28,12 @@ import java.util.Set;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import org.apache.brooklyn.api.objs.HighlightTuple;
 import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.EntitySpec;
 import org.apache.brooklyn.rest.domain.PolicyConfigSummary;
@@ -45,6 +45,7 @@ import org.apache.brooklyn.rest.testing.mocks.RestMockSimplePolicy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+
 import javax.ws.rs.core.GenericType;
 
 @Test(singleThreaded = true,
@@ -139,5 +140,26 @@ public class PolicyResourceTest extends BrooklynRestResourceTest {
         String configVal = client().path(ENDPOINT + policyId + "/config/" + configName)
                 .get(String.class);
         assertEquals(configVal, expectedVal);
+    }
+
+    @Test
+    public void testHighlights() throws Exception {
+        Set<PolicySummary> policies = client().path(ENDPOINT).get(new GenericType<Set<PolicySummary>>() {});
+
+        assertEquals(policies.size(), 1);
+        PolicySummary policySummary = policies.iterator().next();
+
+        Map<String, HighlightTuple> highlights = policySummary.getHighlights();
+
+        assertEquals(highlights.size(), 2);
+        HighlightTuple highlightTupleTask = highlights.get("testNameTask");
+        assertEquals(highlightTupleTask.getDescription(), "testDescription");
+        assertEquals(highlightTupleTask.getTime(), 123L);
+        assertEquals(highlightTupleTask.getTaskId(), "testTaskId");
+
+        HighlightTuple highlightTupleNoTask = highlights.get("testNameNoTask");
+        assertEquals(highlightTupleNoTask.getDescription(), "testDescription");
+        assertEquals(highlightTupleNoTask.getTime(), 123L);
+        assertEquals(highlightTupleNoTask.getTaskId(), null);
     }
 }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimplePolicy.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/mocks/RestMockSimplePolicy.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.rest.testing.mocks;
 
+import org.apache.brooklyn.api.objs.HighlightTuple;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
@@ -32,6 +33,8 @@ public class RestMockSimplePolicy extends AbstractPolicy {
 
     public RestMockSimplePolicy() {
         super();
+        this.addHighlight("testNameTask",  new HighlightTuple("testDescription", 123L, "testTaskId"));
+        this.addHighlight("testNameNoTask",  new HighlightTuple("testDescription", 123L, null));
     }
 
     @SetFromFlag("sampleConfig")


### PR DESCRIPTION
Policies now return highlights from the REST API. Highlights are a map of ids -> (description, time, task id). They are used to expose more information about a policy, for example the last action or the triggers for a policy.

I have also updated the rebind code such that policies can have there highlights re-bound.

In the future highlights will be extended to all adjuncts.