### PR TITLE
Improve config key descriptions

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -154,7 +154,11 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     /**
      * The default name to use for this entity, if not explicitly overridden.
      */
-    public static final ConfigKey<String> DEFAULT_DISPLAY_NAME = BasicConfigKey.builder(String.class).name("defaultDisplayName").runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED).build();
+    public static final ConfigKey<String> DEFAULT_DISPLAY_NAME = BasicConfigKey.builder(String.class)
+            .name("defaultDisplayName")
+            .description("Optional default display name to use (rather than auto-generating, if no name is explicitly supplied)")
+            .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+            .build();
 
     public static final BasicNotificationSensor<Location> LOCATION_ADDED = new BasicNotificationSensor<Location>(
             Location.class, "entity.location.added", "Location dynamically added to entity");

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
@@ -52,11 +52,15 @@ public interface Attributes {
 
     // TODO these should switch to being TemplatedStringAttributeSensorAndConfigKey
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new BasicAttributeSensorAndConfigKey<String>(
-            String.class, "download.url", "URL pattern for downloading the installer (will substitute things like ${version} automatically)");
+            String.class, 
+            "download.url", 
+            "URL pattern for downloading the installer (will substitute things like ${version} automatically)");
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     BasicAttributeSensorAndConfigKey<Map<String,String>> DOWNLOAD_ADDON_URLS = new BasicAttributeSensorAndConfigKey(
-            Map.class, "download.addon.urls", "URL patterns for downloading named add-ons (will substitute things like ${version} automatically)");
+            Map.class, 
+            "download.addon.urls", 
+            "URL patterns for downloading named add-ons (will substitute things like ${version} automatically)");
 
     /*
      * Port number attributes.
@@ -74,7 +78,7 @@ public interface Attributes {
             "http.port", "HTTP port", ImmutableList.of(8080,"18080+"));
     
     PortAttributeSensorAndConfigKey HTTPS_PORT = new PortAttributeSensorAndConfigKey(
-            "https.port", "HTTP port (with SSL/TLS)", ImmutableList.of(8443,"18443+"));
+            "https.port", "HTTPS port (with SSL/TLS)", ImmutableList.of(8443,"18443+"));
                     
     PortAttributeSensorAndConfigKey SSH_PORT = new PortAttributeSensorAndConfigKey("ssh.port", "SSH port", 22);
     PortAttributeSensorAndConfigKey SMTP_PORT = new PortAttributeSensorAndConfigKey("smtp.port", "SMTP port", 25);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Attributes.java
@@ -54,13 +54,13 @@ public interface Attributes {
     BasicAttributeSensorAndConfigKey<String> DOWNLOAD_URL = new BasicAttributeSensorAndConfigKey<String>(
             String.class, 
             "download.url", 
-            "URL pattern for downloading the installer (will substitute things like ${version} automatically)");
+            "URL for downloading the installer; uses FreeMarker templating format to substitute things like ${version} automatically");
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     BasicAttributeSensorAndConfigKey<Map<String,String>> DOWNLOAD_ADDON_URLS = new BasicAttributeSensorAndConfigKey(
             Map.class, 
             "download.addon.urls", 
-            "URL patterns for downloading named add-ons (will substitute things like ${version} automatically)");
+            "URL for downloading named add-ons; uses FreeMarker templating format to substitute things like ${version} automatically");
 
     /*
      * Port number attributes.

--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.core.entity;
 
-import static org.apache.brooklyn.core.config.ConfigKeys.newBooleanConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
 import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
@@ -59,7 +58,9 @@ public class BrooklynConfigKeys {
             false);
 
     // TODO Rename to VERSION, instead of SUGGESTED_VERSION? And declare as BasicAttributeSensorAndConfigKey?
-    public static final ConfigKey<String> SUGGESTED_VERSION = newStringConfigKey("install.version", "Suggested version");
+    public static final ConfigKey<String> SUGGESTED_VERSION = newStringConfigKey(
+            "install.version", 
+            "The suggested version of the software to be installed");
 
     public static final ConfigKey<String> INSTALL_UNIQUE_LABEL = ConfigKeys.newStringConfigKey("install.unique_label",
             "Provides a label which uniquely identifies an installation, used in the computation of the install dir; " +
@@ -77,9 +78,12 @@ public class BrooklynConfigKeys {
      * If this key is set on a {@link Location} then all entities in that location will be treated in this way. This is useful
      * when the location is configured with a particular image containing installed and running services.
      *
-     * @see #ENTITY_RUNNING
+     * @see #SKIP_ENTITY_START_IF_RUNNING
      */
-    public static final ConfigKey<Boolean> SKIP_ENTITY_START = newBooleanConfigKey("entity.started", "Skip the startup process entirely, for running services");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_START = ConfigKeys.builder(Boolean.class)
+            .name("entity.started") 
+            .description("Whether to skip the startup process entirely (useful for auto-running software, such as in containers)")
+            .build();
 
     /**
      * Set this configuration value to true to skip the entity startup process as with {@link #ENTITY_STARTED} if the process or
@@ -88,40 +92,46 @@ public class BrooklynConfigKeys {
      * <p>
      * If this key is set on a {@link Location} then all entities in that location will be treated in this way, again as with {@link #ENTITY_STARTED}.
      *
-     * @see #ENTITY_STARTED
+     * @see #SKIP_ENTITY_START
      */
-    public static final ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = newBooleanConfigKey("entity.running", "Skip the startup process entirely, if service already running");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = ConfigKeys.builder(Boolean.class)
+            .name("entity.running") 
+            .description("Whether to skip the startup process entirely, but only if it already running")
+            .build();
 
     /**
-     * Set this configuration value to true if the entity installation, customization and launch process is to be skipped entirely.
+     * Set this configuration value to true if the entity installation is to be skipped entirely.
      * <p>
-     * This will skip the installation phase of the lifecycle, and move directl;y to customization and launching of the entity.
+     * This will skip the installation phase of the lifecycle, and move directly to customization and launching of the entity.
      */
-    public static final ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = newBooleanConfigKey("install.skip", "Skip the driver install commands entirely, for pre-installed software");
+    public static final ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = ConfigKeys.builder(Boolean.class)
+            .name("install.skip") 
+            .description("Whether to skip the install commands entirely (useful for pre-installed images)")
+            .build();
 
     // The implementation in AbstractSoftwareSshDriver runs this command as an SSH command 
     public static final ConfigKey<String> PRE_INSTALL_COMMAND = ConfigKeys.builder(String.class, "pre.install.command")
