### PR TITLE
Fix npr when reading streamed bundle

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
@@ -406,7 +406,7 @@ class OsgiArchiveInstaller {
                     // or if the bundle should be reinstalled/updated
                     if (!force) {
                         if (!isBringingExistingOsgiInstalledBundleUnderBrooklynManagement) {
-                            if (Objects.equal(b.get().getLocation(), suppliedKnownBundleMetadata.getUrl())) {
+                            if (Objects.equal(b.get().getLocation(), inferredMetadata.getUrl())) {
                                 // installation request was for identical location, so assume we are simply bringing under mgmt
                                 log.debug("Request to install "+inferredMetadata+" from same location "+b.get().getLocation()+
                                     " as existing OSGi installed (but not Brooklyn-managed) bundle "+b.get()+", so skipping reinstall");


### PR DESCRIPTION
This happens when there is an existing unmanaged bundle with the same id
and a replacement bundle is uploaded without the force flag

Tested manually using boms and jars (yaml only and with java)
using curl and br tool.