### PR TITLE
Fix BasicBrooklynCatalog create Spec

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -433,7 +433,21 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     public <T, SpecT extends AbstractBrooklynObjectSpec<? extends T, SpecT>> SpecT createSpec(CatalogItem<T, SpecT> item) {
         if (item == null) return null;
         CatalogItemDo<T,SpecT> loadedItem = (CatalogItemDo<T, SpecT>) getCatalogItemDo(item.getSymbolicName(), item.getVersion());
-        if (loadedItem == null) throw new RuntimeException(item+" not in catalog; cannot create spec");
+
+        if (loadedItem == null) {
+            RegisteredType registeredType = mgmt.getTypeRegistry().get(item.getSymbolicName(), item.getVersion());
+            if(registeredType == null) {
+                throw new RuntimeException(item + " not in catalog; cannot create spec");
+            }
+
+            AbstractBrooklynObjectSpec<?, ?> spec = mgmt.getTypeRegistry().createSpec(registeredType, null, null);
+            if(spec == null) {
+                throw new RuntimeException("Problem loading spec for type "+registeredType);
+            }
+
+            return (SpecT)spec;
+        }
+
         if (loadedItem.getSpecType()==null) return null;
         
         SpecT spec = internalCreateSpecLegacy(mgmt, loadedItem, MutableSet.<String>of(), true);


### PR DESCRIPTION
If the BasicBrooklynCatalog fails to load a catalog item, it will now fall back to the type registry.