-            .description("Command to be run prior to the install method being called on the driver")
+            .description("Command to be run prior to the install phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
     public static final ConfigKey<String> POST_INSTALL_COMMAND = ConfigKeys.builder(String.class, "post.install.command")
-            .description("Command to be run after the install method being called on the driver")
+            .description("Command to be run after the install phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
     public static final ConfigKey<String> PRE_CUSTOMIZE_COMMAND = ConfigKeys.builder(String.class, "pre.customize.command")
-            .description("Command to be run prior to the customize method being called on the driver")
+            .description("Command to be run prior to the customize phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
     public static final ConfigKey<String> POST_CUSTOMIZE_COMMAND = ConfigKeys.builder(String.class, "post.customize.command")
-            .description("Command to be run after the customize method being called on the driver")
+            .description("Command to be run after the customize phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
     public static final ConfigKey<String> PRE_LAUNCH_COMMAND = ConfigKeys.builder(String.class, "pre.launch.command")
-            .description("Command to be run prior to the launch method being called on the driver")
+            .description("Command to be run prior to the launch phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
     public static final ConfigKey<String> POST_LAUNCH_COMMAND = ConfigKeys.builder(String.class, "post.launch.command")
-            .description("Command to be run after the launch method being called on the driver")
+            .description("Command to be run after the launch phase")
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
 
@@ -133,7 +143,9 @@ public class BrooklynConfigKeys {
             .build();
 
     // TODO these dirs should also not be reinherited at runtime
-    public static final AttributeSensorAndConfigKey<String, String> INSTALL_DIR = new TemplatedStringAttributeSensorAndConfigKey("install.dir", "Directory for this software to be installed in",
+    public static final AttributeSensorAndConfigKey<String, String> INSTALL_DIR = new TemplatedStringAttributeSensorAndConfigKey(
+            "install.dir", 
+            "Directory in which this software will be installed (if downloading/unpacking artifacts explicitly); uses FreeMarker templating format",
             "${" +
             "config['"+ONBOX_BASE_DIR.getName()+"']!" +
             "config['"+BROOKLYN_DATA_DIR.getName()+"']!" +
@@ -151,7 +163,9 @@ public class BrooklynConfigKeys {
             "((config['install.version']??)?string('_'+(config['install.version']!'X'),''))" +
             ")}");
 
-    public static final AttributeSensorAndConfigKey<String, String> RUN_DIR = new TemplatedStringAttributeSensorAndConfigKey("run.dir", "Directory for this software to be run from",
+    public static final AttributeSensorAndConfigKey<String, String> RUN_DIR = new TemplatedStringAttributeSensorAndConfigKey(
+            "run.dir", 
+            "Directory from which this software to be run; uses FreeMarker templating format",
             "${" +
             "config['"+ONBOX_BASE_DIR.getName()+"']!" +
             "config['"+BROOKLYN_DATA_DIR.getName()+"']!" +
@@ -180,23 +194,59 @@ public class BrooklynConfigKeys {
      * component is up, but this entity does not care about the dependent component's actual config values.
      */
 
-    public static final ConfigKey<Boolean> PROVISION_LATCH = newBooleanConfigKey("provision.latch", "Latch for blocking location provision until ready");
-    public static final ConfigKey<Boolean> START_LATCH = newBooleanConfigKey("start.latch", "Latch for blocking start until ready");
+    public static final ConfigKey<Boolean> PROVISION_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("provision.latch")
+            .description("Latch for blocking machine provisioning; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> START_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("start.latch")
+            .description("Latch for blocking start (done post-provisioning for software processes); if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
 
     @Beta // on stop DSLs time out after a minute and unblock; may be easier to fix after https://github.com/apache/brooklyn-server/pull/390
-    public static final ConfigKey<Boolean> STOP_LATCH = newBooleanConfigKey("stop.latch", "Latch for blocking stop until a condition is met; will block for at most 1 minute and then time out");
+    public static final ConfigKey<Boolean> STOP_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("stop.latch")
+            .description("Latch for blocking stop; if non-null will wait for at most 1 minute for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
 
-    public static final ConfigKey<Boolean> SETUP_LATCH = newBooleanConfigKey("setup.latch", "Latch for blocking setup until ready");
-    public static final ConfigKey<Boolean> PRE_INSTALL_RESOURCES_LATCH = newBooleanConfigKey("resources.preInstall.latch", "Latch for blocking pre-install resources until ready");
-    public static final ConfigKey<Boolean> INSTALL_RESOURCES_LATCH = newBooleanConfigKey("resources.install.latch", "Latch for blocking install resources until ready");
-    public static final ConfigKey<Boolean> INSTALL_LATCH = newBooleanConfigKey("install.latch", "Latch for blocking install until ready");
-    public static final ConfigKey<Boolean> RUNTIME_RESOURCES_LATCH = newBooleanConfigKey("resources.runtime.latch", "Latch for blocking runtime resources until ready");
-    public static final ConfigKey<Boolean> CUSTOMIZE_LATCH = newBooleanConfigKey("customize.latch", "Latch for blocking customize until ready");
-    public static final ConfigKey<Boolean> CUSTOMIZE_RESOURCES_LATCH = newBooleanConfigKey("resources.customize.latch", "Latch for blocking customize resources until ready");
-    public static final ConfigKey<Boolean> LAUNCH_LATCH = newBooleanConfigKey("launch.latch", "Latch for blocking launch until ready");
+    public static final ConfigKey<Boolean> SETUP_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("setup.latch")
+            .description("Latch for blocking setup; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    
+    public static final ConfigKey<Boolean> PRE_INSTALL_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("resources.preInstall.latch")
+            .description("Latch for blocking files being copied before the pre-install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> INSTALL_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("resources.install.latch")
+            .description("Latch for blocking files being copied before the install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> INSTALL_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("install.latch")
+            .description("Latch for blocking install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> CUSTOMIZE_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("resources.customize.latch")
+            .description("Latch for blocking files being copied before customize; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> CUSTOMIZE_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("customize.latch")
+            .description("Latch for blocking customize; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> RUNTIME_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("resources.runtime.latch")
+            .description("Latch for blocking files being copied before the launch; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
+    public static final ConfigKey<Boolean> LAUNCH_LATCH = ConfigKeys.builder(Boolean.class)
+            .name("launch.latch")
+            .description("Latch for blocking luanch; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
+            .build();
 
     public static final ConfigKey<Duration> START_TIMEOUT = newConfigKey(
-            "start.timeout", "Time to wait for process and for SERVICE_UP before failing (in seconds, default 2m)", Duration.seconds(120));
+            "start.timeout", 
+            "Time to wait, after launching, for SERVICE_UP before failing (default to '2m')", 
+            Duration.seconds(120));
 
     /* selected properties from SshTool for external public access (e.g. putting on entities) */
 
@@ -241,7 +291,7 @@ public class BrooklynConfigKeys {
     public static final ConfigKey<Boolean> SSH_CONFIG_NO_DELETE_SCRIPT = newConfigKeyWithPrefix(BROOKLYN_SSH_CONFIG_KEY_PREFIX, ShellTool.PROP_NO_DELETE_SCRIPT);
 
     public static final MapConfigKey<Object> PROVISIONING_PROPERTIES = new MapConfigKey.Builder<Object>(Object.class, "provisioning.properties")
-            .description("Custom properties to be passed in when provisioning a new machine")
+            .description("Custom properties to be passed in to the location when provisioning a new machine")
             .defaultValue(ImmutableMap.<String, Object>of())
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)

--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import static org.apache.brooklyn.core.config.ConfigKeys.newBooleanConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
 import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
@@ -81,7 +82,8 @@ public class BrooklynConfigKeys {
      * @see #SKIP_ENTITY_START_IF_RUNNING
      */
     public static final ConfigKey<Boolean> SKIP_ENTITY_START = ConfigKeys.builder(Boolean.class)
-            .name("entity.started") 
+            .name("skip.start") 
+            .deprecatedNames("entity.started")
             .description("Whether to skip the startup process entirely (useful for auto-running software, such as in containers)")
             .build();
 
@@ -95,7 +97,8 @@ public class BrooklynConfigKeys {
      * @see #SKIP_ENTITY_START
      */
     public static final ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = ConfigKeys.builder(Boolean.class)
-            .name("entity.running") 
+            .name("skip.start.ifRunning") 
+            .deprecatedNames("entity.running") 
             .description("Whether to skip the startup process entirely, but only if it already running")
             .build();
 
@@ -105,7 +108,8 @@ public class BrooklynConfigKeys {
      * This will skip the installation phase of the lifecycle, and move directly to customization and launching of the entity.
      */
     public static final ConfigKey<Boolean> SKIP_ENTITY_INSTALLATION = ConfigKeys.builder(Boolean.class)
-            .name("install.skip") 
+            .name("skip.install") 
+            .deprecatedNames("install.skip") 
             .description("Whether to skip the install commands entirely (useful for pre-installed images)")
             .build();
 
@@ -195,51 +199,62 @@ public class BrooklynConfigKeys {
      */
 
     public static final ConfigKey<Boolean> PROVISION_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("provision.latch")
+            .name("latch.provision")
+            .deprecatedNames("provision.latch")
             .description("Latch for blocking machine provisioning; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> START_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("start.latch")
+            .name("latch.start")
+            .deprecatedNames("start.latch")
             .description("Latch for blocking start (done post-provisioning for software processes); if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
 
     @Beta // on stop DSLs time out after a minute and unblock; may be easier to fix after https://github.com/apache/brooklyn-server/pull/390
     public static final ConfigKey<Boolean> STOP_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("stop.latch")
+            .name("latch.stop")
+            .deprecatedNames("stop.latch")
             .description("Latch for blocking stop; if non-null will wait for at most 1 minute for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
 
     public static final ConfigKey<Boolean> SETUP_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("setup.latch")
+            .name("latch.setup")
+            .deprecatedNames("setup.latch")
             .description("Latch for blocking setup; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     
     public static final ConfigKey<Boolean> PRE_INSTALL_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("resources.preInstall.latch")
+            .name("latch.preInstall.resources")
+            .deprecatedNames("resources.preInstall.latch") 
             .description("Latch for blocking files being copied before the pre-install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> INSTALL_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("resources.install.latch")
+            .name("latch.install.reources")
+            .deprecatedNames("resources.install.latch") 
             .description("Latch for blocking files being copied before the install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> INSTALL_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("install.latch")
+            .name("latch.install")
+            .deprecatedNames("install.latch")
             .description("Latch for blocking install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> CUSTOMIZE_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("resources.customize.latch")
+            .name("latch.customize.resources")
+            .deprecatedNames("resources.customize.latch") 
             .description("Latch for blocking files being copied before customize; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> CUSTOMIZE_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("customize.latch")
+            .name("latch.customize")
+            .deprecatedNames("customize.latch") 
             .description("Latch for blocking customize; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> RUNTIME_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("resources.runtime.latch")
+            .name("latch.launch.resources")
+            .deprecatedNames("resources.runtime.latch") 
             .description("Latch for blocking files being copied before the launch; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> LAUNCH_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("launch.latch")
+            .name("latch.launch")
+            .deprecatedNames("launch.latch") 
             .description("Latch for blocking luanch; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.core.entity;
 
-import static org.apache.brooklyn.core.config.ConfigKeys.newBooleanConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newConfigKeyWithPrefix;
 import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
@@ -260,7 +259,7 @@ public class BrooklynConfigKeys {
 
     public static final ConfigKey<Duration> START_TIMEOUT = newConfigKey(
             "start.timeout", 
-            "Time to wait, after launching, for SERVICE_UP before failing (default to '2m')", 
+            "Time to wait, after launching, for SERVICE_UP before failing", 
             Duration.seconds(120));
 
     /* selected properties from SshTool for external public access (e.g. putting on entities) */

--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -98,7 +98,7 @@ public class BrooklynConfigKeys {
     public static final ConfigKey<Boolean> SKIP_ENTITY_START_IF_RUNNING = ConfigKeys.builder(Boolean.class)
             .name("skip.start.ifRunning") 
             .deprecatedNames("entity.running") 
-            .description("Whether to skip the startup process entirely, but only if it already running")
+            .description("Whether to skip the startup process if the entity is detected as already running")
             .build();
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
@@ -50,18 +50,26 @@ public abstract class AbstractAggregator<T,U> extends AbstractEnricher implement
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractAggregator.class);
 
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
-            "enricher.producer", "The entity whose children/members will be aggregated");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
+            Entity.class,
+            "enricher.producer", 
+            "The entity whose children/members will be aggregated");
 
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.targetSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor",
+            "The sensor that will be set on the associated entity, with the target value");
 
     // FIXME this is not just for "members" i think -Alex
-    public static final ConfigKey<?> DEFAULT_MEMBER_VALUE = ConfigKeys.newConfigKey(Object.class,
-            "enricher.defaultMemberValue");
+    public static final ConfigKey<?> DEFAULT_MEMBER_VALUE = ConfigKeys.newConfigKey(
+            Object.class,
+            "enricher.defaultMemberValue",
+            "The value to use for a new producer if its source sensor is null");
 
-    public static final ConfigKey<Set<? extends Entity>> FROM_HARDCODED_PRODUCERS = ConfigKeys.newConfigKey(new TypeToken<Set<? extends Entity>>() {},
-            "enricher.aggregating.fromHardcodedProducers");
+    public static final ConfigKey<Set<? extends Entity>> FROM_HARDCODED_PRODUCERS = ConfigKeys.newConfigKey(
+            new TypeToken<Set<? extends Entity>>() {},
+            "enricher.aggregating.fromHardcodedProducers",
+            "The producers to be aggregated (this an alternative way of configuring it, rather than using members or children)");
 
     public static final ConfigKey<Boolean> FROM_MEMBERS = ConfigKeys.newBooleanConfigKey(
             "enricher.aggregating.fromMembers",
@@ -72,11 +80,16 @@ public abstract class AbstractAggregator<T,U> extends AbstractEnricher implement
             "enricher.aggregating.fromChildren",
             "Whether this enricher looks at children; this is the default for non-Group producers");
 
-    public static final ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<? super Entity>>() {},
-            "enricher.aggregating.entityFilter");
+    public static final ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(
+            new TypeToken<Predicate<? super Entity>>() {},
+            "enricher.aggregating.entityFilter",
+            "A filter of the possible producers");
 
-    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<?>>() {},
-            "enricher.aggregating.valueFilter");
+    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(
+            new TypeToken<Predicate<?>>() {},
+            "enricher.aggregating.valueFilter",
+            "A filter of the possible producers, based on their sensor value");
+    
     public static final ConfigKey<Boolean> EXCLUDE_BLANK = ConfigKeys.newBooleanConfigKey(
             "enricher.aggregator.excludeBlank",
             "Whether explicit nulls or blank strings should be excluded (default false); " +

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractAggregator.java
@@ -58,7 +58,7 @@ public abstract class AbstractAggregator<T,U> extends AbstractEnricher implement
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<Sensor<?>>() {},
             "enricher.targetSensor",
-            "The sensor that will be set on the associated entity, with the target value");
+            "The sensor to be set on the associated entity with the value computed here");
 
     // FIXME this is not just for "members" i think -Alex
     public static final ConfigKey<?> DEFAULT_MEMBER_VALUE = ConfigKeys.newConfigKey(

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
@@ -45,14 +45,20 @@ public abstract class AbstractTransformer<T,U> extends AbstractEnricher implemen
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractTransformer.class);
 
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
-            "enricher.producer");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
+            Entity.class,
+            "enricher.producer",
+            "The entity with the trigger sensor (defaults to the enricher's entity)");
 
-    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.sourceSensor");
+    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {},
+            "enricher.sourceSensor",
+            "The sensor whose change triggers re-evaluation of the target value");
 
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.targetSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor",
+            "The sensor that will be set on the associated entity, with the target value");
     
     public static final ConfigKey<List<? extends Sensor<?>>> TRIGGER_SENSORS = ConfigKeys.newConfigKey(
             new TypeToken<List<? extends Sensor<?>>>() {}, 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/AbstractTransformer.java
@@ -58,7 +58,7 @@ public abstract class AbstractTransformer<T,U> extends AbstractEnricher implemen
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<Sensor<?>>() {},
             "enricher.targetSensor",
-            "The sensor that will be set on the associated entity, with the target value");
+            "The sensor to be set on the associated entity with the value computed here");
     
     public static final ConfigKey<List<? extends Sensor<?>>> TRIGGER_SENSORS = ConfigKeys.newConfigKey(
             new TypeToken<List<? extends Sensor<?>>>() {}, 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
@@ -54,7 +54,8 @@ public class Aggregator<T,U> extends AbstractAggregator<T,U> implements SensorEv
     private static final Logger LOG = LoggerFactory.getLogger(Aggregator.class);
 
     public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.sourceSensor");
+            "enricher.sourceSensor",
+            "The sensor whose change triggers re-evaluation of the target value");
     
     @SetFromFlag("transformation")
     public static final ConfigKey<Object> TRANSFORMATION_UNTYPED = ConfigKeys.newConfigKey(Object.class,
@@ -65,18 +66,22 @@ public class Aggregator<T,U> extends AbstractAggregator<T,U> implements SensorEv
                     "'list' (the default, putting any collection of items into a list), " +
                     "or 'first' (the first value, or null if empty)");
 
-    public static final ConfigKey<Function<? super Collection<?>, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(new TypeToken<Function<? super Collection<?>, ?>>() {},
-            "enricher.transformation");
+    public static final ConfigKey<Function<? super Collection<?>, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(
+            new TypeToken<Function<? super Collection<?>, ?>>() {},
+            "enricher.transformation",
+            "A function to be executed to evaluate the target sensor");
     
     /**
      * @see QuorumChecks
      */
     public static final ConfigKey<String> QUORUM_CHECK_TYPE = ConfigKeys.newStringConfigKey(
-            "quorum.check.type", "The requirement to be considered quorate -- possible values: " +
+            "quorum.check.type", 
+            "The requirement to be considered quorate (used with transformation of type 'isQuorate') -- possible values: " +
                     "'all', 'allAndAtLeastOne', 'atLeastOne', 'atLeastOneUnlessEmpty', 'alwaysHealthy'", "allAndAtLeastOne");
 
     public static final ConfigKey<Integer> QUORUM_TOTAL_SIZE = ConfigKeys.newIntegerConfigKey(
-            "quorum.total.size", "The total size to consider when determining if quorate", 1);
+            "quorum.total.size", 
+            "The total size to consider when determining if quorate (used iwth transformation of type 'isQuorate')", 1);
 
     protected Sensor<T> sourceSensor;
     protected Function<? super Collection<T>, ? extends U> transformation;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Aggregator.java
@@ -81,7 +81,7 @@ public class Aggregator<T,U> extends AbstractAggregator<T,U> implements SensorEv
 
     public static final ConfigKey<Integer> QUORUM_TOTAL_SIZE = ConfigKeys.newIntegerConfigKey(
             "quorum.total.size", 
-            "The total size to consider when determining if quorate (used iwth transformation of type 'isQuorate')", 1);
+            "The total size to consider when determining if quorate (used with transformation of type 'isQuorate')", 1);
 
     protected Sensor<T> sourceSensor;
     protected Function<? super Collection<T>, ? extends U> transformation;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Combiner.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Combiner.java
@@ -73,7 +73,7 @@ public class Combiner<T,U> extends AbstractEnricher implements SensorEventListen
     public static ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<Sensor<?>>() {}, 
             "enricher.targetSensor",
-            "The sensor that will be set on the associated entity, with the target value");
+            "The sensor to be set on the associated entity with the value computed here");
 
     public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(
             new TypeToken<Predicate<?>>() {}, 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Combiner.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Combiner.java
@@ -55,15 +55,30 @@ public class Combiner<T,U> extends AbstractEnricher implements SensorEventListen
 
     private static final Logger LOG = LoggerFactory.getLogger(Combiner.class);
 
-    public static ConfigKey<Function<?, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {}, "enricher.transformation");
+    public static ConfigKey<Function<?, ?>> TRANSFORMATION = ConfigKeys.newConfigKey(
+            new TypeToken<Function<?, ?>>() {}, 
+            "enricher.transformation",
+            "The function to be applied, to combine the sensor values");
 
-    public static ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
+    public static ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
+            Entity.class, 
+            "enricher.producer",
+            "The entity that has the source sensors (defaults to the entity that the enricher is attached to)");
 
-    public static ConfigKey<Set<Sensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(new TypeToken<Set<Sensor<?>>>() {}, "enricher.sourceSensors");
+    public static ConfigKey<Set<Sensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(
+            new TypeToken<Set<Sensor<?>>>() {}, 
+            "enricher.sourceSensors",
+            "The source sensors to be combined");
 
-    public static ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
+    public static ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {}, 
+            "enricher.targetSensor",
+            "The sensor that will be set on the associated entity, with the target value");
 
-    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<?>>() {}, "enricher.aggregating.valueFilter");
+    public static final ConfigKey<Predicate<?>> VALUE_FILTER = ConfigKeys.newConfigKey(
+            new TypeToken<Predicate<?>>() {}, 
+            "enricher.aggregating.valueFilter",
+            "A filter of the source sensors to include, based on their sensor values");
 
     protected Function<? super Collection<T>, ? extends U> transformation;
     protected Entity producer;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
@@ -56,7 +56,7 @@ public class Joiner<T> extends AbstractEnricher implements SensorEventListener<T
     
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
             "enricher.targetSensor",
-            "The sensor that will be set on the associated entity, with the target value");
+            "The sensor to be set on the associated entity with the value computed here");
 
     @SetFromFlag("separator")
     public static final ConfigKey<String> SEPARATOR = ConfigKeys.newStringConfigKey(

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Joiner.java
@@ -47,31 +47,42 @@ public class Joiner<T> extends AbstractEnricher implements SensorEventListener<T
     private static final Logger LOG = LoggerFactory.getLogger(Joiner.class);
 
     public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
-            "enricher.producer");
+            "enricher.producer",
+            "The entity that has the source sensors (defaults to the entity that the enricher is attached to)");
+    
     public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.sourceSensor");
+            "enricher.sourceSensor",
+            "The sensor (expected to be of type Map or Iterable) whose change triggers re-evaluation of the target value");
+    
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.targetSensor");
+            "enricher.targetSensor",
+            "The sensor that will be set on the associated entity, with the target value");
+
     @SetFromFlag("separator")
     public static final ConfigKey<String> SEPARATOR = ConfigKeys.newStringConfigKey(
             "enricher.joiner.separator",
             "Separator string to insert between each argument", ",");
+    
     @SetFromFlag("keyValueSeparator")
     public static final ConfigKey<String> KEY_VALUE_SEPARATOR = ConfigKeys.newStringConfigKey(
             "enricher.joiner.keyValueSeparator",
             "Separator string to insert between each key-value pair", "=");
+    
     @SetFromFlag("joinMapEntries")
     public static final ConfigKey<Boolean> JOIN_MAP_ENTRIES = ConfigKeys.newBooleanConfigKey(
             "enricher.joiner.joinMapEntries",
             "Whether to add map entries as key-value pairs or just use the value, defaulting to false", false);
+    
     @SetFromFlag("quote")
     public static final ConfigKey<Boolean> QUOTE = ConfigKeys.newBooleanConfigKey(
             "enricher.joiner.quote",
             "Whether to bash-escape each parameter and wrap in double-quotes, defaulting to true", true);
+    
     @SetFromFlag("minimum")
     public static final ConfigKey<Integer> MINIMUM = ConfigKeys.newIntegerConfigKey(
             "enricher.joiner.minimum",
             "Minimum number of elements to join; if fewer than this, sets null; default 0 (no minimum)");
+    
     @SetFromFlag("maximum")
     public static final ConfigKey<Integer> MAXIMUM = ConfigKeys.newIntegerConfigKey(
             "enricher.joiner.maximum",

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/MapAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/MapAggregator.java
@@ -40,8 +40,15 @@ import org.apache.brooklyn.util.collections.MutableMap;
 @SuppressWarnings("serial")
 public class MapAggregator<U> extends AbstractMultipleSensorAggregator<U> {
 
-    public static final ConfigKey<Sensor<?>> KEY_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.keySensor");
-    public static final ConfigKey<Sensor<?>> VALUE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.valueSensor");
+    public static final ConfigKey<Sensor<?>> KEY_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {}, 
+            "enricher.keySensor",
+            "The sensor to use for the key in the map entry");
+    
+    public static final ConfigKey<Sensor<?>> VALUE_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {}, 
+            "enricher.valueSensor",
+            "The sensor to use for the value in the map entry");
 
     private Sensor<?> keySensor;
     private Sensor<?> valueSensor;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
@@ -67,7 +67,7 @@ public class PercentageEnricher extends AbstractEnricher implements SensorEventL
     public static final ConfigKey<AttributeSensor<Double>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<AttributeSensor<Double>>() {},
             "enricher.targetSensor",
-            "The sensor on which to emit the ratio");
+            "The sensor to be set on the associated entity with the value computed here");
 
     public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
             Entity.class, 

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/PercentageEnricher.java
@@ -69,7 +69,10 @@ public class PercentageEnricher extends AbstractEnricher implements SensorEventL
             "enricher.targetSensor",
             "The sensor on which to emit the ratio");
 
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class, "enricher.producer");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
+            Entity.class, 
+            "enricher.producer",
+            "The entity with the trigger sensor (defaults to the enricher's entity)");
 
     protected AttributeSensor<? extends Number> sourceCurrentSensor;
     protected AttributeSensor<? extends Number> sourceTotalSensor;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.enricher.stock;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import org.apache.brooklyn.api.catalog.Catalog;
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.config.ConfigKey;
@@ -42,12 +43,22 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
     private static final Logger LOG = LoggerFactory.getLogger(Transformer.class);
 
     // exactly one of these should be supplied to set a value
-    public static final ConfigKey<Object> TARGET_VALUE = ConfigKeys.newConfigKey(Object.class,
-            "enricher.targetValue");
-    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {},
-            "enricher.transformation");
-    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(new TypeToken<Function<?, ?>>() {},
-            "enricher.transformation.fromevent");
+    @CatalogConfig(label = "Target value")
+    public static final ConfigKey<Object> TARGET_VALUE = ConfigKeys.newConfigKey(
+            Object.class,
+            "enricher.targetValue",
+            "The value for the target sensor. This can use the Brooklyn DSL, which will be "
+                    + "re-evaluated each time the trigger sensor(s) change");
+
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_VALUE = ConfigKeys.newConfigKey(
+            new TypeToken<Function<?, ?>>() {},
+            "enricher.transformation",
+            "A function for computing the target sensor's new value (will be passed the trigger sensor's value each time)");
+
+    public static final ConfigKey<Function<?, ?>> TRANSFORMATION_FROM_EVENT = ConfigKeys.newConfigKey(
+            new TypeToken<Function<?, ?>>() {},
+            "enricher.transformation.fromevent",
+            "A function for computing the target sensor's new value (will be passed the trigger sensor's change-event each time)");
 
     public Transformer() { }
     

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
@@ -66,22 +66,33 @@ public class UpdatingMap<S,TKey,TVal> extends AbstractEnricher implements Sensor
     private static final Logger LOG = LoggerFactory.getLogger(UpdatingMap.class);
 
     public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
-            "enricher.producer");
+            "enricher.producer",
+            "The entity with the trigger sensor (defaults to the enricher's entity)");
 
     @SetFromFlag("fromSensor")
-    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.sourceSensor");
+    public static final ConfigKey<Sensor<?>> SOURCE_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {}, 
+            "enricher.sourceSensor",
+            "The sensor whose change triggers re-evaluation of the target value");
     
     @SetFromFlag("targetSensor")
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {}, "enricher.targetSensor");
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {}, 
+            "enricher.targetSensor",
+            "The map-sensor that will be updated on the associated entity");
+
     
     @SetFromFlag("key")
-    public static final ConfigKey<Object> KEY_IN_TARGET_SENSOR = ConfigKeys.newConfigKey(Object.class, "enricher.updatingMap.keyInTargetSensor",
-        "Key to update in the target sensor map, defaulting to the name of the source sensor");
+    public static final ConfigKey<Object> KEY_IN_TARGET_SENSOR = ConfigKeys.newConfigKey(
+            Object.class, 
+            "enricher.updatingMap.keyInTargetSensor",
+            "Key to update in the target sensor map, defaulting to the name of the source sensor");
 
     @SetFromFlag("computing")
     public static final ConfigKey<Function<?, ?>> COMPUTING = ConfigKeys.newConfigKey(
             new TypeToken<Function<?,?>>() {}, 
-            "enricher.updatingMap.computing");
+            "enricher.updatingMap.computing",
+            "The function to evaluate the value, which will to be set in the target map-sensor. See 'removingIfResultIsNull' for how null is handled.");
     
     @SetFromFlag("removingIfResultIsNull")
     public static final ConfigKey<Boolean> REMOVING_IF_RESULT_IS_NULL = ConfigKeys.newBooleanConfigKey(

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/UpdatingMap.java
@@ -79,7 +79,7 @@ public class UpdatingMap<S,TKey,TVal> extends AbstractEnricher implements Sensor
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<Sensor<?>>() {}, 
             "enricher.targetSensor",
-            "The map-sensor that will be updated on the associated entity");
+            "The map-sensor to be updated on the associated entity with the value computed here");
 
     
     @SetFromFlag("key")

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlRollingTimeWindowMeanEnricher.java
@@ -57,11 +57,16 @@ import com.google.common.base.Function;
 @Catalog(name = "YAML Rolling Average", description = "Transforms sensor data into a rolling average based on a time window.")
 public class YamlRollingTimeWindowMeanEnricher<T extends Number> extends AbstractTransformer<T,Double> {
     
-    public static ConfigKey<Duration> WINDOW_DURATION = ConfigKeys.newConfigKey(Duration.class, "enricher.window.duration",
-        "Duration for which this window should store data, default one minute", Duration.ONE_MINUTE);
+    public static ConfigKey<Duration> WINDOW_DURATION = ConfigKeys.newConfigKey(
+            Duration.class, 
+            "enricher.window.duration",
+            "Duration for which this window should store data, default one minute", 
+            Duration.ONE_MINUTE);
 
-    public static ConfigKey<Double> CONFIDENCE_REQUIRED_TO_PUBLISH = ConfigKeys.newDoubleConfigKey("enricher.window.confidenceRequired",
-        "Minimum confidence level (ie period covered) required to publish a rolling average", 0.8d);
+    public static ConfigKey<Double> CONFIDENCE_REQUIRED_TO_PUBLISH = ConfigKeys.newDoubleConfigKey(
+            "enricher.window.confidenceRequired",
+            "Minimum confidence level (ie period covered) required to publish a rolling average", 
+            0.8d);
 
     public static class ConfidenceQualifiedNumber {
         final Double value;

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlTimeWeightedDeltaEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/YamlTimeWeightedDeltaEnricher.java
@@ -47,8 +47,11 @@ public class YamlTimeWeightedDeltaEnricher<T extends Number> extends AbstractTra
     Number lastValue;
     long lastTime = -1;
     
-    public static final ConfigKey<Duration> DELTA_PERIOD = ConfigKeys.newConfigKey(Duration.class, "enricher.delta.period",
-        "Duration that this delta should compute for, default per second", Duration.ONE_SECOND);
+    public static final ConfigKey<Duration> DELTA_PERIOD = ConfigKeys.newConfigKey(
+            Duration.class, 
+            "enricher.delta.period",
+            "Duration that this delta should compute for (default is one second)", 
+            Duration.ONE_SECOND);
     
     @Override
     public void setEntity(EntityLocal entity) {

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
@@ -62,7 +62,7 @@ public class Reducer extends AbstractEnricher implements SensorEventListener<Obj
     public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
             new TypeToken<Sensor<?>>() {},
             "enricher.targetSensor",
-            "The sensor that will be set on the associated entity, with the target value");
+            "The sensor to be set on the associated entity with the value computed here");
 
     public static final ConfigKey<List<? extends AttributeSensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(
             new TypeToken<List<? extends AttributeSensor<?>>>() {},

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/reducer/Reducer.java
@@ -54,18 +54,30 @@ public class Reducer extends AbstractEnricher implements SensorEventListener<Obj
     private static final Logger LOG = LoggerFactory.getLogger(Reducer.class);
 
     @SetFromFlag("producer")
-    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(Entity.class,
-            "enricher.producer");
-    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(new TypeToken<Sensor<?>>() {},
-            "enricher.targetSensor");
-    public static final ConfigKey<List<? extends AttributeSensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(new TypeToken<List<? extends AttributeSensor<?>>>() {},
-            "enricher.sourceSensors");
+    public static final ConfigKey<Entity> PRODUCER = ConfigKeys.newConfigKey(
+            Entity.class,
+            "enricher.producer",
+            "The entity with the trigger sensor (defaults to the enricher's entity)");
+    
+    public static final ConfigKey<Sensor<?>> TARGET_SENSOR = ConfigKeys.newConfigKey(
+            new TypeToken<Sensor<?>>() {},
+            "enricher.targetSensor",
+            "The sensor that will be set on the associated entity, with the target value");
+
+    public static final ConfigKey<List<? extends AttributeSensor<?>>> SOURCE_SENSORS = ConfigKeys.newConfigKey(
+            new TypeToken<List<? extends AttributeSensor<?>>>() {},
+            "enricher.sourceSensors",
+            "The sensors whose change triggers re-evaluation of the target value");
+
     public static final ConfigKey<Function<List<?>,?>> REDUCER_FUNCTION = ConfigKeys.newConfigKey(new TypeToken<Function<List<?>, ?>>() {},
-            "enricher.reducerFunction");
+            "enricher.reducerFunction",
+            "The function to execute to evaluate the target sensor value");
+    
     @SetFromFlag("transformation")
     public static final ConfigKey<String> REDUCER_FUNCTION_TRANSFORMATION = ConfigKeys.newStringConfigKey(
             "enricher.reducerFunction.transformation",
             "A string matching a pre-defined named reducer function, such as joiner, formatString, etc");
+    
     public static final ConfigKey<Map<String, Object>> PARAMETERS = ConfigKeys.newConfigKey(new TypeToken<Map<String, Object>>() {},
             "enricher.reducerFunction.parameters",
             "A map of parameters to pass into the reducer function");

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
@@ -63,9 +63,13 @@ public interface AbstractGroup extends Entity, Group, Changeable {
     ConfigKey<Boolean> MEMBER_DELEGATE_CHILDREN = ConfigKeys.newBooleanConfigKey(
             "group.members.delegate", "Deprecated: Add delegate child entities for members of the group", Boolean.FALSE);
 
+    /**
+     * @deprecated since 0.12.0, but was only ever used in {@link #MEMBER_DELEGATE_CHILDREN} was set (so effectively deprecated since 0.9.0).
+     */
+    @Deprecated
     ConfigKey<String> MEMBER_DELEGATE_NAME_FORMAT = ConfigKeys.newStringConfigKey(
             "group.members.delegate.nameFormat", 
-            "Delegate members name format string (Use %s for the original entity display name)", 
+            "Deprecated: Delegate members name format string (Use %s for the original entity display name)", 
             "%s");
 
     ConfigKey<QuorumCheck> UP_QUORUM_CHECK = ConfigKeys.newConfigKeyWithDefault(ComputeServiceIndicatorsFromChildrenAndMembers.UP_QUORUM_CHECK, 

--- a/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/AbstractGroup.java
@@ -64,12 +64,15 @@ public interface AbstractGroup extends Entity, Group, Changeable {
             "group.members.delegate", "Deprecated: Add delegate child entities for members of the group", Boolean.FALSE);
 
     ConfigKey<String> MEMBER_DELEGATE_NAME_FORMAT = ConfigKeys.newStringConfigKey(
-            "group.members.delegate.nameFormat", "Delegate members name format string (Use %s for the original entity display name)", "%s");
+            "group.members.delegate.nameFormat", 
+            "Delegate members name format string (Use %s for the original entity display name)", 
+            "%s");
 
-    public static final ConfigKey<QuorumCheck> UP_QUORUM_CHECK = ConfigKeys.newConfigKeyWithDefault(ComputeServiceIndicatorsFromChildrenAndMembers.UP_QUORUM_CHECK, 
+    ConfigKey<QuorumCheck> UP_QUORUM_CHECK = ConfigKeys.newConfigKeyWithDefault(ComputeServiceIndicatorsFromChildrenAndMembers.UP_QUORUM_CHECK, 
         "Up check, applied by default to members, requiring at least one present and up",
         QuorumChecks.atLeastOne());
-    public static final ConfigKey<QuorumCheck> RUNNING_QUORUM_CHECK = ConfigKeys.newConfigKeyWithDefault(ComputeServiceIndicatorsFromChildrenAndMembers.RUNNING_QUORUM_CHECK,
+    
+    ConfigKey<QuorumCheck> RUNNING_QUORUM_CHECK = ConfigKeys.newConfigKeyWithDefault(ComputeServiceIndicatorsFromChildrenAndMembers.RUNNING_QUORUM_CHECK,
         "Problems check from children actual states (lifecycle), applied by default to members and children, not checking upness, but requiring by default that none are on-fire",
         QuorumChecks.all());
 

--- a/core/src/main/java/org/apache/brooklyn/entity/group/Cluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/Cluster.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.group;
 
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.entity.trait.Resizable;
@@ -29,6 +30,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
  */
 public interface Cluster extends Group, Startable, Resizable {
     
+    @CatalogConfig(label = "Initial size")
     @SetFromFlag("initialSize")
     BasicConfigKey<Integer> INITIAL_SIZE = new BasicConfigKey<Integer>(
             Integer.class, "cluster.initial.size", "Initial cluster size", 1);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
@@ -103,13 +104,16 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
     ConfigKey<String> RESTART_MODE = ConfigKeys.newStringConfigKey(
             "dynamiccluster.restartMode", 
             "How this cluster should handle restarts; "
-            + "by default it is disallowed, but this key can specify a different mode. "
-            + "Modes supported by dynamic cluster are 'off', 'sequential', or 'parallel'. "
-            + "However subclasses can define their own modes or may ignore this.", null);
+                    + "by default it is disallowed, but this key can specify a different mode. "
+                    + "Modes supported by dynamic cluster are 'off', 'sequential', or 'parallel'. "
+                    + "However subclasses can define their own modes or may ignore this.", 
+            null);
 
     @SetFromFlag("quarantineFailedEntities")
     ConfigKey<Boolean> QUARANTINE_FAILED_ENTITIES = ConfigKeys.newBooleanConfigKey(
-            "dynamiccluster.quarantineFailedEntities", "If true, will quarantine entities that fail to start; if false, will get rid of them (i.e. delete them)", true);
+            "dynamiccluster.quarantineFailedEntities", 
+            "If true, will quarantine entities that fail to start; if false, will get rid of them (i.e. delete them)", 
+            true);
 
     @SetFromFlag("quarantineFilter")
     ConfigKey<Predicate<? super Throwable>> QUARANTINE_FILTER = ConfigKeys.newConfigKey(
@@ -132,6 +136,7 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
             "Initial cluster quorum size - number of initial nodes that must have been successfully started to report success (if < 0, then use value of INITIAL_SIZE)",
             -1);
 
+    @CatalogConfig(label = "Member spec")
     @SetFromFlag("memberSpec")
     ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() { },
@@ -140,7 +145,9 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
     @SetFromFlag("firstMemberSpec")
     ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() { },
-            "dynamiccluster.firstmemberspec", "entity spec for creating new cluster members, used for the very first member if different", null);
+            "dynamiccluster.firstmemberspec", 
+            "entity spec for creating the first member of the cluster (if unset, will use the member spec for all)", 
+            null);
 
     @SetFromFlag("removalStrategy")
     ConfigKey<Function<Collection<Entity>, Entity>> REMOVAL_STRATEGY = ConfigKeys.newConfigKey(
@@ -183,7 +190,9 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
             "Time to wait (after members' start() effectors return) for SERVICE_UP before failing (default is not to wait)",
             null);
 
-    ConfigKey<Integer> MAX_SIZE = ConfigKeys.newIntegerConfigKey("cluster.max.size", "Size after which it will throw InsufficientCapacityException", Integer.MAX_VALUE);
+    ConfigKey<Integer> MAX_SIZE = ConfigKeys.newIntegerConfigKey("cluster.max.size", 
+            "Size after which it will throw InsufficientCapacityException", 
+            Integer.MAX_VALUE);
 
     @Beta
     @SetFromFlag("maxConcurrentChildCommands")

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.group;
 
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -50,13 +51,20 @@ public interface DynamicFabric extends AbstractGroup, Startable, Fabric {
                     + "for each given location).",
             true);
     
+    @CatalogConfig(label = "Member spec")
     @SetFromFlag("memberSpec")
     ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
-            new TypeToken<EntitySpec<?>>() {}, "dynamiccfabric.memberspec", "entity spec for creating new cluster members", null);
+            new TypeToken<EntitySpec<?>>() {}, 
+            "dynamiccfabric.memberspec", 
+            "entity spec for creating new members (one per location)", 
+            null);
 
     @SetFromFlag("firstMemberSpec")
     ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.newConfigKey(
-            new TypeToken<EntitySpec<?>>() {}, "dynamiccfabric.firstmemberspec", "entity spec for creating new cluster members", null);
+            new TypeToken<EntitySpec<?>>() {}, 
+            "dynamiccfabric.firstmemberspec", 
+            "entity spec for the first member", 
+            null);
 
     @SetFromFlag("displayNamePrefix")
     ConfigKey<String> DISPLAY_NAME_PREFIX = ConfigKeys.newStringConfigKey(

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
@@ -56,27 +56,32 @@ public interface DynamicFabric extends AbstractGroup, Startable, Fabric {
     ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() {}, 
             "dynamiccfabric.memberspec", 
-            "entity spec for creating new members (one per location)", 
+            "Entity spec for creating new members (one per location)", 
             null);
 
     @SetFromFlag("firstMemberSpec")
     ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() {}, 
             "dynamiccfabric.firstmemberspec", 
-            "entity spec for the first member", 
+            "Entity spec for the first member", 
             null);
 
     @SetFromFlag("displayNamePrefix")
     ConfigKey<String> DISPLAY_NAME_PREFIX = ConfigKeys.newStringConfigKey(
-            "dynamicfabric.displayNamePrefix", "Display name prefix, for created children");
+            "dynamicfabric.displayNamePrefix", 
+            "Display name prefix, for created children");
 
     @SetFromFlag("displayNameSuffix")
     ConfigKey<String> DISPLAY_NAME_SUFFIX = ConfigKeys.newStringConfigKey(
-            "dynamicfabric.displayNameSuffix", "Display name suffix, for created children");
+            "dynamicfabric.displayNameSuffix", 
+            "Display name suffix, for created children");
 
     @SetFromFlag("customChildFlags")
     MapConfigKey<Object> CUSTOM_CHILD_FLAGS = new MapConfigKey<Object>(
-            Object.class, "dynamicfabric.customChildFlags", "Additional flags to be passed to children when they are being created", ImmutableMap.<String,Object>of());
+            Object.class, 
+            "dynamicfabric.customChildFlags", 
+            "Additional flags to be passed to children when they are being created", 
+            ImmutableMap.<String,Object>of());
 
     AttributeSensor<Integer> FABRIC_SIZE = Sensors.newIntegerSensor("fabric.size", "Fabric size");
     

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroup.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroup.java
@@ -41,8 +41,10 @@ public interface DynamicGroup extends AbstractGroup {
 
     @SuppressWarnings("serial")
     @SetFromFlag("entityFilter")
-    ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(new TypeToken<Predicate<? super Entity>>() { },
-            "dynamicgroup.entityfilter", "Filter for entities which will automatically be in the group");
+    ConfigKey<Predicate<? super Entity>> ENTITY_FILTER = ConfigKeys.newConfigKey(
+            new TypeToken<Predicate<? super Entity>>() { },
+            "dynamicgroup.entityfilter", 
+            "Filter for entities which will automatically be in the group");
 
     AttributeSensor<Boolean> RUNNING = Sensors.newBooleanSensor(
             "dynamicgroup.running", "Whether the entity is running, and will automatically update group membership");

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
@@ -41,8 +41,10 @@ public interface BasicStartable extends Entity, Startable {
     @SetFromFlag("startLatch")
     ConfigKey<Boolean> START_LATCH = BrooklynConfigKeys.START_LATCH;
 
-    ConfigKey<Locations.LocationsFilter> LOCATIONS_FILTER = ConfigKeys.newConfigKey(Locations.LocationsFilter.class,
-            "brooklyn.locationsFilter", "Provides a hook for customizing locations to be used for a given context");
+    ConfigKey<Locations.LocationsFilter> LOCATIONS_FILTER = ConfigKeys.newConfigKey(
+            Locations.LocationsFilter.class,
+            "brooklyn.locationsFilter", 
+            "Provides a hook for customizing locations to be used for a given context");
 
     /** @deprecated since 0.7.0; use {@link Locations#LocationFilter} */
     @Deprecated

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/DelegateEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/DelegateEntity.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.entity.stock;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.entity.ImplementedBy;
@@ -37,7 +38,11 @@ import com.google.common.base.Function;
 @ImplementedBy(DelegateEntityImpl.class)
 public interface DelegateEntity extends Entity {
 
-    AttributeSensorAndConfigKey<Entity, Entity> DELEGATE_ENTITY = ConfigKeys.newSensorAndConfigKey(Entity.class, "delegate.entity", "The delegate entity");
+    @CatalogConfig(label = "Delegate")
+    AttributeSensorAndConfigKey<Entity, Entity> DELEGATE_ENTITY = ConfigKeys.newSensorAndConfigKey(
+            Entity.class, 
+            "delegate.entity", 
+            "The delegate entity");
 
     AttributeSensor<String> DELEGATE_ENTITY_LINK = Sensors.newStringSensor("webapp.url", "The delegate entity link");
 

--- a/core/src/main/resources/catalog.bom
+++ b/core/src/main/resources/catalog.bom
@@ -23,42 +23,68 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.group.QuarantineGroup
       item:
         type: org.apache.brooklyn.entity.group.QuarantineGroup
+        name: Quarantine Group
+        description: A grouping for entities that are in quarantine (i.e. removed from the main cluster)
     - id: org.apache.brooklyn.entity.group.BasicGroup
       item:
         type: org.apache.brooklyn.entity.group.BasicGroup
+        name: Basic Group
+        description: A grouping of entities
     - id: org.apache.brooklyn.entity.stock.BasicEntity
       item:
         type: org.apache.brooklyn.entity.stock.BasicEntity
+        name: Basic Entity
+        description: The simplest basic entity (can be useful for testing)
     - id: org.apache.brooklyn.entity.stock.DataEntity
       item:
         type: org.apache.brooklyn.entity.stock.DataEntity
+        name: Basic Entity
+        description: An entity that supplies data as sensor values (periodically evaluating given suppliers).
     - id: org.apache.brooklyn.entity.group.DynamicGroup
       item:
         type: org.apache.brooklyn.entity.group.DynamicGroup
+        name: Dynamic Group
+        description: A grouping of entities, where membership of the group is based on a given filter.
     - id: org.apache.brooklyn.entity.stock.DelegateEntity
       item:
         type: org.apache.brooklyn.entity.stock.DelegateEntity
+        name: Delegate Entity
+        description: An entity that mirrors another entity (mirroring its sensors)
     - id: org.apache.brooklyn.entity.group.DynamicRegionsFabric
       item:
         type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+        name: Dynamic Regions Fabric
+        description: A 'fabric' (see 'Dynamic Fabric') that allows new locations to be added/removed. 
     - id: org.apache.brooklyn.core.server.entity.BrooklynMetrics
       item:
         type: org.apache.brooklyn.core.server.entity.BrooklynMetrics
+        name: Brooklyn Metrics
+        description: An entity that gives information about this Brooklyn server.
     - id: org.apache.brooklyn.entity.stock.BasicApplication
       item:
         type: org.apache.brooklyn.entity.stock.BasicApplication
+        name: Basic Application
+        description: The simplest application.
     - id: org.apache.brooklyn.entity.stock.BasicStartable
       item:
         type: org.apache.brooklyn.entity.stock.BasicStartable
+        name: Basic Startable
+        description: Provides a pass-through Startable entity, which can control the location(s) passed to its children.
     - id: org.apache.brooklyn.entity.group.DynamicCluster
       item:
         type: org.apache.brooklyn.entity.group.DynamicCluster
+        name: Dynamic Cluster
+        description: A cluster of entities that can dynamically increase or decrease the number of members.
     - id: org.apache.brooklyn.entity.group.DynamicMultiGroup
       item:
         type: org.apache.brooklyn.entity.group.DynamicMultiGroup
+        name: Dynamic Multi Group
+        description: Similar to 'Dynamic Group', but with multiple child groups. Entities are added to the child groups based on a supplied filter. 
     - id: org.apache.brooklyn.entity.group.DynamicFabric
       item:
         type: org.apache.brooklyn.entity.group.DynamicFabric
+        name: Dynamic Fabric
+        description: The 'fabric' creates and starts an entity in each of its locations.
 
   - itemType: enricher
     items:
@@ -66,51 +92,78 @@ brooklyn.catalog:
       itemType: enricher
       item:
         type: org.apache.brooklyn.core.network.OnPublicNetworkEnricher
+        name: Public Network Advertiser
+        description: Advertises entity's public mapped ports. This can be used with sensors of type URI, HostAndPort or plain integer port values
     - id: org.apache.brooklyn.core.network.OnSubnetNetworkEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.core.network.OnSubnetNetworkEnricher
+        name: Subnet Network Advertiser
+        description: Advertises entity's subnet mapped ports. This can be used with sensors of type URI, HostAndPort or plain integer port values
     - id: org.apache.brooklyn.enricher.stock.Aggregator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Aggregator
+        name: Aggregator
+        description: Aggregates sensors from multiple entities into a single sensor value
     - id: org.apache.brooklyn.enricher.stock.Combiner
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Combiner
+        name: Combiner
+        description: Combines and apply a transformation to sensors of an entity
     - id: org.apache.brooklyn.enricher.stock.Joiner
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Joiner
+        name: Joiner
+        description: Joins entity's sensors into another one, i.e. creates a comma separated string from a list
     - id: org.apache.brooklyn.enricher.stock.MapAggregator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.MapAggregator
+        name: Map Aggregator
+        description: Aggregates a pair of sensors on multiple children and/or members that are used as key-value pairs in a generated Map
     - id: org.apache.brooklyn.enricher.stock.PercentageEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.PercentageEnricher
+        name: Percentage Transformer
+        description: Computes and advertises the percentage based on a current and total values
     - id: org.apache.brooklyn.enricher.stock.Propagator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Propagator
+        name: Propagator
+        description: Propagates sensors from one entity to another
     - id: org.apache.brooklyn.enricher.stock.Transformer
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Transformer
+        name: Transformer
+        description: Transforms sensors of an entity
     - id: org.apache.brooklyn.enricher.stock.UpdatingMap
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.UpdatingMap
+        name: Map Updater
+        description: Updates an entry in a sensor Map
     - id: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
+        name: YAML Rolling Average
+        description: Transforms sensor data into a rolling average based on a time window.")
     - id: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
+        name: YAML Time-weighted Delta
+        description: Converts an absolute count sensor into a delta sensor
     - id: org.apache.brooklyn.enricher.stock.reducer.Reducer
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.reducer.Reducer
+        name: Reducer
+        description: Applies a transformation to a sensor
+        

--- a/core/src/main/resources/catalog.bom
+++ b/core/src/main/resources/catalog.bom
@@ -38,7 +38,7 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.stock.DataEntity
       item:
         type: org.apache.brooklyn.entity.stock.DataEntity
-        name: Basic Entity
+        name: Data Entity
         description: An entity that supplies data as sensor values (periodically evaluating given suppliers).
     - id: org.apache.brooklyn.entity.group.DynamicGroup
       item:

--- a/karaf/init/src/main/resources/catalog-classes.bom
+++ b/karaf/init/src/main/resources/catalog-classes.bom
@@ -24,42 +24,68 @@ brooklyn.catalog:
      - id: org.apache.brooklyn.entity.group.QuarantineGroup
        item:
          type: org.apache.brooklyn.entity.group.QuarantineGroup
+         name: Quarantine Group
+         description: A grouping for entities that are in quarantine (i.e. removed from the main cluster)
      - id: org.apache.brooklyn.entity.group.BasicGroup
        item:
          type: org.apache.brooklyn.entity.group.BasicGroup
+         name: Basic Group
+         description: A grouping of entities
      - id: org.apache.brooklyn.entity.stock.BasicEntity
        item:
          type: org.apache.brooklyn.entity.stock.BasicEntity
+         name: Basic Entity
+         description: The simplest basic entity (can be useful for testing)
      - id: org.apache.brooklyn.entity.stock.DataEntity
        item:
          type: org.apache.brooklyn.entity.stock.DataEntity
+         name: Data Entity
+         description: An entity that supplies data as sensor values (periodically evaluating given suppliers).
      - id: org.apache.brooklyn.entity.group.DynamicGroup
        item:
          type: org.apache.brooklyn.entity.group.DynamicGroup
+         name: Dynamic Group
+         description: A grouping of entities, where membership of the group is based on a given filter.
      - id: org.apache.brooklyn.entity.stock.DelegateEntity
        item:
          type: org.apache.brooklyn.entity.stock.DelegateEntity
+         name: Delegate Entity
+         description: An entity that mirrors another entity (mirroring its sensors)
      - id: org.apache.brooklyn.entity.group.DynamicRegionsFabric
        item:
          type: org.apache.brooklyn.entity.group.DynamicRegionsFabric
+         name: Dynamic Regions Fabric
+         description: A 'fabric' (see 'Dynamic Fabric') that allows new locations to be added/removed. 
      - id: org.apache.brooklyn.core.server.entity.BrooklynMetrics
        item:
          type: org.apache.brooklyn.core.server.entity.BrooklynMetrics
+         name: Brooklyn Metrics
+         description: An entity that gives information about this Brooklyn server.
      - id: org.apache.brooklyn.entity.stock.BasicApplication
        item:
          type: org.apache.brooklyn.entity.stock.BasicApplication
+         name: Basic Application
+         description: The simplest application.
      - id: org.apache.brooklyn.entity.stock.BasicStartable
        item:
          type: org.apache.brooklyn.entity.stock.BasicStartable
+         name: Basic Startable
+         description: Provides a pass-through Startable entity, which can control the location(s) passed to its children.
      - id: org.apache.brooklyn.entity.group.DynamicCluster
        item:
          type: org.apache.brooklyn.entity.group.DynamicCluster
+         name: Dynamic Cluster
+         description: A cluster of entities that can dynamically increase or decrease the number of members.
      - id: org.apache.brooklyn.entity.group.DynamicMultiGroup
        item:
          type: org.apache.brooklyn.entity.group.DynamicMultiGroup
+         name: Dynamic Multi Group
+         description: Similar to 'Dynamic Group', but with multiple child groups. Entities are added to the child groups based on a supplied filter. 
      - id: org.apache.brooklyn.entity.group.DynamicFabric
        item:
          type: org.apache.brooklyn.entity.group.DynamicFabric
+         name: Dynamic Fabric
+         description: The 'fabric' creates and starts an entity in each of its locations.
 
   # org.apache.brooklyn.policy
   - items:
@@ -81,24 +107,26 @@ brooklyn.catalog:
         type: org.apache.brooklyn.policy.ha.SshMachineFailureDetector
         name: Ssh Connectivity Failure Detector
         description: HA policy for monitoring an SshMachine, 
-#    removed from catalog because it cannot currently be configured via catalog mechanisms
+
+#    Removed from catalog because 'FollowTheSunPool' cannot currently be configured via catalog mechanisms.
+#    Also removing associated 'BalanceableWorkerPool' etc as they are only useful with 'FollowTheSunPool'
 #    - id: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
 #      item:
 #        type: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
-    - id: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
-      itemType: entity
-      item:
-        type: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+#    - id: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+#      itemType: entity
+#      item:
+#        type: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+#    - id: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
+#      itemType: entity
+#      item:
+#        type: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
     - id: org.apache.brooklyn.policy.ha.ServiceReplacer
       itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ServiceReplacer
         name: Service Replacer
         description: HA policy for replacing a failed member of a group
-    - id: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
-      itemType: entity
-      item:
-        type: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
     - id: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
       itemType: policy
       item:
@@ -113,82 +141,126 @@ brooklyn.catalog:
       itemType: enricher
       item:
         type: org.apache.brooklyn.core.network.OnPublicNetworkEnricher
+        name: Public Network Advertiser
+        description: Advertises entity's public mapped ports. This can be used with sensors of type URI, HostAndPort or plain integer port values
     - id: org.apache.brooklyn.core.network.OnSubnetNetworkEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.core.network.OnSubnetNetworkEnricher
+        name: Subnet Network Advertiser
+        description: Advertises entity's subnet mapped ports. This can be used with sensors of type URI, HostAndPort or plain integer port values
     - id: org.apache.brooklyn.enricher.stock.Aggregator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Aggregator
+        name: Aggregator
+        description: Aggregates sensors from multiple entities into a single sensor value
     - id: org.apache.brooklyn.enricher.stock.Combiner
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Combiner
+        name: Combiner
+        description: Combines and apply a transformation to sensors of an entity
     - id: org.apache.brooklyn.enricher.stock.Joiner
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Joiner
+        name: Joiner
+        description: Joins entity's sensors into another one, i.e. creates a comma separated string from a list
     - id: org.apache.brooklyn.enricher.stock.MapAggregator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.MapAggregator
+        name: Map Aggregator
+        description: Aggregates a pair of sensors on multiple children and/or members that are used as key-value pairs in a generated Map
     - id: org.apache.brooklyn.enricher.stock.PercentageEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.PercentageEnricher
+        name: Percentage Transformer
+        description: Computes and advertises the percentage based on a current and total values
     - id: org.apache.brooklyn.enricher.stock.Propagator
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Propagator
+        name: Propagator
+        description: Propagates sensors from one entity to another
     - id: org.apache.brooklyn.enricher.stock.Transformer
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.Transformer
+        name: Transformer
+        description: Transforms sensors of an entity
     - id: org.apache.brooklyn.enricher.stock.UpdatingMap
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.UpdatingMap
+        name: Map Updater
+        description: Updates an entry in a sensor Map
     - id: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
+        name: YAML Rolling Average
+        description: Transforms sensor data into a rolling average based on a time window.")
     - id: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
+        name: YAML Time-weighted Delta
+        description: Converts an absolute count sensor into a delta sensor
     - id: org.apache.brooklyn.enricher.stock.reducer.Reducer
       itemType: enricher
       item:
         type: org.apache.brooklyn.enricher.stock.reducer.Reducer
+        name: Reducer
+        description: Applies a transformation to a sensor
     - id: org.apache.brooklyn.policy.enricher.DeltaEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.DeltaEnricher
+        name: Delta
+        description: Converts an absolute sensor into a delta sensor (i.e. the diff between the current and previous value)
     - id: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
+        name: HTTP Latency Detector
+        description: Computes latency in accessing a URL, normally by periodically polling that URL
     - id: org.apache.brooklyn.policy.enricher.RollingMeanEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingMeanEnricher
+        name: Rolling Mean
+        description: |
+          Transforms a sensor into a rolling average based on a fixed window size. 
+          This is useful for smoothing sample type metrics, such as latency or CPU time.
     - id: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
+        name: [DEPRECATED] Rolling Mean in Time Window
+        description: [DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher
     - id: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
+        name: Time-fraction Delta
+        description: |
+          Converts an absolute measure of time into a fraction of time, 
+          based on the delta between consecutive values and the elapsed time between those values.
     - id: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
+        name: [DEPRECATED] Time Weighted Delta
+        description: [DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'
     - id: org.apache.brooklyn.policy.ha.ServiceFailureDetector
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.ha.ServiceFailureDetector
+        name: Service Failure Detector
+        description: Emits a new sensor if the current entity fails
 
     # org.apache.brooklyn.software-base
   - itemType: entity
@@ -224,6 +296,7 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.java.VanillaJavaApp
       item:
         type: org.apache.brooklyn.entity.java.VanillaJavaApp
+        name: Vanilla Java App
     - id: org.apache.brooklyn.entity.brooklynnode.BrooklynNode
       item:
         type: org.apache.brooklyn.entity.brooklynnode.BrooklynNode
@@ -232,9 +305,12 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.brooklynnode.BrooklynCluster
       item:
         type: org.apache.brooklyn.entity.brooklynnode.BrooklynCluster
+        name: Brooklyn Cluster
     - id: org.apache.brooklyn.entity.brooklynnode.LocalBrooklynNode
       item:
         type: org.apache.brooklyn.entity.brooklynnode.LocalBrooklynNode
+        name: Local Brooklyn Node
+        description: An entity that represents the local Brooklyn server.
     - id: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
       item:
         type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
@@ -246,34 +322,43 @@ brooklyn.catalog:
         name: Server Pool
         description: Creates a pre-allocated server pool, which other applications can deploy to
 
-
   # org.apache.brooklyn.test-framework
   - itemType: entity
     items:
     - id: org.apache.brooklyn.test.framework.TestSshCommand
       item:
         type: org.apache.brooklyn.test.framework.TestSshCommand
+        name: Test SSH Command
     - id: org.apache.brooklyn.test.framework.SimpleShellCommandTest
       item:
         type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
+        name: [DEPRECATED] Simple Shell Command Test
+        description:  [DEPRECATED] Instead use TestSshCommand
     - id: org.apache.brooklyn.test.framework.ParallelTestCase
       item:
         type: org.apache.brooklyn.test.framework.ParallelTestCase
+        name: Parallel Test Case
     - id: org.apache.brooklyn.test.framework.TestCase
       item:
         type: org.apache.brooklyn.test.framework.TestCase
+        name: Test Case
     - id: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
       item:
         type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        name: Infrastructure Deployment Test Case
     - id: org.apache.brooklyn.test.framework.TestSensor
       item:
         type: org.apache.brooklyn.test.framework.TestSensor
+        name: Test Sensor
     - id: org.apache.brooklyn.test.framework.TestEffector
       item:
         type: org.apache.brooklyn.test.framework.TestEffector
+        name: Test Effector
     - id: org.apache.brooklyn.test.framework.TestHttpCall
       item:
         type: org.apache.brooklyn.test.framework.TestHttpCall
+        name: Test HTTP Call
     - id: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
       item:
         type: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
+        name: Loop Over Group Members Test Case

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ConnectionFailureDetector.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ConnectionFailureDetector.java
@@ -40,9 +40,16 @@ import com.google.common.net.HostAndPort;
         + "emitting an event if the connection is lost/restored")
 public class ConnectionFailureDetector extends AbstractFailureDetector {
 
-    public static final ConfigKey<HostAndPort> ENDPOINT = ConfigKeys.newConfigKey(HostAndPort.class, "connectionFailureDetector.endpoint");
+    public static final ConfigKey<HostAndPort> ENDPOINT = ConfigKeys.newConfigKey(
+            HostAndPort.class, 
+            "connectionFailureDetector.endpoint",
+            "The host:port to be checked periodically");
 
-    public static final ConfigKey<Duration> POLL_PERIOD = ConfigKeys.newConfigKey(Duration.class, "connectionFailureDetector.pollPeriod", "", Duration.ONE_SECOND);
+    public static final ConfigKey<Duration> POLL_PERIOD = ConfigKeys.newConfigKey(
+            Duration.class, 
+            "connectionFailureDetector.pollPeriod", 
+            "The poll period for checking that the endpoint is reachable", 
+            Duration.ONE_SECOND);
 
     public static final BasicNotificationSensor<FailureDescriptor> CONNECTION_FAILED = HASensors.CONNECTION_FAILED;
 
@@ -61,7 +68,8 @@ public class ConnectionFailureDetector extends AbstractFailureDetector {
     @SetFromFlag("connectionRecoveredStabilizationDelay")
     public static final ConfigKey<Duration> CONNECTION_RECOVERED_STABILIZATION_DELAY = BasicConfigKey.builder(Duration.class)
             .name("connectionFailureDetector.serviceRecoveredStabilizationDelay")
-            .description("For a failed connection, time period for which the connection must be consistently up for (e.g. doesn't report up-down-up) before concluding recovered")
+            .description("For a failed connection, time period for which the connection must be consistently up for "
+                    + "(e.g. doesn't report up-down-up) before concluding recovered")
             .defaultValue(Duration.ZERO)
             .build();
 

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceFailureDetector.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceFailureDetector.java
@@ -75,11 +75,15 @@ public class ServiceFailureDetector extends ServiceStateLogic.ComputeServiceStat
     public static final BasicNotificationSensor<FailureDescriptor> ENTITY_FAILED = HASensors.ENTITY_FAILED;
 
     @SetFromFlag("onlyReportIfPreviouslyUp")
-    public static final ConfigKey<Boolean> ENTITY_FAILED_ONLY_IF_PREVIOUSLY_UP = ConfigKeys.newBooleanConfigKey("onlyReportIfPreviouslyUp", 
-        "Prevents the policy from emitting ENTITY_FAILED if the entity fails on startup (ie has never been up)", true);
+    public static final ConfigKey<Boolean> ENTITY_FAILED_ONLY_IF_PREVIOUSLY_UP = ConfigKeys.newBooleanConfigKey(
+            "onlyReportIfPreviouslyUp", 
+            "Prevents the policy from emitting ENTITY_FAILED if the entity fails on startup (ie has never been up)", 
+            true);
     
-    public static final ConfigKey<Boolean> MONITOR_SERVICE_PROBLEMS = ConfigKeys.newBooleanConfigKey("monitorServiceProblems", 
-        "Whether to monitor service problems, and emit on failures there (if set to false, this monitors only service up)", true);
+    public static final ConfigKey<Boolean> MONITOR_SERVICE_PROBLEMS = ConfigKeys.newBooleanConfigKey(
+            "monitorServiceProblems", 
+            "Whether to monitor service problems, and emit on failures there (if set to false, this monitors only service up)", 
+            true);
 
     @SetFromFlag("serviceOnFireStabilizationDelay")
     public static final ConfigKey<Duration> SERVICE_ON_FIRE_STABILIZATION_DELAY = BasicConfigKey.builder(Duration.class)

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
@@ -62,28 +62,38 @@ public class ServiceReplacer extends AbstractPolicy {
     // TODO if there are multiple failures perhaps we should abort quickly
     
     public static final BasicNotificationSensor<FailureDescriptor> ENTITY_REPLACEMENT_FAILED = new BasicNotificationSensor<FailureDescriptor>(
-            FailureDescriptor.class, "ha.entityFailed.replacement", "Indicates that an entity replacement attempt has failed");
+            FailureDescriptor.class, 
+            "ha.entityFailed.replacement", 
+            "Indicates that an entity replacement attempt has failed");
 
     @SetFromFlag("setOnFireOnFailure")
-    public static final ConfigKey<Boolean> SET_ON_FIRE_ON_FAILURE = ConfigKeys.newBooleanConfigKey("setOnFireOnFailure", "", true);
+    public static final ConfigKey<Boolean> SET_ON_FIRE_ON_FAILURE = ConfigKeys.newBooleanConfigKey(
+            "setOnFireOnFailure", 
+            "Whether to set the entity as 'ON_FIRE' when failure is detected", 
+            true);
     
     /** monitors this sensor, by default ENTITY_RESTART_FAILED */
     @SetFromFlag("failureSensorToMonitor")
     @SuppressWarnings("rawtypes")
-    public static final ConfigKey<Sensor> FAILURE_SENSOR_TO_MONITOR = new BasicConfigKey<Sensor>(Sensor.class, "failureSensorToMonitor", "", ServiceRestarter.ENTITY_RESTART_FAILED); 
+    public static final ConfigKey<Sensor> FAILURE_SENSOR_TO_MONITOR = new BasicConfigKey<Sensor>(
+            Sensor.class, 
+            "failureSensorToMonitor", 
+            "The sensor, emitted by an entity, used to trigger its replacement. Defaults to 'ha.entityFailed.restart' "
+                    + "(i.e. a 'ServiceRestarter' policy tried and failed to restart the entity)", 
+            ServiceRestarter.ENTITY_RESTART_FAILED); 
 
     /** skips replace if replacement has failed this many times failure re-occurs within this time interval */
     @SetFromFlag("failOnRecurringFailuresInThisDuration")
     public static final ConfigKey<Long> FAIL_ON_RECURRING_FAILURES_IN_THIS_DURATION = ConfigKeys.newLongConfigKey(
             "failOnRecurringFailuresInThisDuration", 
-            "abandon replace if replacement has failed many times within this time interval",
+            "Abandon replace if replacement has failed many times within this time interval",
             5*60*1000L);
 
     /** skips replace if replacement has failed this many times failure re-occurs within this time interval */
     @SetFromFlag("failOnNumRecurringFailures")
     public static final ConfigKey<Integer> FAIL_ON_NUM_RECURRING_FAILURES = ConfigKeys.newIntegerConfigKey(
             "failOnNumRecurringFailures", 
-            "abandon replace if replacement has failed this many times (100% of attempts) within the time interval",
+            "Abandon replace if replacement has failed this many times (100% of attempts) within the time interval",
             5);
 
     @SetFromFlag("ticker")

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
@@ -57,7 +57,9 @@ public class ServiceRestarter extends AbstractPolicy {
     private static final Logger LOG = LoggerFactory.getLogger(ServiceRestarter.class);
 
     public static final BasicNotificationSensor<FailureDescriptor> ENTITY_RESTART_FAILED = new BasicNotificationSensor<FailureDescriptor>(
-            FailureDescriptor.class, "ha.entityFailed.restart", "Indicates that an entity restart attempt has failed");
+            FailureDescriptor.class, 
+            "ha.entityFailed.restart", 
+            "Indicates that an entity restart attempt has failed");
 
     /** skips retry if a failure re-occurs within this time interval */
     @SetFromFlag("failOnRecurringFailuresInThisDuration")
@@ -68,12 +70,20 @@ public class ServiceRestarter extends AbstractPolicy {
             Duration.minutes(3));
 
     @SetFromFlag("setOnFireOnFailure")
-    public static final ConfigKey<Boolean> SET_ON_FIRE_ON_FAILURE = ConfigKeys.newBooleanConfigKey("setOnFireOnFailure", "", true);
+    public static final ConfigKey<Boolean> SET_ON_FIRE_ON_FAILURE = ConfigKeys.newBooleanConfigKey(
+            "setOnFireOnFailure", 
+            "Whether to set the entity as 'ON_FIRE' if restart fails", 
+            true);
 
     /** monitors this sensor, by default ENTITY_FAILED */
     @SetFromFlag("failureSensorToMonitor")
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static final ConfigKey<Sensor<?>> FAILURE_SENSOR_TO_MONITOR = (ConfigKey) ConfigKeys.newConfigKey(Sensor.class, "failureSensorToMonitor", "", HASensors.ENTITY_FAILED); 
+    public static final ConfigKey<Sensor<?>> FAILURE_SENSOR_TO_MONITOR = (ConfigKey) ConfigKeys.newConfigKey(
+            Sensor.class, 
+            "failureSensorToMonitor", 
+            "The sensor, emitted by an entity, used to trigger its restart. Defaults to 'ha.entityFailed' "
+                    + "(i.e. a 'ServiceFailureDetector' policy detected failure)", 
+            HASensors.ENTITY_FAILED); 
     
     protected final AtomicReference<Long> lastFailureTime = new AtomicReference<Long>();
 

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/SshMachineFailureDetector.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/SshMachineFailureDetector.java
@@ -48,7 +48,9 @@ public class SshMachineFailureDetector extends AbstractFailureDetector {
     public static final BasicNotificationSensor<FailureDescriptor> CONNECTION_RECOVERED = HASensors.CONNECTION_RECOVERED;
 
     public static final ConfigKey<Duration> CONNECT_TIMEOUT = ConfigKeys.newDurationConfigKey(
-            "ha.sshConnection.timeout", "How long to wait for conneciton before declaring failure", Duration.TEN_SECONDS);
+            "ha.sshConnection.timeout", 
+            "How long to wait for conneciton before declaring failure", 
+            Duration.TEN_SECONDS);
 
     @Override
     public void init() {

--- a/policy/src/main/resources/catalog.bom
+++ b/policy/src/main/resources/catalog.bom
@@ -16,77 +16,92 @@
 # under the License.
 
 brooklyn.catalog:
-    version: "0.12.0-SNAPSHOT" # BROOKLYN_VERSION
+  version: "0.12.0-SNAPSHOT" # BROOKLYN_VERSION
+  items:
+
+  - itemType: policy
     items:
     - id: org.apache.brooklyn.policy.ha.ConnectionFailureDetector
-      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ConnectionFailureDetector
         name: Connection Failure Detector
-        description: HA policy for monitoring a host:port, 
+        description: HA policy for monitoring a host:port, emitting an event if the connection is lost/restored
     - id: org.apache.brooklyn.policy.ha.ServiceRestarter
-      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ServiceRestarter
         name: Service Restarter
-        description: HA policy for restarting a service automatically, 
+        description: HA policy for restarting a service automatically, and for emitting an events if the service repeatedly fails
     - id: org.apache.brooklyn.policy.ha.SshMachineFailureDetector
-      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.SshMachineFailureDetector
         name: Ssh Connectivity Failure Detector
-        description: HA policy for monitoring an SshMachine, 
-#    removed from catalog because it cannot currently be configured via catalog mechanisms
-#    - id: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
-#      item:
-#        type: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
-    - id: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
-      itemType: entity
-      item:
-        type: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+        description: HA policy for monitoring an SshMachine, emitting an event if the connection is lost/restored
     - id: org.apache.brooklyn.policy.ha.ServiceReplacer
-      itemType: policy
       item:
         type: org.apache.brooklyn.policy.ha.ServiceReplacer
         name: Service Replacer
         description: HA policy for replacing a failed member of a group
-    - id: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
-      itemType: entity
-      item:
-        type: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
     - id: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
-      itemType: policy
       item:
         type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
         name: Auto-scaler
-        description: Policy that is attached to a Resizable entity and dynamically 
+        description: |
+          Policy that is attached to a Resizable entity and dynamically adjusts its size in 
+          response to either keep a metric within a given range, or in response to 
+          POOL_COLD and POOL_HOT events
 
-    # Enrichers
+#  Removed from catalog because 'FollowTheSunPool' cannot currently be configured via catalog mechanisms.
+#  Also removing associated 'BalanceableWorkerPool' etc as they are only useful with 'FollowTheSunPool'
+#  - itemType: entity
+#    items:
+#    - id: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
+#      item:
+#        type: org.apache.brooklyn.policy.followthesun.FollowTheSunPool
+#    - id: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+#      item:
+#        type: org.apache.brooklyn.policy.loadbalancing.BalanceableWorkerPool
+#    - id: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
+#      item:
+#        type: org.apache.brooklyn.policy.loadbalancing.ItemsInContainersGroup
+
+  - itemType: enricher
+    items:
     - id: org.apache.brooklyn.policy.enricher.DeltaEnricher
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.DeltaEnricher
+        name: Delta
+        description: Converts an absolute sensor into a delta sensor (i.e. the diff between the current and previous value)
     - id: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
+        name: HTTP Latency Detector
+        description: Computes latency in accessing a URL, normally by periodically polling that URL
     - id: org.apache.brooklyn.policy.enricher.RollingMeanEnricher
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingMeanEnricher
+        name: Rolling Mean
+        description: |
+          Transforms a sensor into a rolling average based on a fixed window size. 
+          This is useful for smoothing sample type metrics, such as latency or CPU time.
     - id: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
+        name: [DEPRECATED] Rolling Mean in Time Window
+        description: [DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher
     - id: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
+        name: Time-fraction Delta
+        description: |
+          Converts an absolute measure of time into a fraction of time, 
+          based on the delta between consecutive values and the elapsed time between those values.
     - id: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
+        name: [DEPRECATED] Time Weighted Delta
+        description: [DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'
     - id: org.apache.brooklyn.policy.ha.ServiceFailureDetector
-      itemType: enricher
       item:
         type: org.apache.brooklyn.policy.ha.ServiceFailureDetector
+        name: Service Failure Detector
+        description: Emits a new sensor if the current entity fails

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EntityConfigResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EntityConfigResourceTest.java
@@ -97,7 +97,7 @@ public class EntityConfigResourceTest extends BrooklynRestResourceTest {
         assertTrue(configKeyOptional.isPresent());
         
         assertEquals(configKeyOptional.get().getType(), "java.lang.String");
-        assertEquals(configKeyOptional.get().getDescription(), "Suggested version");
+        assertEquals(configKeyOptional.get().getDescription(), "The suggested version of the software to be installed");
         assertFalse(configKeyOptional.get().isReconfigurable());
         assertNull(configKeyOptional.get().getDefaultValue());
         assertNull(configKeyOptional.get().getLabel());

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/UsesJava.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/UsesJava.java
@@ -32,7 +32,9 @@ public interface UsesJava {
     /** system properties (-D) to append to JAVA_OPTS; normally accessed through {@link JavaEntityMethods#javaSysProp(String)} */
     @SetFromFlag("javaSysProps")
     public static final MapConfigKey<String> JAVA_SYSPROPS = new MapConfigKey<String>(String.class,
-            "java.sysprops", "Java command line system properties", Maps.<String,String>newLinkedHashMap());
+            "java.sysprops", 
+            "Java command line system properties (converted automatically into the format '-Dkey=value')",
+            Maps.<String,String>newLinkedHashMap());
 
     /**
      * Used to set java options. These options are prepended to the defaults.
@@ -58,8 +60,10 @@ public interface UsesJava {
             "java.opts", "Java command line options", ImmutableSet.<String>of());
 
     public static final ConfigKey<Boolean> CHECK_JAVA_HOSTNAME_BUG = ConfigKeys.newBooleanConfigKey(
-            "java.check.hostname.bug", "Check whether hostname is too long and will likely crash Java" +
-                    "due to bug 7089443", true);
+            "java.check.hostname.bug", 
+            "Check whether hostname is too long and will likely crash Java 1.7 "
+                    + "due to bug http://bugs.java.com/view_bug.do?bug_id=7089443", 
+            true);
 
     @SetFromFlag("javaVersionRequired")
     ConfigKey<String> JAVA_VERSION_REQUIRED = ConfigKeys.newStringConfigKey("java.version.required", "Java version required", "1.7");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/java/UsesJmx.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/java/UsesJmx.java
@@ -38,18 +38,25 @@ public interface UsesJmx extends UsesJava {
     public static final int DEFAULT_JMX_PORT = 1099; // RMI port?
 
     @SetFromFlag("useJmx")
-    ConfigKey<Boolean> USE_JMX = ConfigKeys.newConfigKey("jmx.enabled", "JMX enabled", Boolean.TRUE);
+    ConfigKey<Boolean> USE_JMX = ConfigKeys.newConfigKey(
+            "jmx.enabled", 
+            "Whether JMX is enabled", 
+            Boolean.TRUE);
 
     /** Chosen by Java itself by default, setting this will only have any effect if using an agent. */
     @SetFromFlag("jmxPort")
     PortAttributeSensorAndConfigKey JMX_PORT = new PortAttributeSensorAndConfigKey(
-        "jmx.direct.port", "JMX direct/private port (e.g. JMX RMI server port, or JMXMP port, but not RMI registry port)", PortRanges.fromString("31001+"));
+            "jmx.direct.port", 
+            "JMX direct/private port (e.g. JMX RMI server port, or JMXMP port, but not RMI registry port)", 
+            PortRanges.fromString("31001+"));
     
     // Default is deliberately null for this unused config; if we used "31001+" then we'd potentially give this sensor 
     // the value 31001 and jmx.direct.port the value 31002. See https://issues.apache.org/jira/browse/BROOKLYN-98
     /** @deprecated since 0.7.0, kept for rebinding with the anonymous class; code should only ever use {@link #JMX_PORT} */ @Deprecated
     PortAttributeSensorAndConfigKey JMX_PORT_LEGACY = new PortAttributeSensorAndConfigKey(
-            "jmx.direct.port.legacy.NOT_USED", "Legacy definition JMX direct/private port (e.g. JMX RMI server port, or JMXMP port, but not RMI registry port)", null) {
+            "jmx.direct.port.legacy.NOT_USED", 
+            "Legacy definition JMX direct/private port (e.g. JMX RMI server port, or JMXMP port, but not RMI registry port)", 
+            null) {
         private static final long serialVersionUID = 3846846080809179437L;
         @Override protected Integer convertConfigToSensor(PortRange value, Entity entity) {
             // TODO when using JmxAgentModes.NONE we should *not* convert, but leave it null
@@ -67,14 +74,19 @@ public interface UsesJmx extends UsesJava {
             "rmi.registry.port", "RMI registry port, used for discovering JMX (private) port", PortRanges.fromString("1099,19099+"));
 
     @SetFromFlag("jmxContext")
-    AttributeSensorAndConfigKey<String, String> JMX_CONTEXT = ConfigKeys.newStringSensorAndConfigKey("jmx.context", "JMX context path", "jmxrmi");
+    AttributeSensorAndConfigKey<String, String> JMX_CONTEXT = ConfigKeys.newStringSensorAndConfigKey("jmx.context", "JMX context path (defaults to 'jmxrmi')", "jmxrmi");
 
     AttributeSensor<String> JMX_URL = new BasicAttributeSensorAndConfigKey<String>(
-            String.class, "jmx.service.url", "The URL for connecting to the MBean Server");
+            String.class, 
+            "jmx.service.url", 
+            "The URL for connecting to the MBean Server");
 
     /** Forces JMX to be secured, using JMXMP so it gets through firewalls <em>and</em> SSL/TLS. */
     @SetFromFlag("jmxSecure")
-    ConfigKey<Boolean> JMX_SSL_ENABLED = ConfigKeys.newBooleanConfigKey("jmx.ssl.enabled", "JMX over JMXMP enabled with SSL/TLS", Boolean.FALSE);
+    ConfigKey<Boolean> JMX_SSL_ENABLED = ConfigKeys.newBooleanConfigKey(
+            "jmx.ssl.enabled", 
+            "Whether to enable JMX over JMXMP with SSL/TLS", 
+            Boolean.FALSE);
 
     enum JmxAgentModes {
         /** Auto-detect the agent to use based on location. Prefer {@link #JMXMP} except at localhost which uses {@link #JMX_RMI_CUSTOM_AGENT}. */
@@ -105,10 +117,17 @@ public interface UsesJmx extends UsesJava {
             JmxAgentModes.AUTODETECT);
 
     /* Currently these are only used to connect, so only applies where systems set this up themselves. */
-    AttributeSensorAndConfigKey<String, String> JMX_USER = ConfigKeys.newStringSensorAndConfigKey("jmx.user", "JMX username");
-    AttributeSensorAndConfigKey<String, String> JMX_PASSWORD = ConfigKeys.newStringSensorAndConfigKey("jmx.password", "JMX password");
+    AttributeSensorAndConfigKey<String, String> JMX_USER = ConfigKeys.newStringSensorAndConfigKey(
+            "jmx.user", 
+            "Optional JMX username to use when connecting");
     
-    AttributeSensorAndConfigKey<String, String> JMX_AGENT_LOCAL_PATH = ConfigKeys.newStringSensorAndConfigKey("jmx.agent.local.path", "Path to JMX driver on the local machine");
+    AttributeSensorAndConfigKey<String, String> JMX_PASSWORD = ConfigKeys.newStringSensorAndConfigKey(
+            "jmx.password", 
+            "Optional JMX password to use when connecting");
+    
+    AttributeSensorAndConfigKey<String, String> JMX_AGENT_LOCAL_PATH = ConfigKeys.newStringSensorAndConfigKey(
+            "jmx.agent.local.path", 
+            "Optional path to where JMX driver should be installed on the local machine (if using JMXMP or custom agent)");
 
     /*
      * Synopsis of how the keys work for JMX_SSL:

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractVanillaProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractVanillaProcess.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.config.ConfigInheritance;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -28,25 +29,33 @@ public interface AbstractVanillaProcess extends SoftwareProcess {
 
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "0.0.0");
 
+    @CatalogConfig(label = "Install Command", priority=5)
     ConfigKey<String> INSTALL_COMMAND = ConfigKeys.builder(String.class, "install.command")
             .description("command to run during the install phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
+    
+    @CatalogConfig(label = "Customize command", priority=4)
     ConfigKey<String> CUSTOMIZE_COMMAND = ConfigKeys.builder(String.class, "customize.command")
             .description("command to run during the customization phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
+    
+    @CatalogConfig(label = "Launch Command", priority=3)
     ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.builder(String.class, "launch.command")
             .description("command to run to launch the process")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
+    
+    @CatalogConfig(label = "Check-running Command", priority=2)
     ConfigKey<String> CHECK_RUNNING_COMMAND = ConfigKeys.builder(String.class, "checkRunning.command")
             .description("command to determine whether the process is running")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
+    
+    @CatalogConfig(label = "Stop Command", priority=1)
     ConfigKey<String> STOP_COMMAND = ConfigKeys.builder(String.class, "stop.command")
             .description("command to run to stop the process")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
-
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcess.java
@@ -56,15 +56,18 @@ public interface SoftwareProcess extends Entity, Startable {
     ConfigKey<Collection<Integer>> REQUIRED_OPEN_LOGIN_PORTS = ConfigKeys.newConfigKey(
             new TypeToken<Collection<Integer>>() {},
             "requiredOpenLoginPorts",
-            "The port(s) to be opened, to allow login",
+            "The port(s) to be opened (also see 'inboundPorts.autoInfer')",
             ImmutableSet.of(22));
 
     ConfigKey<String> INBOUND_PORTS_CONFIG_REGEX = ConfigKeys.newStringConfigKey("inboundPorts.configRegex",
-            "Regex governing the opening of ports based on config names",
+            "Regex governing the opening of ports based on config names (see 'inboundPorts.autoInfer')",
             ".*\\.port");
 
     ConfigKey<Boolean> INBOUND_PORTS_AUTO_INFER = ConfigKeys.newBooleanConfigKey("inboundPorts.autoInfer",
-            "If set to false turns off the opening of ports based on naming convention, and also those that are of type PortRange in Java entities",
+            "By default, the ports to open in iptables and security group is inferred from the config keys. "
+                    + "This follows a naming convention (defaulting to all config keys matching the name '*.\\.port', "
+                    + "but customizable with the config key 'inboundPorts.configRegex'), and also including all "
+                    + "config keys of type 'PortRange'. This behaviour is turned off by setting it to 'false'.",
             true);
 
     @SetFromFlag("startTimeout")
@@ -150,16 +153,20 @@ public interface SoftwareProcess extends Entity, Startable {
     @SetFromFlag("runDir")
     AttributeSensorAndConfigKey<String,String> RUN_DIR = BrooklynConfigKeys.RUN_DIR;
 
-    ConfigKey<Boolean> ADD_OPEN_INBOUND_PORTS_EFFECTOR = ConfigKeys.newBooleanConfigKey("effector.add.openInboundPorts",
-            "Flag which adds effector for opening ports through Cloud security groups", false);
+    ConfigKey<Boolean> ADD_OPEN_INBOUND_PORTS_EFFECTOR = ConfigKeys.newBooleanConfigKey(
+            "effector.add.openInboundPorts",
+            "Whether to add an effector to the entity for opening ports through Cloud security groups", 
+            false);
 
     ConfigKey<Boolean> OPEN_IPTABLES = ConfigKeys.newBooleanConfigKey("openIptables",
             "Whether to open the INBOUND_PORTS via iptables rules; " +
-            "if true then ssh in to run iptables commands, as part of machine provisioning", false);
+            "if true then ssh in to run iptables commands, as part of machine provisioning", 
+            false);
 
     ConfigKey<Boolean> STOP_IPTABLES = ConfigKeys.newBooleanConfigKey("stopIptables",
             "Whether to stop iptables entirely; " +
-            "if true then ssh in to stop the iptables service, as part of machine provisioning", false);
+            "if true then ssh in to stop the iptables service, as part of machine provisioning", 
+            false);
 
     ConfigKey<Boolean> DONT_REQUIRE_TTY_FOR_SUDO = ConfigKeys.newBooleanConfigKey("dontRequireTtyForSudo",
             "Whether to explicitly set /etc/sudoers, so don't need tty (will leave unchanged if 'false'); " +
@@ -187,7 +194,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("preInstallFiles")
     MapConfigKey<String> PRE_INSTALL_FILES = new MapConfigKey.Builder<String>(String.class, "files.preinstall")
-            .description("Mapping of files, to be copied before install, to destination name relative to installDir") 
+            .description("Files to be copied before pre-install; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -200,7 +207,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("preInstallTemplates")
     MapConfigKey<String> PRE_INSTALL_TEMPLATES = new MapConfigKey.Builder<String>(String.class, "templates.preinstall")
-            .description("Mapping of templates, to be filled in and copied before pre-install, to destination name relative to installDir") 
+            .description("Templated files to be filled in and copied before pre-install; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -216,7 +223,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("installFiles")
     MapConfigKey<String> INSTALL_FILES = new MapConfigKey.Builder<String>(String.class, "files.install")
-            .description("Mapping of files, to be copied before install, to destination name relative to installDir") 
+            .description("Files to be copied before install; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -229,7 +236,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("installTemplates")
     MapConfigKey<String> INSTALL_TEMPLATES = new MapConfigKey.Builder<String>(String.class, "templates.install")
-            .description("Mapping of templates, to be filled in and copied before install, to destination name relative to installDir") 
+            .description("Templated files to be filled in and copied before install; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -245,7 +252,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("customizeFiles")
     MapConfigKey<String> CUSTOMIZE_FILES = new MapConfigKey.Builder<String>(String.class, "files.customize")
-            .description("Mapping of files, to be copied before customize, to destination name relative to installDir")
+            .description("Files to be copied before customize; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -258,7 +265,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("customizeTemplates")
     MapConfigKey<String> CUSTOMIZE_TEMPLATES = new MapConfigKey.Builder<String>(String.class, "templates.customize")
-            .description("Mapping of templates, to be filled in and copied before customize, to destination name relative to installDir")
+            .description("Templated files to be filled in and copied before customize; mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -274,7 +281,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("runtimeFiles")
     MapConfigKey<String> RUNTIME_FILES = new MapConfigKey.Builder<String>(String.class, "files.runtime")
-            .description("Mapping of files, to be copied before customisation, to destination name relative to runDir") 
+            .description("Files to be copied before launch (and before pre-launch); mapping from resource to the destination name relative to runDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();
@@ -287,7 +294,7 @@ public interface SoftwareProcess extends Entity, Startable {
     @Beta
     @SetFromFlag("runtimeTemplates")
     MapConfigKey<String> RUNTIME_TEMPLATES = new MapConfigKey.Builder<String>(String.class, "templates.runtime")
-            .description("Mapping of templates, to be filled in and copied before customisation, to destination name relative to runDir") 
+            .description("Templated files to be filled in and copied before launch (and before pre-launch); mapping from resource to the destination name relative to installDir")
             .typeInheritance(BasicConfigInheritance.DEEP_MERGE)
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED_ELSE_DEEP_MERGE)
             .build();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SoftwareProcessImpl.java
@@ -525,7 +525,6 @@ public abstract class SoftwareProcessImpl extends AbstractEntity implements Soft
      * @see #INBOUND_PORTS_AUTO_INFER
      * @see #INBOUND_PORTS_CONFIG_REGEX
      */
-    @SuppressWarnings("serial")
     protected Collection<Integer> getRequiredOpenPorts() {
         Set<Integer> ports = MutableSet.copyOf(getConfig(REQUIRED_OPEN_LOGIN_PORTS));
         Boolean portsAutoInfer = getConfig(INBOUND_PORTS_AUTO_INFER);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcess.java
@@ -20,8 +20,6 @@ package org.apache.brooklyn.entity.software.base;
 
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
 
 /** 
  * A {@link SoftwareProcess} entity that runs commands from an archive.
@@ -58,5 +56,4 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 @Catalog(name="Vanilla Software Process", description="A software process configured with scripts, e.g. for launch, check-running and stop")
 @ImplementedBy(VanillaSoftwareProcessImpl.class)
 public interface VanillaSoftwareProcess extends AbstractVanillaProcess {
-    ConfigKey<String> LAUNCH_COMMAND = ConfigKeys.newConfigKeyWithDefault(AbstractVanillaProcess.LAUNCH_COMMAND, "./start.sh");
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessSshDriver.java
@@ -156,10 +156,14 @@ public class VanillaSoftwareProcessSshDriver extends AbstractSoftwareProcessSshD
 
     @Override
     public void launch() {
-        newScript(LAUNCHING)
-            .failOnNonZeroResultCode()
-            .body.append(getEntity().getConfig(VanillaSoftwareProcess.LAUNCH_COMMAND))
-            .execute();
+        String launchCommand = getEntity().getConfig(VanillaSoftwareProcess.LAUNCH_COMMAND);
+        
+        if (Strings.isNonBlank(launchCommand)) {
+            newScript(LAUNCHING)
+                .failOnNonZeroResultCode()
+                .body.append(launchCommand)
+                .execute();
+        }
     }
 
     @Override

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcess.java
@@ -44,7 +44,7 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     @CatalogConfig(label = "Install PowerShell command", priority=5.5)
     ConfigKey<String> INSTALL_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "install.powershell.command")
             .description("powershell command to run during the install phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     @CatalogConfig(label = "Install Command", priority=5)
@@ -53,7 +53,7 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     @CatalogConfig(label = "Customize PowerShell command", priority=4.5)
     ConfigKey<String> CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "customize.powershell.command")
             .description("powershell command to run during the customization phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     @CatalogConfig(label = "Customize command", priority=4)
@@ -62,7 +62,7 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     @CatalogConfig(label = "Launch PowerShell command", priority=3.5)
     ConfigKey<String> LAUNCH_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "launch.powershell.command")
             .description("command to run to launch the process")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     @CatalogConfig(label = "Launch Command", priority=3)
@@ -71,7 +71,7 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     @CatalogConfig(label = "Check-running PowerShell Command", priority=2.5)
     ConfigKey<String> CHECK_RUNNING_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "checkRunning.powershell.command")
             .description("command to determine whether the process is running")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     @CatalogConfig(label = "Check-running Command", priority=2)
@@ -80,7 +80,7 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
     @CatalogConfig(label = "Stop PowerShell Command", priority=1.5)
     ConfigKey<String> STOP_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "stop.powershell.command")
             .description("command to run to stop the process")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     @CatalogConfig(label = "Stop Command", priority=1)
@@ -88,32 +88,32 @@ public interface VanillaWindowsProcess extends AbstractVanillaProcess {
 
     ConfigKey<String> PRE_INSTALL_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "pre.install.powershell.command")
             .description("powershell command to run during the pre-install phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<String> POST_INSTALL_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "post.install.powershell.command")
             .description("powershell command to run during the post-install phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<String> PRE_CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "pre.customize.powershell.command")
             .description("powershell command to run during the pre-customize phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<String> POST_CUSTOMIZE_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "post.customize.powershell.command")
             .description("powershell command to run during the post-customize phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<String> PRE_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "pre.launch.powershell.command")
             .description("powershell command to run during the pre-launch phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<String> POST_LAUNCH_POWERSHELL_COMMAND = ConfigKeys.builder(String.class, "post.launch.powershell.command")
             .description("powershell command to run during the post-launch phase")
-            .parentInheritance(ConfigInheritance.NONE)
+            .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
     ConfigKey<Boolean> PRE_INSTALL_REBOOT_REQUIRED = ConfigKeys.newBooleanConfigKey("pre.install.reboot.required",

--- a/software/base/src/main/resources/catalog.bom
+++ b/software/base/src/main/resources/catalog.bom
@@ -27,20 +27,29 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.software.base.SameServerEntity
       item:
         type: org.apache.brooklyn.entity.software.base.SameServerEntity
+        name: Same Server Entity
+        description: |
+          An entity that, on start, will obtain a machine and pass that to each of its children 
+          by calling their start effectors.
     - id: org.apache.brooklyn.entity.chef.ChefEntity
       item:
         type: org.apache.brooklyn.entity.chef.ChefEntity
+        name: Chef Entity
     - id: org.apache.brooklyn.entity.brooklynnode.BrooklynEntityMirror
       item:
         type: org.apache.brooklyn.entity.brooklynnode.BrooklynEntityMirror
         name: Brooklyn Entity Mirror
-        description: Provides an entity which can sit in one brooklyn 
+        description: |
+          Provides an entity which can sit in one brooklyn
+          domain and reflect the status of an entity via the REST API of another domain.
     - id: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
       item:
         type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
+        name: Empty Software Process
     - id: org.apache.brooklyn.entity.software.base.EmptyWindowsProcess
       item:
         type: org.apache.brooklyn.entity.software.base.EmptyWindowsProcess
+        name: Empty Windows Process
     - id: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
       item:
         type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
@@ -49,6 +58,7 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.java.VanillaJavaApp
       item:
         type: org.apache.brooklyn.entity.java.VanillaJavaApp
+        name: Vanilla Java App
     - id: org.apache.brooklyn.entity.brooklynnode.BrooklynNode
       item:
         type: org.apache.brooklyn.entity.brooklynnode.BrooklynNode
@@ -57,9 +67,12 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.entity.brooklynnode.BrooklynCluster
       item:
         type: org.apache.brooklyn.entity.brooklynnode.BrooklynCluster
+        name: Brooklyn Cluster
     - id: org.apache.brooklyn.entity.brooklynnode.LocalBrooklynNode
       item:
         type: org.apache.brooklyn.entity.brooklynnode.LocalBrooklynNode
+        name: Local Brooklyn Node
+        description: An entity that represents the local Brooklyn server.
     - id: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
       item:
         type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess

--- a/test-framework/src/main/resources/catalog.bom
+++ b/test-framework/src/main/resources/catalog.bom
@@ -22,27 +22,37 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.test.framework.TestSshCommand
       item:
         type: org.apache.brooklyn.test.framework.TestSshCommand
+        name: Test SSH Command
     - id: org.apache.brooklyn.test.framework.SimpleShellCommandTest
       item:
         type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
+        name: [DEPRECATED] Simple Shell Command Test
+        description:  [DEPRECATED] Instead use TestSshCommand
     - id: org.apache.brooklyn.test.framework.ParallelTestCase
       item:
         type: org.apache.brooklyn.test.framework.ParallelTestCase
+        name: Parallel Test Case
     - id: org.apache.brooklyn.test.framework.TestCase
       item:
         type: org.apache.brooklyn.test.framework.TestCase
+        name: Test Case
     - id: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
       item:
         type: org.apache.brooklyn.test.framework.InfrastructureDeploymentTestCase
+        name: Infrastructure Deployment Test Case
     - id: org.apache.brooklyn.test.framework.TestSensor
       item:
         type: org.apache.brooklyn.test.framework.TestSensor
+        name: Test Sensor
     - id: org.apache.brooklyn.test.framework.TestEffector
       item:
         type: org.apache.brooklyn.test.framework.TestEffector
+        name: Test Effector
     - id: org.apache.brooklyn.test.framework.TestHttpCall
       item:
         type: org.apache.brooklyn.test.framework.TestHttpCall
+        name: Test HTTP Call
     - id: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
       item:
         type: org.apache.brooklyn.test.framework.LoopOverGroupMembersTestCase
+        name: Loop Over Group Members Test Case


### PR DESCRIPTION
See individual commits for details.

Note the last two commits make significant changes to config:
* remove the default for `launch.command` of `VanillaSoftwareProcess`.
* Rename some config keys (deprecating the old names) for `latch.*` and `skip.*`.