### PR TITLE
Fix BundleMaker to handle an empty classpath dir

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
@@ -359,7 +359,14 @@ public class BundleMaker {
         if (startPos<0) {
             throw new IllegalStateException("URL of "+item+" does not appear relative to root "+root);
         }
-        String itemE = item.substring(startPos + root.length()+1);
+        String itemE = item.substring(startPos + root.length());
+        itemE = Strings.removeFromStart(itemE, "/");
+        
+        if (Strings.isEmpty(itemE)) {
+            // Can happen if we're given an empty folder. addUrlDirToZipRecursively will have returned false, so 
+            // will try to add it as a file.
+            return; 
+        }
         if (!filter.apply(itemE)) {
             return;
         }

--- a/core/src/test/java/org/apache/brooklyn/util/core/osgi/BundleMakerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/osgi/BundleMakerTest.java
@@ -209,7 +209,13 @@ public class BundleMakerTest extends BrooklynMgmtUnitTestSupport {
                 "Manifest-Version: 1.2.3\r\n" + 
                 "mykey: myval\r\n" +
                 "\r\n";
-        assertJarContents(generatedJar, ImmutableMap.of(JarFile.MANIFEST_NAME, expectedManifest, "myfile.txt", "mytext", "subdir/myfile2.txt", "mytext2"), false);
+        assertJarContents(generatedJar, 
+                ImmutableMap.of(
+                        JarFile.MANIFEST_NAME, expectedManifest,
+                        "myfile.txt", "mytext",
+                        "myemptyfile.txt", "", 
+                        "subdir/myfile2.txt", "mytext2"),
+                false);
     }
     
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Fixes the jenkins exception we hit in https://github.com/apache/brooklyn-server/pull/847#issuecomment-333528749.

This fixes the exception. However, the underlying cause on jenkins was probably a messed up build (the classpath dir should not have been empty!).

Note that I couldn't add the test for this because git can't have an empty dir (it needs to be really empty, rather than containing a single `.gitignore` file or whatever).

The test I ran locally was:
```
    @Test
    public void testCreateJarFromEmptyClasspathDir() throws Exception {
        generatedJar = bundleMaker.createJarFromClasspathDir("/org/apache/brooklyn/util/core/osgi/test/bundlemaker/emptyfolder/");
        
        assertJarContents(generatedJar, ImmutableMap.of(), false);
    }
```