### PR TITLE
Deprecate `@Catalog` annotation

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/Catalog.java
@@ -30,7 +30,10 @@ import java.lang.annotation.Target;
  * the "id" field used in the catalog is not exposed here but is always taken as the Class.getName() of the annotated item
  * if loaded from an annotation.  (the "type" field unsurprisingly is given the same value).  
  * {@link #name()}, if not supplied, is the SimpleName of the class.
+ * 
+ * @deprecated since 1.0.0; instead use a {@code catalog.bom} file
  */
+@Deprecated
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(value = { ElementType.TYPE })
 public @interface Catalog {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -671,6 +671,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (scanJavaAnnotations==null || !scanJavaAnnotations) {
             // don't scan
         } else {
+            log.warn("Deprecated use of scanJavaAnnotations" + (containingBundle != null ? " in bundle " + containingBundle.getVersionedName() : ""));
+            
             if (isNoBundleOrSimpleWrappingBundle(mgmt, containingBundle)) {
                 Collection<CatalogItemDtoAbstract<?, ?>> scanResult;
                 // BOMs wrapped in JARs, or without JARs, have special treatment
@@ -1076,11 +1078,19 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return oldValue;
     }
 
+    /**
+     * @deprecated since 1.0.0; Catalog annotation is deprecated.
+     */
+    @Deprecated
     private Collection<CatalogItemDtoAbstract<?, ?>> scanAnnotationsFromLocalNonBundleClasspath(ManagementContext mgmt, Map<?, ?> catalogMetadata, ManagedBundle containingBundle) {
         CatalogDto dto = CatalogDto.newNamedInstance("Local Scanned Catalog", "All annotated Brooklyn entities detected in the classpath", "scanning-local-classpath");
         return scanAnnotationsInternal(mgmt, new CatalogDo(dto), catalogMetadata, containingBundle);
     }
     
+    /**
+     * @deprecated since 1.0.0; Catalog annotation is deprecated.
+     */
+    @Deprecated
     private Collection<CatalogItemDtoAbstract<?, ?>> scanAnnotationsLegacyInListOfLibraries(ManagementContext mgmt, Collection<? extends OsgiBundleWithUrl> libraries, Map<?, ?> catalogMetadata, ManagedBundle containingBundle) {
         CatalogDto dto = CatalogDto.newNamedInstance("Bundles Scanned Catalog", "All annotated Brooklyn entities detected in bundles", "scanning-bundles-classpath-"+libraries.hashCode());
         List<String> urls = MutableList.of();
@@ -1104,6 +1114,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return scanAnnotationsInternal(mgmt, subCatalog, catalogMetadata, containingBundle);
     }
     
+    /**
+     * @deprecated since 1.0.0; Catalog annotation is deprecated.
+     */
+    @Deprecated
     @SuppressWarnings("unused")  // keep during 0.12.0 until we are decided we won't support this; search for this method name
     // (note that this now could work after rebind since we have the OSGi cache)
     private Collection<CatalogItemDtoAbstract<?, ?>> scanAnnotationsInBundle(ManagementContext mgmt, ManagedBundle containingBundle) {
@@ -1136,6 +1150,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         }
     }
 
+    /**
+     * @deprecated since 1.0.0; Catalog annotation is deprecated.
+     */
+    @Deprecated
     private Collection<CatalogItemDtoAbstract<?, ?>> scanAnnotationsInternal(ManagementContext mgmt, CatalogDo subCatalog, Map<?, ?> catalogMetadata, ManagedBundle containingBundle) {
         subCatalog.mgmt = mgmt;
         subCatalog.setClasspathScanForEntities(CatalogScanningModes.ANNOTATIONS);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogClasspathDo.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogClasspathDo.java
@@ -68,8 +68,13 @@ public class CatalogClasspathDo {
          * then editing the resulting XML (e.g. setting the classpath and removing the scan attribute) */
         NONE, 
         
-        /** types in the classpath are scanned for annotations indicating inclusion in the catalog ({@link Catalog});
-         * this is the default if no catalog is supplied, scanning the local classpath */
+        /** 
+         * Types in the classpath are scanned for annotations indicating inclusion in the catalog ({@link Catalog});
+         * this is the default if no catalog is supplied, scanning the local classpath.
+         * 
+         * @deprecated since 1.0.0; instead use catalog.bom files
+         */
+        @Deprecated
         ANNOTATIONS,
         
         @Beta
@@ -197,6 +202,7 @@ public class CatalogClasspathDo {
         if (scanner!=null) {
             int count = 0, countApps = 0;
             if (scanMode==CatalogScanningModes.ANNOTATIONS) {
+                log.warn("Deprecated scanning of @Catalog annotations; instead use catalog.bom");
                 Set<Class<?>> catalogClasses = scanner.getTypesAnnotatedWith(Catalog.class);
                 for (Class<?> c: catalogClasses) {
                     try {


### PR DESCRIPTION
As discussed on dev@brooklyn mailing list (subject "Deprecating @Catalog annotation?")