### PR TITLE
Add ManagementNodeStateListener support

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -143,6 +143,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     protected ClassLoader baseClassLoader;
     protected Iterable<URL> baseClassPathForScanning;
 
+    private final ManagementNodeStateListenerManager managementNodeStateListenerManager;
     private final RebindManager rebindManager;
     private final HighAvailabilityManager highAvailabilityManager;
     
@@ -177,7 +178,8 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         
         this.storage = new BrooklynStorageImpl();
         this.rebindManager = new RebindManagerImpl(this); // TODO leaking "this" reference; yuck
-        this.highAvailabilityManager = new HighAvailabilityManagerImpl(this); // TODO leaking "this" reference; yuck
+        this.managementNodeStateListenerManager = new ManagementNodeStateListenerManager(this); // TODO leaking "this" reference; yuck
+        this.highAvailabilityManager = new HighAvailabilityManagerImpl(this, managementNodeStateListenerManager); // TODO leaking "this" reference; yuck
         
         this.entitlementManager = Entitlements.newManager(this, brooklynProperties);
         this.configSupplierRegistry = new BasicExternalConfigSupplierRegistry(this); // TODO leaking "this" reference; yuck
@@ -188,6 +190,7 @@ public abstract class AbstractManagementContext implements ManagementContextInte
         highAvailabilityManager.stop();
         running = false;
         rebindManager.stop();
