### PR TITLE
Separate dumper class

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/YamlLauncherAbstract.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/YamlLauncherAbstract.java
@@ -27,6 +27,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.camp.spi.Assembly;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.BrooklynShutdownHooks;
@@ -109,7 +110,7 @@ public abstract class YamlLauncherAbstract {
             }
 
             log.info("Application started from YAML: "+app);
-            Entities.dumpInfo(app);
+            Dumper.dumpInfo(app);
             return (Application)app;
         } catch (Exception e) {
             throw Exceptions.propagate(e);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
@@ -34,7 +34,7 @@ import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.camp.brooklyn.spi.creation.CampTypePlanTransformer;
 import org.apache.brooklyn.camp.spi.PlatformRootSummary;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
@@ -185,7 +185,7 @@ public class AbstractYamlRebindTest extends RebindTestFixture<StartableApplicati
         waitForApplicationTasks(app);
 
         getLogger().info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         return app;
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigNestedYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigNestedYamlTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
@@ -53,7 +53,7 @@ public class ConfigNestedYamlTest extends AbstractYamlTest {
     public void testCatalogParameterFromSuperYamlType() throws Exception {
         addCatalogItems( loadYaml("config-nested-test.bom") );
         Entity ent = doTestWithBlueprint( "services: [ { type: test-map-parameter } ]", false);
-        Entities.dumpInfo(ent);
+        Dumper.dumpInfo(ent);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ConfigNestedYamlTest extends AbstractYamlTest {
     public void testCatalogParameterFromSuperYamlTypeInCluster() throws Exception {
         addCatalogItems( loadYaml("config-nested-test.bom") );
         Entity cluster = makeBlueprint("services: [ { type: test-cluster-with-map-parameter } ]");
-        Entities.dumpInfo(cluster.getApplication());
+        Dumper.dumpInfo(cluster.getApplication());
         Entity parentInCluster = Iterables.getOnlyElement( ((DynamicCluster)cluster).getMembers() );
         Entity target = Iterables.getOnlyElement(parentInCluster.getChildren());
         checkEntity( target, false );
@@ -88,7 +88,7 @@ public class ConfigNestedYamlTest extends AbstractYamlTest {
     public void testCatalogParameterFromSuperYamlTypeAsSoftware() throws Exception {
         addCatalogItems( loadYaml("config-nested-test.bom") );
         Entity ent = doTestWithBlueprint( "services: [ { type: test-map-parameter-software } ]", false);
-        Entities.dumpInfo(ent);
+        Dumper.dumpInfo(ent);
     }
 
     @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -29,7 +29,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -46,7 +45,7 @@ import org.apache.brooklyn.core.config.ConfigPredicates;
 import org.apache.brooklyn.core.config.ConstraintViolationException;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -875,7 +874,7 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         TestEntity entity2 = entity1.addChild(EntitySpec.create(TestEntity.class));
         entity2.start(Collections.<Location>emptyList());
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());
@@ -904,7 +903,7 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         TestEntity entity2 = entity1.addChild(EntitySpec.create(TestEntity.class));
         entity2.start(Collections.<Location>emptyList());
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());
@@ -941,7 +940,7 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
             })
             .get();
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         LOG.info("E1 keys: "+entity1.getEntityType().getConfigKeys());
         LOG.info("E2 keys: "+entity2.getEntityType().getConfigKeys());

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DslAndRebindYamlTest.java
@@ -39,6 +39,7 @@ import org.apache.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -101,7 +102,7 @@ public class DslAndRebindYamlTest extends AbstractYamlRebindTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertTrue(app.getChildren().iterator().hasNext(), "Expected app to have child entity");
         Entity entity = app.getChildren().iterator().next();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EmptySoftwareProcessYamlTest.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
@@ -77,7 +77,7 @@ public class EmptySoftwareProcessYamlTest extends AbstractYamlTest {
         waitForApplicationTasks(app);
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         EmptySoftwareProcess entity = (EmptySoftwareProcess) app.getChildren().iterator().next();
         Map<String, Object> pp = entity.getConfig(EmptySoftwareProcess.PROVISIONING_PROPERTIES);
@@ -99,7 +99,7 @@ public class EmptySoftwareProcessYamlTest extends AbstractYamlTest {
                 "      sshToolClass: "+RecordingSshTool.class.getName(),
                 "location: byon:(hosts=\"127.0.0.1\", name=loopback on app)");
         waitForApplicationTasks(app);
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Location appLocation = Iterables.getOnlyElement(app.getLocations());
         Assert.assertEquals(appLocation.getDisplayName(), "loopback on app");

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EnrichersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EnrichersYamlTest.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityAsserts;
@@ -60,7 +61,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-app-with-enricher");
         
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertEquals(EntityAdjuncts.getNonSystemEnrichers(app).size(), 1);
         final Enricher enricher = EntityAdjuncts.getNonSystemEnrichers(app).iterator().next();
@@ -95,7 +96,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-with-enricher");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertEquals(EntityAdjuncts.getNonSystemEnrichers(app).size(), 0);
         Assert.assertEquals(app.getChildren().size(), 1);
@@ -139,7 +140,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         
         log.info("App started:");
         final Entity parentEntity = app.getChildren().iterator().next();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Assert.assertTrue(parentEntity instanceof TestEntity, "Expected parent entity to be TestEntity, found:" + parentEntity);
         parentEntity.sensors().set(TestEntity.SEQUENCE, 1234);
         Asserts.eventually(Entities.attributeSupplier(parentEntity, Sensors.newStringSensor("main.uri")), Predicates.<String>equalTo("http://www.example.org:1234/"));
@@ -177,7 +178,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         
         log.info("App started:");
         final TestEntity entity = (TestEntity) app.getChildren().iterator().next();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         entity.sensors().set(sourceSensor, "STANDBY"); // trigger enricher
         EntityAsserts.assertAttributeEqualsEventually(entity, targetSensor, "not master");
@@ -213,7 +214,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         
         log.info("App started:");
         final TestEntity entity = (TestEntity) app.getChildren().iterator().next();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         entity.sensors().set(otherSensor, "myval");
         entity.sensors().set(sourceSensor, "any-val"); // trigger enricher
@@ -231,7 +232,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-propagating-enricher");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         TestEntity entity = (TestEntity)app.getChildren().iterator().next();
         entity.sensors().set(TestEntity.NAME, "New Name");
         Asserts.eventually(Entities.attributeSupplier(app, TestEntity.NAME), Predicates.<String>equalTo("New Name"));
@@ -256,7 +257,7 @@ public class EnrichersYamlTest extends AbstractYamlTest {
         waitForApplicationTasks(app);
         
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Assert.assertEquals(app.getChildren().size(), 1);
         final Entity parentEntity = app.getChildren().iterator().next();
         Assert.assertTrue(parentEntity instanceof TestEntity, "Expected parent entity to be TestEntity, found:" + parentEntity);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -88,12 +89,12 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Entity app = createAndStartApplication(loadYaml("test-entity-basic-template.yaml", extras));
         waitForApplicationTasks(app);
 
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertTrue(app.getChildren().iterator().hasNext(), "Expected app to have child entity");
         Entity entity = app.getChildren().iterator().next();
@@ -238,7 +239,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Entity entity = app.getChildren().iterator().next();
         Assert.assertNotNull(entity, "Expected app to have child entity");
@@ -269,7 +270,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Entity entity = app.getChildren().iterator().next();
         Assert.assertNotNull(entity, "Expected app to have child entity");
@@ -293,7 +294,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Entity entity = app.getChildren().iterator().next();
         Assert.assertNotNull(entity, "Expected app to have child entity");
@@ -313,7 +314,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         waitForApplicationTasks(app);
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         TestEntity entity = (TestEntity) app.getChildren().iterator().next();
         Object object = entity.getConfig(TestEntity.CONF_OBJECT);
@@ -413,7 +414,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Assert.assertNotNull(testWithConfigInit, "Expected app to contain TestEntityWithInitConfig child");
         Assert.assertEquals(testWithConfigInit.getEntityCachedOnInit(), testEntity);
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
     }
 
     @Test
@@ -448,7 +449,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         final Entity app = createAndStartApplication(loadYaml("test-referencing-entities.yaml"));
         waitForApplicationTasks(app);
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertEquals(app.getDisplayName(), "test-referencing-entities");
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntityRefsYamlTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.sensor.Sensors;
@@ -157,7 +158,7 @@ public class EntityRefsYamlTest extends AbstractYamlTest {
                 "    id: "+duplicatedId,
                 "    name: entity2.2");
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Entity entity1 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity1"));
         Entity entity1_1 = Iterables.find(Entities.descendantsAndSelf(app), EntityPredicates.displayNameEqualTo("entity1.1"));

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JavaWebAppWithDslYamlRebindIntegrationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JavaWebAppWithDslYamlRebindIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.camp.spi.Assembly;
 import org.apache.brooklyn.camp.spi.AssemblyTemplate;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
@@ -101,7 +102,7 @@ public class JavaWebAppWithDslYamlRebindIntegrationTest extends AbstractYamlTest
 
         Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt().getExecutionManager(), app);
         for (Task<?> t: tasks) t.blockUntilEnded();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Application app2 = rebind(app);
         Assert.assertEquals(app2.getChildren().size(), 2);
@@ -118,7 +119,7 @@ public class JavaWebAppWithDslYamlRebindIntegrationTest extends AbstractYamlTest
 
         Set<Task<?>> tasks = BrooklynTaskTags.getTasksInEntityContext(mgmt().getExecutionManager(), app);
         for (Task<?> t: tasks) t.blockUntilEnded();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Application app2 = rebind(app);
         Assert.assertEquals(app2.getChildren().size(), 2);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/MapReferenceYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/MapReferenceYamlTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.stock.BasicEntity;
@@ -44,7 +45,7 @@ public class MapReferenceYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-reference-map-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertEquals(Iterables.size(app.getChildren()), 3, "Expected app to have child entity");
         Iterable<BasicEntity> basicEntities = Iterables.filter(app.getChildren(), BasicEntity.class);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
@@ -32,7 +32,7 @@ import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -213,7 +213,7 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertTrue(app.getChildren().iterator().hasNext(), "Expected app to have child entity");
         Entity entity = app.getChildren().iterator().next();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/PoliciesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/PoliciesYamlTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.policy.TestPolicy;
@@ -51,7 +51,7 @@ public class PoliciesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-app-with-policy");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertEquals(app.policies().size(), 1);
         Policy policy = app.policies().iterator().next();
@@ -71,7 +71,7 @@ public class PoliciesYamlTest extends AbstractYamlTest {
         Assert.assertEquals(app.getDisplayName(), "test-entity-with-policy");
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
 
         Assert.assertEquals(app.policies().size(), 0);
         Assert.assertEquals(app.getChildren().size(), 1);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaBashNetcatYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaBashNetcatYamlTest.java
@@ -24,7 +24,7 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -58,7 +58,7 @@ public class VanillaBashNetcatYamlTest extends AbstractYamlTest {
         waitForApplicationTasks(app);
         
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertEquals(app.getDisplayName(), "Simple Netcat with Client");
         
@@ -102,7 +102,7 @@ public class VanillaBashNetcatYamlTest extends AbstractYamlTest {
         EntityAsserts.assertAttributeEventually(app, Sensors.newStringSensor("output.last"), StringPredicates.containsLiteral("yo yo yo"));
         
         log.info("after all is said and done, app is:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
     }
     
     @Override

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaSoftwareProcessYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/VanillaSoftwareProcessYamlTest.java
@@ -32,7 +32,7 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.RecordingSensorEventListener;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
@@ -109,7 +109,7 @@ public class VanillaSoftwareProcessYamlTest extends AbstractYamlTest {
         waitForApplicationTasks(app);
 
         log.info("App started:");
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         VanillaSoftwareProcess entity = (VanillaSoftwareProcess) Iterables.getOnlyElement(app.getChildren());
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WindowsYamlLiveTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -289,7 +290,7 @@ public class WindowsYamlLiveTest extends AbstractWindowsYamlTest {
             app = createAndStartApplication(Joiner.on("\n").join(yaml));
             waitForApplicationTasks(app);
             log.info("App started:");
-            Entities.dumpInfo(app);
+            Dumper.dumpInfo(app);
             
             VanillaWindowsProcess entity = (VanillaWindowsProcess) app.getChildren().iterator().next();
             
@@ -300,7 +301,7 @@ public class WindowsYamlLiveTest extends AbstractWindowsYamlTest {
             app = createAndStartApplication(Joiner.on("\n").join(yaml));
             waitForApplicationTasks(app);
             log.info("App started:");
-            Entities.dumpInfo(app);
+            Dumper.dumpInfo(app);
             VanillaWindowsProcess entity = (VanillaWindowsProcess) app.getChildren().iterator().next();
             EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
             

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiLibraryTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiLibraryTest.java
@@ -34,7 +34,7 @@ import org.apache.brooklyn.api.typereg.OsgiBundleWithUrl;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.core.config.external.AbstractExternalConfigSupplier;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.mgmt.internal.ExternalConfigSupplierRegistry;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -263,7 +263,7 @@ public class CatalogOsgiLibraryTest extends AbstractYamlTest {
         ResourceUtils ru = ResourceUtils.create(entity);
         Iterable<URL> files = ru.getResources("org/apache/brooklyn/test/osgi/resources/message.txt");
         if (!files.iterator().hasNext()) {
-            Entities.dumpInfo(entity);
+            Dumper.dumpInfo(entity);
             Assert.fail("Expected to find 'messages.txt'");
         }
     }
@@ -272,7 +272,7 @@ public class CatalogOsgiLibraryTest extends AbstractYamlTest {
         ResourceUtils ru = ResourceUtils.create(entity);
         Iterable<URL> files = ru.getResources("org/apache/brooklyn/test/osgi/resources/message.txt");
         if (files.iterator().hasNext()) {
-            Entities.dumpInfo(entity);
+            Dumper.dumpInfo(entity);
             Assert.fail("Expected NOT to find 'messages.txt'");
         }
     }
@@ -305,7 +305,7 @@ public class CatalogOsgiLibraryTest extends AbstractYamlTest {
         Entity app = createAndStartApplication("services: [ { type: item-from-library } ]");
         Entity entity1 = app.getChildren().iterator().next();
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         
         Assert.assertEquals(entity1.getCatalogItemId(), "item-from-library:1.0");
         assertCanFindMessages( entity1 );

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlCombiTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlCombiTest.java
@@ -23,7 +23,7 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.entity.stock.BasicStartable;
 import org.apache.brooklyn.policy.ha.ServiceRestarter;
@@ -117,7 +117,7 @@ public class CatalogYamlCombiTest extends AbstractYamlTest {
 
         Entity b = launchEntity("B", false);
         Assert.assertTrue(BasicStartable.class.isInstance(b), "Wrong type: "+b);
-        Entities.dumpInfo(b);
+        Dumper.dumpInfo(b);
         
         Assert.assertEquals(Iterables.getOnlyElement(b.getLocations()).getConfig(ConfigKeys.newIntegerConfigKey("z")), (Integer)9);
         

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlTemplateTest.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
@@ -103,7 +103,7 @@ public class CatalogYamlTemplateTest extends AbstractYamlTest {
                 "- type: t2");
         waitForApplicationTasks(app);
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Entity t1a = Iterables.get(app.getChildren(), 0);
         Entity t1b = Iterables.get(app.getChildren(), 1);
         assertEquals(app.getChildren().size(), 2);
@@ -141,7 +141,7 @@ public class CatalogYamlTemplateTest extends AbstractYamlTest {
                 "- type: t2");
         waitForApplicationTasks(app);
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Entity t2 = Iterables.getOnlyElement(app.getChildren());
         Entity t1 = Iterables.getOnlyElement(t2.getChildren());
         assertEquals(t1.getChildren().size(), 0);
@@ -181,7 +181,7 @@ public class CatalogYamlTemplateTest extends AbstractYamlTest {
                 "- type: t2");
         waitForApplicationTasks(app);
         
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         DynamicCluster t2 = (DynamicCluster) Iterables.getOnlyElement(app.getChildren());
         Entity t1 = Iterables.getOnlyElement(t2.getMembers());
         assertEquals(t1.getChildren().size(), 0);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.entity;
+
+import static org.apache.brooklyn.core.entity.Entities.isSecret;
+import static org.apache.brooklyn.core.entity.Entities.isTrivial;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.Group;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.policy.Policy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.Enricher;
+import org.apache.brooklyn.api.sensor.Feed;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.location.internal.LocationInternal;
+import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
+import org.apache.brooklyn.util.core.flags.FlagUtils;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+/**
+ * Convenience methods for dumping info about entities etc.
+ */
+public class Dumper {
+
+    public static void dumpInfo(Iterable<? extends Entity> entities) {
+        for (Entity e : entities) {
+            dumpInfo(e);
+        }
+    }
+
+    public static void dumpInfo(Entity e) {
+        try {
+            dumpInfo(e, new PrintWriter(System.out), "", "  ");
+        } catch (IOException exc) {
+            // system.out throwing an exception is odd, so don't have IOException on signature
+            throw new RuntimeException(exc);
+        }
+    }
+    
+    public static void dumpInfo(Entity e, Writer out) throws IOException {
+        dumpInfo(e, out, "", "  ");
+    }
+    
+    public static void dumpInfo(Entity e, String currentIndentation, String tab) throws IOException {
+        dumpInfo(e, new PrintWriter(System.out), currentIndentation, tab);
+    }
+    
+    public static void dumpInfo(Entity e, Writer out, String currentIndentation, String tab) throws IOException {
+        out.append(currentIndentation+e.toString()+" "+e.getId()+"\n");
+
+        out.append(currentIndentation+tab+tab+"displayName = "+e.getDisplayName()+"\n");
+        if (Strings.isNonBlank(e.getCatalogItemId())) {
+            out.append(currentIndentation+tab+tab+"catalogItemId = "+e.getCatalogItemId()+"\n");
+        }
+        final List<String> searchPath = e.getCatalogItemIdSearchPath();
+        if (!searchPath.isEmpty()) {
+            out.append(currentIndentation + tab + tab + "searchPath = [");
+            for (int i = 0 ; i < searchPath.size() ; i++) {
+                out.append(i > 0 ? ",\n" : "\n");
+                out.append(currentIndentation + tab + tab + searchPath.get(i));
+            }
+            out.append("\n" + currentIndentation + tab + tab + "]");
+        }
+
+        out.append(currentIndentation+tab+tab+"locations = "+e.getLocations()+"\n");
+
+        Set<ConfigKey<?>> keys = Sets.newLinkedHashSet(
+            ((EntityInternal)e).config().getLocalBag().getAllConfigAsConfigKeyMap().keySet()
+            //((EntityInternal)e).getConfigMap().getLocalConfig().keySet() 
+            );
+        for (ConfigKey<?> it : sortConfigKeys(keys)) {
+            // use the official config key declared on the type if available
+            // (since the map sometimes contains <object> keys
+            ConfigKey<?> realKey = e.getEntityType().getConfigKey(it.getName());
+            if (realKey!=null) it = realKey;
+
+            Maybe<Object> mv = ((EntityInternal)e).config().getLocalRaw(it);
+            if (!isTrivial(mv)) {
+                Object v = mv.get();
+                out.append(currentIndentation+tab+tab+it.getName());
+                out.append(" = ");
+                if (isSecret(it.getName())) out.append("xxxxxxxx");
+                else if ((v instanceof Task) && ((Task<?>)v).isDone()) {
+                    if (((Task<?>)v).isError()) {
+                        out.append("ERROR in "+v);
+                    } else {
+                        try {
+                            out.append(((Task<?>)v).get() + " (from "+v+")");
+                        } catch (ExecutionException ee) {
+                            throw new IllegalStateException("task "+v+" done and !isError, but threw exception on get", ee);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                    }
+                } else out.append(""+v);
+                out.append("\n");
+            }
+        }
+
+        for (Sensor<?> it : sortSensors(e.getEntityType().getSensors())) {
+            if (it instanceof AttributeSensor) {
+                Object v = e.getAttribute((AttributeSensor<?>)it);
+                if (!isTrivial(v)) {
+                    out.append(currentIndentation+tab+tab+it.getName());
+                    out.append(": ");
+                    if (isSecret(it.getName())) out.append("xxxxxxxx");
+                    else out.append(""+v);
+                    out.append("\n");
+                }
+            }
+        }
+
+        if (e instanceof Group) {
+            StringBuilder members = new StringBuilder();
+            for (Entity it : ((Group)e).getMembers()) {
+                if (members.length()>0) members.append(", ");
+                members.append(it.getId());
+            }
+            out.append(currentIndentation+tab+tab+"Members: "+members.toString()+"\n");
+        }
+
+        if (!e.policies().isEmpty()) {
+            out.append(currentIndentation+tab+tab+"Policies:\n");
+            for (Policy policy : e.policies()) {
+                dumpInfo(policy, out, currentIndentation+tab+tab+tab, tab);
+            }
+        }
+
+        if (!e.enrichers().isEmpty()) {
+            out.append(currentIndentation+tab+tab+"Enrichers:\n");
+            for (Enricher enricher : e.enrichers()) {
+                dumpInfo(enricher, out, currentIndentation+tab+tab+tab, tab);
+            }
+        }
+
+        if (!((EntityInternal)e).feeds().getFeeds().isEmpty()) {
+            out.append(currentIndentation+tab+tab+"Feeds:\n");
+            for (Feed feed : ((EntityInternal)e).feeds().getFeeds()) {
+                dumpInfo(feed, out, currentIndentation+tab+tab+tab, tab);
+            }
+        }
+
+        for (Entity it : e.getChildren()) {
+            dumpInfo(it, out, currentIndentation+tab, tab);
+        }
+
+        out.flush();
+    }
+
+    public static void dumpInfo(Location loc) {
+        try {
+            dumpInfo(loc, new PrintWriter(System.out), "", "  ");
+        } catch (IOException exc) {
+            // system.out throwing an exception is odd, so don't have IOException on signature
+            throw new RuntimeException(exc);
+        }
+    }
+    
+    public static void dumpInfo(Location loc, Writer out) throws IOException {
+        dumpInfo(loc, out, "", "  ");
+    }
+    
+    public static void dumpInfo(Location loc, String currentIndentation, String tab) throws IOException {
+        dumpInfo(loc, new PrintWriter(System.out), currentIndentation, tab);
+    }
+    
+    @SuppressWarnings("rawtypes")
+    public static void dumpInfo(Location loc, Writer out, String currentIndentation, String tab) throws IOException {
+        out.append(currentIndentation+loc.toString()+"\n");
+
+        for (Object entryO : ((LocationInternal)loc).config().getBag().getAllConfig().entrySet()) {
+            Map.Entry entry = (Map.Entry)entryO;
+            Object keyO = entry.getKey();
+            String key =
+                    keyO instanceof HasConfigKey ? ((HasConfigKey)keyO).getConfigKey().getName() :
+                    keyO instanceof ConfigKey ? ((ConfigKey)keyO).getName() :
+                    keyO == null ? null :
+                    keyO.toString();
+            Object val = entry.getValue();
+            if (!isTrivial(val)) {
+                out.append(currentIndentation+tab+tab+key);
+                out.append(" = ");
+                if (isSecret(key)) out.append("xxxxxxxx");
+                else out.append(""+val);
+                out.append("\n");
+            }
+        }
+
+        for (Map.Entry<String,?> entry : sortMap(FlagUtils.getFieldsWithFlags(loc)).entrySet()) {
+            String key = entry.getKey();
+            Object val = entry.getValue();
+            if (!isTrivial(val)) {
+                out.append(currentIndentation+tab+tab+key);
+                out.append(" = ");
+                if (isSecret(key)) out.append("xxxxxxxx");
+                else out.append(""+val);
+                out.append("\n");
+            }
+        }
+
+        for (Location it : loc.getChildren()) {
+            dumpInfo(it, out, currentIndentation+tab, tab);
+        }
+
+        out.flush();
+    }
+
+    public static void dumpInfo(Task<?> t) {
+        Tasks.dumpInfo(t);
+    }
+    
+    public static void dumpInfo(Enricher enr) {
+        try {
+            dumpInfo(enr, new PrintWriter(System.out), "", "  ");
+        } catch (IOException exc) {
+            // system.out throwing an exception is odd, so don't have IOException on signature
+            throw new RuntimeException(exc);
+        }
+    }
+    
+    public static void dumpInfo(Enricher enr, Writer out) throws IOException {
+        dumpInfo(enr, out, "", "  ");
+    }
+    
+    public static void dumpInfo(Enricher enr, String currentIndentation, String tab) throws IOException {
+        dumpInfo(enr, new PrintWriter(System.out), currentIndentation, tab);
+    }
+    
+    public static void dumpInfo(Enricher enr, Writer out, String currentIndentation, String tab) throws IOException {
+        out.append(currentIndentation+enr.toString()+"\n");
+
+        for (ConfigKey<?> key : sortConfigKeys(enr.getEnricherType().getConfigKeys())) {
+            Maybe<Object> val = ((BrooklynObjectInternal)enr).config().getRaw(key);
+            if (!isTrivial(val)) {
+                out.append(currentIndentation+tab+tab+key);
+                out.append(" = ");
+                if (isSecret(key.getName())) out.append("xxxxxxxx");
+                else out.append(""+val.get());
+                out.append("\n");
+            }
+        }
+
+        out.flush();
+    }
+    
+    public static void dumpInfo(Feed feed, String currentIndentation, String tab) throws IOException {
+        dumpInfo(feed, new PrintWriter(System.out), currentIndentation, tab);
+    }
+    
+    public static void dumpInfo(Feed feed, Writer out, String currentIndentation, String tab) throws IOException {
+        out.append(currentIndentation+feed.toString()+"\n");
+
+        // TODO create a FeedType cf EnricherType ?
+        for (ConfigKey<?> key : sortConfigKeys(((BrooklynObjectInternal)feed).config().getBag().getAllConfigAsConfigKeyMap().keySet())) {
+            Maybe<Object> val = ((BrooklynObjectInternal)feed).config().getRaw(key);
+            if (!isTrivial(val)) {
+                out.append(currentIndentation+tab+tab+key);
+                out.append(" = ");
+                if (isSecret(key.getName())) out.append("xxxxxxxx");
+                else out.append(""+val.get());
+                out.append("\n");
+            }
+        }
+
+        out.flush();
+    }
+
+    public static void dumpInfo(Policy pol) {
+        try {
+            dumpInfo(pol, new PrintWriter(System.out), "", "  ");
+        } catch (IOException exc) {
+            // system.out throwing an exception is odd, so don't have IOException on signature
+            throw new RuntimeException(exc);
+        }
+    }
+    
+    public static void dumpInfo(Policy pol, Writer out) throws IOException {
+        dumpInfo(pol, out, "", "  ");
+    }
+    
+    public static void dumpInfo(Policy pol, String currentIndentation, String tab) throws IOException {
+        dumpInfo(pol, new PrintWriter(System.out), currentIndentation, tab);
+    }
+    
+    public static void dumpInfo(Policy pol, Writer out, String currentIndentation, String tab) throws IOException {
+        out.append(currentIndentation+pol.toString()+"\n");
+
+        for (ConfigKey<?> key : sortConfigKeys(pol.getPolicyType().getConfigKeys())) {
+            Maybe<Object> val = ((BrooklynObjectInternal)pol).config().getRaw(key);
+            if (!isTrivial(val)) {
+                out.append(currentIndentation+tab+tab+key);
+                out.append(" = ");
+                if (isSecret(key.getName())) out.append("xxxxxxxx");
+                else out.append(""+val.get());
+                out.append("\n");
+            }
+        }
+
+        out.flush();
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static List<Sensor<?>> sortSensors(Set<Sensor<?>> sensors) {
+        List result = new ArrayList(sensors);
+        Collections.sort(result, new Comparator<Sensor>() {
+                    @Override
+                    public int compare(Sensor arg0, Sensor arg1) {
+                        return arg0.getName().compareTo(arg1.getName());
+                    }
+
+        });
+        return result;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static List<ConfigKey<?>> sortConfigKeys(Set<ConfigKey<?>> configs) {
+        List result = new ArrayList(configs);
+        Collections.sort(result, new Comparator<ConfigKey>() {
+                    @Override
+                    public int compare(ConfigKey arg0, ConfigKey arg1) {
+                        return arg0.getName().compareTo(arg1.getName());
+                    }
+
+        });
+        return result;
+    }
+    
+    public static <T> Map<String, T> sortMap(Map<String, T> map) {
+        Map<String,T> result = Maps.newLinkedHashMap();
+        List<String> order = Lists.newArrayList(map.keySet());
+        Collections.sort(order, String.CASE_INSENSITIVE_ORDER);
+
+        for (String key : order) {
+            result.put(key, map.get(key));
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
@@ -46,7 +46,6 @@ import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
-import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -244,7 +243,7 @@ public class Dumper {
     }
 
     public static void dumpInfo(Task<?> t) {
-        Tasks.dumpInfo(t);
+        Dumper.dumpInfo(t);
     }
     
     public static void dumpInfo(Enricher enr) {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Dumper.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.core.entity;
 
-import static org.apache.brooklyn.core.entity.Entities.isSecret;
 import static org.apache.brooklyn.core.entity.Entities.isTrivial;
 
 import java.io.IOException;
@@ -43,6 +42,7 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
@@ -78,11 +78,11 @@ public class Dumper {
         dumpInfo(e, out, "", "  ");
     }
     
-    public static void dumpInfo(Entity e, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Entity e, String currentIndentation, String tab) throws IOException {
         dumpInfo(e, new PrintWriter(System.out), currentIndentation, tab);
     }
     
-    public static void dumpInfo(Entity e, Writer out, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Entity e, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+e.toString()+" "+e.getId()+"\n");
 
         out.append(currentIndentation+tab+tab+"displayName = "+e.getDisplayName()+"\n");
@@ -198,12 +198,12 @@ public class Dumper {
         dumpInfo(loc, out, "", "  ");
     }
     
-    public static void dumpInfo(Location loc, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Location loc, String currentIndentation, String tab) throws IOException {
         dumpInfo(loc, new PrintWriter(System.out), currentIndentation, tab);
     }
     
     @SuppressWarnings("rawtypes")
-    public static void dumpInfo(Location loc, Writer out, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Location loc, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+loc.toString()+"\n");
 
         for (Object entryO : ((LocationInternal)loc).config().getBag().getAllConfig().entrySet()) {
@@ -260,11 +260,11 @@ public class Dumper {
         dumpInfo(enr, out, "", "  ");
     }
     
-    public static void dumpInfo(Enricher enr, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Enricher enr, String currentIndentation, String tab) throws IOException {
         dumpInfo(enr, new PrintWriter(System.out), currentIndentation, tab);
     }
     
-    public static void dumpInfo(Enricher enr, Writer out, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Enricher enr, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+enr.toString()+"\n");
 
         for (ConfigKey<?> key : sortConfigKeys(enr.getEnricherType().getConfigKeys())) {
@@ -281,11 +281,11 @@ public class Dumper {
         out.flush();
     }
     
-    public static void dumpInfo(Feed feed, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Feed feed, String currentIndentation, String tab) throws IOException {
         dumpInfo(feed, new PrintWriter(System.out), currentIndentation, tab);
     }
     
-    public static void dumpInfo(Feed feed, Writer out, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Feed feed, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+feed.toString()+"\n");
 
         // TODO create a FeedType cf EnricherType ?
@@ -316,11 +316,11 @@ public class Dumper {
         dumpInfo(pol, out, "", "  ");
     }
     
-    public static void dumpInfo(Policy pol, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Policy pol, String currentIndentation, String tab) throws IOException {
         dumpInfo(pol, new PrintWriter(System.out), currentIndentation, tab);
     }
     
-    public static void dumpInfo(Policy pol, Writer out, String currentIndentation, String tab) throws IOException {
+    static void dumpInfo(Policy pol, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+pol.toString()+"\n");
 
         for (ConfigKey<?> key : sortConfigKeys(pol.getPolicyType().getConfigKeys())) {
@@ -338,7 +338,7 @@ public class Dumper {
     }
     
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static List<Sensor<?>> sortSensors(Set<Sensor<?>> sensors) {
+    static List<Sensor<?>> sortSensors(Set<Sensor<?>> sensors) {
         List result = new ArrayList(sensors);
         Collections.sort(result, new Comparator<Sensor>() {
                     @Override
@@ -351,7 +351,7 @@ public class Dumper {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static List<ConfigKey<?>> sortConfigKeys(Set<ConfigKey<?>> configs) {
+    static List<ConfigKey<?>> sortConfigKeys(Set<ConfigKey<?>> configs) {
         List result = new ArrayList(configs);
         Collections.sort(result, new Comparator<ConfigKey>() {
                     @Override
@@ -363,7 +363,7 @@ public class Dumper {
         return result;
     }
     
-    public static <T> Map<String, T> sortMap(Map<String, T> map) {
+    static <T> Map<String, T> sortMap(Map<String, T> map) {
         Map<String,T> result = Maps.newLinkedHashMap();
         List<String> order = Lists.newArrayList(map.keySet());
         Collections.sort(order, String.CASE_INSENSITIVE_ORDER);
@@ -372,5 +372,9 @@ public class Dumper {
             result.put(key, map.get(key));
         }
         return result;
+    }
+    
+    private static boolean isSecret(String name) {
+        return Sanitizer.IS_SECRET_PREDICATE.apply(name);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -22,19 +22,15 @@ import static org.apache.brooklyn.util.guava.Functionals.isSatisfied;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.Writer;
 import java.lang.reflect.Proxy;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +40,6 @@ import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.entity.drivers.EntityDriver;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolver;
 import org.apache.brooklyn.api.location.Location;
@@ -69,7 +64,6 @@ import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.location.Locations;
-import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.BrooklynShutdownHooks;
 import org.apache.brooklyn.core.mgmt.internal.EffectorUtils;
@@ -77,14 +71,12 @@ import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.internal.NonDeploymentManagementContext;
-import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.core.objs.proxy.EntityProxyImpl;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.FlagUtils;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.ParallelTask;
 import org.apache.brooklyn.util.core.task.TaskTags;
@@ -95,7 +87,6 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.stream.Streams;
-import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +102,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Atomics;
@@ -270,305 +260,190 @@ public class Entities {
                 (v instanceof CharSequence&& ((CharSequence)v).length() == 0);
     }
 
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Iterable<? extends Entity> entities) {
-        for (Entity e : entities) {
-            dumpInfo(e);
-        }
+        Dumper.dumpInfo(entities);
     }
 
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Entity e) {
-        try {
-            dumpInfo(e, new PrintWriter(System.out), "", "  ");
-        } catch (IOException exc) {
-            // system.out throwing an exception is odd, so don't have IOException on signature
-            throw new RuntimeException(exc);
-        }
+        Dumper.dumpInfo(e);
     }
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Entity e, Writer out) throws IOException {
-        dumpInfo(e, out, "", "  ");
-    }
-    public static void dumpInfo(Entity e, String currentIndentation, String tab) throws IOException {
-        dumpInfo(e, new PrintWriter(System.out), currentIndentation, tab);
-    }
-    public static void dumpInfo(Entity e, Writer out, String currentIndentation, String tab) throws IOException {
-        out.append(currentIndentation+e.toString()+" "+e.getId()+"\n");
-
-        out.append(currentIndentation+tab+tab+"displayName = "+e.getDisplayName()+"\n");
-        if (Strings.isNonBlank(e.getCatalogItemId())) {
-            out.append(currentIndentation+tab+tab+"catalogItemId = "+e.getCatalogItemId()+"\n");
-        }
-        final List<String> searchPath = e.getCatalogItemIdSearchPath();
-        if (!searchPath.isEmpty()) {
-            out.append(currentIndentation + tab + tab + "searchPath = [");
-            for (int i = 0 ; i < searchPath.size() ; i++) {
-                out.append(i > 0 ? ",\n" : "\n");
-                out.append(currentIndentation + tab + tab + searchPath.get(i));
-            }
-            out.append("\n" + currentIndentation + tab + tab + "]");
-        }
-
-        out.append(currentIndentation+tab+tab+"locations = "+e.getLocations()+"\n");
-
-        Set<ConfigKey<?>> keys = Sets.newLinkedHashSet(
-            ((EntityInternal)e).config().getLocalBag().getAllConfigAsConfigKeyMap().keySet()
-            //((EntityInternal)e).getConfigMap().getLocalConfig().keySet() 
-            );
-        for (ConfigKey<?> it : sortConfigKeys(keys)) {
-            // use the official config key declared on the type if available
-            // (since the map sometimes contains <object> keys
-            ConfigKey<?> realKey = e.getEntityType().getConfigKey(it.getName());
-            if (realKey!=null) it = realKey;
-
-            Maybe<Object> mv = ((EntityInternal)e).config().getLocalRaw(it);
-            if (!isTrivial(mv)) {
-                Object v = mv.get();
-                out.append(currentIndentation+tab+tab+it.getName());
-                out.append(" = ");
-                if (isSecret(it.getName())) out.append("xxxxxxxx");
-                else if ((v instanceof Task) && ((Task<?>)v).isDone()) {
-                    if (((Task<?>)v).isError()) {
-                        out.append("ERROR in "+v);
-                    } else {
-                        try {
-                            out.append(((Task<?>)v).get() + " (from "+v+")");
-                        } catch (ExecutionException ee) {
-                            throw new IllegalStateException("task "+v+" done and !isError, but threw exception on get", ee);
-                        } catch (InterruptedException ie) {
-                            Thread.currentThread().interrupt();
-                            return;
-                        }
-                    }
-                } else out.append(""+v);
-                out.append("\n");
-            }
-        }
-
-        for (Sensor<?> it : sortSensors(e.getEntityType().getSensors())) {
-            if (it instanceof AttributeSensor) {
-                Object v = e.getAttribute((AttributeSensor<?>)it);
-                if (!isTrivial(v)) {
-                    out.append(currentIndentation+tab+tab+it.getName());
-                    out.append(": ");
-                    if (isSecret(it.getName())) out.append("xxxxxxxx");
-                    else out.append(""+v);
-                    out.append("\n");
-                }
-            }
-        }
-
-        if (e instanceof Group) {
-            StringBuilder members = new StringBuilder();
-            for (Entity it : ((Group)e).getMembers()) {
-                if (members.length()>0) members.append(", ");
-                members.append(it.getId());
-            }
-            out.append(currentIndentation+tab+tab+"Members: "+members.toString()+"\n");
-        }
-
-        if (!e.policies().isEmpty()) {
-            out.append(currentIndentation+tab+tab+"Policies:\n");
-            for (Policy policy : e.policies()) {
-                dumpInfo(policy, out, currentIndentation+tab+tab+tab, tab);
-            }
-        }
-
-        if (!e.enrichers().isEmpty()) {
-            out.append(currentIndentation+tab+tab+"Enrichers:\n");
-            for (Enricher enricher : e.enrichers()) {
-                dumpInfo(enricher, out, currentIndentation+tab+tab+tab, tab);
-            }
-        }
-
-        if (!((EntityInternal)e).feeds().getFeeds().isEmpty()) {
-            out.append(currentIndentation+tab+tab+"Feeds:\n");
-            for (Feed feed : ((EntityInternal)e).feeds().getFeeds()) {
-                dumpInfo(feed, out, currentIndentation+tab+tab+tab, tab);
-            }
-        }
-
-        for (Entity it : e.getChildren()) {
-            dumpInfo(it, out, currentIndentation+tab, tab);
-        }
-
-        out.flush();
-    }
-
-    public static void dumpInfo(Location loc) {
-        try {
-            dumpInfo(loc, new PrintWriter(System.out), "", "  ");
-        } catch (IOException exc) {
-            // system.out throwing an exception is odd, so don't have IOException on signature
-            throw new RuntimeException(exc);
-        }
-    }
-    public static void dumpInfo(Location loc, Writer out) throws IOException {
-        dumpInfo(loc, out, "", "  ");
-    }
-    public static void dumpInfo(Location loc, String currentIndentation, String tab) throws IOException {
-        dumpInfo(loc, new PrintWriter(System.out), currentIndentation, tab);
-    }
-    @SuppressWarnings("rawtypes")
-    public static void dumpInfo(Location loc, Writer out, String currentIndentation, String tab) throws IOException {
-        out.append(currentIndentation+loc.toString()+"\n");
-
-        for (Object entryO : ((LocationInternal)loc).config().getBag().getAllConfig().entrySet()) {
-            Map.Entry entry = (Map.Entry)entryO;
-            Object keyO = entry.getKey();
-            String key =
-                    keyO instanceof HasConfigKey ? ((HasConfigKey)keyO).getConfigKey().getName() :
-                    keyO instanceof ConfigKey ? ((ConfigKey)keyO).getName() :
-                    keyO == null ? null :
-                    keyO.toString();
-            Object val = entry.getValue();
-            if (!isTrivial(val)) {
-                out.append(currentIndentation+tab+tab+key);
-                out.append(" = ");
-                if (isSecret(key)) out.append("xxxxxxxx");
-                else out.append(""+val);
-                out.append("\n");
-            }
-        }
-
-        for (Map.Entry<String,?> entry : sortMap(FlagUtils.getFieldsWithFlags(loc)).entrySet()) {
-            String key = entry.getKey();
-            Object val = entry.getValue();
-            if (!isTrivial(val)) {
-                out.append(currentIndentation+tab+tab+key);
-                out.append(" = ");
-                if (isSecret(key)) out.append("xxxxxxxx");
-                else out.append(""+val);
-                out.append("\n");
-            }
-        }
-
-        for (Location it : loc.getChildren()) {
-            dumpInfo(it, out, currentIndentation+tab, tab);
-        }
-
-        out.flush();
-    }
-
-    public static void dumpInfo(Task<?> t) {
-        Tasks.dumpInfo(t);
+        Dumper.dumpInfo(e, out);
     }
     
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Entity e, String currentIndentation, String tab) throws IOException {
+        Dumper.dumpInfo(e, currentIndentation, tab);
+    }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Entity e, Writer out, String currentIndentation, String tab) throws IOException {
+        Dumper.dumpInfo(e, out, currentIndentation, tab);
+    }
+
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Location loc) {
+        Dumper.dumpInfo(loc);
+    }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Location loc, Writer out) throws IOException {
+        Dumper.dumpInfo(loc, out);
+    }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Location loc, String currentIndentation, String tab) throws IOException {
+        Dumper.dumpInfo(loc, currentIndentation, tab);
+    }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Location loc, Writer out, String currentIndentation, String tab) throws IOException {
+        Dumper.dumpInfo(loc, out, currentIndentation, tab);
+    }
+
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
+    public static void dumpInfo(Task<?> t) {
+        Dumper.dumpInfo(t);
+    }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Enricher enr) {
-        try {
-            dumpInfo(enr, new PrintWriter(System.out), "", "  ");
-        } catch (IOException exc) {
-            // system.out throwing an exception is odd, so don't have IOException on signature
-            throw new RuntimeException(exc);
-        }
+        Dumper.dumpInfo(enr);
     }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Enricher enr, Writer out) throws IOException {
-        dumpInfo(enr, out, "", "  ");
+        Dumper.dumpInfo(enr, out);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Enricher enr, String currentIndentation, String tab) throws IOException {
-        dumpInfo(enr, new PrintWriter(System.out), currentIndentation, tab);
+        Dumper.dumpInfo(enr, currentIndentation, tab);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Enricher enr, Writer out, String currentIndentation, String tab) throws IOException {
-        out.append(currentIndentation+enr.toString()+"\n");
-
-        for (ConfigKey<?> key : sortConfigKeys(enr.getEnricherType().getConfigKeys())) {
-            Maybe<Object> val = ((BrooklynObjectInternal)enr).config().getRaw(key);
-            if (!isTrivial(val)) {
-                out.append(currentIndentation+tab+tab+key);
-                out.append(" = ");
-                if (isSecret(key.getName())) out.append("xxxxxxxx");
-                else out.append(""+val.get());
-                out.append("\n");
-            }
-        }
-
-        out.flush();
+        Dumper.dumpInfo(enr, out, currentIndentation, tab);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Feed feed, String currentIndentation, String tab) throws IOException {
-        dumpInfo(feed, new PrintWriter(System.out), currentIndentation, tab);
+        Dumper.dumpInfo(feed, currentIndentation, tab);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Feed feed, Writer out, String currentIndentation, String tab) throws IOException {
-        out.append(currentIndentation+feed.toString()+"\n");
-
-        // TODO create a FeedType cf EnricherType ?
-        for (ConfigKey<?> key : sortConfigKeys(((BrooklynObjectInternal)feed).config().getBag().getAllConfigAsConfigKeyMap().keySet())) {
-            Maybe<Object> val = ((BrooklynObjectInternal)feed).config().getRaw(key);
-            if (!isTrivial(val)) {
-                out.append(currentIndentation+tab+tab+key);
-                out.append(" = ");
-                if (isSecret(key.getName())) out.append("xxxxxxxx");
-                else out.append(""+val.get());
-                out.append("\n");
-            }
-        }
-
-        out.flush();
+        Dumper.dumpInfo(feed, out, currentIndentation, tab);
     }
 
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Policy pol) {
-        try {
-            dumpInfo(pol, new PrintWriter(System.out), "", "  ");
-        } catch (IOException exc) {
-            // system.out throwing an exception is odd, so don't have IOException on signature
-            throw new RuntimeException(exc);
-        }
+        Dumper.dumpInfo(pol);
     }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Policy pol, Writer out) throws IOException {
-        dumpInfo(pol, out, "", "  ");
+        Dumper.dumpInfo(pol, out);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Policy pol, String currentIndentation, String tab) throws IOException {
-        dumpInfo(pol, new PrintWriter(System.out), currentIndentation, tab);
+        Dumper.dumpInfo(pol, currentIndentation, tab);
     }
+    
+    /**
+     * @deprecated since 1.0.0; such fine-grained customization will be removed from API, instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Policy pol, Writer out, String currentIndentation, String tab) throws IOException {
-        out.append(currentIndentation+pol.toString()+"\n");
-
-        for (ConfigKey<?> key : sortConfigKeys(pol.getPolicyType().getConfigKeys())) {
-            Maybe<Object> val = ((BrooklynObjectInternal)pol).config().getRaw(key);
-            if (!isTrivial(val)) {
-                out.append(currentIndentation+tab+tab+key);
-                out.append(" = ");
-                if (isSecret(key.getName())) out.append("xxxxxxxx");
-                else out.append(""+val.get());
-                out.append("\n");
-            }
-        }
-
-        out.flush();
+        Dumper.dumpInfo(pol, out, currentIndentation, tab);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    /**
+     * Sorts the sensors into alphabetical order by name.
+     * @deprecated since 1.0.0; viewed as unnecessary in the API, will be removed
+     */
+    @Deprecated
     public static List<Sensor<?>> sortSensors(Set<Sensor<?>> sensors) {
-        List result = new ArrayList(sensors);
-        Collections.sort(result, new Comparator<Sensor>() {
-                    @Override
-                    public int compare(Sensor arg0, Sensor arg1) {
-                        return arg0.getName().compareTo(arg1.getName());
-                    }
-
-        });
-        return result;
+        return Dumper.sortSensors(sensors);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    /**
+     * Sorts the sensors into alphabetical order by name.
+     * @deprecated since 1.0.0; viewed as unnecessary in the API, will be removed
+     */
+    @Deprecated
     public static List<ConfigKey<?>> sortConfigKeys(Set<ConfigKey<?>> configs) {
-        List result = new ArrayList(configs);
-        Collections.sort(result, new Comparator<ConfigKey>() {
-                    @Override
-                    public int compare(ConfigKey arg0, ConfigKey arg1) {
-                        return arg0.getName().compareTo(arg1.getName());
-                    }
-
-        });
-        return result;
+        return Dumper.sortConfigKeys(configs);
     }
 
+    /**
+     * Sorts the sensors into alphabetical order by name.
+     * @deprecated since 1.0.0; viewed as unnecessary in the API, will be removed
+     */
+    @Deprecated
     public static <T> Map<String, T> sortMap(Map<String, T> map) {
-        Map<String,T> result = Maps.newLinkedHashMap();
-        List<String> order = Lists.newArrayList(map.keySet());
-        Collections.sort(order, String.CASE_INSENSITIVE_ORDER);
-
-        for (String key : order) {
-            result.put(key, map.get(key));
-        }
-        return result;
+        return Dumper.sortMap(map);
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.api.mgmt.TaskQueueingContext;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.ReferenceWithError;
@@ -502,20 +503,34 @@ public class Tasks {
     }
 
 
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Task<?> t) {
-        try {
-            dumpInfo(t, new PrintWriter(System.out), "", "  ");
-        } catch (IOException exc) {
-            // system.out throwing an exception is odd, so don't have IOException on signature
-            throw new RuntimeException(exc);
-        }
+        Dumper.dumpInfo(t);
     }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Task<?> t, Writer out) throws IOException {
-        dumpInfo(t, out, "", "  ");
+        Dumper.dumpInfo(t, out);
     }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Task<?> t, String currentIndentation, String tab) throws IOException {
         dumpInfo(t, new PrintWriter(System.out), currentIndentation, tab);
     }
+    
+    /**
+     * @deprecated since 1.0.0; instead use {@link Dumper} methods
+     */
+    @Deprecated
     public static void dumpInfo(Task<?> t, Writer out, String currentIndentation, String tab) throws IOException {
         out.append(currentIndentation+t+": "+t.getStatusDetail(false)+"\n");
 

--- a/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLifecycleStateTest.java
@@ -41,9 +41,7 @@ import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
-import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
 import org.apache.brooklyn.core.entity.trait.FailingEntity;
-import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
@@ -52,13 +50,11 @@ import org.apache.brooklyn.core.test.entity.TestApplicationNoEnrichersImpl;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityNoEnrichersImpl;
 import org.apache.brooklyn.enricher.stock.AbstractMultipleSensorAggregator;
-import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.QuorumCheck;
 import org.apache.brooklyn.util.core.task.ValueResolver;
-import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -419,7 +415,7 @@ public class ApplicationLifecycleStateTest extends BrooklynMgmtUnitTestSupport {
             EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
             EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
         } catch (Throwable t) {
-            Entities.dumpInfo(entity);
+            Dumper.dumpInfo(entity);
             String err = "(Dumped entity info - see log); entity=" + entity + "; " + 
                     "state=" + entity.sensors().get(Attributes.SERVICE_STATE_ACTUAL) + "; " + 
                     "up="+entity.sensors().get(Attributes.SERVICE_UP) + "; " +

--- a/core/src/test/java/org/apache/brooklyn/core/entity/DependentConfigurationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/DependentConfigurationTest.java
@@ -337,7 +337,7 @@ public class DependentConfigurationTest extends BrooklynAppUnitTestSupport {
                 return;
             
             log.warn("Did not abort as expected: "+e, e);
-            Entities.dumpInfo(entity);
+            Dumper.dumpInfo(entity);
             
             throw Exceptions.propagate(e);
         }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogicTest.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityAsserts;
@@ -338,7 +339,7 @@ public class ServiceStateLogicTest extends BrooklynAppUnitTestSupport {
             EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", Duration.seconds(3)), x, sensor, value);
         } catch (Throwable e) {
             log.warn("Expected "+x+" eventually to have "+sensor+" = "+value+"; instead:");
-            Entities.dumpInfo(x);
+            Dumper.dumpInfo(x);
             throw Exceptions.propagate(e);
         }
     }
@@ -347,7 +348,7 @@ public class ServiceStateLogicTest extends BrooklynAppUnitTestSupport {
             EntityAsserts.assertAttributeEqualsContinually(ImmutableMap.of("timeout", Duration.millis(25)), x, sensor, value);
         } catch (Throwable e) {
             log.warn("Expected "+x+" continually to have "+sensor+" = "+value+"; instead:");
-            Entities.dumpInfo(x);
+            Dumper.dumpInfo(x);
             throw Exceptions.propagate(e);
         }
     }
@@ -356,7 +357,7 @@ public class ServiceStateLogicTest extends BrooklynAppUnitTestSupport {
             EntityAsserts.assertAttributeEquals(x, sensor, value);
         } catch (Throwable e) {
             log.warn("Expected "+x+" to have "+sensor+" = "+value+"; instead:");
-            Entities.dumpInfo(x);
+            Dumper.dumpInfo(x);
             throw Exceptions.propagate(e);
         }
     }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEnricherTest.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
@@ -308,14 +309,14 @@ public class RebindEnricherTest extends RebindTestFixtureWithApp {
         TestEntity e1 = origApp.createAndManageChild(EntitySpec.create(TestEntity.class, MyTestEntityWithEnricher.class));
         Collection<Enricher> e1e = e1.enrichers().asList();
         log.info("enrichers1: "+e1e);
-        Entities.dumpInfo(e1);
+        Dumper.dumpInfo(e1);
         assertEquals(e1e.size(), 5);
 
         newApp = rebind();
         Entity e2 = Iterables.getOnlyElement( Entities.descendantsAndSelf(newApp, EntityPredicates.idEqualTo(e1.getId())) );
         Collection<Enricher> e2e = e2.enrichers().asList();
         log.info("enrichers2: "+e2e);
-        Entities.dumpInfo(e2);
+        Dumper.dumpInfo(e2);
         
         assertEquals(e2e.size(), e1e.size()+1);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformerTest.java
@@ -23,14 +23,16 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
-import com.google.common.collect.Iterables;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
 
 /** Tests the sample {@link XmlPlanToSpecTransformer}
  * which illustrates how the {@link PlanToSpecTransformer} can be used. */
@@ -57,7 +59,7 @@ public class XmlPlanToSpecTransformerTest {
         EntitySpec<? extends Application> appSpec = EntityManagementUtils.createEntitySpecForApplication(mgmt, 
             "<root><a_kid foo=\"bar\"/></root>");
         Application app = EntityManagementUtils.createStarting(mgmt, appSpec).get();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Assert.assertEquals(app.getDisplayName(), "root");
         Entity child = Iterables.getOnlyElement(app.getChildren());
         Assert.assertEquals(child.getDisplayName(), "a_kid");

--- a/core/src/test/java/org/apache/brooklyn/core/typereg/ExampleXmlTypePlanTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/typereg/ExampleXmlTypePlanTransformerTest.java
@@ -23,8 +23,10 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
+import org.apache.brooklyn.core.plan.PlanToSpecTransformer;
 import org.apache.brooklyn.core.plan.XmlPlanToSpecTransformer;
 import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
 import org.testng.Assert;
@@ -57,7 +59,7 @@ public class ExampleXmlTypePlanTransformerTest {
         EntitySpec<? extends Application> appSpec = EntityManagementUtils.createEntitySpecForApplication(mgmt, 
             "<root><a_kid foo=\"bar\"/></root>");
         Application app = EntityManagementUtils.createStarting(mgmt, appSpec).get();
-        Entities.dumpInfo(app);
+        Dumper.dumpInfo(app);
         Assert.assertEquals(app.getDisplayName(), "root");
         Entity child = Iterables.getOnlyElement(app.getChildren());
         Assert.assertEquals(child.getDisplayName(), "a_kid");

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -1127,7 +1127,7 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
         
         // and after re-size
         cluster.resize(4);
-//        Entities.dumpInfo(cluster);
+//        Dumper.dumpInfo(cluster);
         assertFirstAndNonFirstCounts(cluster.getMembers(), 1, 3);
         
         // and re-size to 1

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -44,7 +44,7 @@ import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatformLauncherNoServer;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.catalog.internal.CatalogInitialization;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
@@ -90,7 +90,7 @@ import com.google.common.collect.Maps;
  *     .location("localhost")
  *     .start();
  * 
- * Entities.dumpInfo(launcher.getApplications());
+ * Dumper.dumpInfo(launcher.getApplications());
  * </pre>
  */
 public class BasicLauncher<T extends BasicLauncher<T>> {
@@ -714,7 +714,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
                 try {
                     LOG.info("Starting brooklyn application {} in location{} {}", new Object[] { app, locations.size()!=1?"s":"", locations });
                     ((Startable)app).start(locations);
-                    Entities.dumpInfo(app);
+                    Dumper.dumpInfo(app);
                     String sensors = "";
                     if (app.getAttribute(Attributes.MAIN_URI_MAPPED_PUBLIC)!=null) {
                         sensors = ": "+app.getAttribute(Attributes.MAIN_URI_MAPPED_PUBLIC);

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ActivityRestTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ActivityRestTest.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.effector.SampleManyTasksEffector;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils.CreationResult;
@@ -43,7 +44,6 @@ import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.time.CountdownTimer;
@@ -133,7 +133,7 @@ Task[eatand]@J90TKfIX: Waiting on Task[eat-sleep-rave-repeat]@QPa5o4kF
             }
             i++;
         } while (true);
-        Tasks.dumpInfo(me.lastTask);
+        Dumper.dumpInfo(me.lastTask);
         log.info("Seed "+i+" is good ^");
     }
     

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestWinrmCommandTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestWinrmCommandTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
@@ -231,7 +231,7 @@ public class TestWinrmCommandTest extends BrooklynAppUnitTestSupport {
             app.start(ImmutableList.<Location>of());
             Asserts.shouldHaveFailedPreviously();
         } catch (Exception e) {
-            Entities.dumpInfo(app);
+            Dumper.dumpInfo(app);
             Asserts.expectedFailureContains(e, "exit code expected equals 1 but found 0", "exit code expected equals 255 but found 0");
         }
 


### PR DESCRIPTION
Move all `Entities.dumpInfo` to `Dumper`, deprecating the methods in `Entities`.

Previously, `Entities` was too much of a dumping ground for lots of methods related to entities, and has become huge! We've previously moved some stuff from it, such as `sanitize` to `Sanitizer`. This PR continues that trend.