### PR TITLE
use type registry when confirming catalog on startup

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
+++ b/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
@@ -146,7 +146,7 @@ public class BrooklynFeatureEnablement {
         setDefault(FEATURE_DEFAULT_STANDBY_IS_HOT_PROPERTY, false);
         setDefault(FEATURE_RENAME_THREADS, false);
         setDefault(FEATURE_JITTER_THREADS, false);
-        setDefault(FEATURE_BACKWARDS_COMPATIBILITY_INFER_CATALOG_ITEM_ON_REBIND, true);
+        setDefault(FEATURE_BACKWARDS_COMPATIBILITY_INFER_CATALOG_ITEM_ON_REBIND, false);
         setDefault(FEATURE_AUTO_FIX_CATALOG_REF_ON_REBIND, false);
         setDefault(FEATURE_SSH_ASYNC_EXEC, false);
         setDefault(FEATURE_VALIDATE_LOCATION_SSH_KEYS, true);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -401,6 +401,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
             }
         }
         PropagatedRuntimeException wrap = new PropagatedRuntimeException("Error loading catalog item "+details, throwable);
+        log.warn(Exceptions.collapseText(wrap));
         log.debug("Trace for: "+wrap, wrap);
 
         ((ManagementContextInternal)getManagementContext()).errors().add(wrap);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -189,7 +189,7 @@ public class BrooklynPersistenceUtils {
                 result.policy(instanceAdjunct.getId(), serializer.toString(newObjectMemento(instanceAdjunct)));
             }
         }
-        for (CatalogItem<?,?> instance: mgmt.getCatalog().getCatalogItems()) {
+        for (CatalogItem<?,?> instance: mgmt.getCatalog().getCatalogItemsLegacy()) {
             result.catalogItem(instance.getId(), serializer.toString(newObjectMemento(instance)));
         }
         OsgiManager osgi = ((LocalManagementContext)mgmt).getOsgiManager().orNull();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -1122,12 +1122,13 @@ public abstract class RebindIteration {
                 throw new IllegalStateException("Unable to load "+jType+" for catalog item " + catalogItemId + " for " + contextSuchAsId);
                 
             } else if (BrooklynFeatureEnablement.isEnabled(FEATURE_BACKWARDS_COMPATIBILITY_INFER_CATALOG_ITEM_ON_REBIND)) {
-                //Try loading from whichever catalog bundle succeeds.
+                //Try loading from whichever catalog bundle succeeds (legacy CI items only; also disabling this, as no longer needed 2017-09)
                 BrooklynCatalog catalog = managementContext.getCatalog();
-                for (CatalogItem<?, ?> item : catalog.getCatalogItems()) {
+                for (CatalogItem<?, ?> item : catalog.getCatalogItemsLegacy()) {
                     BrooklynClassLoadingContext catalogLoader = CatalogUtils.newClassLoadingContext(managementContext, item);
                     Maybe<Class<?>> catalogClass = catalogLoader.tryLoadClass(jType);
                     if (catalogClass.isPresent()) {
+                        LOG.warn("Found "+jType+" only by scanning catalog item search paths");
                         return new LoadedClass<T>((Class<? extends T>) catalogClass.get(), catalogItemId, reboundSearchPath);
                     }
                 }


### PR DESCRIPTION
prevents errors trying to check legacy catalog items

#814 caused legacy CI instances to be created for TR items which could cause errors; this limits search to legacy CIs to prevent error, and confirms TR items also