### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/SpecParameterUnwrappingTest.java
@@ -62,7 +62,7 @@ import com.google.common.collect.Iterables;
 public class SpecParameterUnwrappingTest extends AbstractYamlTest {
     
     // Expect app to have the following config keys already: 
-    // "application.stop.shouldDestroy", "defaultDisplayName", "quorum.running", "quorum.up", "start.latch"
+    // "application.stop.shouldDestroy", "defaultDisplayName", "quorum.running", "quorum.up", "latch.start"
     public static final int NUM_APP_DEFAULT_CONFIG_KEYS = 5;
     // "defaultDisplayName"
     public static final int NUM_ENTITY_DEFAULT_CONFIG_KEYS = 1;

--- a/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/BrooklynConfigKeys.java
@@ -227,7 +227,7 @@ public class BrooklynConfigKeys {
             .description("Latch for blocking files being copied before the pre-install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();
     public static final ConfigKey<Boolean> INSTALL_RESOURCES_LATCH = ConfigKeys.builder(Boolean.class)
-            .name("latch.install.reources")
+            .name("latch.install.resources")
             .deprecatedNames("resources.install.latch") 
             .description("Latch for blocking files being copied before the install; if non-null will wait for this to resolve (normal use is with '$brooklyn:attributeWhenReady')")
             .build();


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names. It also fixes a typo for `latch.install.resources`