### PR TITLE
Fix back compat of catalog java api

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -25,6 +25,7 @@ import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
@@ -45,24 +46,50 @@ public interface BrooklynCatalog {
      * {@link CatalogItem#getSymbolicName() symbolicName} 
      * and optionally {@link CatalogItem#getVersion()},
      * taking the best version if the version is {@link #DEFAULT_VERSION} or null,
-     * returning null if no matches are found. */
+     * returning null if no matches are found. 
+     * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */ 
+    @Deprecated
     CatalogItem<?,?> getCatalogItem(String symbolicName, String version);
+    
+    /** As {@link #getCatalogItem(String, String)} but only looking in legacy catalog
+     * @deprecated since 0.12.0 only provided to allow TypeRegistry to see the legacy items */
+    CatalogItem<?,?> getCatalogItemLegacy(String symbolicName, String version);
 
     /** @return Deletes the item with the given {@link CatalogItem#getSymbolicName()
      * symbolicName} and version
-     * @throws NoSuchElementException if not found */
+     * @throws NoSuchElementException if not found 
+     * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */
+    @Deprecated
     void deleteCatalogItem(String symbolicName, String version);
 
     /** variant of {@link #getCatalogItem(String, String)} which checks (and casts) type for convenience
-     * (returns null if type does not match) */
+     * (returns null if type does not match)
+     * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */ 
+    @Deprecated
     <T,SpecT> CatalogItem<T,SpecT> getCatalogItem(Class<T> type, String symbolicName, String version);
+    
+    /** As non-legacy method but only looking in legacy catalog
+     * @deprecated since 0.12.0 only provided to allow TypeRegistry to see the legacy items */
+    <T,SpecT> CatalogItem<T,SpecT> getCatalogItemLegacy(Class<T> type, String symbolicName, String version);
 
-    /** @return All items in the catalog */
+    /** @return All items in the catalog
+     * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */ 
+    @Deprecated
     <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItems();
 
-    /** convenience for filtering items in the catalog; see CatalogPredicates for useful filters */
-//    XXX
+    /** As non-legacy method but only looking in legacy catalog
+     * @deprecated since 0.12.0 only provided to allow TypeRegistry to see the legacy items */
+    @Deprecated
+    <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItemsLegacy();
+
+    /** convenience for filtering items in the catalog; see CatalogPredicates for useful filters
+     * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */ 
+    @Deprecated
     <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItems(Predicate<? super CatalogItem<T,SpecT>> filter);
+
+    /** As non-legacy method but only looking in legacy catalog
+     * @deprecated since 0.12.0 only provided to allow TypeRegistry to see the legacy items */
+    <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItemsLegacy(Predicate<? super CatalogItem<T,SpecT>> filter);
 
     /** persists the catalog item to the object store, if persistence is enabled */
     public void persist(CatalogItem<?, ?> catalogItem);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -283,8 +283,16 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return ImmutableSortedSet.orderedBy(CatalogItemComparator.<T,SpecT>getInstance()).addAll(versions).build();
     }
 
-    @Override
+    @Override @Deprecated
     public CatalogItem<?,?> getCatalogItem(String symbolicName, String version) {
+        CatalogItem<?,?> legacy = getCatalogItemLegacy(symbolicName, version);
+        if (legacy!=null) return legacy;
+        RegisteredType rt = mgmt.getTypeRegistry().get(symbolicName, version);
+        if (rt!=null) return RegisteredTypes.toPartialCatalogItem(rt);
+        return null;
+    }
+    @Override @Deprecated
+    public CatalogItem<?,?> getCatalogItemLegacy(String symbolicName, String version) {
         if (symbolicName == null) return null;
         CatalogItemDo<?, ?> itemDo = getCatalogItemDo(symbolicName, version);
         if (itemDo == null) return null;
@@ -337,9 +345,21 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public <T,SpecT> CatalogItem<T,SpecT> getCatalogItem(Class<T> type, String id, String version) {
+        RegisteredType rt = mgmt.getTypeRegistry().get(id, version);
+        if (rt!=null) {
+            if (rt.getSuperTypes().contains(type) || rt.getSuperTypes().contains(type.getName())) {
+                return (CatalogItem) RegisteredTypes.toPartialCatalogItem(rt);
+            }
+        }
+        return getCatalogItemLegacy(type, id, version);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T,SpecT> CatalogItem<T,SpecT> getCatalogItemLegacy(Class<T> type, String id, String version) {
         if (id==null || version==null) return null;
         CatalogItem<?,?> result = getCatalogItem(id, version);
         if (result==null) return null;
@@ -1777,8 +1797,25 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Override
+    @Deprecated
     public <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItems() {
+        Map<String,CatalogItem<T,SpecT>> result = MutableMap.of();
+        if (!getCatalog().isLoaded()) {
+            // some callers use this to force the catalog to load (maybe when starting as hot_backup without a catalog ?)
+            log.debug("Forcing catalog load on access of catalog items");
+            load();
+        }
+        result.putAll((Map)catalog.getIdCache());
+        for (RegisteredType rt: mgmt.getTypeRegistry().getAll()) {
+            result.put(rt.getId(), (CatalogItem)RegisteredTypes.toPartialCatalogItem(rt));
+        }
+        return result.values();
+    }
+    
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    @Deprecated
+    public <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItemsLegacy() {
         if (!getCatalog().isLoaded()) {
             // some callers use this to force the catalog to load (maybe when starting as hot_backup without a catalog ?)
             log.debug("Forcing catalog load on access of catalog items");
@@ -1788,18 +1825,23 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    @Override
+    @Override @Deprecated
     public <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItems(Predicate<? super CatalogItem<T,SpecT>> filter) {
+        Iterable<CatalogItem<T,SpecT>> filtered = Iterables.filter(getCatalogItems(), (Predicate) filter);
+        return Iterables.transform(filtered, BasicBrooklynCatalog.<T,SpecT>itemDoToDto());
+    }
+    @Override @Deprecated
+    public <T,SpecT> Iterable<CatalogItem<T,SpecT>> getCatalogItemsLegacy(Predicate<? super CatalogItem<T,SpecT>> filter) {
         Iterable<CatalogItemDo<T,SpecT>> filtered = Iterables.filter((Iterable)catalog.getIdCache().values(), (Predicate<CatalogItem<T,SpecT>>)(Predicate) filter);
         return Iterables.transform(filtered, BasicBrooklynCatalog.<T,SpecT>itemDoToDto());
     }
 
-    private static <T,SpecT> Function<CatalogItemDo<T,SpecT>, CatalogItem<T,SpecT>> itemDoToDto() {
-        return new Function<CatalogItemDo<T,SpecT>, CatalogItem<T,SpecT>>() {
+    private static <T,SpecT> Function<CatalogItem<T,SpecT>, CatalogItem<T,SpecT>> itemDoToDto() {
+        return new Function<CatalogItem<T,SpecT>, CatalogItem<T,SpecT>>() {
             @Override
-            public CatalogItem<T,SpecT> apply(@Nullable CatalogItemDo<T,SpecT> item) {
-                if (item==null) return null;
-                return item.getDto();
+            public CatalogItem<T,SpecT> apply(@Nullable CatalogItem<T,SpecT> item) {
+                if (!(item instanceof CatalogItemDo)) return item;
+                return ((CatalogItemDo<T,SpecT>) item).getDto();
             }
         };
     }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -336,7 +336,7 @@ public class CatalogUtils {
     }
 
     /** @deprecated since 0.9.0 use {@link BrooklynTypeRegistry#get(String, org.apache.brooklyn.api.typereg.BrooklynTypeRegistry.RegisteredTypeKind, Class)} */
-    // only one item left, in deprecated service resolver
+    // not used
     @Deprecated
     public static <T,SpecT> CatalogItem<T, SpecT> getCatalogItemOptionalVersion(ManagementContext mgmt, Class<T> type, String versionedId) {
         if (looksLikeVersionedId(versionedId)) {

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -96,8 +96,14 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 Iterables.transform(mgmt.getCatalog().getCatalogItemsLegacy(), RegisteredTypes.CI_TO_RT), 
                 filter)) {
             if (!result.containsKey(rt.getId())) {
-                // shouldn't be using this now
-                log.warn("Item '"+rt.getId()+"' not in type registry; only found in legacy catalog");
+                // TODO ideally never come here, however
+                // legacy cataog currently still used for java-scanned annotations; 
+                // hopefully that will be deprecated and removed in near future
+                // (probably after switch to osgi and using catalog.bom --
+                // though it would not be too hard for java scan code in CatalogClasspath.load to
+                // make TypeRegistry instances instead of CatalogItem, esp if we had YOML to write that plan)
+                
+                //log.warn("Item '"+rt.getId()+"' not in type registry; only found in legacy catalog");
                 result.put(rt.getId(), rt);
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -93,7 +93,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
             result.put(rt.getId(), rt);
         }
         for (RegisteredType rt: Iterables.filter(
-                Iterables.transform(mgmt.getCatalog().getCatalogItems(), RegisteredTypes.CI_TO_RT), 
+                Iterables.transform(mgmt.getCatalog().getCatalogItemsLegacy(), RegisteredTypes.CI_TO_RT), 
                 filter)) {
             if (!result.containsKey(rt.getId())) {
                 // shouldn't be using this now
@@ -146,7 +146,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         }
         
         // missing case is to look for exact version in legacy catalog
-        CatalogItem<?, ?> item = mgmt.getCatalog().getCatalogItem(symbolicNameOrAliasIfNoVersion, version);
+        CatalogItem<?, ?> item = mgmt.getCatalog().getCatalogItemLegacy(symbolicNameOrAliasIfNoVersion, version);
         if (item!=null) 
             return Maybe.of( RegisteredTypes.CI_TO_RT.apply( item ) );
         
@@ -237,7 +237,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         
         // fallback: look up in (legacy) catalog
         // TODO remove once all transformers are available in the new style
-        CatalogItem item = symbolicName!=null ? (CatalogItem) mgmt.getCatalog().getCatalogItem(symbolicName, version) : null;
+        CatalogItem item = symbolicName!=null ? (CatalogItem) mgmt.getCatalog().getCatalogItemLegacy(symbolicName, version) : null;
         if (item==null) {
             // if not in catalog (because loading a new item?) then look up item based on type
             // (only really used in tests; possibly also for any recursive legacy transformers we might have to create a CI; cross that bridge when we come to it)

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
@@ -150,6 +150,11 @@ public class RegisteredTypes {
         @Override public String getContainingBundle() { return type.getContainingBundle(); }
         @Override public String getVersion() { return type.getVersion(); }
 
+        @Override public void setDeprecated(boolean deprecated) { RegisteredTypes.setDeprecated(type, deprecated); }
+        @Override public void setDisabled(boolean disabled) { RegisteredTypes.setDisabled(type, disabled); }
+        @Override public boolean isDeprecated() { return type.isDeprecated(); }
+        @Override public boolean isDisabled() { return type.isDisabled(); }
+        
         @Override public List<String> getCatalogItemIdSearchPath() { throw new UnsupportedOperationException(); }
         @Override public TagSupport tags() { throw new UnsupportedOperationException(); }
         @Override public RelationSupport<?> relations() { throw new UnsupportedOperationException(); }
@@ -166,10 +171,6 @@ public class RegisteredTypes {
         }
         @Override public String getPlanYaml() { throw new UnsupportedOperationException(); }
         @Override public RebindSupport<CatalogItemMemento> getRebindSupport() { throw new UnsupportedOperationException(); }
-        @Override public void setDeprecated(boolean deprecated) { throw new UnsupportedOperationException(); }
-        @Override public void setDisabled(boolean disabled) { throw new UnsupportedOperationException(); }
-        @Override public boolean isDeprecated() { throw new UnsupportedOperationException(); }
-        @Override public boolean isDisabled() { throw new UnsupportedOperationException(); }
     }
     
     /** Preferred mechanism for defining a bean {@link RegisteredType}. 


### PR DESCRIPTION
The switch to osgi bundles and `TypeRegistry` caused confusion where people were consuming the `BrooklynCatalog` API and expecting (reasonably) to see the things they've added.  This PR makes those methods also look in the `TypeRegistry` with `...Legacy(...)` methods added to explicitly search only in the catalog.

All methods are deprecated so in 1.0 we can hopefully delete!