### PR TITLE
Fix PeriodicEffectorPolicy

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntityImpl.java
@@ -219,7 +219,7 @@ public class TestEntityImpl extends AbstractEntity implements TestEntity {
     
     @Override
     public void clearCallHistory() {
-        callHistory.clear();;
+        callHistory.clear();
     }
     
     public static class TestEntityWithoutEnrichers extends TestEntityImpl {

--- a/policy/src/main/java/org/apache/brooklyn/policy/action/ScheduledEffectorPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/action/ScheduledEffectorPolicy.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A {@link Policy} the executes an {@link Effector} at a specific time in the future.
@@ -59,8 +60,8 @@ public class ScheduledEffectorPolicy extends AbstractScheduledEffectorPolicy {
     public void setEntity(final EntityLocal entity) {
         super.setEntity(entity);
 
-        subscriptions().subscribe(entity, INVOKE_IMMEDIATELY, this);
-        subscriptions().subscribe(entity, INVOKE_AT, this);
+        subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, INVOKE_IMMEDIATELY, this);
+        subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, INVOKE_AT, this);
     }
 
     @Override
@@ -89,7 +90,7 @@ public class ScheduledEffectorPolicy extends AbstractScheduledEffectorPolicy {
                 }
             }
             if (event.getSensor().getName().equals(INVOKE_IMMEDIATELY.getName())) {
-                Boolean invoke = (Boolean) event.getValue();
+                Boolean invoke = Boolean.TRUE.equals(event.getValue());
                 if (invoke) {
                     schedule(Duration.ZERO);
                 }

--- a/policy/src/test/java/org/apache/brooklyn/policy/action/AbstractEffectorPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/action/AbstractEffectorPolicyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.policy.action;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.brooklyn.api.objs.Configurable;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.time.Duration;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+public class AbstractEffectorPolicyTest extends BrooklynAppUnitTestSupport {
+
+    protected static final AttributeSensor<Boolean> START = Sensors.newBooleanSensor("start");
+
+    protected <T> void assertConfigEqualsEventually(Configurable obj, ConfigKey<T> running, T val) {
+        Asserts.eventually(() -> obj.config().get(running), Predicates.equalTo(val));
+    }
+
+    protected void assertCallHistoryNeverContinually(TestEntity entity, String effector) {
+        Asserts.continually(() -> entity.getCallHistory(), l -> !l.contains(effector));
+    }
+
+    protected void assertCallHistoryContainsEventually(TestEntity entity, String effector) {
+        assertCallHistoryEventually(entity, effector, 1);
+    }
+
+    protected void assertCallHistoryEventually(TestEntity entity, String effector, int minSize) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                int size = getCallHistoryCount(entity, effector);
+                assertTrue(size >= minSize, "size="+size);
+            }});
+    }
+    
+    protected void assertCallsStopEventually(TestEntity entity, String effector) {
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                int size1 = getCallHistoryCount(entity, effector);
+                Asserts.succeedsContinually(ImmutableMap.of("timeout", Duration.millis(100)), new Runnable() {
+                    public void run() {
+                        int size2 = getCallHistoryCount(entity, effector);
+                        assertEquals(size1, size2);
+                    }});
+            }});
+    }
+
+    protected int getCallHistoryCount(TestEntity entity, String effector) {
+        List<String> callHistory = entity.getCallHistory();
+        synchronized (callHistory) {
+            return Iterables.size(Iterables.filter(callHistory, Predicates.equalTo("myEffector")));
+        }
+    }
+}


### PR DESCRIPTION
The `PeriodicEffectorPolicy` rebind test(s) were failing non-deterministically in the jenkins master build, and same for me locally.

This PR makes a bunch of changes to fix those, along with various other improvements to the policy implementations. The config / documented behaviour of the policies should be unaffected by these changes.