+        managementNodeStateListenerManager.terminate();
         storage.terminate();
         // Don't unmanage everything; different entities get given their events at different times 
         // so can cause problems (e.g. a group finds out that a member is unmanaged, before the

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/ManagementNodeStateListenerManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/ManagementNodeStateListenerManager.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
+import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
+import org.apache.brooklyn.core.mgmt.usage.ManagementNodeStateListener;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+import org.apache.brooklyn.util.core.ClassLoaderUtils;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+/**
+ * Handles the notification of {@link ManagementNodeStateListener}s.
+ * 
+ * @see {@link BrooklynServerConfig#MANAGEMENT_NODE_STATE_LISTENERS} for configuring this.
+ * @see {@link org.apache.brooklyn.core.mgmt.ha.HighAvailabilityManagerImpl#HighAvailabilityManagerImpl(ManagementContextInternal, ManagementNodeStateListener)}
+ *      for how we get notified of the state-change.
+ */
+public class ManagementNodeStateListenerManager implements ManagementNodeStateListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagementNodeStateListenerManager.class);
+
+    private final ManagementContextInternal mgmt;
+    
+    private final Object mutex = new Object();
+
+    private final List<ManagementNodeStateListener> listeners = Lists.newCopyOnWriteArrayList();
+    private ManagementNodeState lastPublishedVal;
+    
+    private final AtomicInteger listenerQueueSize = new AtomicInteger();
+    
+    private ListeningExecutorService listenerExecutor = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+            .setNameFormat("brooklyn-managementnodestate-listener-%d")
+            .build()));
+
+    public ManagementNodeStateListenerManager(ManagementContextInternal managementContext) {
+        this.mgmt = checkNotNull(managementContext, "managementContext");
+        
+        // Register a coercion from String->ManagementNodeStateListener, so that MANAGEMENT_NODE_STATE_LISTENERS defined in brooklyn.cfg
+        // will be instantiated, given their class names.
+        TypeCoercions.BrooklynCommonAdaptorTypeCoercions.registerInstanceForClassnameAdapter(
+                new ClassLoaderUtils(this.getClass(), managementContext), 
+                ManagementNodeStateListener.class);
+
+        // Although changing listeners to Collection<ManagementNodeStateListener> is valid at compile time
+        // the collection will contain any objects that could not be coerced by the function
+        // declared above. Generally this means any string declared in brooklyn.properties
+        // that is not a ManagementNodeStateListener.
+        Collection<?> rawListeners = managementContext.getBrooklynProperties().getConfig(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS);
+        if (rawListeners != null) {
+            for (Object obj : rawListeners) {
+                if (obj == null) {
+                    throw new NullPointerException("null listener in config " + BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS);
+                } else if (!(obj instanceof ManagementNodeStateListener)) {
+                    throw new ClassCastException("Configured object is not a "+ManagementNodeStateListener.class.getSimpleName()+". This probably means coercion failed: " + obj);
+                } else {
+                    ManagementNodeStateListener listener = (ManagementNodeStateListener) obj;
+                    if (listener instanceof ManagementContextInjectable) {
+                        ((ManagementContextInjectable) listener).setManagementContext(managementContext);
+                    }
+                    listeners.add((ManagementNodeStateListener)listener);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onStateChange(ManagementNodeState state) {
+        // Filtering out duplicates/nulls, schedule the notification of the listeners with this latest value.
+        synchronized (mutex) {
+            if (state != null && lastPublishedVal != state) {
+                LOG.debug("Notifying {} listener(s) of management-node state changed to {}", new Object[] {listeners.size(), state});
+                lastPublishedVal = state;
+                execOnListeners(new Function<ManagementNodeStateListener, Void>() {
+                        @Override
+                        public Void apply(ManagementNodeStateListener listener) {
+                            listener.onStateChange(state);
+                            return null;
+                        }
+                        @Override
+                        public String toString() {
+                            return "stateChange("+state+")";
+                        }});
+            }
+        }
+    }
+
+    public void terminate() {
+        // Wait for the listeners to finish + close the listeners
+        Duration timeout = mgmt.getBrooklynProperties().getConfig(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENER_TERMINATION_TIMEOUT);
+        if (listenerQueueSize.get() > 0) {
+            LOG.info("Management-node-state-listener manager waiting for "+listenerQueueSize+" listener events for up to "+timeout);
+        }
+        List<ListenableFuture<?>> futures = Lists.newArrayList();
+        for (final ManagementNodeStateListener listener : listeners) {
+            ListenableFuture<?> future = listenerExecutor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    if (listener instanceof Closeable) {
+                        try {
+                            ((Closeable)listener).close();
+                        } catch (IOException | RuntimeException e) {
+                            LOG.warn("Problem closing management-node-state listener "+listener, e);
+                            Exceptions.propagateIfFatal(e);
+                        }
+                    }
+                }});
+            futures.add(future);
+        }
+        try {
+            Futures.successfulAsList(futures).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            LOG.warn("Problem terminiating management-node-state listeners (continuing)", e);
+        } finally {
+            listenerExecutor.shutdownNow();
+        }
+    }
+
+    private void execOnListeners(final Function<ManagementNodeStateListener, Void> job) {
+        for (final ManagementNodeStateListener listener : listeners) {
+            listenerQueueSize.incrementAndGet();
+            listenerExecutor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        job.apply(listener);
+                    } catch (RuntimeException e) {
+                        LOG.error("Problem notifying listener "+listener+" of "+job, e);
+                        Exceptions.propagateIfFatal(e);
+                    } finally {
+                        listenerQueueSize.decrementAndGet();
+                    }
+                }});
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/usage/ManagementNodeStateListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/usage/ManagementNodeStateListener.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.mgmt.usage;
+
+import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Listener to be notified of this Brooklyn node's state.
+ * 
+ * See {@link BrooklynServerConfig#MANAGEMENT_NODE_STATE_LISTENERS}.
+ */
+@Beta
+public interface ManagementNodeStateListener {
+
+    /**
+     * A no-op implementation of {@link ManagementNodeStateListener}, for users to extend.
+     * 
+     * Users are encouraged to extend this class, which will shield the user 
+     * from the addition of other usage event methods being added. If additional
+     * methods are added in a future release, a no-op implementation will be
+     * added to this class.
+     */
+    @Beta
+    public static class BasicListener implements ManagementNodeStateListener {
+        @Override
+        public void onStateChange(ManagementNodeState state) {
+        }
+    }
+    
+    ManagementNodeStateListener NOOP = new BasicListener();
+
+    @Beta
+    void onStateChange(ManagementNodeState state);
+}

--- a/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
@@ -22,6 +22,7 @@ import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
 
 import java.io.File;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -29,10 +30,16 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.catalog.internal.CatalogInitialization;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.mgmt.usage.ManagementNodeStateListener;
+import org.apache.brooklyn.core.mgmt.usage.UsageListener;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
 
 /** Config keys for the brooklyn server */
 public class BrooklynServerConfig {
@@ -96,6 +103,19 @@ public class BrooklynServerConfig {
             + "if false, the persistence store will be overwritten with changes (but files not removed if they are unreadable); "
             + "if null or not set, the legacy beahviour of creating backups where possible (e.g. file system) is currently used; "
             + "this key is DEPRECATED in favor of promotion and demotion specific flags now defaulting to true");
+
+    @SuppressWarnings("serial")
+    public static final ConfigKey<List<ManagementNodeStateListener>> MANAGEMENT_NODE_STATE_LISTENERS = ConfigKeys.newConfigKey(
+            new TypeToken<List<ManagementNodeStateListener>>() {},
+            "brooklyn.managementNodeState.listeners",
+            "Optional list of ManagementNodeStateListener instances",
+            ImmutableList.<ManagementNodeStateListener>of());
+
+    public static final ConfigKey<Duration> MANAGEMENT_NODE_STATE_LISTENER_TERMINATION_TIMEOUT = ConfigKeys.newConfigKey(
+            Duration.class,
+            "brooklyn.managementNodeState.listeners.timeout",
+            "Timeout on termination, to wait for queue of management-node-state listener events to be processed",
+            Duration.TEN_SECONDS);
 
     public static final ConfigKey<String> BROOKLYN_CATALOG_URL = ConfigKeys.newStringConfigKey("brooklyn.catalog.url",
         "The URL of a custom catalog.bom to load");

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerInMemoryTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerInMemoryTest.java
@@ -53,11 +53,6 @@ public class HighAvailabilityManagerInMemoryTest extends HighAvailabilityManager
         return new InMemoryObjectStore();
     }
     
-    @Override
-    public void testGetManagementPlaneStatus() throws Exception {
-        super.testGetManagementPlaneStatus();
-    }
-
     // extra test that promoteToMaster doesn't interfere with what is managed
     public void testLocationsStillManagedCorrectlyAfterDoublePromotion() throws NoMachinesAvailableException {
         HighAvailabilityManagerImpl ha = (HighAvailabilityManagerImpl) managementContext.getHighAvailabilityManager();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/usage/ManagementNodeStateListenerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/usage/ManagementNodeStateListenerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.core.mgmt.usage;
+
+import static org.apache.brooklyn.api.mgmt.ha.ManagementNodeState.INITIALIZING;
+import static org.apache.brooklyn.api.mgmt.ha.ManagementNodeState.MASTER;
+import static org.apache.brooklyn.api.mgmt.ha.ManagementNodeState.TERMINATED;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.brooklyn.api.mgmt.ha.ManagementNodeState;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+public class ManagementNodeStateListenerTest extends BrooklynMgmtUnitTestSupport {
+
+    @BeforeMethod(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        RecordingStaticManagementNodeStateListener.clearInstances();
+        super.setUp();
+    }
+
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        RecordingStaticManagementNodeStateListener.clearInstances();
+    }
+
+    private LocalManagementContext newManagementContext(BrooklynProperties brooklynProperties) {
+        // Need to call HighAvailabilityManager explicitly; otherwise it will never publish
+        // the ManagementNodeState.
+        LocalManagementContext result = LocalManagementContextForTests.newInstance(brooklynProperties);
+        result.getHighAvailabilityManager().disabled();
+        result.noteStartupComplete();
+        return result;
+    }
+    
+    @Test
+    public void testAddUsageListenerInstance() throws Exception {
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
+        brooklynProperties.put(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS, ImmutableList.of(new RecordingStaticManagementNodeStateListener()));
+        replaceManagementContext(newManagementContext(brooklynProperties));
+
+        assertEventsEventually(RecordingStaticManagementNodeStateListener.getInstance(), ImmutableList.of(INITIALIZING, MASTER));
+        
+        mgmt.terminate();
+        assertEventsEventually(RecordingStaticManagementNodeStateListener.getInstance(), ImmutableList.of(INITIALIZING, MASTER, TERMINATED));
+    }
+
+    @Test
+    public void testAddUsageListenerViaProperties() throws Exception {
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
+        brooklynProperties.put(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS, RecordingStaticManagementNodeStateListener.class.getName());
+        replaceManagementContext(newManagementContext(brooklynProperties));
+        
+        assertEventsEventually(RecordingStaticManagementNodeStateListener.getInstance(), ImmutableList.of(INITIALIZING, MASTER));
+    }
+
+    @Test
+    public void testAddMultipleUsageListenersViaProperties() throws Exception {
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
+        brooklynProperties.put(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS, RecordingStaticManagementNodeStateListener.class.getName() + "," + RecordingStaticManagementNodeStateListener.class.getName());
+        replaceManagementContext(newManagementContext(brooklynProperties));
+        
+        final List<RecordingStaticManagementNodeStateListener> listeners = RecordingStaticManagementNodeStateListener.getInstances();
+        assertEquals(listeners.size(), 2);
+        assertTrue(listeners.get(0) instanceof RecordingStaticManagementNodeStateListener, "listeners="+listeners);
+        assertTrue(listeners.get(1) instanceof RecordingStaticManagementNodeStateListener, "listeners="+listeners);
+        
+        assertEventsEventually(listeners.get(0), ImmutableList.of(INITIALIZING, MASTER));
+        assertEventsEventually(listeners.get(1), ImmutableList.of(INITIALIZING, MASTER));
+    }
+
+    @Test(expectedExceptions = ClassCastException.class)
+    public void testErrorWhenConfiguredClassIsNotAListener() {
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newEmpty();
+        brooklynProperties.put(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS, Integer.class.getName());
+        replaceManagementContext(LocalManagementContextForTests.newInstance(brooklynProperties));
+    }
+
+    private void assertEventsEventually(RecordingManagementNodeStateListener listener, List<ManagementNodeState> expected) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                List<ManagementNodeState> actual = listener.getEvents();
+                String errMsg = "actual="+actual+"; expected="+expected;
+                assertEquals(actual, expected, errMsg);
+            }});
+    }
+    
+    public static class RecordingStaticManagementNodeStateListener extends RecordingManagementNodeStateListener implements ManagementNodeStateListener {
+        private static final List<RecordingStaticManagementNodeStateListener> STATIC_INSTANCES = Lists.newCopyOnWriteArrayList();
+
+        public static RecordingStaticManagementNodeStateListener getInstance() {
+            return Iterables.getOnlyElement(STATIC_INSTANCES);
+        }
+
+        public static RecordingStaticManagementNodeStateListener getLastInstance() {
+            return Iterables.getLast(STATIC_INSTANCES);
+        }
+        
+        public static List<RecordingStaticManagementNodeStateListener> getInstances() {
+            return ImmutableList.copyOf(STATIC_INSTANCES);
+        }
+
+        public static void clearInstances() {
+            STATIC_INSTANCES.clear();
+        }
+
+        public RecordingStaticManagementNodeStateListener() {
+            // Bad to leak a ref to this before constructor finished, but we'll live with it because
+            // it's just test code!
+            STATIC_INSTANCES.add(this);
+        }
+    }
+    
+    public static class RecordingManagementNodeStateListener implements ManagementNodeStateListener {
+        private final List<ManagementNodeState> events = Lists.newCopyOnWriteArrayList();
+
+        @Override
+        public void onStateChange(ManagementNodeState state) {
+            events.add(state);
+        }
+        
+        public List<ManagementNodeState> getEvents() {
+            return ImmutableList.copyOf(events);
+        }
+    }
+}

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/HighAvailabilityManagerJcloudsObjectStoreTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/HighAvailabilityManagerJcloudsObjectStoreTest.java
@@ -23,17 +23,22 @@ import org.apache.brooklyn.core.mgmt.ha.HighAvailabilityManagerTestFixture;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.jclouds.JcloudsBlobStoreBasedObjectStore;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
 
 @Test(groups={"Live", "Live-sanity"})
 public class HighAvailabilityManagerJcloudsObjectStoreTest extends HighAvailabilityManagerTestFixture {
 
     @Override
     protected ManagementContextInternal newLocalManagementContext() {
-        return new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+        BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newDefault();
+        brooklynProperties.put(BrooklynServerConfig.MANAGEMENT_NODE_STATE_LISTENERS, ImmutableList.of(stateListener));
+        return new LocalManagementContextForTests(brooklynProperties);
     }
 
     @Override @BeforeMethod


### PR DESCRIPTION
As discussed on the dev@brooklyn mailing list, subject `UsageListener: notified of promotion to master?`...

Adds support for registering a `ManagementNodeStateListener`, to be notified of the Brooklyn server's state changes such as when it becomes "master".