### PR TITLE
[WIP] deprecate Task as values in config and getImmediately(Task) in favour of TaskFactory

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionContext.java
@@ -97,8 +97,12 @@ public interface ExecutionContext extends Executor {
     @Beta
     <T> Maybe<T> getImmediately(Object callableOrSupplierOrTask);
     /** As {@link #getImmediately(Object)} but strongly typed for a task. */
+    // TODO deprecate
     @Beta
-    <T> Maybe<T> getImmediately(Task<T> callableOrSupplierOrTask);
+    <T> Maybe<T> getImmediately(TaskAdaptable<T> callableOrSupplierOrTask);
+    /** As {@link #getImmediately(Object)} but strongly typed for a task factory. */
+    @Beta
+    <T> Maybe<T> getImmediately(TaskFactory<Task<T>> callableOrSupplierOrTask);
 
     /**
      * Efficient implementation of common case when {@link #submit(TaskAdaptable)} is followed by an immediate {@link Task#get()}.

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionContext.java
@@ -52,11 +52,21 @@ public interface ExecutionContext extends Executor {
      */
     <T> Task<T> submit(Map<?,?> properties, Callable<T> callable);
 
-    /** {@link ExecutionManager#submit(Runnable) */
+    /** {@link ExecutionManager#submit(Runnable) 
+     * @deprecated since 0.13.0 pass a display name or a more detailed map */
+    @Deprecated
     Task<?> submit(Runnable runnable);
  
-    /** {@link ExecutionManager#submit(Callable) */
+    /** {@link ExecutionManager#submit(Callable)
+     * @deprecated since 0.13.0 pass a display name or a more detailed map */
+    @Deprecated
     <T> Task<T> submit(Callable<T> callable);
+
+    /** {@link ExecutionManager#submit(String Runnable) */
+    Task<?> submit(String displayName, Runnable runnable);
+ 
+    /** {@link ExecutionManager#submit(String, Callable) */
+    <T> Task<T> submit(String displayName, Callable<T> callable);
 
     /** See {@link ExecutionManager#submit(Map, TaskAdaptable)}. */
     <T> Task<T> submit(TaskAdaptable<T> task);
@@ -86,18 +96,23 @@ public interface ExecutionContext extends Executor {
     // TODO reference ImmediateSupplier when that class is moved to utils project
     @Beta
     <T> Maybe<T> getImmediately(Object callableOrSupplierOrTask);
+    /** As {@link #getImmediately(Object)} but strongly typed for a task. */
+    @Beta
+    <T> Maybe<T> getImmediately(Task<T> callableOrSupplierOrTask);
 
     /**
-     * Efficient shortcut for {@link #submit(TaskAdaptable)} followed by an immediate {@link Task#get()}.
+     * Efficient implementation of common case when {@link #submit(TaskAdaptable)} is followed by an immediate {@link Task#get()}.
      * <p>
-     * Implementations will typically attempt to execute in the current thread, with appropriate
-     * configuration to make it look like it is in a sub-thread, 
-     * ie registering this as a task and allowing
-     * context methods on tasks to see the given sub-task.
+     * This is efficient in that it may typically attempt to execute in the current thread, 
+     * with appropriate configuration to make it look like it is in a sub-thread, 
+     * ie registering this as a task and allowing context methods on tasks to see the given sub-task.
+     * However it will normally be non-blocking which reduces overhead and 
+     * is permissible within a {@link #getImmediately(Object)} task
      * <p>
-     * If the argument has already been submitted it simply blocks on it.
+     * If the argument has already been submitted it simply blocks on it 
+     * (i.e. no additional execution, and in that case would fail within a {@link #getImmediately(Object)}).
      * 
-     * @param task
+     * @param task the task whose result is being sought
      * @return result of the task execution
      */
     @Beta

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ExecutionManager.java
@@ -79,11 +79,21 @@ public interface ExecutionManager {
 //    /** returns all tasks known to this manager (immutable) */
 //    public Set<Task<?>> getAllTasks();
 
-    /** see {@link #submit(Map, TaskAdaptable)} */
+    /** see {@link #submit(Map, TaskAdaptable)} 
+     * @deprecated since 0.13.0 pass displayName or map */
+    @Deprecated
     public Task<?> submit(Runnable r);
 
+    /** see {@link #submit(Map, TaskAdaptable)} 
+     * @deprecated since 0.13.0 pass displayName or map */
+    @Deprecated
+    public <T> Task<T> submit(Callable<T> r);
+
     /** see {@link #submit(Map, TaskAdaptable)} */
-    public <T> Task<T> submit(Callable<T> c);
+    public Task<?> submit(String displayName, Runnable c);
+
+    /** see {@link #submit(Map, TaskAdaptable)} */
+    public <T> Task<T> submit(String displayName, Callable<T> c);
 
     /** see {@link #submit(Map, TaskAdaptable)} */
     public <T> Task<T> submit(TaskAdaptable<T> task);

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.mgmt.entitlement.EntitlementManager;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityManager;
 import org.apache.brooklyn.api.mgmt.rebind.RebindManager;
 import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -176,6 +177,9 @@ public interface ManagementContext {
      */
     SubscriptionContext getSubscriptionContext(Entity entity);
 
+    /** As {@link #getSubscriptionContext(Entity)} where there is also an adjunct */
+    SubscriptionContext getSubscriptionContext(Entity e, EntityAdjunct a);
+    
     /**
      * Returns a {@link SubscriptionContext} instance representing subscriptions
      * (from the {@link SubscriptionManager}) associated with this location, and capable 

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/SubscriptionManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/SubscriptionManager.java
@@ -42,8 +42,10 @@ public interface SubscriptionManager {
      * 
      * The method returns an id which can be used to {@link #unsubscribe(SubscriptionHandle)} later.
      * <p>
-     * The listener callback is in-order single-threaded and synchronized on this object. The flags
-     * parameters can include the following:
+     * The listener callback is in-order single-threaded and synchronized on this object.
+     * In other words message delivery from a producer to a given subscriber is in publish order
+     * (or in the case of a late subscriber getting initial values, in subscribe order). 
+     * The flags parameters can include the following:
      * <ul>
      * <li>subscriber - object to identify the subscriber (e.g. entity, or console session uid) 
      * <li><i>in future</i> - control parameters for the subscription (period, minimum delta for updates, etc)

--- a/api/src/main/java/org/apache/brooklyn/api/objs/Configurable.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/Configurable.java
@@ -20,10 +20,13 @@ package org.apache.brooklyn.api.objs;
 
 import java.util.Set;
 
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.config.ConfigMap;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.config.ConfigMap;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Predicate;
@@ -85,19 +88,39 @@ public interface Configurable {
         <T> T set(HasConfigKey<T> key, T val);
         
         /**
-         * Sets the config to the value returned by the task.
+         * Sets the config to return the value returned by the task this generates,
+         * on demand when invoked.
+         * <p>
+         * Returns immediately without blocking; subsequent calls to {@link #getConfig(ConfigKey)} 
+         * will create and execute an instance of the task, blocking unless otherwise configured.
          * 
+         * @see {@link #setConfig(ConfigKey, Object)}
+         */
+        <T> T set(ConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val);
+        
+        /**
+         * Sets the config to the value returned by the task.
+         * <p>
+         * It is recommended to use {@link #set(ConfigKey, TaskFactory)} instead so that calls to validate 
+         * items via {@link ExecutionContext#getImmediately(Object)} do not interrupt and wreck the task set here. 
+         * <p>
          * Returns immediately without blocking; subsequent calls to {@link #getConfig(ConfigKey)} 
          * will execute the task, and block until the task completes.
          * 
          * @see {@link #setConfig(ConfigKey, Object)}
          */
-        <T> T set(ConfigKey<T> key, Task<T> val);
+        <T> T set(ConfigKey<T> key, TaskAdaptable<T> val);
+        
+        /**
+         * @see {@link #setConfig(ConfigKey, TaskFactory)}
+         */
+        <T> T set(HasConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val);
         
         /**
          * @see {@link #setConfig(ConfigKey, Task)}
          */
-        <T> T set(HasConfigKey<T> key, Task<T> val);
+        // TODO deprecate
+        <T> T set(HasConfigKey<T> key, TaskAdaptable<T> val);
         
         /** @deprecated since 0.11.0 see {@link ConfigMap#findKeys(Predicate)} */
         @Deprecated

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -934,13 +934,12 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         Entity app = createStartWaitAndLogApplication(yaml);
         final TestEntity entity1 = (TestEntity) Iterables.getOnlyElement(app.getChildren());
 
-        TestEntity entity2 = entity1.getExecutionContext().submit(new Callable<TestEntity>() {
-            public TestEntity call() {
-                TestEntity entity2 = entity1.addChild(EntitySpec.create(TestEntity.class));
-                entity2.start(Collections.<Location>emptyList());
-                return entity2;
-            } 
-        }).get();
+        TestEntity entity2 = entity1.getExecutionContext().submit("create and start", () -> {
+                TestEntity entity2i = entity1.addChild(EntitySpec.create(TestEntity.class));
+                entity2i.start(Collections.<Location>emptyList());
+                return entity2i;
+            })
+            .get();
         
         Entities.dumpInfo(app);
         

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
@@ -27,7 +27,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
@@ -182,12 +183,22 @@ public class ObjectsYamlTest extends AbstractYamlTest {
             }
 
             @Override
-            public <T> T set(ConfigKey<T> key, Task<T> val) {
+            public <T> T set(ConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
                 throw new UnsupportedOperationException();
             }
 
             @Override
-            public <T> T set(HasConfigKey<T> key, Task<T> val) {
+            public <T> T set(HasConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+                return set(key.getConfigKey(), val);
+            }
+            
+            @Override
+            public <T> T set(ConfigKey<T> key, TaskAdaptable<T> val) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T set(HasConfigKey<T> key, TaskAdaptable<T> val) {
                 return set(key.getConfigKey(), val);
             }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslTest.java
@@ -327,7 +327,7 @@ public class DslTest extends BrooklynAppUnitTestSupport {
     protected void runConcurrentWorker(Supplier<Runnable> taskSupplier) {
         Collection<Task<?>> results = new ArrayList<>();
         for (int i = 0; i < MAX_PARALLEL_RESOLVERS; i++) {
-            Task<?> result = app.getExecutionContext().submit(taskSupplier.get());
+            Task<?> result = app.getExecutionContext().submit("parallel "+i, taskSupplier.get());
             results.add(result);
         }
         for (Task<?> result : results) {
@@ -550,7 +550,7 @@ public class DslTest extends BrooklynAppUnitTestSupport {
             }
         };
         if (execInTask) {
-            Task<Maybe<?>> task = ((EntityInternal)context).getExecutionContext().submit(job);
+            Task<Maybe<?>> task = ((EntityInternal)context).getExecutionContext().submit("Resolving DSL for test: "+dsl, job);
             task.get(Asserts.DEFAULT_LONG_TIMEOUT);
             assertTrue(task.isDone());
             return task.get();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslTest.java
@@ -209,7 +209,7 @@ public class DslTest extends BrooklynAppUnitTestSupport {
     public void testConfigImmediatelyDoesNotBlock() throws Exception {
         ConfigKey<String> configKey = ConfigKeys.newStringConfigKey("testConfig");
         BrooklynDslDeferredSupplier<?> attributeDsl = BrooklynDslCommon.attributeWhenReady(TestApplication.MY_ATTRIBUTE.getName());
-        app.config().set((ConfigKey)configKey, attributeDsl); // ugly cast because val is DSL, resolving to a string
+        app.config().set((ConfigKey)configKey, (Object)attributeDsl); // ugly cast because val is DSL, resolving to a string
         BrooklynDslDeferredSupplier<?> configDsl = BrooklynDslCommon.config(configKey.getName());
         Maybe<?> actualValue = execDslImmediately(configDsl, configKey.getType(), app, true);
         assertTrue(actualValue.isAbsent());

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
@@ -25,12 +25,15 @@ import java.util.List;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.core.objs.BrooklynObjectPredicate;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,12 +115,21 @@ public abstract class ConfigConstraints<T extends BrooklynObject> {
     abstract Iterable<ConfigKey<?>> getBrooklynObjectTypeConfigKeys();
 
     public Iterable<ConfigKey<?>> getViolations() {
-        // TODO in new task
-        return validateAll();
+        ExecutionContext exec = 
+            getBrooklynObject() instanceof EntityInternal ? ((EntityInternal)getBrooklynObject()).getExecutionContext() :
+            // getBrooklynObject() instanceof AbstractEntityAdjunct ? ((AbstractEntityAdjunct)getBrooklynObject()).getExecutionContext() :
+            null;
+        if (exec!=null) {
+            return exec.get(
+                Tasks.<Iterable<ConfigKey<?>>>builder().dynamic(false).displayName("Validating config").body(
+                    () -> validateAll() ).build() );
+        } else {
+            return validateAll();
+        }
     }
 
     @SuppressWarnings("unchecked")
-    private Iterable<ConfigKey<?>> validateAll() {
+    protected Iterable<ConfigKey<?>> validateAll() {
         List<ConfigKey<?>> violating = Lists.newLinkedList();
         Iterable<ConfigKey<?>> configKeys = getBrooklynObjectTypeConfigKeys();
         LOG.trace("Checking config keys on {}: {}", getBrooklynObject(), configKeys);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -529,6 +529,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
      * through this method. Internally, all attribute updates synch on this object. Code wishing to
      * update attributes or publish while holding some other lock should acquire the monitor on this
      * object first to prevent deadlock. */
+    @Beta
     protected Object getAttributesSynchObjectInternal() {
         return attributesInternal.getSynchObjectInternal();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
@@ -49,20 +49,20 @@ public class StartableMethods {
     /** Common implementation for start in parent nodes; just invokes start on all children of the entity */
     public static void start(Entity e, Collection<? extends Location> locations) {
         log.debug("Starting entity "+e+" at "+locations);
-        DynamicTasks.queueIfPossible(startingChildren(e, locations)).orSubmitAsync(e).getTask().getUnchecked();
+        DynamicTasks.get(startingChildren(e, locations), e);
     }
     
     /** Common implementation for stop in parent nodes; just invokes stop on all children of the entity */
     public static void stop(Entity e) {
         log.debug("Stopping entity "+e);
-        DynamicTasks.queueIfPossible(stoppingChildren(e)).orSubmitAsync(e).getTask().getUnchecked();
+        DynamicTasks.get(stoppingChildren(e), e);
         if (log.isDebugEnabled()) log.debug("Stopped entity "+e);
     }
 
     /** Common implementation for restart in parent nodes; just invokes restart on all children of the entity */
     public static void restart(Entity e) {
         log.debug("Restarting entity "+e);
-        DynamicTasks.queueIfPossible(restartingChildren(e)).orSubmitAsync(e).getTask().getUnchecked();
+        DynamicTasks.get(restartingChildren(e), e);
         if (log.isDebugEnabled()) log.debug("Restarted entity "+e);
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/Poller.java
@@ -139,7 +139,7 @@ public class Poller<V> {
         
         for (final Callable<?> oneOffJob : oneOffJobs) {
             Task<?> task = Tasks.builder().dynamic(false).body((Callable<Object>) oneOffJob).displayName("Poll").description("One-time poll job "+oneOffJob).build();
-            oneOffTasks.add(((EntityInternal)entity).getExecutionContext().submit(task));
+            oneOffTasks.add(feed.getExecutionContext().submit(task));
         }
         
         Duration minPeriod = null;

--- a/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineDetails.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/BasicMachineDetails.java
@@ -96,10 +96,7 @@ public class BasicMachineDetails implements MachineDetails {
      */
     @Beta
     public static BasicMachineDetails forSshMachineLocationLive(SshMachineLocation location) {
-        return TaskTags.markInessential(DynamicTasks.queueIfPossible(taskForSshMachineLocation(location))
-                .orSubmitAsync()
-                .asTask())
-                .getUnchecked();
+        return DynamicTasks.get(TaskTags.markInessential(taskForSshMachineLocation(location)));
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/location/access/BrooklynAccessUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/access/BrooklynAccessUtils.java
@@ -119,7 +119,7 @@ public class BrooklynAccessUtils {
     public static String getResolvedAddress(Entity entity, SshMachineLocation origin, String hostnameTarget) {
         ProcessTaskWrapper<Integer> task = SshTasks.newSshExecTaskFactory(origin, "ping -c 1 -t 1 "+hostnameTarget)
             .summary("checking resolution of "+hostnameTarget).allowingNonZeroExitCode().newTask();
-        DynamicTasks.queueIfPossible(task).orSubmitAndBlock(entity).asTask().blockUntilEnded();
+        DynamicTasks.queueIfPossible(task).orSubmitAndBlock(entity).getTask().blockUntilEnded();
         if (task.asTask().isError()) {
             log.warn("ping could not be run, at "+entity+" / "+origin+": "+Tasks.getError(task.asTask()));
             return "";

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTaskTags.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionManager;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -59,13 +60,14 @@ import com.google.common.collect.ImmutableSet;
 /** Provides utilities for making Tasks easier to work with in Brooklyn.
  * Main thing at present is to supply (and find) wrapped entities for tasks to understand the
  * relationship of the entity to the task.
- * TODO Longer term it would be better to remove 'tags' on Tasks and use a strongly typed context object.
+ * <p>
+ * Eventually it may be better to replace these 'tags' on Tasks with strongly typed context objects.
  * (Tags there are used mainly for determining who called it (caller), what they called it on (target entity),
  * and what type of task it is (effector, schedule/sensor, etc).)
  */
 public class BrooklynTaskTags extends TaskTags {
 
-    private static final Logger log = LoggerFactory.getLogger(BrooklynTaskTags.WrappedEntity.class);
+    private static final Logger log = LoggerFactory.getLogger(BrooklynTaskTags.class);
 
     /** Tag for tasks which are running on behalf of the management server, rather than any entity */
     public static final String BROOKLYN_SERVER_TASK_TAG = "BROOKLYN-SERVER";
@@ -85,36 +87,65 @@ public class BrooklynTaskTags extends TaskTags {
 
     // ------------- entity tags -------------------------
     
-    public static class WrappedEntity {
+    public abstract static class WrappedItem<T> {
+        /** @deprecated since 0.13.0 going private; use {@link #getWrappingType()} */
+        @Deprecated
         public final String wrappingType;
-        public final Entity entity;
-        protected WrappedEntity(String wrappingType, Entity entity) {
+        protected WrappedItem(String wrappingType) {
             Preconditions.checkNotNull(wrappingType);
-            Preconditions.checkNotNull(entity);
             this.wrappingType = wrappingType;
-            this.entity = entity;
+        }
+        public abstract T unwrap();
+        public String getWrappingType() {
+            return wrappingType;
         }
         @Override
         public String toString() {
-            return "Wrapped["+wrappingType+":"+entity+"]";
+            return "Wrapped["+getWrappingType()+":"+unwrap()+"]";
         }
         @Override
         public int hashCode() {
-            return Objects.hashCode(entity, wrappingType);
+            return Objects.hashCode(unwrap(), getWrappingType());
         }
         @Override
         public boolean equals(Object obj) {
             if (this==obj) return true;
-            if (!(obj instanceof WrappedEntity)) return false;
+            if (!(obj instanceof WrappedItem)) return false;
             return 
-                Objects.equal(entity, ((WrappedEntity)obj).entity) &&
-                Objects.equal(wrappingType, ((WrappedEntity)obj).wrappingType);
+                Objects.equal(unwrap(), ((WrappedItem<?>)obj).unwrap()) &&
+                Objects.equal(getWrappingType(), ((WrappedItem<?>)obj).getWrappingType());
         }
+    }
+    public static class WrappedEntity extends WrappedItem<Entity> {
+        /** @deprecated since 0.13.0 going private; use {@link #unwrap()} */
+        @Deprecated
+        public final Entity entity;
+        protected WrappedEntity(String wrappingType, Entity entity) {
+            super(wrappingType);
+            this.entity = Preconditions.checkNotNull(entity);
+        }
+        @Override
+        public Entity unwrap() {
+            return entity;
+        }
+    }
+    public static class WrappedObject<T> extends WrappedItem<T> {
+        private final T object;
+        protected WrappedObject(String wrappingType, T object) {
+            super(wrappingType);
+            this.object = Preconditions.checkNotNull(object);
+        }
+        @Override
+        public T unwrap() {
+            return object;
+        }        
     }
     
     public static final String CONTEXT_ENTITY = "contextEntity";
     public static final String CALLER_ENTITY = "callerEntity";
     public static final String TARGET_ENTITY = "targetEntity";
+    
+    public static final String CONTEXT_ADJUNCT = "contextAdjunct";
     
     /**
      * Marks a task as running in the context of the entity. This means
@@ -137,6 +168,15 @@ public class BrooklynTaskTags extends TaskTags {
     public static WrappedEntity tagForTargetEntity(Entity entity) {
         return new WrappedEntity(TARGET_ENTITY, entity);
     }
+
+    /**
+     * As {@link #tagForContextEntity(Entity)} but wrapping an adjunct.
+     * Tasks with this tag will also have a {@link #tagForContextEntity(Entity)}.
+     */
+    public static WrappedObject<EntityAdjunct> tagForContextAdjunct(EntityAdjunct adjunct) {
+        return new WrappedObject<EntityAdjunct>(CONTEXT_ADJUNCT, adjunct);
+    }
+    
 
     public static WrappedEntity getWrappedEntityTagOfType(Task<?> t, String wrappingType) {
         if (t==null) return null;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -91,9 +91,11 @@ public class EntityManagementUtils {
      */
     @Beta
     public static <T extends Application> T createUnstarted(ManagementContext mgmt, EntitySpec<T> spec, Optional<String> entityId) {
-        // TODO wrap in task
-        T app = ((EntityManagerInternal)mgmt.getEntityManager()).createEntity(spec, entityId);
-        return app;
+        return mgmt.getServerExecutionContext().get(Tasks.<T>builder().dynamic(false)
+            .displayName("Creating entity "+
+                (Strings.isNonBlank(spec.getDisplayName()) ? spec.getDisplayName() : spec.getType().getName()) )
+            .body(() -> ((EntityManagerInternal)mgmt.getEntityManager()).createEntity(spec, entityId))
+            .build() );
     }
 
     /** as {@link #createUnstarted(ManagementContext, EntitySpec)} but for a string plan (e.g. camp yaml) */

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractManagementContext.java
@@ -51,6 +51,7 @@ import org.apache.brooklyn.api.mgmt.entitlement.EntitlementManager;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityManager;
 import org.apache.brooklyn.api.mgmt.rebind.RebindManager;
 import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.config.StringConfigMap;
@@ -259,6 +260,14 @@ public abstract class AbstractManagementContext implements ManagementContextInte
     public SubscriptionContext getSubscriptionContext(Entity e) {
         // BSC is a thin wrapper around SM so fine to create a new one here
         Map<String, ?> flags = ImmutableMap.of("tags", ImmutableList.of(BrooklynTaskTags.tagForContextEntity(e)));
+        return new BasicSubscriptionContext(flags, getSubscriptionManager(), e);
+    }
+    
+    @Override
+    public SubscriptionContext getSubscriptionContext(Entity e, EntityAdjunct a) {
+        // BSC is a thin wrapper around SM so fine to create a new one here
+        Map<String, ?> flags = ImmutableMap.of("tags", ImmutableList.of(BrooklynTaskTags.tagForContextEntity(e), BrooklynTaskTags.tagForContextAdjunct(a)),
+            "subscriptionDescription", "adjunct "+a.getId());
         return new BasicSubscriptionContext(flags, getSubscriptionManager(), e);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractSubscriptionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/AbstractSubscriptionManager.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.api.mgmt.SubscriptionManager;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,6 +146,10 @@ public abstract class AbstractSubscriptionManager implements SubscriptionManager
 
     protected <T> Object getSubscriber(Map<String, Object> flags, Subscription<T> s) {
         return s.subscriber!=null ? s.subscriber : flags.containsKey("subscriber") ? flags.remove("subscriber") : s.listener;
+    }
+
+    protected <T> String getSubscriptionDescription(Map<String, Object> flags, Subscription<T> s) {
+        return s.subscriptionDescription!=null ? s.subscriptionDescription : flags.containsKey("subscriptionDescription") ? Strings.toString(flags.remove("subscriptionDescription")) : null;
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -305,27 +305,20 @@ public class BrooklynGarbageCollector {
         if (tags.contains(ManagementContextInternal.EFFECTOR_TAG) || tags.contains(ManagementContextInternal.NON_TRANSIENT_TASK_TAG))
             return false;
         
-        if (task.getSubmittedByTask()!=null) {
-            Task<?> parent = task.getSubmittedByTask();
-            if (executionManager.getTask(parent.getId())==null) {
-                // parent is already cleaned up
-                return true;
-            }
-            if (parent instanceof HasTaskChildren && Iterables.contains(((HasTaskChildren)parent).getChildren(), task)) {
-                // it is a child, let the parent manage this task's death
-                return false;
-            }
-            Entity associatedEntity = BrooklynTaskTags.getTargetOrContextEntity(task);
-            if (associatedEntity!=null) {
-                // this is associated to an entity; destroy only if the entity is unmanaged
-                return !Entities.isManaged(associatedEntity);
-            }
-            // if not associated to an entity, then delete immediately
-            return true;
+        if (!isSubmitterExpired(task)) {
+            return false;
+        }
+        if (isChild(task)) {
+            // parent should manage this task's death; but above already kicks in if parent is not expired, so probably shouldn't come here?
+            LOG.warn("Unexpected expiry candidacy for "+task);
+            return false;
+        }
+        if (isAssociatedToActiveEntity(task)) {
+            return false;
         }
         
         // e.g. scheduled tasks, sensor events, etc
-        // TODO (in future may keep some of these with another limit, based on a new TagCategory)
+        // (in future may keep some of these with another limit, based on a new TagCategory)
         // there may also be a server association for server-side tasks which should be kept
         // (but be careful not to keep too many subscriptions!)
         
@@ -337,7 +330,7 @@ public class BrooklynGarbageCollector {
      * {@link #maxTasksPerTag} and {@link #maxTaskAge}.
      */
     protected synchronized int gcTasks() {
-        // TODO Must be careful with memory usage here: have seen OOME if we get crazy lots of tasks.
+        // NB: be careful with memory usage here: have seen OOME if we get crazy lots of tasks.
         // hopefully the use new limits, filters, and use of live lists in some places (added Sep 2014) will help.
         // 
         // An option is for getTasksWithTag(tag) to return an ArrayList rather than a LinkedHashSet. That
@@ -397,11 +390,21 @@ public class BrooklynGarbageCollector {
         int deletedCount = 0;
         deletedCount += expireOverCapacityTagsInCategory(taskNonEntityTagsOverCapacity, taskAllTagsOverCapacity, TagCategory.NON_ENTITY_NORMAL, false);
         deletedCount += expireOverCapacityTagsInCategory(taskEntityTagsOverCapacity, taskAllTagsOverCapacity, TagCategory.ENTITY, true);
-        deletedCount += expireSubTasksWhoseSubmitterIsExpired();
         
-        int deletedGlobally = expireIfOverCapacityGlobally();
-        deletedCount += deletedGlobally;
-        if (deletedGlobally>0) deletedCount += expireSubTasksWhoseSubmitterIsExpired();
+        // if expensive we could optimize task GC here to avoid repeated lookups by
+        // counting all expired above (not just prev two lines) and skipping if none
+        // but that seems unlikely
+        int deletedHere = 0;
+        while ((deletedHere = expireHistoricTasksNowReadyForImmediateDeletion()) > 0) {
+            // delete in loop so we don't have descendants sticking around until deleted in later cycles
+            deletedCount += deletedHere; 
+        }
+        
+        deletedHere = expireIfOverCapacityGlobally();
+        deletedCount += deletedHere;
+        while (deletedHere > 0) {
+            deletedCount += (deletedHere = expireHistoricTasksNowReadyForImmediateDeletion()); 
+        }
         
         return deletedCount;
     }
@@ -471,7 +474,9 @@ public class BrooklynGarbageCollector {
         }
     }
     
-    protected int expireSubTasksWhoseSubmitterIsExpired() {
+    protected int expireHistoricTasksNowReadyForImmediateDeletion() {
+        // find tasks which weren't ready for immediate deletion, but which now are 
+        
         // ideally we wouldn't have this; see comments on CHECK_SUBTASK_SUBMITTERS
         if (!brooklynProperties.getConfig(CHECK_SUBTASK_SUBMITTERS))
             return 0;
@@ -480,13 +485,15 @@ public class BrooklynGarbageCollector {
         Collection<Task<?>> tasksToDelete = MutableList.of();
         try {
             for (Task<?> task: allTasks) {
-                if (!task.isDone()) continue;
-                Task<?> submitter = task.getSubmittedByTask();
-                // if we've leaked, ie a subtask which is not a child task, 
-                // and the submitter is GC'd, then delete this also
-                if (submitter!=null && submitter.isDone() && executionManager.getTask(submitter.getId())==null) {
-                    tasksToDelete.add(task);
+                if (!shouldDeleteTaskImmediately(task)) {
+                    // 2017-09 previously we only checked done and submitter expired, and deleted if both were true
+                    // so could pick up even things that were non_transient -- now much stricter
+                    continue;
+                } else {
+                    if (LOG.isTraceEnabled()) LOG.trace("Deleting task which really is no longer wanted: "+task+" (submitted by "+task.getSubmittedByTask()+")");
                 }
+                
+                tasksToDelete.add(task);
             }
             
         } catch (ConcurrentModificationException e) {
@@ -500,6 +507,32 @@ public class BrooklynGarbageCollector {
         return tasksToDelete.size();
     }
     
+    private boolean isAssociatedToActiveEntity(Task<?> task) {
+        Entity associatedEntity = BrooklynTaskTags.getTargetOrContextEntity(task);
+        if (associatedEntity==null) {
+            return false;
+        }
+        // this is associated to an entity; destroy only if the entity is unmanaged
+        return Entities.isManaged(associatedEntity);
+    }
+    
+    private boolean isChild(Task<?> task) {
+        Task<?> parent = task.getSubmittedByTask();
+        return (parent instanceof HasTaskChildren && Iterables.contains(((HasTaskChildren)parent).getChildren(), task));
+    }
+    
+    private boolean isSubmitterExpired(Task<?> task) {
+        if (Strings.isBlank(task.getSubmittedByTaskId())) {
+            return false;
+        }
+        Task<?> submitter = task.getSubmittedByTask();
+        if (submitter!=null && (!submitter.isDone() || executionManager.getTask(submitter.getId())!=null)) {
+            return false;
+        }
+        // submitter task is GC'd
+        return true;
+    }
+
     protected enum TagCategory { 
         ENTITY, NON_ENTITY_NORMAL;
         

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManager.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.sensor.BasicSensorEvent;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -53,6 +54,7 @@ import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
@@ -105,6 +107,7 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         Entity producer = s.producer;
         Sensor<T> sensor= s.sensor;
         s.subscriber = getSubscriber(flags, s);
+        s.subscriptionDescription = getSubscriptionDescription(flags, s);
         if (flags.containsKey("tags") || flags.containsKey("tag")) {
             Iterable<?> tags = (Iterable<?>) flags.get("tags");
             Object tag = flags.get("tag");
@@ -127,6 +130,24 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         
         if (LOG.isDebugEnabled()) LOG.debug("Creating subscription {} for {} on {} {} in {}", new Object[] {s.id, s.subscriber, producer, sensor, this});
         allSubscriptions.put(s.id, s);
+        T lastVal;
+        if (notifyOfInitialValue) {
+            notifyOfInitialValue = false;
+            if (producer == null) {
+                LOG.warn("Cannot notifyOfInitialValue for subscription with wildcard producer: "+s);
+            } else if (sensor == null) {
+                LOG.warn("Cannot notifyOfInitialValue for subscription with wilcard sensor: "+s);
+            } else if (!(sensor instanceof AttributeSensor)) {
+                LOG.warn("Cannot notifyOfInitialValue for subscription with non-attribute sensor: "+s);
+            } else {
+                notifyOfInitialValue = true;
+            }
+        }
+        if (notifyOfInitialValue) {
+            lastVal = (T) s.producer.sensors().get((AttributeSensor<?>) s.sensor);
+        } else {
+            lastVal = null;  // won't be used
+        }
         addToMapOfSets(subscriptionsByToken, makeEntitySensorToken(s.producer, s.sensor), s);
         if (s.subscriber!=null) {
             addToMapOfSets(subscriptionsBySubscriber, s.subscriber, s);
@@ -136,17 +157,40 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         }
 
         if (notifyOfInitialValue) {
-            if (producer == null) {
-                LOG.warn("Cannot notifyOfInitialValue for subscription with wildcard producer: "+s);
-            } else if (sensor == null) {
-                LOG.warn("Cannot notifyOfInitialValue for subscription with wilcard sensor: "+s);
-            } else if (!(sensor instanceof AttributeSensor)) {
-                LOG.warn("Cannot notifyOfInitialValue for subscription with non-attribute sensor: "+s);
-            } else {
-                if (LOG.isTraceEnabled()) LOG.trace("sending initial value of {} -> {} to {}", new Object[] {s.producer, s.sensor, s});
-                T val = (T) s.producer.getAttribute((AttributeSensor<?>) s.sensor);
-                submitPublishEvent(s, new BasicSensorEvent<T>(s.sensor, s.producer, val), true);
-            }
+            if (LOG.isTraceEnabled()) LOG.trace("sending initial value of {} -> {} to {}", new Object[] {s.producer, s.sensor, s});
+            // this is run asynchronously to prevent deadlock when trying to get attribute and publish;
+            // however we want it:
+            // (a) to run in the same order as subscriptions are made, so use the manager tag scheduler
+            // (b) ideally to use the last value that was not published to this target, and
+            // (c) to deliver before any subsequent value notification
+            // but we can't guarantee either (b) or (c) without taking a lock from before we added 
+            // the subscriber above, mutexing other sets and publications, which feels heavy and dangerous.
+            // so the compromise is to skip this delivery in cases where the last value has obviously changed -
+            // because a more recent notification is guaranteed to be sent.
+            // we may occasionally still send a duplicate, if delivery got sent in the tiny
+            // window between adding the subscription and taking the last value,
+            // we will think the last value hasn't changed.  but we will never send a
+            // wrong value as this backs out if there is any confusion over the last value.
+            em.submit(
+                MutableMap.of("tags", getPublishTags(s, s.producer),
+                    "displayName", "Initial value publication on subscription to "+s.sensor.getName()),
+                () -> {
+                    T val = (T) s.producer.sensors().get((AttributeSensor<?>) s.sensor);
+                    if (!Objects.equal(lastVal, val)) {
+                        // bail out - value has been changed;
+                        // this might be a duplicate if value changed in small window earlier,
+                        // but it won't be delivering an old value later than a newer value
+                        if (LOG.isDebugEnabled()) LOG.debug("skipping initial value delivery of {} -> {} to {} as value changed from {} to {}", new Object[] {s.producer, s.sensor, s, lastVal, val});
+                        return;
+                    }
+                    // guard against case where other thread changes the val and publish
+                    // while we are publishing, and our older val is then delivered after theirs.
+                    // 2017-10 previously we did not do this, then looked at doing it with the attribute lock object
+                    // synchronized (((AbstractEntity)s.producer).getAttributesSynchObjectInternal()) {
+                    // but realized a better thing is to have initial delivery _done_, not just submitted, 
+                    // by ourselves, as we are already in the right thread now and can prevent interleaving this way
+                    submitPublishEvent(s, new BasicSensorEvent<T>(s.sensor, s.producer, val), true);
+                });
         }
         
         return s;
@@ -203,7 +247,6 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         // (recommend exactly one per subscription to prevent deadlock)
         // this is done with:
         // em.setTaskSchedulerForTag(subscriberId, SingleThreadedScheduler.class);
-        
         //note, generating the notifications must be done in the calling thread to preserve order
         //e.g. emit(A); emit(B); should cause onEvent(A); onEvent(B) in that order
         if (LOG.isTraceEnabled()) LOG.trace("{} got event {}", this, event);
@@ -221,16 +264,11 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private void submitPublishEvent(final Subscription s, final SensorEvent<?> event, final boolean isInitial) {
+    private void submitPublishEvent(final Subscription s, final SensorEvent<?> event, final boolean isInitialPublicationOfOldValueInCorrectScheduledThread) {
         if (s.eventFilter!=null && !s.eventFilter.apply(event))
             return;
         
-        List<Object> tags = MutableList.builder()
-            .addAll(s.subscriberExtraExecTags == null ? ImmutableList.of() : s.subscriberExtraExecTags)
-            .add(s.subscriberExecutionManagerTag)
-            .add(BrooklynTaskTags.SENSOR_TAG)
-            .build()
-            .asUnmodifiable();
+        List<Object> tags = getPublishTags(s, event.getSource()).asUnmodifiable();
         
         StringBuilder name = new StringBuilder("sensor ");
         StringBuilder description = new StringBuilder("Sensor ");
@@ -247,6 +285,10 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
         description.append(sourceName==null ? "<null-source>" : sourceName);
         description.append(" publishing to ");
         description.append(s.subscriber instanceof Entity ? ((Entity)s.subscriber).getId() : s.subscriber);
+        if (Strings.isNonBlank(s.subscriptionDescription)) {
+            description.append(", ");
+            description.append(s.subscriptionDescription);
+        }
         
         if (includeDescriptionForSensorTask(event)) {
             name.append(" ");
@@ -258,10 +300,12 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
             "displayName", name.toString(),
             "description", description.toString());
         
-        em.submit(execFlags, new Runnable() {
+        boolean isEntityStarting = s.subscriber instanceof Entity && isInitialPublicationOfOldValueInCorrectScheduledThread;
+        // will have entity (and adjunct) execution context from tags, so can skip getting exec context
+        Runnable deliverer = new Runnable() {
             @Override
             public String toString() {
-                if (isInitial) {
+                if (isInitialPublicationOfOldValueInCorrectScheduledThread) {
                     return "LSM.publishInitial("+event+")";
                 } else {
                     return "LSM.publish("+event+")";
@@ -270,6 +314,22 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
             @Override
             public void run() {
                 try {
+                    if (isEntityStarting) {
+                        /* don't let sub deliveries start until this is completed;
+                         * this is a pragmatic way to ensure the publish events 
+                         * if submitted during management starting, aren't executed
+                         * until after management is starting.
+                         *   without this we can get deadlocks as this goes to publish,
+                         * has the attribute sensors lock, and waits on the publish lock
+                         * (any of management support, local subs, queueing subs).
+                         * meanwhile the management startup has those three locks,
+                         * then goes to publish and in the process looks up a sensor value.
+                         *   usually this is not an issue because some other task
+                         * does something (eg entity.getExecutionContext()) which
+                         * also has a wait-on-management-support semantics.
+                         */
+                        synchronized (((EntityInternal)s.subscriber).getManagementSupport()) {}
+                    }
                     int count = s.eventCount.incrementAndGet();
                     if (count > 0 && count % 1000 == 0) LOG.debug("{} events for subscriber {}", count, s);
                     
@@ -281,7 +341,26 @@ public class LocalSubscriptionManager extends AbstractSubscriptionManager {
                         LOG.warn("Error processing subscriptions to "+this+": "+t, t);
                     }
                 }
-            }});
+            }};
+        if (!isInitialPublicationOfOldValueInCorrectScheduledThread) {
+            em.submit(execFlags, deliverer);
+        } else {
+            // for initial, caller guarantees he is running in the right thread/context
+            // where the above submission would take place, typically the
+            // subscriber single threaded executor with the entity context;
+            // this allows caller to do extra assertions and bailout steps at the right time
+            deliverer.run();
+        }
+    }
+
+    private MutableList<Object> getPublishTags(final Subscription<?> s, final Entity source) {
+        return MutableList.builder()
+            .addAll(s.subscriberExtraExecTags == null ? ImmutableList.of() : s.subscriberExtraExecTags)
+            .add(s.subscriberExecutionManagerTag)
+            .add(BrooklynTaskTags.SENSOR_TAG)
+            // associate the publish event with the publisher (though on init it might be triggered by subscriber)
+            .addIfNotNull(source!=null ? BrooklynTaskTags.tagForTargetEntity(source) : null)
+            .build();
     }
     
     protected boolean includeDescriptionForSensorTask(SensorEvent<?> event) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/QueueingSubscriptionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/QueueingSubscriptionManager.java
@@ -55,6 +55,7 @@ public class QueueingSubscriptionManager extends AbstractSubscriptionManager {
         QueuedSubscription<T> qs = new QueuedSubscription<T>();
         qs.flags = flags;
         s.subscriber = getSubscriber(flags, s);
+        s.subscriptionDescription = getSubscriptionDescription(flags, s);
         qs.s = s;
         queuedSubscriptions.add(qs);
         return s;
@@ -76,7 +77,7 @@ public class QueueingSubscriptionManager extends AbstractSubscriptionManager {
     
     @SuppressWarnings("unchecked")
     public synchronized void startDelegatingForSubscribing() {
-        // TODO wrap in same-thread task
+        // could wrap in same-thread task, but there's enough context without it
         assert delegate!=null;
         for (QueuedSubscription s: queuedSubscriptions) {
             delegate.subscribe(s.flags, s.s);
@@ -87,7 +88,7 @@ public class QueueingSubscriptionManager extends AbstractSubscriptionManager {
     
     @SuppressWarnings("unchecked")
     public synchronized void startDelegatingForPublishing() {
-        // TODO wrap in same-thread task
+        // could wrap in same-thread task, but there's enough context without it
         assert delegate!=null;
         for (SensorEvent evt: queuedSensorEvents) {
             delegate.publish(evt);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/Subscription.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/Subscription.java
@@ -37,6 +37,7 @@ class Subscription<T> implements SubscriptionHandle {
     public Object subscriberExecutionManagerTag;
     /** whether the tag was supplied by user, in which case we should not clear execution semantics */
     public boolean subscriberExecutionManagerTagSupplied;
+    public String subscriptionDescription;
     public Iterable<?> subscriberExtraExecTags;
     public final Entity producer;
     public final Sensor<T> sensor;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -490,15 +490,7 @@ public class RebindManagerImpl implements RebindManager {
         ExecutionContext ec = BasicExecutionContext.getCurrentExecutionContext();
         if (ec == null) {
             ec = managementContext.getServerExecutionContext();
-            Task<List<Application>> task = ec.submit(new Callable<List<Application>>() {
-                @Override public List<Application> call() throws Exception {
-                    return rebindImpl(classLoader, exceptionHandler, mode);
-                }});
-            try {
-                return task.get();
-            } catch (Exception e) {
-                throw Exceptions.propagate(e);
-            }
+            return ec.get(Tasks.<List<Application>>builder().displayName("rebind").dynamic(false).body(() -> rebindImpl(classLoader, exceptionHandler, mode)).build());
         } else {
             return rebindImpl(classLoader, exceptionHandler, mode);
         }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
@@ -141,7 +143,12 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
     }
 
     @Override
-    public <T> T set(HasConfigKey<T> key, Task<T> val) {
+    public <T> T set(HasConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+        return set(key.getConfigKey(), val);
+    }
+
+    @Override
+    public <T> T set(HasConfigKey<T> key, TaskAdaptable<T> val) {
         return set(key.getConfigKey(), val);
     }
 
@@ -176,10 +183,19 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
     }
 
     @Override
-    public <T> T set(ConfigKey<T> key, Task<T> val) {
+    public <T> T set(ConfigKey<T> key, TaskAdaptable<T> val) {
+        LOG.warn("Setting a task as a config value is deprecated; use a TaskFactory instead, "
+            + "when setting "+getContainer()+" "+key+" to "+val);
+        LOG.debug("Trace for setting "+getContainer()+" "+key+" to task "+val,
+            new Exception("Trace for setting "+getContainer()+" "+key+" to task "+val));
         return setConfigInternal(key, val);
     }
 
+    @Override
+    public <T> T set(ConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+        return setConfigInternal(key, val);
+    }
+    
     @Override
     public ConfigBag getLocalBag() {
         return ConfigBag.newInstance(getConfigsInternal().getAllConfigLocalRaw());

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -106,8 +106,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
             }
         };
 
-        // TODO can we remove the DST ?  this is structured so maybe not
-        Task<T> t = Tasks.<T>builder().body(job)
+        Task<T> t = Tasks.<T>builder().dynamic(false).body(job)
                 .displayName("Resolving config "+key.getName())
                 .description("Internal non-blocking structured key resolution")
                 .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
@@ -126,20 +125,13 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
      * See {@link #getNonBlockingResolvingStructuredKey(ConfigKey)}.
      */
     protected <T> Maybe<T> getNonBlockingResolvingSimple(ConfigKey<T> key) {
-        // TODO See AbstractConfigMapImpl.getConfigImpl, for how it looks up the "container" of the
-        // key, so that it gets the right context entity etc.
-
-        // getRaw returns Maybe(val) if the key was explicitly set (where val can be null)
-        // or Absent if the config key was unset.
         Object unresolved = getRaw(key).or(key.getDefaultValue());
-        // TODO add description that we are evaluating this config key to be used if the code below submits futher tasks
-        // and look at other uses of "description" method
-        // and make sure it is marked transient
         Maybe<Object> resolved = Tasks.resolving(unresolved)
                 .as(Object.class)
                 .immediately(true)
                 .deep(true)
                 .context(getContext())
+                .description("Resolving raw value of simple config "+key)
                 .getMaybe();
         if (resolved.isAbsent()) return Maybe.Absent.<T>castAbsent(resolved);
         

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -37,6 +36,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.objs.BrooklynObject;
@@ -54,12 +54,15 @@ import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.internal.ConfigUtilsInternal;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.SubscriptionTracker;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +89,8 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     @Deprecated
     protected Map<String,Object> leftoverProperties = Maps.newLinkedHashMap();
 
+    /** @deprecated since 0.13.0, going private, use {@link #getExecutionContext()} */
+    @Deprecated
     protected transient ExecutionContext execution;
 
     private final BasicConfigurationSupport config = new BasicConfigurationSupport();
@@ -213,6 +218,14 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         return _legacyNoConstructionInit;
     }
 
+    /** If the entity has been set, returns the execution context indicating this adjunct.
+     * Primarily intended for this adjunct to execute tasks, but in some cases, mainly low level,
+     * it may make sense for other components to execute tasks against this adjunct. */
+    @Beta
+    public ExecutionContext getExecutionContext() {
+        return execution;
+    }
+    
     @Override
     public ConfigurationSupportInternal config() {
         return config;
@@ -276,7 +289,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
             synchronized (AbstractEntityAdjunct.this) {
                 if (_subscriptionTracker!=null) return _subscriptionTracker;
                 if (entity==null) return null;
-                _subscriptionTracker = new SubscriptionTracker(((EntityInternal)entity).subscriptions().getSubscriptionContext());
+                _subscriptionTracker = new SubscriptionTracker(getManagementContext().getSubscriptionContext(entity, AbstractEntityAdjunct.this));
                 return _subscriptionTracker;
             }
         }
@@ -334,7 +347,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
 
         @Override
         protected ExecutionContext getContext() {
-            return AbstractEntityAdjunct.this.execution;
+            return AbstractEntityAdjunct.this.getExecutionContext();
         }
 
         @Override
@@ -402,10 +415,21 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         this.name = name;
     }
 
+    @Override
+    public ManagementContext getManagementContext() {
+        ManagementContext result = super.getManagementContext();
+        if (result!=null) return result;
+        if (entity!=null) {
+            return ((EntityInternal)entity).getManagementContext();
+        }
+        return null;
+    }
+    
     public void setEntity(EntityLocal entity) {
         if (destroyed.get()) throw new IllegalStateException("Cannot set entity on a destroyed entity adjunct");
         this.entity = entity;
-        this.execution = ((EntityInternal) entity).getExecutionContext();
+        this.execution = new BasicExecutionContext( getManagementContext().getExecutionManager(),
+                MutableList.of(BrooklynTaskTags.tagForContextAdjunct(this), BrooklynTaskTags.tagForContextEntity(entity)) );
         if (entity!=null && getCatalogItemId() == null) {
             setCatalogItemIdAndSearchPath(entity.getCatalogItemId(), entity.getCatalogItemIdSearchPath());
         }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctConfigMap.java
@@ -69,9 +69,7 @@ public class AdjunctConfigMap extends AbstractConfigMapImpl<EntityAdjunct> {
 
     @Override
     protected ExecutionContext getExecutionContext(BrooklynObject bo) {
-        // TODO expose ((AbstractEntityAdjunct)bo).execution ?
-        Entity entity = ((AbstractEntityAdjunct)bo).entity;
-        return (entity != null) ? ((EntityInternal)entity).getExecutionContext() : null;
+        return ((AbstractEntityAdjunct)bo).getExecutionContext();
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicConfigurableObject.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicConfigurableObject.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.api.objs.Identifiable;
 import org.apache.brooklyn.config.ConfigKey;
@@ -115,12 +117,22 @@ public class BasicConfigurableObject implements Configurable, Identifiable, Mana
         }
 
         @Override
-        public <T> T set(ConfigKey<T> key, Task<T> val) {
-            throw new UnsupportedOperationException();
+        public <T> T set(ConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+            throw new UnsupportedOperationException("Setting tasks only supported on subtypes");
         }
 
         @Override
-        public <T> T set(HasConfigKey<T> key, Task<T> val) {
+        public <T> T set(HasConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+            return set(key.getConfigKey(), val);
+        }
+        
+        @Override
+        public <T> T set(ConfigKey<T> key, TaskAdaptable<T> val) {
+            throw new UnsupportedOperationException("Setting tasks only supported on subtypes");
+        }
+
+        @Override
+        public <T> T set(HasConfigKey<T> key, TaskAdaptable<T> val) {
             return set(key.getConfigKey(), val);
         }
 

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
@@ -96,7 +96,9 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
         /**
          * Returns the uncoerced value for this config key, if available, not taking any default.
          * If there is no local value and there is an explicit inherited value, will return the inherited.
+         * May return a {@link Maybe}-wrapped null if the value is explicitly null.
          * Returns {@link Maybe#absent()} if the key is not explicitly set on this object or an ancestor.
+         * Often this is used with {@link Maybe#or(Object))} to return default value.
          * <p>
          * See also {@link #getLocalRaw(ConfigKey).
          */

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/EntityProxyImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/EntityProxyImpl.java
@@ -209,7 +209,7 @@ public class EntityProxyImpl implements java.lang.reflect.InvocationHandler {
                     TaskAdaptable<?> task = ((EffectorWithBody)eff).getBody().newTask(delegate, eff, ConfigBag.newInstance(parameters));
                     // as per LocalManagementContext.runAtEntity(Entity entity, TaskAdaptable<T> task) 
                     TaskTags.markInessential(task);
-                    result = DynamicTasks.queueIfPossible(task.asTask()).orSubmitAsync(delegate).andWaitForSuccess();
+                    result = DynamicTasks.get(task.asTask(), delegate);
                 } else {
                     result = m.invoke(delegate, nonNullArgs);
                 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -309,7 +309,7 @@ public class InternalEntityFactory extends InternalFactory {
          * which currently show up at the top level once the initializer task completes.
          * TODO It would be nice if these schedule tasks were grouped in a bucket! 
          */
-        ((EntityInternal)entity).getExecutionContext().submit(Tasks.builder().dynamic(false).displayName("Entity initialization")
+        ((EntityInternal)entity).getExecutionContext().get(Tasks.builder().dynamic(false).displayName("Entity initialization")
                 .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
                 .body(new Runnable() {
             @Override
@@ -354,7 +354,7 @@ public class InternalEntityFactory extends InternalFactory {
                     initEntityAndDescendants(child.getId(), entitiesByEntityId, specsByEntityId);
                 }
             }
-        }).build()).getUnchecked();
+        }).build());
     }
     
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -102,8 +102,15 @@ import groovy.lang.Closure;
  * </pre>
  * <p>
  * Note that these methods return one-time tasks. The DslComponent methods return long-lasting pointers
- * and should now normally be used instead.
+ * and should now normally be used instead. If using these methods that return {@link Task} instances
+ * you should either ensure it is submitted or that validation and any other attempts to 
+ * {@link ExecutionContext#getImmediately(TaskAdaptable)} on this task is blocked;
+ * it is all to easy otherwise for an innocuous immediate-get to render this task interrupted
  */
+// possibly even the REST API just looking at config could cancel?
+// TODO should we deprecate these and provide variants that return TaskFactory instances?
+// maybe even ones that are nicely persistable? i (alex) think so, 2017-10.
+// see https://github.com/apache/brooklyn-server/pull/816#issuecomment-333858098
 public class DependentConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(DependentConfiguration.class);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -827,10 +827,8 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
         for (Entity member : removedStartables) {
             tasks.add(newThrottledEffectorTask(member, Startable.STOP, Collections.emptyMap()));
         }
-        Task<?> invoke = Tasks.parallel(tasks.build());
-        DynamicTasks.queueIfPossible(invoke).orSubmitAsync();
         try {
-            invoke.get();
+            DynamicTasks.get( Tasks.parallel(tasks.build()) );
             return removedEntities;
         } catch (Exception e) {
             throw Exceptions.propagate(e);
@@ -1075,8 +1073,7 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
         try {
             if (member instanceof Startable) {
                 Task<?> task = newThrottledEffectorTask(member, Startable.STOP, Collections.<String, Object>emptyMap());
-                DynamicTasks.queueIfPossible(task).orSubmitAsync();
-                task.getUnchecked();
+                DynamicTasks.get(task);
             }
         } finally {
             Entities.unmanage(member);

--- a/core/src/main/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicy.java
@@ -186,7 +186,7 @@ public class SshCommandMembershipTrackingPolicy extends AbstractMembershipTracki
 
         // Try to resolve the configuration in the env Map
         try {
-            env = (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, ((EntityInternal) entity).getExecutionContext());
+            env = (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, getExecutionContext());
         } catch (InterruptedException | ExecutionException e) {
             throw Exceptions.propagate(e);
         }

--- a/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
@@ -229,7 +229,7 @@ public class ShellFeed extends AbstractFeed {
 
             final ProcessTaskFactory<?> taskFactory = newTaskFactory(pollInfo.command, pollInfo.env, pollInfo.dir, 
                     pollInfo.input, pollInfo.context, pollInfo.timeout);
-            final ExecutionContext executionContext = ((EntityInternal) entity).getExecutionContext();
+            final ExecutionContext executionContext = getExecutionContext();
 
             getPoller().scheduleAtFixedRate(
                     new Callable<SshPollValue>() {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/AbstractExecutionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/AbstractExecutionContext.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ExecutionManager;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.util.collections.MutableMap;
 
 import com.google.common.collect.Maps;
 
@@ -41,11 +42,16 @@ public abstract class AbstractExecutionContext implements ExecutionContext {
     public Task<?> submit(Map<?,?> properties, Runnable runnable) { return submitInternal(properties, runnable); }
     
     /** @see #submit(Map, Runnable) */
-    @Override
+    @Override 
+    public Task<?> submit(String displayName, Runnable runnable) { return submitInternal(MutableMap.of("displayName", displayName), runnable); }
+    @Override @Deprecated
     public Task<?> submit(Runnable runnable) { return submitInternal(Maps.newLinkedHashMap(), runnable); }
+    
  
     /** @see #submit(Map, Runnable) */
-    @Override
+    @Override 
+    public <T> Task<T> submit(String displayName, Callable<T> callable) { return submitInternal(MutableMap.of("displayName", displayName), callable); }
+    @Override @Deprecated
     public <T> Task<T> submit(Callable<T> callable) { return submitInternal(Maps.newLinkedHashMap(), callable); }
     
     /** @see #submit(Map, Runnable) */

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionManager.java
@@ -57,6 +57,7 @@ import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.TaskInternal.TaskCancellationMode;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
@@ -387,10 +388,12 @@ public class BasicExecutionManager implements ExecutionManager {
         }
     }
 
-    @Override public Task<?> submit(Runnable r) { return submit(new LinkedHashMap<Object,Object>(1), r); }
+    @Override @Deprecated public Task<?> submit(Runnable r) { return submit(new LinkedHashMap<Object,Object>(1), r); }
+    @Override public Task<?> submit(String displayName, Runnable r) { return submit(MutableMap.of("displayName", displayName), r); }
     @Override public Task<?> submit(Map<?,?> flags, Runnable r) { return submit(flags, new BasicTask<Void>(flags, r)); }
 
-    @Override public <T> Task<T> submit(Callable<T> c) { return submit(new LinkedHashMap<Object,Object>(1), c); }
+    @Override @Deprecated public <T> Task<T> submit(Callable<T> c) { return submit(new LinkedHashMap<Object,Object>(1), c); }
+    @Override public <T> Task<T> submit(String displayName, Callable<T> c) { return submit(MutableMap.of("displayName", displayName), c); }
     @Override public <T> Task<T> submit(Map<?,?> flags, Callable<T> c) { return submit(flags, new BasicTask<T>(flags, c)); }
 
     @Override public <T> Task<T> submit(TaskAdaptable<T> t) { return submit(new LinkedHashMap<Object,Object>(1), t); }
@@ -797,6 +800,7 @@ public class BasicExecutionManager implements ExecutionManager {
                 .description("Details of the original task have been forgotten.")
                 .body(Callables.returning((T)null)).build();
             ((BasicTask<T>)t).ignoreIfNotRun();
+            ((BasicTask<T>)t).cancelled = true;
             return t;
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicTasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicTasks.java
@@ -41,6 +41,16 @@ import com.google.common.collect.Iterables;
 
 /** 
  * Contains static methods which detect and use the current {@link TaskQueueingContext} to execute tasks.
+ * <p>
+ * Queueing is supported by some task contexts (eg {@link DynamicSequentialTask}) to let that task
+ * build up a complex sequence of tasks and logic. This utility class gives conveniences to allow:
+ * <p>
+ * <li> "queue-if-possible-else-submit-async", so that it is backgrounded, using queueing semantics if available;
+ * <li> "queue-if-possible-else-submit-blocking", so that it is in the queue if there is one, else it will complete synchronously;
+ * <li> "queue-if-possible-else-submit-and-in-both-cases-block", so that it is returned immediately, but waits in its queue if there is one.
+ * <p>
+ * Over time the last mode has been the most prevalent and {@link #get(TaskAdaptable)} is introduced here
+ * as a convenience.  If a timeout is desired then the first should be used.
  * 
  * @since 0.6.0
  */
@@ -107,7 +117,7 @@ public class DynamicTasks {
             this.execContext = ((EntityInternal)entity).getExecutionContext();
             return this;
         }
-        private boolean orSubmitInternal() {
+        private boolean orSubmitInternal(boolean samethread) {
             if (!wasQueued()) {
                 if (isQueuedOrSubmitted()) {
                     log.warn("Redundant call to execute "+getTask()+"; skipping");
@@ -118,43 +128,58 @@ public class DynamicTasks {
                         ec = BasicExecutionContext.getCurrentExecutionContext();
                     if (ec==null)
                         throw new IllegalStateException("Cannot execute "+getTask()+" without an execution context; ensure caller is in an ExecutionContext");
-                    ec.submit(getTask());
+                    if (samethread) ec.get(getTask());
+                    else ec.submit(getTask());
                     return true;
                 }
             } else {
                 return false;
             }
         }
-        /** causes the task to be submitted (asynchronously) if it hasn't already been,
-         * requiring an entity execution context (will try to find a default if not set) */
+        /** Causes the task to be submitted (asynchronously) if it hasn't already been,
+         * such as if a previous {@link DynamicTasks#queueIfPossible(TaskAdaptable)} did not have a queueing context.
+         * <p>
+         * An {@link #executionContext(ExecutionContext)} should typically have been set
+         * (or use {@link #orSubmitAsync(Entity)}).
+         */
         public TaskQueueingResult<T> orSubmitAsync() {
-            orSubmitInternal();
+            orSubmitInternal(false);
             return this;
         }
-        /** convenience for setting {@link #executionContext(ExecutionContext)} then submitting async */
+        /** Convenience for setting {@link #executionContext(Entity)} then {@link #orSubmitAsync()}. */
         public TaskQueueingResult<T> orSubmitAsync(Entity entity) {
             executionContext(entity);
             return orSubmitAsync();
         }
-        /** causes the task to be submitted *synchronously* if it hasn't already been submitted;
-         * useful in contexts such as libraries where callers may be either on a legacy call path 
-         * (which assumes all commands complete immediately);
-         * requiring an entity execution context (will try to find a default if not set) */
+        /** Alternative to {@link #orSubmitAsync()} but where, if the submission is needed
+         * (usually because a previous {@link DynamicTasks#queueIfPossible(TaskAdaptable)} did not have a queueing context)
+         * it will wait until execution completes (and in fact will execute the task in this thread,
+         * as per {@link ExecutionContext#get(TaskAdaptable)}. 
+         * <p>
+         * If the task is already queued, this method does nothing, not even blocks,
+         * to permit cases where a caller is building up a set of tasks to be executed sequentially:
+         * with a queueing context the caller can line them all up, but without that the caller needs this task
+         * finished before submitting subsequent tasks. 
+         * <p>
+         * If blocking is desired in all cases and this call should fail on task failure, invoke {@link #andWaitForSuccess()} on the result,
+         * or consider using {@link DynamicTasks#get(TaskAdaptable)} instead of this method,
+         * or {@link DynamicTasks#get(TaskAdaptable, Entity)} if an execuiton context a la {@link #orSubmitAndBlock(Entity)} is needed. */
         public TaskQueueingResult<T> orSubmitAndBlock() {
-            if (orSubmitInternal()) task.getUnchecked();
+            orSubmitInternal(true);
             return this;
         }
-        /** convenience for setting {@link #executionContext(ExecutionContext)} then submitting blocking */
+        /** Variant of {@link #orSubmitAndBlock()} doing what {@link #orSubmitAsync(Entity)} does for {@link #orSubmitAsync()}. */
         public TaskQueueingResult<T> orSubmitAndBlock(Entity entity) {
             executionContext(entity);
             return orSubmitAndBlock();
         }
-        /** blocks for the task to be completed
+        /** Blocks for the task to be completed, throwing if there are any errors
+         * and otherwise returning the value.
          * <p>
-         * needed in any context where subsequent commands assume the task has completed.
+         * In addition to cases where a result is wanted, this is needed in any context where subsequent commands assume the task has completed.
          * not needed in a context where the task is simply being built up and queued.
          * <p>
-         * throws if there are any errors
+         * 
          */
         public T andWaitForSuccess() {
             return task.getUnchecked();
@@ -169,16 +194,12 @@ public class DynamicTasks {
     /**
      * Tries to add the task to the current addition context if there is one, otherwise does nothing.
      * <p/>
-     * Call {@link TaskQueueingResult#orSubmitAsync() orSubmitAsync()} on the returned
+     * Call {@link TaskQueueingResult#orSubmitAsync()} on the returned
      * {@link TaskQueueingResult TaskQueueingResult} to handle execution of tasks in a
      * {@link BasicExecutionContext}.
      */
     public static <T> TaskQueueingResult<T> queueIfPossible(TaskAdaptable<T> task) {
-        TaskQueueingContext adder = getTaskQueuingContext();
-        boolean result = false;
-        if (adder!=null)
-            result = Tasks.tryQueueing(adder, task);
-        return new TaskQueueingResult<T>(task, result);
+        return new TaskQueueingResult<T>(task, Tasks.tryQueueing(getTaskQueuingContext(), task));
     }
 
     /** @see #queueIfPossible(TaskAdaptable) */
@@ -189,22 +210,17 @@ public class DynamicTasks {
     /** adds the given task to the nearest task addition context,
      * either set as a thread-local, or in the current task, or the submitter of the task, etc
      * <p>
-     * throws if it cannot add */
+     * throws if it cannot add or addition/execution would fail including if calling thread is interrupted */
     public static <T> Task<T> queueInTaskHierarchy(Task<T> task) {
         Preconditions.checkNotNull(task, "Task to queue cannot be null");
         Preconditions.checkState(!Tasks.isQueuedOrSubmitted(task), "Task to queue must not yet be submitted: {}", task);
         
-        TaskQueueingContext adder = getTaskQueuingContext();
-        if (adder!=null) { 
-            if (Tasks.tryQueueing(adder, task)) {
-                log.debug("Queued task {} at context {} (no hierarchy)", task, adder);
-                return task;
-            }
+        if (Tasks.tryQueueing(getTaskQueuingContext(), task)) {
+            log.debug("Queued task {} at context {} (no hierarchy)", task, getTaskQueuingContext());
+            return task;
         }
         
-        Task<?> t = Tasks.current();
-        Preconditions.checkState(t!=null || adder!=null, "No task addition context available for queueing task "+task);
-        
+        Task<?> t = Tasks.current();        
         while (t!=null) {
             if (t instanceof TaskQueueingContext) {
                 if (Tasks.tryQueueing((TaskQueueingContext)t, task)) {
@@ -288,12 +304,9 @@ public class DynamicTasks {
         return task;
     }
     
-    /** submits/queues the given task if needed, and gets the result (unchecked) 
-     * only permitted in a queueing context (ie a DST main job) if the task is not yet submitted */
-    // things get really confusing if you try to queueInTaskHierarchy -- easy to cause deadlocks!
+    /** submits/queues the given task if needed, and gets the result (unchecked) */
     public static <T> T get(TaskAdaptable<T> t) {
-        // TODO do in foreground?
-        return queueIfNeeded(t).asTask().getUnchecked();
+        return queueIfPossible(t).orSubmitAndBlock().andWaitForSuccess();
     }
 
     /** As {@link #drain(Duration, boolean)} waiting forever and throwing the first error 
@@ -333,6 +346,11 @@ public class DynamicTasks {
      * {@link Task#getUnchecked()} or {@link Task#blockUntilEnded()} */
     public static <T> Task<T> submit(TaskAdaptable<T> task, Entity entity) {
         return queueIfPossible(task).orSubmitAsync(entity).asTask();
+    }
+    
+    /** queues the task if possible and waits for the result, otherwise executes synchronously as per {@link ExecutionContext#get(TaskAdaptable)} */
+    public static <T> T get(TaskAdaptable<T> task, Entity e) {
+        return queueIfPossible(task).orSubmitAndBlock(e).andWaitForSuccess();
     }
 
     /** Breaks the parent-child relation between Tasks.current() and the task passed,

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -278,11 +278,11 @@ public class Tasks {
     }
     
     /**
-     * Adds the given task to the given context. Does not throw an exception if the addition fails.
-     * @return true if the task was added, false otherwise.
+     * Adds the given task to the given context. Does not throw an exception if the addition fails or would fail.
+     * @return true if the task was added, false otherwise including if context is null or thread is interrupted.
      */
     public static boolean tryQueueing(TaskQueueingContext adder, TaskAdaptable<?> task) {
-        if (task==null || isQueued(task))
+        if (task==null || adder==null || isQueued(task) || Thread.currentThread().isInterrupted())
             return false;
         try {
             adder.queue(task.asTask());

--- a/core/src/test/java/org/apache/brooklyn/core/config/DeferredConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/DeferredConfigTest.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.core.config;
 import static org.testng.Assert.assertEquals;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.Sensor;
@@ -55,13 +54,10 @@ public class DeferredConfigTest extends BrooklynAppUnitTestSupport {
     
     void doTestDeferredConfigInList(final boolean delay) throws Exception {
         // Simulate a deferred value
-        Task<Sensor<?>> sensorFuture = app.getExecutionContext().submit(new Callable<Sensor<?>>() {
-            @Override
-            public Sensor<?> call() throws Exception {
+        Task<Sensor<?>> sensorFuture = app.getExecutionContext().submit("deferred return sensor", () -> {
                 if (delay) Time.sleep(Duration.FIVE_SECONDS);
                 return TestApplication.MY_ATTRIBUTE;
-            }
-        });
+            });
         app.config().set(SENSORS_UNTYPED, (Object)ImmutableList.of(sensorFuture));
 
         if (!delay) sensorFuture.get(Duration.ONE_SECOND);

--- a/core/src/test/java/org/apache/brooklyn/core/effector/EffectorSayHiTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/EffectorSayHiTest.java
@@ -61,6 +61,7 @@ public class EffectorSayHiTest extends BrooklynAppUnitTestSupport {
     //TODO test edge/error conditions
     //(missing parameters, wrong number of params, etc)
 
+    @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(EffectorSayHiTest.class);
 
     private MyEntity e;
@@ -109,11 +110,10 @@ public class EffectorSayHiTest extends BrooklynAppUnitTestSupport {
             .get( Effectors.invocation(e, MyEntity.SAY_HI_1, ImmutableMap.of("name", "Bob", "greeting", "hi")) ), "hi Bob");
     }
     
-    @Test(groups="WIP")  // see comments at BasicExecutionContext.getImmediately
-    // TODO this will be fixed soon by #835
+    @Test
     public void testInvocationGetImmediately() throws Exception {
         assertEquals(((EntityInternal)e).getExecutionContext()
-            .getImmediately( Effectors.invocation(e, MyEntity.SAY_HI_1, ImmutableMap.of("name", "Bob", "greeting", "hi")) ), "hi Bob");
+            .getImmediately( Effectors.invocation(e, MyEntity.SAY_HI_1, ImmutableMap.of("name", "Bob", "greeting", "hi")) ).get(), "hi Bob");
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
@@ -267,20 +267,14 @@ public class ApplicationLifecycleStateTest extends BrooklynMgmtUnitTestSupport {
             }
         });
 
-        Task<?> first = mgmt.getExecutionManager().submit(new Runnable() {
-            @Override
-            public void run() {
+        Task<?> first = mgmt.getExecutionManager().submit("setting test sensor", () -> {
                 app.sensors().set(TEST_SENSOR, "first");
                 log.debug("set first");
-            }
-        });
-        Task<?> second = mgmt.getExecutionManager().submit(new Runnable() {
-            @Override
-            public void run() {
+            });
+        Task<?> second = mgmt.getExecutionManager().submit("setting test sensor", () -> {
                 app.sensors().set(TEST_SENSOR, "second");
                 log.debug("set second");
-            }
-        });
+            });
         first.blockUntilEnded();
         second.blockUntilEnded();
 
@@ -394,8 +388,8 @@ public class ApplicationLifecycleStateTest extends BrooklynMgmtUnitTestSupport {
         };
 
         // Simulates firing the emit method from event handlers in different threads
-        mgmt.getExecutionManager().submit(overrideJob);
-        mgmt.getExecutionManager().submit(overrideJob);
+        mgmt.getExecutionManager().submit("emitting test sensor", overrideJob);
+        mgmt.getExecutionManager().submit("emitting test sensor", overrideJob);
 
         Asserts.eventually(Suppliers.ofInstance(seenValues), CollectionFunctionals.sizeEquals(2));
         Asserts.succeedsContinually(new Runnable() {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySubscriptionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySubscriptionTest.java
@@ -34,6 +34,8 @@ import org.apache.brooklyn.core.test.policy.TestEnricher;
 import org.apache.brooklyn.core.test.policy.TestPolicy;
 import org.apache.brooklyn.entity.group.BasicGroup;
 import org.apache.brooklyn.test.Asserts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -44,7 +46,9 @@ import com.google.common.collect.Iterables;
 
 public class EntitySubscriptionTest extends BrooklynAppUnitTestSupport {
 
-    // TODO Duplication between this and PolicySubscriptionTest
+    // TODO Duplication between this and PolicySubscriptionTest and LocalSubscriptionManagerTest
+
+    private static final Logger log = LoggerFactory.getLogger(EntitySubscriptionTest.class);
     
     private static final long SHORT_WAIT_MS = 100;
 
@@ -221,6 +225,7 @@ public class EntitySubscriptionTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
+    @SuppressWarnings("unused")
     public void testUnsubscribeUsingHandleStopsEvents() {
         SubscriptionHandle handle1 = entity.subscriptions().subscribe(observedEntity, TestEntity.SEQUENCE, listener);
         SubscriptionHandle handle2 = entity.subscriptions().subscribe(observedEntity, TestEntity.NAME, listener);
@@ -300,6 +305,8 @@ public class EntitySubscriptionTest extends BrooklynAppUnitTestSupport {
     
     @Test
     public void testContextEntityOnSubscriptionCallbackTask() {
+        log.info("Observing "+observedEntity+" from "+entity);
+        
         observedEntity.sensors().set(TestEntity.NAME, "myval");
         entity.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), observedEntity, TestEntity.NAME, listener);
         

--- a/core/src/test/java/org/apache/brooklyn/core/feed/PollerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/feed/PollerTest.java
@@ -133,7 +133,7 @@ public class PollerTest extends BrooklynAppUnitTestSupport {
                         }
                     })
                     .build();
-            return DynamicTasks.queueIfPossible(t).orSubmitAsync().asTask().getUnchecked();
+            return DynamicTasks.get(t);
         }
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/EntityExecutionManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/EntityExecutionManagerTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -40,14 +41,18 @@ import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags.WrappedEntity;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags.WrappedItem;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
 import org.apache.brooklyn.util.core.task.ExecutionListener;
+import org.apache.brooklyn.util.core.task.ScheduledTask;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
@@ -129,16 +134,27 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         return Tasks.builder().displayName(name).dynamic(false).body(Callables.returning(null));
     }
 
-    protected void assertTaskCountForEntityEventually(final Entity entity, final int expectedCount) {
+    protected void assertImportantTaskCountForEntityEventually(final Entity entity, final int expectedCount) {
         // Dead task (and initialization task) should have been GC'd on completion.
         // However, the GC'ing happens in a listener, executed in a different thread - the task.get()
         // doesn't block for it. Therefore can't always guarantee it will be GC'ed by now.
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
-                forceGc();
-                Collection<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(((EntityInternal)entity).getManagementContext().getExecutionManager(), entity);
+                forceGc();  
+                Collection<Task<?>> tasks = removeSystemTasks(BrooklynTaskTags.getTasksInEntityContext(((EntityInternal)entity).getManagementContext().getExecutionManager(), entity));
                 Assert.assertEquals(tasks.size(), expectedCount, "Tasks were "+tasks);
             }});
+    }
+
+    static Set<Task<?>> removeSystemTasks(Iterable<Task<?>> tasks) {
+        Set<Task<?>> result = MutableSet.of();
+        for (Task<?> t: tasks) {
+            if (t instanceof ScheduledTask) continue;
+            if (t.getTags().contains(BrooklynTaskTags.SENSOR_TAG)) continue;
+            if (t.getDisplayName().contains("Validating")) continue;
+            result.add(t);
+        }
+        return result;
     }
 
     // Needed because of https://issues.apache.org/jira/browse/BROOKLYN-401
@@ -149,7 +165,7 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         Asserts.succeedsEventually(new Runnable() {
             @Override public void run() {
                 forceGc();
-                Collection<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(((EntityInternal)entity).getManagementContext().getExecutionManager(), entity);
+                Collection<Task<?>> tasks = removeSystemTasks( BrooklynTaskTags.getTasksInEntityContext(((EntityInternal)entity).getManagementContext().getExecutionManager(), entity) );
                 Assert.assertTrue(tasks.size() <= expectedMaxCount,
                         "Expected tasks count max of " + expectedMaxCount + ". Tasks were "+tasks);
             }});
@@ -161,8 +177,8 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         final Task<?> task = runEmptyTaskWithNameAndTags(e, "should-be-kept", ManagementContextInternal.NON_TRANSIENT_TASK_TAG);
         runEmptyTaskWithNameAndTags(e, "should-be-gcd", ManagementContextInternal.TRANSIENT_TASK_TAG);
         
-        assertTaskCountForEntityEventually(e, 1);
-        Collection<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(app.getManagementContext().getExecutionManager(), e);
+        assertImportantTaskCountForEntityEventually(e, 1);
+        Collection<Task<?>> tasks = removeSystemTasks( BrooklynTaskTags.getTasksInEntityContext(app.getManagementContext().getExecutionManager(), e) );
         assertEquals(tasks, ImmutableList.of(task), "Mismatched tasks, got: "+tasks);
     }
 
@@ -281,8 +297,6 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         forceGc();
         stopCondition.set(true);
 
-        // might need an eventually here, if the internal job completion and GC is done in the background
-        // (if there are no test failures for a few months, since Sept 2014, then we can remove this comment)
         assertTaskMaxCountForEntityEventually(e, 2);
     }
 
@@ -306,8 +320,8 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
             if (tag instanceof Entity && ((Entity)tag).getId().equals(eId)) {
                 fail("tags contains unmanaged entity "+tag);
             }
-            if ((tag instanceof WrappedEntity) && ((WrappedEntity)tag).entity.getId().equals(eId) 
-                    && ((WrappedEntity)tag).wrappingType.equals(BrooklynTaskTags.CONTEXT_ENTITY)) {
+            if ((tag instanceof WrappedEntity) && ((WrappedEntity)tag).unwrap().getId().equals(eId) 
+                    && ((WrappedItem<?>)tag).getWrappingType().equals(BrooklynTaskTags.CONTEXT_ENTITY)) {
                 fail("tags contains unmanaged entity (wrapped) "+tag);
             }
         }
@@ -320,7 +334,7 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         // allow background enrichers to complete
         Time.sleep(Duration.ONE_SECOND);
         forceGc();
-        List<Task<?>> t1 = em.getAllTasks();
+        Collection<Task<?>> t1 = em.getAllTasks();
 
         TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class));
         entity.sensors().set(TestEntity.NAME, "bob");
@@ -328,9 +342,17 @@ public class EntityExecutionManagerTest extends BrooklynAppUnitTestSupport {
         Entities.destroy(entity);
         Time.sleep(Duration.ONE_SECOND);
         forceGc();
-        List<Task<?>> t2 = em.getAllTasks();
+        Collection<Task<?>> t2 = em.getAllTasks();
 
-        Assert.assertEquals(t1.size(), t2.size(), "lists are different:\n"+t1+"\n"+t2+"\n");
+        // no tasks from first batch were GC'd
+        Asserts.assertSize(MutableList.builder().addAll(t1).removeAll(t2).build(), 0);
+
+        // and we expect just the add/remove cycle at parent, and service problems
+        Set<String> newOnes = MutableList.<Task<?>>builder().addAll(t2).removeAll(t1).build().stream().map(
+            (t) -> t.getDisplayName()).collect(Collectors.toSet());
+        Function<String,String> prefix = (s) -> "sensor "+app.getId()+":"+s;
+        Assert.assertEquals(newOnes, MutableSet.of(
+            prefix.apply("entity.children.removed"), prefix.apply("entity.children.added"), prefix.apply("service.problems"))); 
     }
 
     /**

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/internal/LocalSubscriptionManagerTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -32,11 +33,21 @@ import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.mgmt.SubscriptionManager;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
+import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.sensor.BasicSensorEvent;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.group.BasicGroup;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * testing the {@link SubscriptionManager} and associated classes.
@@ -168,6 +179,86 @@ public class LocalSubscriptionManagerTest extends BrooklynAppUnitTestSupport {
         }
 
         if (threadException.get() != null) throw threadException.get();
+    }
+
+    @Test
+    // same test as in PolicySubscriptionTest, but for entities / simpler
+    public void testSubscriptionReceivesInitialValueEventsInOrder() {
+        RecordingSensorEventListener<Object> listener = new RecordingSensorEventListener<>();
+        
+        entity.sensors().set(TestEntity.NAME, "myname");
+        entity.sensors().set(TestEntity.SEQUENCE, 123);
+        entity.sensors().emit(TestEntity.MY_NOTIF, -1);
+
+        // delivery should be in subscription order, so 123 then 456
+        entity.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.SEQUENCE, listener);
+        // wait for the above delivery - otherwise it might get dropped
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), () -> { 
+            Asserts.assertSize(listener.getEvents(), 1); });
+        entity.sensors().set(TestEntity.SEQUENCE, 456);
+        
+        // notifications don't have "initial value" so don't get -1
+        entity.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.MY_NOTIF, listener);
+        // but do get 1, after 456
+        entity.sensors().emit(TestEntity.MY_NOTIF, 1);
+        
+        // STOPPING and myname received, in subscription order, after everything else
+        entity.sensors().set(TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.STOPPING);
+        entity.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.SERVICE_STATE_ACTUAL, listener);
+        entity.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.NAME, listener);
+        
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), new Runnable() {
+            @Override public void run() {
+                Asserts.assertEquals(listener.getEvents(), ImmutableList.of(
+                        new BasicSensorEvent<Integer>(TestEntity.SEQUENCE, entity, 123),
+                        new BasicSensorEvent<Integer>(TestEntity.SEQUENCE, entity, 456),
+                        new BasicSensorEvent<Integer>(TestEntity.MY_NOTIF, entity, 1),
+                        new BasicSensorEvent<Lifecycle>(TestEntity.SERVICE_STATE_ACTUAL, entity, Lifecycle.STOPPING),
+                        new BasicSensorEvent<String>(TestEntity.NAME, entity, "myname")),
+                    "actually got: "+listener.getEvents());
+            }});
+    }
+    
+    @Test
+    public void testNotificationOrderMatchesSetValueOrderWhenSynched() {
+        RecordingSensorEventListener<Object> listener = new RecordingSensorEventListener<>();
+        
+        AtomicInteger count = new AtomicInteger();
+        Runnable set = () -> { 
+            synchronized (count) { 
+                entity.sensors().set(TestEntity.SEQUENCE, count.incrementAndGet()); 
+            } 
+        };
+        entity.subscriptions().subscribe(ImmutableMap.of(), entity, TestEntity.SEQUENCE, listener);
+        for (int i=0; i<10; i++) {
+            new Thread(set).start();
+        }
+        
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), () -> { 
+            Asserts.assertSize(listener.getEvents(), 10); });
+        for (int i=0; i<10; i++) {
+            Assert.assertEquals(listener.getEvents().get(i).getValue(), i+1);
+        }
+    }
+
+    @Test
+    public void testNotificationOrderMatchesSetValueOrderWhenNotSynched() {
+        RecordingSensorEventListener<Object> listener = new RecordingSensorEventListener<>();
+        
+        AtomicInteger count = new AtomicInteger();
+        Runnable set = () -> { 
+            // as this is not synched, the sets may interleave
+            entity.sensors().set(TestEntity.SEQUENCE, count.incrementAndGet()); 
+        };
+        entity.subscriptions().subscribe(ImmutableMap.of(), entity, TestEntity.SEQUENCE, listener);
+        for (int i=0; i<10; i++) {
+            new Thread(set).start();
+        }
+        
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), () -> { 
+            Asserts.assertSize(listener.getEvents(), 10); });
+        // all we expect for sure is that the last value is whatever the sensor is at the end - internal update and publish is mutexed
+        Assert.assertEquals(listener.getEvents().get(9).getValue(), entity.sensors().get(TestEntity.SEQUENCE));
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
@@ -611,7 +611,7 @@ public class XmlMementoSerializerTest {
     public void testTask() throws Exception {
         final TestApplication app = TestApplication.Factory.newManagedInstanceForTests();
         mgmt = app.getManagementContext();
-        Task<String> completedTask = app.getExecutionContext().submit(Callables.returning("myval"));
+        Task<String> completedTask = app.getExecutionContext().submit("return myval", Callables.returning("myval"));
         completedTask.get();
         
         String loggerName = UnwantedStateLoggingMapper.class.getName();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.Task;
@@ -101,10 +102,11 @@ public class RebindFeedWithHaTest extends RebindTestFixtureWithApp {
             @Override
             public Boolean call() throws Exception {
                 origManagementContext.getGarbageCollector().gcIteration();
-                List<Task<?>> tasksAfter = ((BasicExecutionManager)origManagementContext.getExecutionManager()).getAllTasks();
+                List<Task<?>> tasksAfter = removeSystemTasks( ((BasicExecutionManager)origManagementContext.getExecutionManager()).getAllTasks() );
                 log.info("tasks after disabling HA, "+tasksAfter.size()+": "+tasksAfter);
                 return tasksAfter.isEmpty();
             }
+
         }).runRequiringTrue();
         
         newManagementContext = createNewManagementContext();
@@ -120,6 +122,10 @@ public class RebindFeedWithHaTest extends RebindTestFixtureWithApp {
         newEntity.sensors().set(SENSOR_STRING, null);
         EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_INT, 200);
         EntityAsserts.assertAttributeEqualsEventually(newEntity, SENSOR_STRING, "{\"foo\":\"myfoo\"}");
+    }
+
+    static List<Task<?>> removeSystemTasks(List<Task<?>> tasks) {
+        return tasks.stream().filter(t -> !("rebind".equals(t.getDisplayName()) || t.getDisplayName().contains("Validating"))).collect(Collectors.toList());
     }
 
     @Test(groups="Integration", invocationCount=50)

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerTest.java
@@ -20,11 +20,8 @@ package org.apache.brooklyn.core.mgmt.rebind;
 
 import static org.testng.Assert.assertEquals;
 
-import java.util.concurrent.Callable;
-
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.util.core.task.BasicTask;
@@ -48,15 +45,7 @@ public class RebindManagerTest extends RebindTestFixtureWithApp {
         @Override
         public void rebind() {
             super.rebind();
-            Task<String> task = new BasicTask<String>(new Callable<String>() {
-                @Override public String call() {
-                    return "abc";
-                }});
-            String val = DynamicTasks.queueIfPossible(task)
-                    .orSubmitAsync()
-                    .asTask()
-                    .getUnchecked();
-            sensors().set(TestEntity.NAME, val);
+            sensors().set(TestEntity.NAME, DynamicTasks.get(new BasicTask<String>(() -> "abc")));
         }
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/PolicySubscriptionTest.java
@@ -24,12 +24,15 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.SubscriptionHandle;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.sensor.BasicSensorEvent;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -102,6 +105,7 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
+    @SuppressWarnings("unused")
     public void testUnsubscribeUsingHandleStopsEvents() throws Exception {
         SubscriptionHandle handle1 = policy.subscriptions().subscribe(entity, TestEntity.SEQUENCE, listener);
         SubscriptionHandle handle2 = policy.subscriptions().subscribe(entity, TestEntity.NAME, listener);
@@ -122,18 +126,37 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
     }
 
     @Test
-    public void testSubscriptionReceivesInitialValueEvents() {
-        entity.sensors().set(TestEntity.SEQUENCE, 123);
+    public void testSubscriptionReceivesInitialValueEventsInOrder() {
         entity.sensors().set(TestEntity.NAME, "myname");
-        
+        entity.sensors().set(TestEntity.SEQUENCE, 123);
+        entity.sensors().emit(TestEntity.MY_NOTIF, -1);
+
+        // delivery should be in subscription order, so 123 then 456
         policy.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.SEQUENCE, listener);
+        // wait for the above delivery - otherwise it might get dropped
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), () -> { 
+            Asserts.assertSize(listener.getEvents(), 1); });
+        entity.sensors().set(TestEntity.SEQUENCE, 456);
+        
+        // notifications don't have "initial value" so don't get -1
+        policy.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.MY_NOTIF, listener);
+        // but do get 1, after 456
+        entity.sensors().emit(TestEntity.MY_NOTIF, 1);
+        
+        // STOPPING and myname received, in subscription order, after everything else
+        entity.sensors().set(TestEntity.SERVICE_STATE_ACTUAL, Lifecycle.STOPPING);
+        policy.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.SERVICE_STATE_ACTUAL, listener);
         policy.subscriptions().subscribe(ImmutableMap.of("notifyOfInitialValue", true), entity, TestEntity.NAME, listener);
         
-        Asserts.succeedsEventually(new Runnable() {
+        Asserts.succeedsEventually(MutableMap.of("timeout", Duration.seconds(5)), new Runnable() {
             @Override public void run() {
                 assertEquals(listener.getEvents(), ImmutableList.of(
                         new BasicSensorEvent<Integer>(TestEntity.SEQUENCE, entity, 123),
-                        new BasicSensorEvent<String>(TestEntity.NAME, entity, "myname")));
+                        new BasicSensorEvent<Integer>(TestEntity.SEQUENCE, entity, 456),
+                        new BasicSensorEvent<Integer>(TestEntity.MY_NOTIF, entity, 1),
+                        new BasicSensorEvent<Lifecycle>(TestEntity.SERVICE_STATE_ACTUAL, entity, Lifecycle.STOPPING),
+                        new BasicSensorEvent<String>(TestEntity.NAME, entity, "myname")),
+                    "actually got: "+listener.getEvents());
             }});
     }
     
@@ -147,7 +170,7 @@ public class PolicySubscriptionTest extends BrooklynAppUnitTestSupport {
         
         Asserts.succeedsContinually(ImmutableMap.of("timeout", SHORT_WAIT_MS), new Runnable() {
             @Override public void run() {
-                assertEquals(listener.getEvents(), ImmutableList.of());
+                Asserts.assertSize(listener.getEvents(), 0);
             }});
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/TaskPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/qa/performance/TaskPerformanceTest.java
@@ -74,11 +74,7 @@ public class TaskPerformanceTest extends AbstractPerformanceTest {
                 .summary("TaskPerformanceTest.testExecuteSimplestRunnable")
                 .iterations(numIterations)
                 .minAcceptablePerSecond(minRatePerSec)
-                .job(new Runnable() {
-                    @Override
-                    public void run() {
-                        executionManager.submit(work);
-                    }})
+                .job(() -> executionManager.submit("inner", work))
                 .completionLatch(completionLatch));
     }
     

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -1325,12 +1325,8 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
                 .body(new Callable<Boolean>() {
                     @Override
                     public Boolean call() throws Exception {
-                        Task<Entity> first = DependentConfiguration.attributeWhenReady(cluster, DynamicCluster.FIRST);
-                        DynamicTasks.queueIfPossible(first).orSubmitAsync();
-                        final Entity source = first.get();
-                        final Task<Boolean> booleanTask = DependentConfiguration.attributeWhenReady(source, Attributes.SERVICE_UP);
-                        DynamicTasks.queueIfPossible(booleanTask).orSubmitAsync();
-                        return booleanTask.get();
+                        final Entity source = DynamicTasks.get( DependentConfiguration.attributeWhenReady(cluster, DynamicCluster.FIRST) );
+                        return DynamicTasks.get( DependentConfiguration.attributeWhenReady(source, Attributes.SERVICE_UP) );
                     }
                 })
                 .build();

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
@@ -123,11 +123,7 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
         BasicExecutionManager execManager = new BasicExecutionManager("mycontextid");
         BasicExecutionContext execContext = new BasicExecutionContext(execManager);
         try {
-            MachineDetails details = execContext.submit(new Callable<MachineDetails>() {
-                @Override
-                public MachineDetails call() {
-                    return host.getMachineDetails();
-                }}).get();
+            MachineDetails details = execContext.submit("get details", () -> host.getMachineDetails()).get();
             LOG.info("machineDetails="+details);
             assertNotNull(details);
         } finally {

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -131,11 +131,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
         BasicExecutionManager execManager = new BasicExecutionManager("mycontextid");
         BasicExecutionContext execContext = new BasicExecutionContext(execManager);
         try {
-            MachineDetails details = execContext.submit(new Callable<MachineDetails>() {
-                @Override
-                public MachineDetails call() {
-                    return host.getMachineDetails();
-                }}).get();
+            MachineDetails details = execContext.submit("get details", () -> host.getMachineDetails()).get();
             LOG.info("machineDetails="+details);
             assertNotNull(details);
             
@@ -166,11 +162,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
         BasicExecutionManager execManager = new BasicExecutionManager("mycontextid");
         BasicExecutionContext execContext = new BasicExecutionContext(execManager);
         try {
-            MachineDetails details = execContext.submit(new Callable<MachineDetails>() {
-                @Override
-                public MachineDetails call() {
-                    return host.getMachineDetails();
-                }}).get();
+            MachineDetails details = execContext.submit("get details", () -> host.getMachineDetails()).get();
             LOG.info("machineDetails="+details);
             assertNotNull(details);
             

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/FlagUtilsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/FlagUtilsTest.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
@@ -399,12 +400,22 @@ public class FlagUtilsTest {
             }
 
             @Override
-            public <T> T set(ConfigKey<T> key, Task<T> val) {
+            public <T> T set(ConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
                 throw new UnsupportedOperationException();
             }
 
             @Override
-            public <T> T set(HasConfigKey<T> key, Task<T> val) {
+            public <T> T set(HasConfigKey<T> key, TaskFactory<? extends TaskAdaptable<T>> val) {
+                return set(key.getConfigKey(), val);
+            }
+            
+            @Override
+            public <T> T set(ConfigKey<T> key, TaskAdaptable<T> val) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <T> T set(HasConfigKey<T> key, TaskAdaptable<T> val) {
                 return set(key.getConfigKey(), val);
             }
 

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/TaskPredicatesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/TaskPredicatesTest.java
@@ -82,14 +82,13 @@ public class TaskPredicatesTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testIsDone() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        Task<?> task = app.getExecutionContext().submit(new Runnable() {
-            public void run() {
+        Task<?> task = app.getExecutionContext().submit("await latch", () -> {
                 try {
                     latch.await();
                 } catch (InterruptedException e) {
                     throw Exceptions.propagate(e);
                 }
-            }});
+            });
         
         assertFalse(TaskPredicates.isDone().apply(task));
         

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
@@ -248,8 +248,8 @@ public class TasksTest extends BrooklynAppUnitTestSupport {
             for (Object tag : Tasks.current().getTags()) {
                 if (tag instanceof WrappedEntity) {
                     WrappedEntity wrapped = (WrappedEntity)tag;
-                    if (BrooklynTaskTags.CONTEXT_ENTITY.equals(wrapped.wrappingType)) {
-                        context.add(wrapped.entity);
+                    if (BrooklynTaskTags.CONTEXT_ENTITY.equals(wrapped.getWrappingType())) {
+                        context.add(wrapped.unwrap());
                     }
                 }
             }

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,19 +88,17 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
         
         Assert.assertTrue(result.isAbsent(), "result="+result);
         Exception exception = Maybe.getException(result);
-        Assert.assertTrue(exception.toString().contains("no execution context available"), "exception="+exception);
+        Asserts.assertStringContains(exception.toString(), "no execution context available");
+        
+        Asserts.assertThat(t, (tt) -> !tt.isBegun());
     }
 
     public void testUnsubmittedTaskWithExecutionContextExecutesAndReturns() {
         final Task<String> t = newSleepTask(Duration.ZERO, "foo");
         
         // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task.
-        Maybe<String>  result = app.getExecutionContext()
-                .submit(new Callable<Maybe<String> >() {
-                    @Override
-                    public Maybe<String>  call() throws Exception {
-                        return Tasks.resolving(t).as(String.class).timeout(Asserts.DEFAULT_LONG_TIMEOUT).getMaybe();
-                    }})
+        Maybe<String> result = app.getExecutionContext()
+                .submit("resolving sleep task", () -> Tasks.resolving(t).as(String.class).timeout(Asserts.DEFAULT_LONG_TIMEOUT).getMaybe())
                 .getUnchecked();
         
         Assert.assertEquals(result.get(), "foo");
@@ -110,17 +109,83 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
         
         // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task.
         // However, it will quickly timeout as the task will not have completed.
-        Maybe<String>  result = app.getExecutionContext()
-                .submit(new Callable<Maybe<String> >() {
-                    @Override
-                    public Maybe<String>  call() throws Exception {
-                        return Tasks.resolving(t).as(String.class).timeout(Duration.ZERO).getMaybe();
-                    }})
+        Maybe<String> result = app.getExecutionContext()
+                .submit("resolving sleep task", () -> Tasks.resolving(t).as(String.class).timeout(Duration.ZERO).getMaybe())
                 .getUnchecked();
         
         Assert.assertTrue(result.isAbsent(), "result="+result);
         Exception exception = Maybe.getException(result);
         Assert.assertTrue(exception.toString().contains("not completed when immediate completion requested"), "exception="+exception);
+        
+        Asserts.eventually(() -> t, (tt) -> tt.isBegun(), Duration.TEN_SECONDS);
+        Asserts.assertThat(t, (tt) -> !tt.isDone());
+    }
+    
+    public void testUnsubmittedTaskWithExecutionContextExecutesAndReturnsForeground() {
+        final Task<String> t = newSleepTask(Duration.ZERO, "foo");
+        
+        // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task.
+        Maybe<String> result = app.getExecutionContext()
+                .get(new BasicTask<>( () -> Tasks.resolving(t).as(String.class).timeout(Asserts.DEFAULT_LONG_TIMEOUT).getMaybe() ));
+        
+        Assert.assertEquals(result.get(), "foo");
+    }
+
+    public void testUnsubmittedTaskWithExecutionContextExecutesAndTimesOutForeground() {
+        final Task<String> t = newSleepTask(Duration.ONE_MINUTE, "foo");
+        
+        // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task.
+        // However, it will quickly timeout as the task will not have completed.
+        Maybe<String> result = app.getExecutionContext()
+            .get(new BasicTask<>( () -> Tasks.resolving(t).as(String.class).timeout(Duration.ZERO).getMaybe() ));
+        
+        Assert.assertTrue(result.isAbsent(), "result="+result);
+        Exception exception = Maybe.getException(result);
+        Assert.assertTrue(exception.toString().contains("not completed when immediate completion requested"), "exception="+exception);
+        
+        Asserts.eventually(() -> t, (tt) -> tt.isBegun(), Duration.TEN_SECONDS);
+        Asserts.assertThat(t, (tt) -> !tt.isDone());
+    }
+
+    public void testUnsubmittedTaskWithExecutionContextTimesOutWhenImmediate() {
+        final Task<String> t = newSleepTask(Duration.ZERO, "foo");
+        
+        // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task
+        Maybe<Maybe<String>> result = app.getExecutionContext()
+                .getImmediately(new BasicTask<>( () -> Tasks.resolving(t).as(String.class).timeout(Asserts.DEFAULT_LONG_TIMEOUT).getMaybe() ));
+        
+        // However, the resubmission will not be waited upon
+        Assert.assertTrue(result.isPresent(), "result="+result);
+        Assert.assertTrue(result.get().isAbsent(), "result="+result);
+        Exception exception = Maybe.getException(result.get());
+        
+        Asserts.assertStringContainsIgnoreCase(exception.toString(), "immediate", "not", "available");
+
+        // But the underlying task is running
+        Asserts.eventually(() -> t, (tt) -> tt.isBegun(), Duration.TEN_SECONDS);
+        Asserts.eventually(() -> t, (tt) -> tt.isDone(), Duration.TEN_SECONDS);
+        Asserts.assertThat(t, (tt) -> Objects.equals(tt.getUnchecked(), "foo"));
+        
+        // And subsequent get _is_ immediate
+        result = app.getExecutionContext()
+            .getImmediately(new BasicTask<>( () -> Tasks.resolving(t).as(String.class).timeout(Asserts.DEFAULT_LONG_TIMEOUT).getMaybe() ));
+        Assert.assertEquals(result.get().get(), "foo");
+    }
+
+    public void testUnsubmittedTaskWithExecutionContextExecutesAndTimesOutImmediate() {
+        final Task<String> t = newSleepTask(Duration.ONE_MINUTE, "foo");
+        
+        // Below, we call ValueResolver.getMaybe() in app's execution context. Therefore it will execute the task.
+        // However, it will quickly timeout as the task will not have completed.
+        Maybe<Maybe<String>> result = app.getExecutionContext()
+            .getImmediately(new BasicTask<>( () -> Tasks.resolving(t).as(String.class).timeout(Duration.ZERO).getMaybe() ));
+        
+        Assert.assertTrue(result.isPresent(), "result="+result);
+        Assert.assertTrue(result.get().isAbsent(), "result="+result);
+        Exception exception = Maybe.getException(result.get());
+        Asserts.assertStringContainsIgnoreCase(exception.toString(), "immediate", "not", "available");
+        Asserts.eventually(() -> t, (tt) -> tt.isBegun(), Duration.TEN_SECONDS);
+        Asserts.assertThat(t, (tt) -> !tt.isDone());
     }
 
     public void testSwallowError() {
@@ -161,7 +226,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
     
     public void testGetImmediatelyInTask() throws Exception {
         final MyImmediateAndDeferredSupplier supplier = new MyImmediateAndDeferredSupplier();
-        Task<CallInfo> task = app.getExecutionContext().submit(new Callable<CallInfo>() {
+        Task<CallInfo> task = app.getExecutionContext().submit("test task for call stack", new Callable<CallInfo>() {
             @Override
             public CallInfo call() {
                 return myUniquelyNamedMethod();

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/policy/jclouds/os/CreateUserPolicy.java
@@ -110,11 +110,7 @@ public class CreateUserPolicy extends AbstractPolicy implements SensorEventListe
     }
 
     protected void addUserAsync(final Entity entity, final SshMachineLocation machine) {
-        ((EntityInternal)entity).getExecutionContext().execute(new Runnable() {
-            @Override
-            public void run() {
-                addUser(entity, machine);
-            }});
+        getExecutionContext().execute(() -> addUser(entity, machine));
     }
     
     protected void addUser(Entity entity, SshMachineLocation machine) {

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceReplacer.java
@@ -129,10 +129,7 @@ public class ServiceReplacer extends AbstractPolicy {
                     if (isRunning()) {
                         highlightViolation("Failure detected");
                         LOG.warn("ServiceReplacer notified; dispatching job for "+entity+" ("+event.getValue()+")");
-                        ((EntityInternal)entity).getExecutionContext().submit(MutableMap.of(), new Runnable() {
-                            @Override public void run() {
-                                onDetectedFailure(event);
-                            }});
+                        getExecutionContext().submit("Analyzing detected failure", () -> onDetectedFailure(event));
                     } else {
                         LOG.warn("ServiceReplacer not running, so not acting on failure detected at "+entity+" ("+event.getValue()+", child of "+entity+")");
                     }
@@ -174,12 +171,9 @@ public class ServiceReplacer extends AbstractPolicy {
             return;
         }
         
-        highlightViolation(violationText+", triggering restart");
+        highlightViolation(violationText+", triggering replacement");
         LOG.warn("ServiceReplacer acting on failure detected at "+failedEntity+" ("+reason+", child of "+entity+")");
-        Task<?> t = ((EntityInternal)entity).getExecutionContext().submit(MutableMap.of(), new Runnable() {
-
-            @Override
-            public void run() {
+        Task<?> t = getExecutionContext().submit("Replace member on failure", () -> {
                 try {
                     Entities.invokeEffectorWithArgs(entity, entity, MemberReplaceable.REPLACE_MEMBER, failedEntity.getId()).get();
                     consecutiveReplacementFailureTimes.clear();
@@ -191,8 +185,7 @@ public class ServiceReplacer extends AbstractPolicy {
                     highlightViolation(violationText+" and replace attempt failed: "+Exceptions.collapseText(e));
                     onReplacementFailed("Replace failure ("+Exceptions.collapseText(e)+") at "+entity+": "+reason);
                 }
-            }
-        });
+            });
         highlightAction("Replacing "+failedEntity, t);
     }
 

--- a/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/ha/ServiceRestarter.java
@@ -29,14 +29,12 @@ import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.policy.ha.HASensors.FailureDescriptor;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.time.Duration;
@@ -112,10 +110,7 @@ public class ServiceRestarter extends AbstractPolicy {
                     
                     if (isRunning()) {
                         LOG.info("ServiceRestarter notified; dispatching job for "+entity+" ("+event.getValue()+")");
-                        ((EntityInternal)entity).getExecutionContext().submit(MutableMap.of(), new Runnable() {
-                            @Override public void run() {
-                                onDetectedFailure(event);
-                            }});
+                        getExecutionContext().submit("Analyzing detected failure", () -> onDetectedFailure(event));
                     } else {
                         LOG.warn("ServiceRestarter not running, so not acting on failure detected at "+entity+" ("+event.getValue()+")");
                     }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/SensorResourceTest.java
@@ -325,7 +325,7 @@ public class SensorResourceTest extends BrooklynRestResourceTest {
     
     @Test
     public void testGetSensorValueOfTypeCompletedTask() throws Exception {
-        Task<String> task = entity.getExecutionContext().submit(Callables.returning("myval"));
+        Task<String> task = entity.getExecutionContext().submit("returning myval", Callables.returning("myval"));
         task.get();
         entity.sensors().set(Sensors.newSensor(Task.class, "myTask"), task);
         doGetSensorTest("myTask", String.class, "\"myval\"");

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynNodeImpl.java
@@ -50,32 +50,32 @@ import org.apache.brooklyn.entity.brooklynnode.EntityHttpClient.ResponseCodePred
 import org.apache.brooklyn.entity.brooklynnode.effector.BrooklynNodeUpgradeEffectorBody;
 import org.apache.brooklyn.entity.brooklynnode.effector.SetHighAvailabilityModeEffectorBody;
 import org.apache.brooklyn.entity.brooklynnode.effector.SetHighAvailabilityPriorityEffectorBody;
-import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess.StopSoftwareParameters.StopMode;
+import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks;
 import org.apache.brooklyn.feed.http.HttpFeed;
 import org.apache.brooklyn.feed.http.HttpPollConfig;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.feed.http.JsonFunctions;
-import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.util.collections.Jsonya;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.TaskTags;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
 import org.apache.brooklyn.util.guava.Functionals;
+import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.javalang.Enums;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Functions;
@@ -222,7 +222,7 @@ public class BrooklynNodeImpl extends SoftwareProcessImpl implements BrooklynNod
             // we could wait for BrooklynTaskTags.getTasksInEntityContext(ExecutionManager, this).isEmpty();
             Task<?> stopEffectorTask = BrooklynTaskTags.getClosestEffectorTask(Tasks.current(), Startable.STOP);
             Task<?> topEntityTask = getTopEntityTask(stopEffectorTask);
-            getManagementContext().getExecutionManager().submit(new UnmanageTask(topEntityTask, this));
+            getManagementContext().getExecutionManager().submit("Unmanage Brooklyn entity after stop", new UnmanageTask(topEntityTask, this));
         }
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SameServerDriverLifecycleEffectorTasks.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/SameServerDriverLifecycleEffectorTasks.java
@@ -111,10 +111,7 @@ public class SameServerDriverLifecycleEffectorTasks extends MachineLifecycleEffe
 
     @Override
     protected String startProcessesAtMachine(Supplier<MachineLocation> machineS) {
-        DynamicTasks.queueIfPossible(StartableMethods.startingChildren(entity(), machineS.get()))
-                .orSubmitAsync(entity())
-                .getTask()
-                .getUnchecked();
+        DynamicTasks.get(StartableMethods.startingChildren(entity(), machineS.get()), entity());
         DynamicTasks.waitForLast();
         return "children started";
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1452,8 +1452,24 @@ public class Asserts {
     }
 
     public static void assertSize(Iterable<?> list, int expectedSize) {
-        if (list==null) fail("List is null");
-        if (Iterables.size(list)!=expectedSize) fail("List has wrong size "+Iterables.size(list)+" (expected "+expectedSize+"): "+list);
+        if (list==null) fail("Collection is null");
+        if (Iterables.size(list)!=expectedSize) fail("Collection has wrong size "+Iterables.size(list)+" (expected "+expectedSize+"): "+list);
+    }
+
+    public static void assertSize(Map<?,?> map, int expectedSize) {
+        if (map==null) fail("Map is null");
+        if (Iterables.size(map.keySet())!=expectedSize) fail("Map has wrong size "+map.size()+" (expected "+expectedSize+"): "+map);
+    }
+
+    /** Ignores duplicates and order */
+    public static void assertSameUnorderedContents(Iterable<?> i1, Iterable<?> i2) {
+        if (i1==null || i2==null) {
+            if (i1==null && i2==null) {
+                return ;
+            }
+            fail("Collections differ in that one is null: "+i1+" and "+i2);
+        }
+        assertEquals(MutableSet.copyOf(i1), MutableSet.copyOf(i2));
     }
 
     public static void assertInstanceOf(Object obj, Class<?> type) {

--- a/utils/common/src/test/java/org/apache/brooklyn/test/AssertsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/test/AssertsTest.java
@@ -25,7 +25,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.brooklyn.test.Asserts.ShouldHaveFailedPreviouslyAssertionError;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.Assert;
@@ -169,5 +171,20 @@ public class AssertsTest {
         reached++;
         // check code flowed the way we expected
         Asserts.assertEquals(reached, 3);
+    }
+    
+    @Test
+    public void testAssertSize() {
+        Asserts.assertSize(MutableList.of("x", "x", "y"), 3);
+        Asserts.assertSize(MutableSet.of("x", "x", "y"), 2);
+        Asserts.assertSize(MutableMap.of("x", "x", "y", "y"), 2);
+    }
+    
+    @Test
+    public void testAssertSetListEqualityAndSameUnoderderedContents() {
+        Assert.assertEquals(MutableSet.of("x", "x", "y"), MutableSet.of("x", "y", "x"));
+        Assert.assertNotEquals(MutableList.of("x", "x", "y"), MutableList.of("x", "y", "x"));
+        // above are baseline checks
+        Asserts.assertSameUnorderedContents(MutableList.of("x", "x", "y"), MutableList.of("y", "x"));
     }
 }


### PR DESCRIPTION
As discussed in #816 and suggested to be fixed in #835 but pushed out to here:

There are bad things that can happen if an unsubmitted `Task` is set as a config value:  attempts to read it change the behaviour for subsequent reads.  In particular a call to `getImmediately` (which can be done during validation, or maybe even during a REST read) can cause it to be submitted in an interrupted state, which damages it for all future use.  But more generally, once it has been evaluated it will always and only return that value, where a user may sensibly expect it to return the current value on each read.

Changing those methods -- `config().set(key, task)` and `getImmediately(task)` -- to take `TaskFactory` instances instead removes this confusion and problems, making it clear that a new task is run on each execution.

However this is a big job due to the prevalence of `Task` being used where a `TaskFactory` is now wanted.  In particular `DependentConfiguration` returns `Task` instances!  (There is a long-standing comment that `DslComponent` should be used instead, as that generates factories internal, and YAML use behaves as proposed to implement here across the board, so it is mainly a concern internally and for people using the Java API.  Still it is a clean-up worth doing.)

I've committed one set of changes so far (it is just one commit beyond the merge of #835), signposting the direction this will go and logging warnings in the deprecated code paths.  Next I will actually deprecate these and update usages.

In particular I will likely deprecate all `Task`-returning `DependentConfig` with `TaskFactory` alternatives; then in a subsequent version we can switch the deprecated methods to return `TaskFactory`:  this means code such as `config().set(key, attributeWhenReady(...))` although it will be deprecated for one release will be migrated with no effort from a user to the new behaviour.

Comments at this early stage very welcome cc @aledsage @sjcorbett @grkvlt .
