### PR TITLE
allow types from different bundles if equivalent

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
@@ -151,8 +151,8 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest implement
     }
 
     @Test
-    /** TODO this test works if we assume most recent version wins, but semantics TBC */
-    public void testMoreEntityV2ThenV1GivesV1() throws Exception {
+    /** Now assumes highest version wins regardless of install order */
+    public void testMoreEntityV1AndV2GivesV2() throws Exception {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-more-entities_0.1.0.jar");
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-more-entities_0.2.0.jar");
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-entities.jar");
@@ -163,8 +163,8 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest implement
         Entity app = createAndStartApplication("services: [ { type: 'more-entity:1.0' } ]");
         Entity moreEntity = Iterables.getOnlyElement(app.getChildren());
         
-        OsgiVersionMoreEntityTest.assertV1EffectorCall(moreEntity);
-        OsgiVersionMoreEntityTest.assertV1MethodCall(moreEntity);
+        OsgiVersionMoreEntityTest.assertV2EffectorCall(moreEntity);
+        OsgiVersionMoreEntityTest.assertV2MethodCall(moreEntity);
     }
 
     /** unlike {@link #testMoreEntityV2ThenV1GivesV1()} this test should always work,

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -950,8 +950,13 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             }
             
             if (version==null) {
-                // use this as default version when nothing specified
-                version = BasicBrooklynCatalog.NO_VERSION;
+                if (containingBundle!=null) {
+                    version = containingBundle.getVersionedName().getVersionString();
+                }
+                if (version==null) {
+                    // use this as default version when nothing specified or inferrable from containing bundle
+                    version = BasicBrooklynCatalog.NO_VERSION;
+                }
             }
             
             if (sourcePlanYaml==null) {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -1440,7 +1440,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)mgmt).getOsgiManager();
         if (osgiManager.isPresent() && AUTO_WRAP_CATALOG_YAML_AS_BUNDLE) {
             // wrap in a bundle to be managed; need to get bundle and version from yaml
-            OsgiBundleInstallationResult result = addItemsOsgi(yaml, forceUpdate, osgiManager);
+            OsgiBundleInstallationResult result = addItemsOsgi(yaml, forceUpdate, osgiManager.get());
             return toLegacyCatalogItems(result.getTypesInstalled());
 
             // if all items pertaining to an older anonymous catalog.bom bundle have been overridden
@@ -1457,7 +1457,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)mgmt).getOsgiManager();
         if (osgiManager.isPresent() && AUTO_WRAP_CATALOG_YAML_AS_BUNDLE) {
             // wrap in a bundle to be managed; need to get bundle and version from yaml
-            return addItemsOsgi(yaml, forceUpdate, osgiManager);
+            return addItemsOsgi(yaml, forceUpdate, osgiManager.get());
 
             // if all items pertaining to an older anonymous catalog.bom bundle have been overridden
             // we delete those later; see list of wrapper bundles kept in OsgiManager
@@ -1472,7 +1472,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return result;
     }
 
-    protected OsgiBundleInstallationResult addItemsOsgi(String yaml, boolean forceUpdate, Maybe<OsgiManager> osgiManager) {
+    protected OsgiBundleInstallationResult addItemsOsgi(String yaml, boolean forceUpdate, OsgiManager osgiManager) {
         Map<?, ?> cm = BasicBrooklynCatalog.getCatalogMetadata(yaml);
 
         if(cm == null) {
@@ -1503,7 +1503,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
         OsgiBundleInstallationResult result = null;
         try {
-            result = osgiManager.get().install(new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(), null), new FileInputStream(bf), true, true, forceUpdate).get();
+            result = osgiManager.install(new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(), null), new FileInputStream(bf), true, true, forceUpdate).get();
         } catch (FileNotFoundException e) {
             throw Exceptions.propagate(e);
         } finally {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -62,6 +62,7 @@ import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.CampYamlParser;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
+import org.apache.brooklyn.core.typereg.BasicManagedBundle;
 import org.apache.brooklyn.core.typereg.BasicRegisteredType;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
 import org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer;
@@ -1502,7 +1503,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
         OsgiBundleInstallationResult result = null;
         try {
-            result = osgiManager.get().install(null, new FileInputStream(bf), true, true, forceUpdate).get();
+            result = osgiManager.get().install(new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(), null), new FileInputStream(bf), true, true, forceUpdate).get();
         } catch (FileNotFoundException e) {
             throw Exceptions.propagate(e);
         } finally {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -1041,7 +1041,12 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             // (originally seen during a race where the empty-remover ran while we were installing)
             throw new IllegalStateException("Loading from a bundle which is not installed");
         }
-        String wrapped = bb.get().getHeaders().get(BROOKLYN_WRAPPED_BOM_BUNDLE);
+        return isWrapperBundle(bb.get());
+    }
+    
+    @Beta
+    public static boolean isWrapperBundle(Bundle b) {
+        String wrapped = b.getHeaders().get(BROOKLYN_WRAPPED_BOM_BUNDLE);
         return wrapped!=null && wrapped.equalsIgnoreCase("true");
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiArchiveInstaller.java
@@ -377,6 +377,7 @@ class OsgiArchiveInstaller {
                     }
                 }
                 if (canUpdate()) { 
+                    
                     result.bundle = osgiManager.framework.getBundleContext().getBundle(result.getMetadata().getOsgiUniqueUrl());
                     if (result.getBundle()==null) {
                         log.warn("Brooklyn thought is was already managing bundle "+result.getMetadata().getVersionedName()+" but it's not installed to framework; reinstalling it");

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -20,8 +20,10 @@ package org.apache.brooklyn.core.typereg;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -37,8 +39,6 @@ import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import org.apache.brooklyn.core.catalog.internal.CatalogItemBuilder;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
-import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
-import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -62,7 +62,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
     private static final Logger log = LoggerFactory.getLogger(BasicBrooklynTypeRegistry.class);
     
     private ManagementContext mgmt;
-    private Map<String,RegisteredType> localRegisteredTypes = MutableMap.of();
+    private Map<String,Map<String,RegisteredType>> localRegisteredTypesAndContainingBundles = MutableMap.of();
 
     public BasicBrooklynTypeRegistry(ManagementContext mgmt) {
         this.mgmt = mgmt;
@@ -76,12 +76,14 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
     private Iterable<RegisteredType> getAllWithoutCatalog(Predicate<? super RegisteredType> filter) {
         // TODO thread safety
         // TODO optimisation? make indexes and look up?
-        return Iterables.filter(localRegisteredTypes.values(), filter);
+        return localRegisteredTypesAndContainingBundles.values().stream().
+            flatMap(m -> m.values().stream()).filter(filter::apply).collect(Collectors.toList());
     }
 
     private Maybe<RegisteredType> getExactWithoutLegacyCatalog(String symbolicName, String version, RegisteredTypeLoadingContext constraint) {
         // TODO look in any nested/private registries
-        RegisteredType item = localRegisteredTypes.get(symbolicName+":"+version);
+        Map<String, RegisteredType> m = localRegisteredTypesAndContainingBundles.get(symbolicName+":"+version);
+        RegisteredType item = m!=null && !m.isEmpty() ? m.values().iterator().next() : null; 
         return RegisteredTypes.tryValidate(item, constraint);
     }
 
@@ -368,12 +370,51 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         if (!type.getId().equals(type.getSymbolicName()+":"+type.getVersion()))
             Asserts.fail("Registered type "+type+" has ID / symname mismatch");
         
-        RegisteredType oldType = mgmt.getTypeRegistry().get(type.getId());
-        if (oldType==null || canForce || BrooklynVersionSyntax.isSnapshot(oldType.getVersion())) {
-            log.debug("Inserting "+type+" into "+this);
-            localRegisteredTypes.put(type.getId(), type);
-        } else {
-            assertSameEnoughToAllowReplacing(oldType, type);
+        Map<String, RegisteredType> knownMatchingTypesByBundles = localRegisteredTypesAndContainingBundles.get(type.getId());
+        if (knownMatchingTypesByBundles!=null && !knownMatchingTypesByBundles.isEmpty()) {
+            for (RegisteredType existingT: knownMatchingTypesByBundles.values()) {
+                String reasonForDetailedCheck = null;
+                if (Objects.equals(existingT.getContainingBundle(), type.getContainingBundle())) {
+                    // they are in the same bundle; is force replacement allowed?
+                    if (canForce) {
+                        log.debug("Addition of "+type+" to replace "+existingT+" allowed because force is on");
+                        continue;
+                    }
+                    if (BrooklynVersionSyntax.isSnapshot(type.getVersion())) {
+                        if (existingT.getContainingBundle()!=null) {
+                            if (BrooklynVersionSyntax.isSnapshot(VersionedName.fromString(existingT.getContainingBundle()).getVersionString())) {
+                                log.debug("Addition of "+type+" to replace "+existingT+" allowed because both are snapshot");
+                                continue;
+                            } else {
+                                reasonForDetailedCheck = "the containing bundle "+existingT.getContainingBundle()+" is not a SNAPSHOT and addition is not forced";
+                            }
+                        } else {
+                            // can this occur?
+                            reasonForDetailedCheck = "the containing bundle of the type is unknown (cannot confirm it is snapshot)";
+                        }
+                    } else {
+                        reasonForDetailedCheck = "the type is not a SNAPSHOT and addition is not forced";
+                    }
+                } else {
+                    reasonForDetailedCheck = type.getId()+" is defined in different bundle";
+                }
+                assertSameEnoughToAllowReplacing(existingT, type, reasonForDetailedCheck);
+            }
+        }
+        
+        log.debug("Inserting "+type+" into "+this);
+        Map<String, RegisteredType> m = localRegisteredTypesAndContainingBundles.get(type.getId());
+        if (m==null) {
+            synchronized (localRegisteredTypesAndContainingBundles) {
+                m = localRegisteredTypesAndContainingBundles.get(type.getId());
+                if (m==null) {
+                    m = MutableMap.of();
+                    localRegisteredTypesAndContainingBundles.put(type.getId(), m);
+                }
+            }
+        }
+        synchronized (m) {
+            m.put(type.getContainingBundle(), type);
         }
     }
 
@@ -384,7 +425,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
      * This is needed when replacing an unresolved item with a resolved one or vice versa;
      * the {@link RegisteredType#equals(Object)} check is too strict.
      */
-    private boolean assertSameEnoughToAllowReplacing(RegisteredType oldType, RegisteredType type) {
+    private boolean assertSameEnoughToAllowReplacing(RegisteredType oldType, RegisteredType type, String reasonForDetailedCheck) {
        /* The bundle checksum check prevents swapping a different bundle at the same name+version.
         * For SNAPSHOT and forced-updates, this method doesn't apply, so we can assume here that
         * either the bundle checksums are the same,
@@ -416,13 +457,13 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         
         if (!oldType.getVersionedName().equals(type.getVersionedName())) {
             // different name - shouldn't even come here
-            throw new IllegalStateException("Cannot add "+type+" to catalog; different "+oldType+" is already present");
+            throw new IllegalStateException("Cannot add "+type+" to catalog; different "+oldType+" is already present ("+reasonForDetailedCheck+")");
         }
         if (Objects.equals(oldType.getContainingBundle(), type.getContainingBundle())) {
             // if named bundles equal then contents must be the same (due to bundle checksum); bail out early
             if (!samePlan(oldType, type)) {
                 String msg = "Cannot add "+type+" to catalog; different plan in "+oldType+" from same bundle "+
-                    type.getContainingBundle()+" is already present";
+                    type.getContainingBundle()+" is already present and "+reasonForDetailedCheck;
                 log.debug(msg+"\n"+
                     "Plan being added is:\n"+type.getPlan()+"\n"+
                     "Plan already present is:\n"+oldType.getPlan() );
@@ -430,7 +471,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
             }
             if (oldType.getKind()!=RegisteredTypeKind.UNRESOLVED && type.getKind()!=RegisteredTypeKind.UNRESOLVED &&
                     !Objects.equals(oldType.getKind(), type.getKind())) {
-                throw new IllegalStateException("Cannot add "+type+" to catalog; different kind in "+oldType+" from same bundle is already present");
+                throw new IllegalStateException("Cannot add "+type+" to catalog; different kind in "+oldType+" from same bundle is already present and "+reasonForDetailedCheck);
             }
             return true;
         }
@@ -438,8 +479,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         // different bundles, either anonymous or same item in two named bundles
         if (!samePlan(oldType, type)) {
             // if plan is different, fail
-            String msg = "Cannot add "+type+" in "+type.getContainingBundle()+" to catalog; different plan in "+oldType+" from bundle "+
-                oldType.getContainingBundle()+" is already present (throwing)";
+            String msg = "Cannot add "+type+" to catalog; it is different to "+oldType+", and "+reasonForDetailedCheck+" (throwing)";
             log.debug(msg+"\n"+
                 "Plan being added from "+type.getContainingBundle()+" is:\n"+type.getPlan()+"\n"+
                 "Plan already present from "+oldType.getContainingBundle()+" is:\n"+oldType.getPlan() );
@@ -448,45 +488,31 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         if (oldType.getKind()!=RegisteredTypeKind.UNRESOLVED && type.getKind()!=RegisteredTypeKind.UNRESOLVED &&
                 !Objects.equals(oldType.getKind(), type.getKind())) {
             // if kind is different and both resolved, fail
-            throw new IllegalStateException("Cannot add "+type+" in "+type.getContainingBundle()+" to catalog; different kind in "+oldType+" from bundle "+
-                oldType.getContainingBundle()+" is already present");
+            throw new IllegalStateException("Cannot add "+type+" to catalog; it is a different kind to "+oldType+", and "
+                + reasonForDetailedCheck);
         }
 
-        // now if old is a wrapper bundle (or old, no bundle), allow it -- metadata may be different here
-        // but we'll allow that, probably the user is updating their catalog to the new format.
-        // icons might change, maybe a few other things (but any such errors can be worked around),
-        // and more useful to be able to upload the same BOM or replace an anonymous BOM with a named bundle.
-        // crucially if old is a wrapper bundle the containing bundle won't actually be needed for anything,
-        // so this is safe in terms of search paths etc.
-        if (oldType.getContainingBundle()==null) {
-            // if old type wasn't from a bundle, let it be replaced by a bundle
-            return true;
-        }
-        // bundle is changing; was old bundle a wrapper?
-        OsgiManager osgi = ((ManagementContextInternal)mgmt).getOsgiManager().orNull();
-        if (osgi==null) {
-            // shouldn't happen, as we got a containing bundle, but just in case
-            return true;
-        }
-        if (BasicBrooklynCatalog.isNoBundleOrSimpleWrappingBundle(mgmt, 
-                osgi.getManagedBundle(VersionedName.fromString(oldType.getContainingBundle())))) {
-            // old was a wrapper bundle; allow it 
-            return true;
-        }
-        
-        throw new IllegalStateException("Cannot add "+type+" in "+type.getContainingBundle()+" to catalog; "
-            + "item  is already present in different bundle "+oldType.getContainingBundle());
+        // it is the same plan as a type in another bundle;
+        // previously we allowed only when the other bundle was a wrapper or no bundle
+        // (or it was forced - which was guaranteed to cause problems on rebind!);
+        // but now we always allow it, and we track which bundles things come from
+        return true;
     }
 
     private boolean samePlan(RegisteredType oldType, RegisteredType type) {
         return RegisteredTypes.arePlansEquivalent(oldType, type);
     }
 
+    /** removes registered type with the given ID from the local in-memory catalog
+     * (ignores bundle, deletes from all bundles if present in multiple; 
+     * falls back to removing from legacy catalog if not known here in any bundles)
+     * @throws NoSuchElementException if not found */
     @Beta // API stabilising
     public void delete(VersionedName type) {
-        RegisteredType registeredTypeRemoved = localRegisteredTypes.remove(type.toString());
-        if (registeredTypeRemoved != null) {
-            return ;
+        synchronized (localRegisteredTypesAndContainingBundles) {
+            if (localRegisteredTypesAndContainingBundles.remove(type.toString()) != null) {
+                return;
+            }
         }
         
         // legacy deletion (may call back to us, but max once)
@@ -498,10 +524,34 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
 //        throw new NoSuchElementException("No catalog item found with id "+type);
     }
     
+    /** removes the given registered type in the noted bundle; 
+     * if not known in that bundle tries deleting from legacy catalog.
+     * @throws NoSuchElementException if not found */
     public void delete(RegisteredType type) {
-        delete(type.getVersionedName());
+        Map<String, RegisteredType> m = localRegisteredTypesAndContainingBundles.get(type.getId());
+        if (m!=null) {
+            RegisteredType removedItem = m.remove(type.getContainingBundle());
+            if (m.isEmpty()) {
+                synchronized (localRegisteredTypesAndContainingBundles) {
+                    m = localRegisteredTypesAndContainingBundles.get(type.getId());
+                    if (m!=null && m.isEmpty()) {
+                        localRegisteredTypesAndContainingBundles.remove(type.getId());
+                    } else {
+                        // either removed in parallel or no longer empty
+                    }
+                }
+                if (removedItem==null) {
+                    throw new NoSuchElementException("Requested to delete "+type+" from "+type.getContainingBundle()+", "
+                        + "but that type was not known in that bundle, it is in "+m.keySet()+" instead");
+                }
+            }
+        } else {
+            // try legacy delete
+            delete(type.getVersionedName());
+        }
     }
     
+    /** as {@link #delete(VersionedName)} */
     @Beta // API stabilising
     public void delete(String id) {
         delete(VersionedName.fromString(id));

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -115,14 +115,17 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
     @SuppressWarnings("deprecation")
     @Override
     public Iterable<RegisteredType> getMatching(Predicate<? super RegisteredType> filter) {
-        Map<String,RegisteredType> result = MutableMap.of();
+        Set<RegisteredType> result = MutableSet.of();
+        // keep name record also so we can remove legacy items that are superseded
+        Set<String> typeNamesFound = MutableSet.of();
         for (RegisteredType rt: getAllWithoutCatalog(filter)) {
-            result.put(rt.getId(), rt);
+            result.add(rt);
+            typeNamesFound.add(rt.getId());
         }
         for (RegisteredType rt: Iterables.filter(
                 Iterables.transform(mgmt.getCatalog().getCatalogItemsLegacy(), RegisteredTypes.CI_TO_RT), 
                 filter)) {
-            if (!result.containsKey(rt.getId())) {
+            if (!typeNamesFound.contains(rt.getId())) {
                 // TODO ideally never come here, however
                 // legacy cataog currently still used for java-scanned annotations; 
                 // hopefully that will be deprecated and removed in near future
@@ -131,10 +134,11 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 // make TypeRegistry instances instead of CatalogItem, esp if we had YOML to write that plan)
                 
                 //log.warn("Item '"+rt.getId()+"' not in type registry; only found in legacy catalog");
-                result.put(rt.getId(), rt);
+                typeNamesFound.add(rt.getId());
+                result.add(rt);
             }
         }
-        return result.values();
+        return result;
     }
 
     @SuppressWarnings("deprecation")

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -404,11 +404,12 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 }
 
                 Set<String> oldContainingBundlesToRemove = MutableSet.of();
+                boolean newIsWrapperBundle = isWrapperBundle(type.getContainingBundle());
                 for (RegisteredType existingT: knownMatchingTypesByBundles.values()) {
                     String reasonForDetailedCheck = null;
                     boolean sameBundle = Objects.equals(existingT.getContainingBundle(), type.getContainingBundle());
                     boolean oldIsWrapperBundle = isWrapperBundle(existingT.getContainingBundle());
-                    if (sameBundle || oldIsWrapperBundle) {
+                    if (sameBundle || (oldIsWrapperBundle && newIsWrapperBundle)) {
                         // allow replacement (different plan for same type) if either
                         // it's the same bundle or the old one was a wrapper, AND
                         // either we're forced or in snapshot-land
@@ -435,6 +436,10 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                         } else {
                             reasonForDetailedCheck = "the type is not a SNAPSHOT and addition is not forced";
                         }
+                    } else if (oldIsWrapperBundle) {
+                        reasonForDetailedCheck = type.getId()+" is in a named bundle replacing an item from an anonymous bundle-wrapped BOM, so definitions must be the same (or else give it a different version)";
+                    } else if (newIsWrapperBundle) {
+                        reasonForDetailedCheck = type.getId()+" is in an anonymous bundle-wrapped BOM replacing an item from a named bundle, so definitions must be the same (or else give it a different version)";
                     } else {
                         reasonForDetailedCheck = type.getId()+" is defined in different bundle";
                     }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicRegisteredType.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicRegisteredType.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.osgi.VersionedName;
+import org.apache.brooklyn.util.text.Strings;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
@@ -155,9 +156,10 @@ public class BasicRegisteredType implements RegisteredType {
     @Override
     public String toString() {
         return JavaClassNames.simpleClassName(this)+"["+getId()+
+            (Strings.isNonBlank(getContainingBundle()) ? ";"+getContainingBundle() : "")+
             (isDisabled() ? ";DISABLED" : "")+
             (isDeprecated() ? ";deprecated" : "")+
-            (getPlan()!=null ? ";"+getPlan().getPlanFormat() : "")+
+            (getPlan()!=null && getPlan().getPlanFormat()!=null ? ";"+getPlan().getPlanFormat() : "")+
             "]";
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/osgi/VersionedName.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/osgi/VersionedName.java
@@ -182,11 +182,14 @@ public class VersionedName implements Comparable<VersionedName> {
         return VersionedNameComparator.INSTANCE.compare(this, other);
     }
 
+    /** Comparator which puts a:3 < a:1 < b:2 < null */
     public static class VersionedNameComparator implements Comparator<VersionedName> {
         public static final VersionedNameComparator INSTANCE = new VersionedNameComparator();
         
         @Override
         public int compare(VersionedName o1, VersionedName o2) {
+            if (o1==null) { return o2==null ? 0 : 1; }
+            if (o2==null) { return -1; }
             return ComparisonChain.start()
                 .compare(o1.getSymbolicName(), o2.getSymbolicName(), NaturalOrderComparator.INSTANCE)
                 .compare(o2.getOsgiVersionString(), o1.getOsgiVersionString(), VersionComparator.INSTANCE)
@@ -194,4 +197,17 @@ public class VersionedName implements Comparable<VersionedName> {
                 .result();
         }
     }
+    
+    // RegisteredTypeNameThenWorstFirstComparator
+    
+    /** Comparator which puts a:3 < a:1 < b:2 < null */
+    public static class VersionedNameStringComparator implements Comparator<String> {
+        public static final VersionedNameStringComparator INSTANCE = new VersionedNameStringComparator();
+        
+        @Override
+        public int compare(String s1, String s2) {
+            return VersionedNameComparator.INSTANCE.compare(parseMaybe(s1, false).orNull(), parseMaybe(s2, false).orNull());
+        }
+    }
+
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/osgi/VersionedNameTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/osgi/VersionedNameTest.java
@@ -18,8 +18,12 @@ package org.apache.brooklyn.util.osgi;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
+import java.util.Comparator;
+
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible;
+import org.apache.brooklyn.util.osgi.VersionedName.VersionedNameComparator;
+import org.apache.brooklyn.util.osgi.VersionedName.VersionedNameStringComparator;
 import org.osgi.framework.Version;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -58,6 +62,30 @@ public class VersionedNameTest {
         assertEquals(VersionedName.fromString("a.b:0.0.0_SNAPSHOT"), new VersionedName("a.b", "0.0.0_SNAPSHOT"));
         assertFalse(VersionedName.parseMaybe("a.b:0.1.2:3.4.5", false).isPresent());
         assertFalse(VersionedName.parseMaybe("", false).isPresent());
+    }
+
+    @Test
+    public void testOrder() {
+        assertOrder(VersionedNameComparator.INSTANCE,
+            VersionedName.fromString("a:3"), VersionedName.fromString("a:1"), 
+            VersionedName.fromString("a:0"), VersionedName.fromString("a:1-SNAPSHOT"), VersionedName.fromString("a"), 
+            VersionedName.fromString("b:2"), null);
+    }
+    
+    @Test
+    public void testStringOrder() {
+        assertOrder(VersionedNameStringComparator.INSTANCE,
+            "a:3", "a:1", "a:0", "a:1-SNAPSHOT", "a", 
+            "b:2", null);
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static <T> void assertOrder(Comparator<T> comparator, T ...items) {
+        for (int i=0; i<items.length; i++) {
+            for (int j=0; j<items.length; j++) {
+                Assert.assertEquals(comparator.compare(items[i], items[j]), Integer.compare(i, j));
+            }
+        }
     }
     
 }


### PR DESCRIPTION
previously this was only allowed if older bundle was a wrapper, or if it was forced;
this could cause problems if such a disallowed addition was forced and then you tried to rebind!

now it stores the bundle from which a registered type comes, so we can sensibly have several types.
we could even allow them to be different - which would of course cause chaos for users,
but if we allow multi-tenant catalogs it will be essential (we simply have to filter for visible
types when looking at the registry, and prevent bundle name collisions - eg by prefixing with tenant)
though for now we don't allow them to be different.

needs testing and test cases still