### PR TITLE
Config for VanillaSoftwareProcess disabling ssh polling

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/FunctionSensorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/FunctionSensorYamlTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.sensor.function.FunctionSensor;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+
+public class FunctionSensorYamlTest extends AbstractYamlRebindTest {
+    private static final Logger log = LoggerFactory.getLogger(FunctionSensorYamlTest.class);
+
+    final static AttributeSensor<String> SENSOR_STRING = Sensors.newStringSensor("aString");
+    final static String TARGET_TYPE = "java.lang.String";
+
+    public static class MyCallable implements Callable<Object> {
+        public static AtomicReference<Object> val = new AtomicReference<>();
+
+        @Override public Object call() throws Exception {
+            return val.get();
+        }
+    }
+
+    @Test
+    public void testFunctionSensor() throws Exception {
+        MyCallable.val.set("first");
+        
+        Entity app = createAndStartApplication(
+            "services:",
+            "- type: " + TestEntity.class.getName(),
+            "  brooklyn.config:",
+            "    onbox.base.dir.skipResolution: true",
+            "  brooklyn.initializers:",
+            "  - type: "+FunctionSensor.class.getName(),
+            "    brooklyn.config:",
+            "      "+FunctionSensor.SENSOR_PERIOD.getName()+": 100ms",
+            "      "+FunctionSensor.SENSOR_NAME.getName()+": " + SENSOR_STRING.getName(),
+            "      "+FunctionSensor.SENSOR_TYPE.getName()+": " + TARGET_TYPE,
+            "      "+FunctionSensor.FUNCTION.getName()+":",
+            "        $brooklyn:object:",
+            "          type: "+MyCallable.class.getName());
+        waitForApplicationTasks(app);
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_STRING, "first");
+        
+        MyCallable.val.set("second");
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_STRING, "second");
+        
+        // Rebind, and confirm that it resumes polling
+        Application newApp = rebind();
+        Entity newEntity = Iterables.getOnlyElement(newApp.getChildren());
+
+        MyCallable.val.set("third");
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "third");
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return log;
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaSoftwareProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaSoftwareProcessYamlTest.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.sensor.function.FunctionSensor;
+import org.apache.brooklyn.enricher.stock.UpdatingMap;
+import org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
+import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.CustomResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+@Test
+public class VanillaSoftwareProcessYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(VanillaSoftwareProcessYamlTest.class);
+
+    public static class MyCallable implements Callable<Object> {
+        public static AtomicReference<Object> val = new AtomicReference<>();
+        public static AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+
+        public static void clear() {
+            val.set(null);
+            latch.set(null);
+        }
+        @Override public Object call() throws Exception {
+            if (latch.get() != null) latch.get().await();
+            return val.get();
+        }
+    }
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MyCallable.clear();
+        RecordingSshTool.clear();
+    }
+    
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        MyCallable.clear();
+        RecordingSshTool.clear();
+    }
+    
+    @Test
+    public void testSshPolling() throws Exception {
+        Entity app = createAndStartApplication(
+            "location:",
+            "  localhost:",
+            "    sshToolClass: "+RecordingSshTool.class.getName(),
+            "services:",
+            "- type: "+VanillaSoftwareProcess.class.getName(),
+            "  brooklyn.config:",
+            "    softwareProcess.serviceProcessIsRunningPollPeriod: 10ms",
+            "    checkRunning.command: myCheckRunning",
+            "    launch.command: myLaunch");
+        waitForApplicationTasks(app);
+
+        log.info("App started:");
+        Entities.dumpInfo(app);
+        
+        VanillaSoftwareProcess entity = (VanillaSoftwareProcess) Iterables.getOnlyElement(app.getChildren());
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        
+        RecordingSshTool.setCustomResponse(".*myCheckRunning.*", new CustomResponse(1, "simulating not running", ""));
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        
+        RecordingSshTool.clear();
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+    }
+    
+    @Test
+    public void testDisableSshPolling() throws Exception {
+        // driver.isRunning will report failure
+        RecordingSshTool.setCustomResponse(".*myCheckRunning.*", new CustomResponse(1, "simulating not running", ""));
+        
+        Entity app = createApplicationUnstarted(
+            "location:",
+            "  localhost:",
+            "    sshToolClass: "+RecordingSshTool.class.getName(),
+            "services:",
+            "- type: "+VanillaSoftwareProcess.class.getName(),
+            "  brooklyn.config:",
+            "    softwareProcess.serviceProcessIsRunningPollPeriod: 10ms",
+            "    sshMonitoring.enabled: false",
+            "    checkRunning.command: myCheckRunning",
+            "    launch.command: myLaunch");
+        
+        VanillaSoftwareProcess entity = (VanillaSoftwareProcess) Iterables.getOnlyElement(app.getChildren());
+        
+        RecordingSensorEventListener<Object> serviceUpListener = subscribe(entity, Attributes.SERVICE_UP);
+        RecordingSensorEventListener<Object> serviceStateListener = subscribe(entity, Attributes.SERVICE_STATE_ACTUAL);
+
+        Task<Void> task = app.invoke(Startable.START, ImmutableMap.of());
+        
+        // Should eventually poll for 'checkRunning', before reporting 'up'
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                ExecCmdAsserts.assertExecHasAtLeastOnce(RecordingSshTool.getExecCmds(), "myCheckRunning");
+            }});
+        
+        assertFalse(task.isDone());
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STARTING);
+
+        // Let startup complete
+        RecordingSshTool.setCustomResponse(".*myCheckRunning.*", new CustomResponse(0, "", ""));
+        waitForApplicationTasks(app);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        // Should never again do ssh-poll of checkRunning
+        RecordingSshTool.clear();
+        Asserts.succeedsContinually(new Runnable() {
+            public void run() {
+                ExecCmdAsserts.assertExecHasNever(RecordingSshTool.getExecCmds(), "myCheckRunning");
+            }});
+        
+        // Should not have transitioned through wrong states (e.g. never "on-fire"!)
+        assertEventsEqualEventually(serviceUpListener, ImmutableList.of(false, true), true);
+        assertEventsEqualEventually(serviceStateListener, ImmutableList.of(Lifecycle.CREATED, Lifecycle.STARTING, Lifecycle.RUNNING), true);
+    }
+   
+    @Test
+    public void testAlternativeServiceUpPolling() throws Exception {
+        AttributeSensor<Boolean> alternativeUpIndicator = Sensors.newBooleanSensor("myAlternativeUpIndicator");
+        MyCallable.latch.set(new CountDownLatch(1));
+        
+        Entity app = createApplicationUnstarted(
+            "location:",
+            "  localhost:",
+            "    sshToolClass: "+RecordingSshTool.class.getName(),
+            "services:",
+            "- type: "+VanillaSoftwareProcess.class.getName(),
+            "  brooklyn.config:",
+            "    softwareProcess.serviceProcessIsRunningPollPeriod: 10ms",
+            "    sshMonitoring.enabled: false",
+            "    checkRunning.command: myCheckRunning",
+            "    launch.command: myLaunch",
+            "  brooklyn.initializers:",
+            "  - type: "+FunctionSensor.class.getName(),
+            "    brooklyn.config:",
+            "      "+FunctionSensor.SENSOR_PERIOD.getName()+": 10ms",
+            "      "+FunctionSensor.SENSOR_NAME.getName()+": " + alternativeUpIndicator.getName(),
+            "      "+FunctionSensor.SENSOR_TYPE.getName()+": boolean",
+            "      "+FunctionSensor.FUNCTION.getName()+":",
+            "        $brooklyn:object:",
+            "          type: "+MyCallable.class.getName(),
+            "  brooklyn.enrichers:",
+            "  - type: " + UpdatingMap.class.getName(),
+            "    brooklyn.config:",
+            "      enricher.sourceSensor: $brooklyn:sensor(\"" + alternativeUpIndicator.getName() + "\")",
+            "      enricher.targetSensor: $brooklyn:sensor(\"service.notUp.indicators\")",
+            "      enricher.updatingMap.computing:",
+            "        $brooklyn:object:",
+            "          type: \"" + Functions.class.getName() + "\"",
+            "          factoryMethod.name: \"forMap\"",
+            "          factoryMethod.args:",
+            "          - false: \"false\"",
+            "            true: null",
+            "          - \"no value\"");
+        
+        VanillaSoftwareProcess entity = (VanillaSoftwareProcess) Iterables.getOnlyElement(app.getChildren());
+        
+        RecordingSensorEventListener<Object> serviceUpListener = subscribe(entity, Attributes.SERVICE_UP);
+        RecordingSensorEventListener<Object> serviceStateListener = subscribe(entity, Attributes.SERVICE_STATE_ACTUAL);
+
+        Task<Void> task = app.invoke(Startable.START, ImmutableMap.of());
+        
+        // Should eventually poll for 'checkRunning', but just once immediately after doing launch etc
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                ExecCmdAsserts.assertExecHasOnlyOnce(RecordingSshTool.getExecCmds(), "myCheckRunning");
+            }});
+        RecordingSshTool.clear();
+
+        assertFalse(task.isDone());
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_NOT_UP_INDICATORS, ImmutableMap.of(alternativeUpIndicator.getName(), "no value"));
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STARTING);
+
+        // Let the function return 'false'
+        MyCallable.val.set(false);
+        MyCallable.latch.get().countDown();
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_NOT_UP_INDICATORS, ImmutableMap.of(alternativeUpIndicator.getName(), "false"));
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        assertFalse(task.isDone());
+
+        // Let startup complete, by the function returning 'true'
+        MyCallable.val.set(true);
+        waitForApplicationTasks(app, Asserts.DEFAULT_LONG_TIMEOUT);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        // Should not have transitioned through wrong states (e.g. never "on-fire"!)
+        assertEventsEqualEventually(serviceUpListener, ImmutableList.of(false, true), true);
+        assertEventsEqualEventually(serviceStateListener, ImmutableList.of(Lifecycle.CREATED, Lifecycle.STARTING, Lifecycle.RUNNING), true);
+        
+        ExecCmdAsserts.assertExecHasNever(RecordingSshTool.getExecCmds(), "myCheckRunning");
+    }
+   
+    private RecordingSensorEventListener<Object> subscribe(Entity entity, Sensor<?> sensor) {
+        RecordingSensorEventListener<Object> listener = new RecordingSensorEventListener<>();
+        mgmt().getSubscriptionManager().subscribe(MutableMap.of("notifyOfInitialValue", true), entity, sensor, listener);
+        return listener;
+    }
+    
+    private void assertEventsEqualEventually(RecordingSensorEventListener<?> listener, Iterable<?> expected, boolean stripLeadingNulls) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertIterablesEqual(listener.getEventValues(), (stripLeadingNulls ? leadingNullsStripper() : Functions.identity()), expected);
+            }});
+    }
+
+    private void assertIterablesEqualEventually(Supplier<? extends Iterable<?>> actual, Function<? super List<?>, List<?>> transformer, Iterable<?> expected) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertIterablesEqual(actual.get(), transformer, expected);
+            }});
+    }
+    
+    private void assertIterablesEqual(Iterable<?> actual, Function<? super List<?>, List<?>> transformer, Iterable<?> expected) {
+        List<?> actualList = (actual instanceof List) ? (List<?>) actual : MutableList.copyOf(actual);
+        List<?> expectedList = (expected instanceof List) ? (List<?>) expected : MutableList.copyOf(expected);
+        String errMsg = "actual="+actualList+"; expected="+expectedList;
+        assertEquals(transformer.apply(actualList), expectedList, errMsg);
+    }
+    
+    private Function<List<?>, List<?>> leadingNullsStripper() {
+        return new Function<List<?>, List<?>>() {
+            @Override public List<?> apply(List<?> input) {
+                if (input == null || input.isEmpty() || input.get(0) != null) {
+                    return input;
+                }
+                List<Object> result = new ArrayList<>();
+                boolean foundNonNull = false;
+                for (Object element : input) {
+                    if (foundNonNull || input != null) {
+                        result.add(element);
+                        foundNonNull = true;
+                    }
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/function/FunctionSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/function/FunctionSensor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor.function;
+
+import java.util.concurrent.Callable;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.feed.function.FunctionFeed;
+import org.apache.brooklyn.feed.function.FunctionPollConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Functions;
+import com.google.common.reflect.TypeToken;
+
+/**
+ * Configurable {@link org.apache.brooklyn.api.entity.EntityInitializer} which adds a function sensor feed.
+ * This calls the function periodically, to compute the sensor's value.
+ *
+ * @see FunctionFeed
+ */
+@Beta
+public final class FunctionSensor<T> extends AddSensor<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FunctionSensor.class);
+
+    public static final ConfigKey<Boolean> SUPPRESS_DUPLICATES = ConfigKeys.newBooleanConfigKey(
+            "suppressDuplicates", 
+            "Whether to publish the sensor value again, if it is the same as the previous value",
+            Boolean.FALSE);
+    
+    public static final ConfigKey<Callable<?>> FUNCTION = ConfigKeys.newConfigKey(
+            new TypeToken<Callable<?>>() {},
+            "function",
+            "The callable to be executed periodically",
+            null);
+    
+    public FunctionSensor(final ConfigBag params) {
+        super(params);
+    }
+
+    @Override
+    public void apply(final EntityLocal entity) {
+        super.apply(entity);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding HTTP JSON sensor {} to {}", name, entity);
+        }
+
+        final ConfigBag allConfig = ConfigBag.newInstanceCopying(this.params).putAll(params);
+        
+        final Callable<?> function = EntityInitializers.resolve(allConfig, FUNCTION);
+        final Boolean suppressDuplicates = EntityInitializers.resolve(allConfig, SUPPRESS_DUPLICATES);
+
+        FunctionPollConfig<?, T> pollConfig = new FunctionPollConfig<Object, T>(sensor)
+                .callable(function)
+                .onSuccess(TypeCoercions.function((Class<T>)sensor.getType()))
+                .onFailureOrException(Functions.constant((T) null))
+                .suppressDuplicates(Boolean.TRUE.equals(suppressDuplicates))
+                .period(period);
+
+        FunctionFeed feed = FunctionFeed.builder().entity(entity)
+                .poll(pollConfig)
+                .build();
+
+        entity.addFeed(feed);
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/entity/RecordingSensorEventListener.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/RecordingSensorEventListener.java
@@ -35,6 +35,7 @@ import org.testng.Assert;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -89,6 +90,17 @@ public class RecordingSensorEventListener<T> implements SensorEventListener<T>, 
     public Iterable<T> getEventValues() {
         return FluentIterable.from(events)
                 .transform(new GetValueFunction<T>());
+    }
+
+    /**
+     * @return A supplier that returns the latest live read-only view of recorded events.
+     */
+    public Supplier<Iterable<T>> getEventValuesSupplier() {
+        return new Supplier<Iterable<T>>() {
+            @Override public Iterable<T> get() {
+                return getEventValues();
+            }
+        };
     }
 
     /**

--- a/core/src/test/java/org/apache/brooklyn/core/sensor/function/FunctionSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/sensor/function/FunctionSensorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.sensor.function;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class FunctionSensorTest extends BrooklynAppUnitTestSupport {
+    final static AttributeSensor<String> SENSOR_STRING = Sensors.newStringSensor("aString");
+    final static String STRING_TARGET_TYPE = "java.lang.String";
+
+    TestEntity entity;
+    
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+        entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
+        app.start(ImmutableList.<Location>of());
+    }
+
+    @Test
+    public void testFunction() throws Exception {
+        AtomicReference<String> val = new AtomicReference<String>("first");
+        Callable<String> callable = new Callable<String>() {
+            @Override public String call() throws Exception {
+                return val.get();
+            }
+        };
+        
+        FunctionSensor<Integer> initializer = new FunctionSensor<Integer>(ConfigBag.newInstance()
+                .configure(FunctionSensor.SENSOR_PERIOD, Duration.millis(10))
+                .configure(FunctionSensor.SENSOR_NAME, SENSOR_STRING.getName())
+                .configure(FunctionSensor.SENSOR_TYPE, STRING_TARGET_TYPE)
+                .configure(FunctionSensor.FUNCTION, callable));
+        initializer.apply(entity);
+        entity.sensors().set(Attributes.SERVICE_UP, true);
+        
+        initializer.apply(entity);
+        entity.sensors().set(Attributes.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_STRING, "first");
+        
+        val.set("second");
+        EntityAsserts.assertAttributeEqualsEventually(entity, SENSOR_STRING, "second");
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/ExecCmdAsserts.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/ExecCmdAsserts.java
@@ -23,8 +23,10 @@ import java.util.List;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecCmd;
+import org.apache.brooklyn.util.math.MathPredicates;
 
 @Beta
 public class ExecCmdAsserts {
@@ -92,7 +94,15 @@ public class ExecCmdAsserts {
         assertExecHasExactly(actuals, expectedCmd, 1);
     }
 
+    public static void assertExecHasAtLeastOnce(List<ExecCmd> actuals, String expectedCmd) {
+        assertExecHasExactly(actuals, expectedCmd, MathPredicates.greaterThanOrEqual(1));
+    }
+
     public static void assertExecHasExactly(List<ExecCmd> actuals, String expectedCmd, int expectedCount) {
+        assertExecHasExactly(actuals, expectedCmd, Predicates.equalTo(expectedCount));
+    }
+
+    public static void assertExecHasExactly(List<ExecCmd> actuals, String expectedCmd, Predicate<Integer> countChecker) {
         String errMsg = "actuals="+actuals+"; expected="+expectedCmd;
         int count = 0;
         for (ExecCmd actual : actuals) {
@@ -103,7 +113,7 @@ public class ExecCmdAsserts {
                 }
             }
         }
-        assertEquals(count, expectedCount, errMsg);
+        assertTrue(countChecker.apply(count), "actualCount="+count+"; expectedCount="+countChecker+"; "+errMsg);
     }
 
     public static ExecCmd findExecContaining(List<ExecCmd> actuals, String cmdRegex) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/EmptySoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/EmptySoftwareProcessImpl.java
@@ -18,7 +18,7 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
-import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 
 public class EmptySoftwareProcessImpl extends SoftwareProcessImpl implements EmptySoftwareProcess {
 
@@ -33,7 +33,7 @@ public class EmptySoftwareProcessImpl extends SoftwareProcessImpl implements Emp
         if (isSshMonitoringEnabled()) {
             connectServiceUpIsRunning();
         } else {
-            sensors().set(Attributes.SERVICE_UP, true);
+            ServiceNotUpLogic.clearNotUpIndicator(this, SERVICE_PROCESS_IS_RUNNING);
         }
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcess.java
@@ -20,6 +20,8 @@ package org.apache.brooklyn.entity.software.base;
 
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 
 /** 
  * A {@link SoftwareProcess} entity that runs commands from an archive.
@@ -56,4 +58,8 @@ import org.apache.brooklyn.api.entity.ImplementedBy;
 @Catalog(name="Vanilla Software Process", description="A software process configured with scripts, e.g. for launch, check-running and stop")
 @ImplementedBy(VanillaSoftwareProcessImpl.class)
 public interface VanillaSoftwareProcess extends AbstractVanillaProcess {
+    ConfigKey<Boolean> USE_SSH_MONITORING = ConfigKeys.newConfigKey(
+            "sshMonitoring.enabled", 
+            "SSH monitoring enabled", 
+            Boolean.TRUE);
 }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessImpl.java
@@ -18,20 +18,34 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 
 public class VanillaSoftwareProcessImpl extends SoftwareProcessImpl implements VanillaSoftwareProcess {
+    
     @Override
     public Class<?> getDriverInterface() {
         return VanillaSoftwareProcessDriver.class;
     }
+
     @Override
     protected void connectSensors() {
         super.connectSensors();
-        connectServiceUpIsRunning();
+        if (isSshMonitoringEnabled()) {
+            connectServiceUpIsRunning();
+        } else {
+            // See SoftwareProcessImpl.waitForEntityStart(). We will already have waited for driver.isRunning.
+            // We will not poll for that again.
+            ServiceNotUpLogic.clearNotUpIndicator(this, SERVICE_PROCESS_IS_RUNNING);
+        }
     }
+    
     @Override
     protected void disconnectSensors() {
         disconnectServiceUpIsRunning();
         super.disconnectSensors();
+    }
+    
+    protected boolean isSshMonitoringEnabled() {
+        return Boolean.TRUE.equals(getConfig(USE_SSH_MONITORING));
     }
 }


### PR DESCRIPTION
See individual commits for more details.

The `FunctionSensor` I primarily added to make it easier to write my `VanillaSoftwareProessYamlTest`, but I think it's a useful addition to allow you to do in yaml what you can do in java entities (i.e. to add a `FunctionFeed` to an entity).