### PR TITLE
Fix catalog YAML

### DIFF
--- a/karaf/init/src/main/resources/catalog-classes.bom
+++ b/karaf/init/src/main/resources/catalog-classes.bom
@@ -239,8 +239,8 @@ brooklyn.catalog:
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
-        name: [DEPRECATED] Rolling Mean in Time Window
-        description: [DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher
+        name: "[DEPRECATED] Rolling Mean in Time Window"
+        description: "[DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher"
     - id: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
       itemType: enricher
       item:
@@ -253,8 +253,8 @@ brooklyn.catalog:
       itemType: enricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
-        name: [DEPRECATED] Time Weighted Delta
-        description: [DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'
+        name: "[DEPRECATED] Time Weighted Delta"
+        description: "[DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'"
     - id: org.apache.brooklyn.policy.ha.ServiceFailureDetector
       itemType: enricher
       item:
@@ -332,8 +332,8 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.test.framework.SimpleShellCommandTest
       item:
         type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-        name: [DEPRECATED] Simple Shell Command Test
-        description:  [DEPRECATED] Instead use TestSshCommand
+        name: "[DEPRECATED] Simple Shell Command Test"
+        description:  "[DEPRECATED] Instead use TestSshCommand"
     - id: org.apache.brooklyn.test.framework.ParallelTestCase
       item:
         type: org.apache.brooklyn.test.framework.ParallelTestCase

--- a/policy/src/main/resources/catalog.bom
+++ b/policy/src/main/resources/catalog.bom
@@ -101,8 +101,8 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
       item:
         type: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
-        name: [DEPRECATED] Rolling Mean in Time Window
-        description: [DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher
+        name: "[DEPRECATED] Rolling Mean in Time Window"
+        description: "[DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher"
     - id: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
@@ -113,8 +113,8 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
-        name: [DEPRECATED] Time Weighted Delta
-        description: [DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'
+        name: "[DEPRECATED] Time Weighted Delta"
+        description: "[DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'"
     - id: org.apache.brooklyn.policy.ha.ServiceFailureDetector
       item:
         type: org.apache.brooklyn.policy.ha.ServiceFailureDetector

--- a/test-framework/src/main/resources/catalog.bom
+++ b/test-framework/src/main/resources/catalog.bom
@@ -26,8 +26,8 @@ brooklyn.catalog:
     - id: org.apache.brooklyn.test.framework.SimpleShellCommandTest
       item:
         type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
-        name: [DEPRECATED] Simple Shell Command Test
-        description:  [DEPRECATED] Instead use TestSshCommand
+        name: "[DEPRECATED] Simple Shell Command Test"
+        description:  "[DEPRECATED] Instead use TestSshCommand"
     - id: org.apache.brooklyn.test.framework.ParallelTestCase
       item:
         type: org.apache.brooklyn.test.framework.ParallelTestCase


### PR DESCRIPTION
Square brackets within the yaml string meant it was interpreted as an array and broke the initial catalog load. This puts speach marks around so it's interpreted as a string.