### PR TITLE
Reverted code for selecting subnet hostname for non aws clouds

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -2827,13 +2827,6 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
             return getPublicHostname(node, sshHostAndPort, userCredentials, setup);
         }
 
-        // NodeMetadata.getHostname() is supposed to return the private hostname. If it's not null, we want to prioritise
-        // this, otherwise we call getPrivateHostnameGeneric()
-        final String hostname = node.getHostname();
-        if (hostname != null) {
-            return hostname;
-        }
-
         Optional<String> preferredAddress = sshHostAndPort.isPresent() ? Optional.of(sshHostAndPort.get().getHostText()) : Optional.<String>absent();
         return getPrivateHostnameGeneric(node, setup, preferredAddress);
     }


### PR DESCRIPTION
A change was made to how Brooklyn retrieves the subnet hostname in https://github.com/apache/brooklyn-server/pull/849.

The intention of that PR was to remove AWS specific functionality, but instead it affected all clouds as it moved all clouds to using ```node.getHostname()```. This functionality cant be relied on for a number of clouds. Openstack, for instance, were getting subnet hostnames like 'qa-tomcat-ser-lc5dhz8sm3-b80' which do not work. Other affected clouds include Azure and Softlayer.

This PR changes the code back to before 849, whilst still removing the AWS specific functionality. However, when testing this code, I discovered that for most clouds we do not actually get a subnet hostname. Instead we use the subnet IP. It's only really AWS that would get a subnet hostname as it uses the AWS specific code. If people prefer, we can simply revert https://github.com/apache/brooklyn-server/pull/849 instead.