### PR TITLE
Add check for test resources

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityRebindTest.java
@@ -339,6 +339,10 @@ public class CatalogOsgiVersionMoreEntityRebindTest extends AbstractYamlRebindTe
     
     @Test
     public void testClusterWithEntitySpecFromOsgi() throws Exception {
+
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), BROOKLYN_TEST_OSGI_ENTITIES_PATH);
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), BROOKLYN_TEST_MORE_ENTITIES_V2_PATH);
+
         // install dependencies
         ((ManagementContextInternal)mgmt()).getOsgiManager().get().install( 
             new ResourceUtils(getClass()).getResourceFromUrl(BROOKLYN_TEST_OSGI_ENTITIES_URL) ).checkNoError();
@@ -356,7 +360,11 @@ public class CatalogOsgiVersionMoreEntityRebindTest extends AbstractYamlRebindTe
         rebind();
     }
 
-    protected RegisteredType installWrappedMoreEntity() {
+    protected RegisteredType installWrappedMoreEntity() throws Exception {
+
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), BROOKLYN_TEST_OSGI_ENTITIES_PATH);
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), BROOKLYN_TEST_MORE_ENTITIES_V2_PATH);
+
         ((ManagementContextInternal)mgmt()).getOsgiManager().get().install( 
             new ResourceUtils(getClass()).getResourceFromUrl(BROOKLYN_TEST_OSGI_ENTITIES_URL) ).checkNoError();
         ((ManagementContextInternal)mgmt()).getOsgiManager().get().install( 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
@@ -71,6 +71,9 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest implement
 
     @Test
     public void testBrooklynManagedBundleInstall() throws Exception {
+
+        TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), BROOKLYN_TEST_MORE_ENTITIES_V1_PATH);
+
         OsgiBundleInstallationResult br = ((ManagementContextInternal)mgmt()).getOsgiManager().get().install( 
             new ResourceUtils(getClass()).getResourceFromUrl(BROOKLYN_TEST_MORE_ENTITIES_V1_URL) ).get();
         Assert.assertEquals(br.getVersionedName().toString(), BROOKLYN_TEST_MORE_ENTITIES_SYMBOLIC_NAME_FULL+":"+"0.1.0");


### PR DESCRIPTION
Apache releases require there to be no binary files included in the release. Some of the tests depend on binary files and these tests must be skipped at release time. This PR adds the check for this to tests which had previously missed them out.