### PR TITLE
Upgrade types and bundles as per bundle manifest headers

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
@@ -38,7 +38,6 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
-import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
@@ -64,6 +63,10 @@ public interface BrooklynMementoPersister {
         BrooklynObject lookup(@Nullable BrooklynObjectType type, String objectId);
         /** like {@link #lookup(BrooklynObjectType, String)} but doesn't record an exception if not found */
         BrooklynObject peek(@Nullable BrooklynObjectType type, String objectId);
+        
+        String getContextDescription();
+        String popContextDescription();
+        void pushContextDescription(String description);
     }
     
     /**

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampInternalUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampInternalUtils.java
@@ -53,6 +53,7 @@ import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog.BrooklynLoaderTracker;
 import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.entity.stock.BasicApplicationImpl;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -240,7 +241,8 @@ class CampInternalUtils {
             Set<String> encounteredCatalogTypes) {
         
         PolicySpec<? extends Policy> spec;
-        RegisteredType item = loader.getManagementContext().getTypeRegistry().get(versionedId);
+        RegisteredType item = loader.getManagementContext().getTypeRegistry().get(
+            CatalogUpgrades.getTypeUpgradedIfNecessary(loader.getManagementContext(), versionedId));
         if (item != null && !encounteredCatalogTypes.contains(item.getSymbolicName())) {
             RegisteredTypeLoadingContext context = RegisteredTypeLoadingContexts.alreadyEncountered(encounteredCatalogTypes);
             return loader.getManagementContext().getTypeRegistry().createSpec(item, context, PolicySpec.class);
@@ -258,7 +260,8 @@ class CampInternalUtils {
             Set<String> encounteredCatalogTypes) {
 
         EnricherSpec<? extends Enricher> spec;
-        RegisteredType item = loader.getManagementContext().getTypeRegistry().get(versionedId);
+        RegisteredType item = loader.getManagementContext().getTypeRegistry().get(
+            CatalogUpgrades.getTypeUpgradedIfNecessary(loader.getManagementContext(), versionedId));
         if (item != null && !encounteredCatalogTypes.contains(item.getSymbolicName())) {
             RegisteredTypeLoadingContext context = RegisteredTypeLoadingContexts.alreadyEncountered(encounteredCatalogTypes);
             return loader.getManagementContext().getTypeRegistry().createSpec(item, context, EnricherSpec.class);

--- a/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
+++ b/core/src/main/java/org/apache/brooklyn/core/BrooklynFeatureEnablement.java
@@ -20,9 +20,11 @@ package org.apache.brooklyn.core;
 
 import java.util.Map;
 
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.util.core.internal.ssh.ShellTool;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +70,12 @@ public class BrooklynFeatureEnablement {
     /** whether the default standby mode is {@link HighAvailabilityMode#HOT_STANDBY} or falling back to the traditional
      * {@link HighAvailabilityMode#STANDBY} */
     public static final String FEATURE_DEFAULT_STANDBY_IS_HOT_PROPERTY = FEATURE_PROPERTY_PREFIX+".defaultStandbyIsHot";
-    
+
+    /** whether $brooklyn:entitySpec blocks persist a {@link DeferredSupplier} containing YAML or the resolved {@link EntitySpec}; 
+     * the former allows upgrades and deferred resolution of other flags, whereas the latter is the traditional 
+     * behaviour (prior to 2017-11) which resolves the {@link EntitySpec} earlier and persists that */  
+    public static final String FEATURE_PERSIST_ENTITY_SPEC_AS_SUPPLIER = FEATURE_PROPERTY_PREFIX+".persist.entitySpecAsSupplier";
+
     /**
      * Renaming threads can really helps with debugging etc; however it's a massive performance hit (2x)
      * <p>
@@ -144,6 +151,7 @@ public class BrooklynFeatureEnablement {
         setDefault(FEATURE_BUNDLE_PERSISTENCE_PROPERTY, true);
         setDefault(FEATURE_CATALOG_PERSISTENCE_PROPERTY, true);
         setDefault(FEATURE_DEFAULT_STANDBY_IS_HOT_PROPERTY, false);
+        setDefault(FEATURE_PERSIST_ENTITY_SPEC_AS_SUPPLIER, true);
         setDefault(FEATURE_RENAME_THREADS, false);
         setDefault(FEATURE_JITTER_THREADS, false);
         setDefault(FEATURE_BACKWARDS_COMPATIBILITY_INFER_CATALOG_ITEM_ON_REBIND, false);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -254,6 +254,8 @@ public class CatalogInitialization implements ManagementContextInjectable {
             
             populateInitialCatalogImpl(true);
             
+            CatalogUpgrades catalogUpgrades = gatherCatalogUpgradesInstructions(rebindLogger);
+            CatalogUpgrades.storeInManagementContext(catalogUpgrades, managementContext);
             PersistedCatalogState filteredPersistedState = filterBundlesAndCatalogInPersistedState(persistedState, rebindLogger);
             addPersistedCatalogImpl(filteredPersistedState, exceptionHandler, rebindLogger);
             
@@ -577,12 +579,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
     }
 
     private PersistedCatalogState filterBundlesAndCatalogInPersistedState(PersistedCatalogState persistedState, RebindLogger rebindLogger) {
-        // TODO Will need to share the results of `findCatalogUpgrades` when we support
-        // other options, such as, `brooklyn-catalog-upgrade-for-bundles`, described in the proposal:
-        //   https://docs.google.com/document/d/1Lm47Kx-cXPLe8BO34-qrL3ZMPosuUHJILYVQUswEH6Y/edit#
-        //   section "Bundle Upgrade Metadata"
-
-        CatalogUpgrades catalogUpgrades = findCatalogUpgradesInstructions(rebindLogger);
+        CatalogUpgrades catalogUpgrades = CatalogUpgrades.getFromManagementContext(managementContext);
         
         if (catalogUpgrades.isEmpty()) {
             return persistedState;
@@ -611,7 +608,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
         return new PersistedCatalogState(bundles, legacyCatalogItems);
     }
 
-    private CatalogUpgrades findCatalogUpgradesInstructions(RebindLogger rebindLogger) {
+    private CatalogUpgrades gatherCatalogUpgradesInstructions(RebindLogger rebindLogger) {
         Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)managementContext).getOsgiManager();
         if (osgiManager.isAbsent()) {
             // Can't find any bundles to tell if there are upgrades. Could be running tests; do no filtering.

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -36,6 +36,7 @@ import org.apache.brooklyn.core.config.ConfigKeys.InheritanceContext;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.internal.ConfigKeySelfExtracting;
 import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.TypeTokens;
 import org.slf4j.Logger;
@@ -440,7 +441,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     }
     
     protected Object resolveValue(Object v, ExecutionContext exec) throws ExecutionException, InterruptedException {
-        if (v instanceof Collection || v instanceof Map) {
+        if (ValueResolver.supportsDeepResolution(v)) {
             return Tasks.resolveDeepValue(v, Object.class, exec, "Resolving deep config "+name);
         } else {
             return Tasks.resolveValue(v, getType(), exec, "Resolving config "+name);

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
@@ -52,8 +52,11 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.internal.ConfigKeySelfExtracting;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.ReferenceWithError;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.guava.Maybe.MaybeSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -359,9 +362,18 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T coerce(Object value, Class<T> type) {
+    protected <T> T coerce(TContainer container, String name, Object value, Class<T> type) {
         if (type==null || value==null) return (T) value;
-        return TypeCoercions.coerce(value, type);
+        ExecutionContext exec = getExecutionContext(container);
+        try {
+            if (value instanceof Collection || value instanceof Map) {
+                return (T) Tasks.resolveDeepValue(value, Object.class, exec, "Resolving deep default config "+name);
+            } else {
+                return Tasks.resolveValue(value, type, exec, "Resolving default config "+name);
+            }
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
     }
 
     protected <T> ReferenceWithError<ConfigValueAtContainer<TContainer,T>> getConfigImpl(final ConfigKey<T> queryKey, final boolean raw) {
@@ -390,7 +402,9 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
         Function<Maybe<Object>, Maybe<T>> coerceFn = new Function<Maybe<Object>, Maybe<T>>() {
             @SuppressWarnings("unchecked") @Override public Maybe<T> apply(Maybe<Object> input) {
                 if (raw || input==null || input.isAbsent()) return (Maybe<T>)input;
-                return Maybe.ofAllowingNull(coerce(input.get(), type));
+                // use lambda to defer execution if default value not needed.
+                // this coercion should never be persisted so this is safe.
+                return new MaybeSupplier<T>(() -> (coerce(getContainer(), ownKey.getName(), input.get(), type)));
             }
         };
         // prefer default and type of ownKey

--- a/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/CatalogLocationResolver.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.location.LocationResolver;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,8 @@ public class CatalogLocationResolver implements LocationResolver {
     @Override
     public LocationSpec<? extends Location> newLocationSpecFromString(String spec, Map<?, ?> locationFlags, LocationRegistry registry) {
         String id = spec.substring(NAME.length()+1);
-        RegisteredType item = managementContext.getTypeRegistry().get(id);
+        RegisteredType item = managementContext.getTypeRegistry().get(
+            CatalogUpgrades.getTypeUpgradedIfNecessary(managementContext, id));
         if (item.isDisabled()) {
             throw new IllegalStateException("Illegal use of disabled catalog item "+item.getSymbolicName()+":"+item.getVersion());
         } else if (item.isDeprecated()) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/BrooklynTags.java
@@ -39,6 +39,7 @@ public class BrooklynTags {
     public static final String NOTES_KIND = "notes";
     public static final String OWNER_ENTITY_ID = "owner_entity_id";
     public static final String ICON_URL = "icon_url";
+    public static final String UPGRADED_FROM = "upgraded_from";
     /** tag on a registered type indicating that an item is intended to be used as a template,
      * and does not have to resolve */
     public static final Object CATALOG_TEMPLATE = "catalog_template";
@@ -140,6 +141,10 @@ public class BrooklynTags {
 
     public static NamedStringTag newIconUrlTag(String iconUrl) {
         return new NamedStringTag(ICON_URL, iconUrl);
+    }
+
+    public static NamedStringTag newUpgradedFromTag(String oldVersion) {
+        return new NamedStringTag(UPGRADED_FROM, oldVersion);
     }
 
     public static TraitsTag newTraitsTag(List<Class<?>> interfaces) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
@@ -49,6 +49,7 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult.ResultCode;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServerPaths;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -453,6 +454,7 @@ public class OsgiManager {
                 log.warn("Error uninstalling catalog items of "+bundleMetadata+": "+e);
                 errors.add(e);
             }
+            CatalogUpgrades.clearBundleInStoredUpgrades(mgmt, bundleMetadata.getVersionedName());
             
             if (!managedBundlesRecord.remove(bundleMetadata)) {
                 Exception e = new IllegalStateException("No such bundle registered with Brooklyn when uninstalling: "+bundleMetadata);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -476,7 +476,13 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
             @Override
             public void visit(BrooklynObjectType type, String objectId, String contents) throws Exception {
                 try {
-                    Memento memento = (Memento) getSerializerWithCustomClassLoader(lookupContext, type, objectId).fromString(contents);
+                    Memento memento;
+                    try {
+                        lookupContext.pushContextDescription(""+type.toString().toLowerCase()+" "+objectId);
+                        memento = (Memento) getSerializerWithCustomClassLoader(lookupContext, type, objectId).fromString(contents);
+                    } finally {
+                        lookupContext.popContextDescription();
+                    }
                     if (memento == null) {
                         LOG.warn("No "+type.toCamelCase()+"-memento deserialized from " + objectId + "; ignoring and continuing");
                     } else {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -424,7 +424,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
                                 builder.catalogItem(memento);
                             }
                         } catch (Exception e) {
-                            exceptionHandler.onLoadMementoFailed(type, "memento "+objectId+" early catalog deserialization error", e);
+                            exceptionHandler.onLoadMementoFailed(type, "catalog memento "+objectId+" early catalog deserialization error", e);
                         }
                         break;
                     case MANAGED_BUNDLE:
@@ -433,7 +433,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
                             builder.bundle( memento );
                             memento.setJarContent(mementoData.getBundleJars().get(objectId));
                         } catch (Exception e) {
-                            exceptionHandler.onLoadMementoFailed(type, "memento "+objectId+" early catalog deserialization error", e);
+                            exceptionHandler.onLoadMementoFailed(type, "bundle memento "+objectId+" early catalog deserialization error", e);
                         }
                         break;
                         
@@ -483,7 +483,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
                         builder.memento(memento);
                     }
                 } catch (Exception e) {
-                    exceptionHandler.onLoadMementoFailed(type, "memento "+objectId+" deserialization error", e);
+                    exceptionHandler.onLoadMementoFailed(type, "memento "+objectId+" ("+type+") deserialization error", e);
                 }
             }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
@@ -174,6 +174,7 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
         this.lookupContext = null;
     }
     
+    @SuppressWarnings("deprecation")
     protected String getContextDescription(Object contextHinter) {
         List<String> entries = MutableList.of();
         

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicCatalogItemRebindSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicCatalogItemRebindSupport.java
@@ -18,11 +18,15 @@
  */
 package org.apache.brooklyn.core.mgmt.rebind;
 
+import java.util.Set;
+
 import org.apache.brooklyn.api.mgmt.rebind.RebindContext;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.CatalogItemMemento;
 import org.apache.brooklyn.core.catalog.internal.CatalogItemDtoAbstract;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
+import org.apache.brooklyn.util.osgi.VersionedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +47,7 @@ public class BasicCatalogItemRebindSupport extends AbstractBrooklynObjectRebindS
         super.reconstruct(rebindContext, memento);
         FlagUtils.setFieldsFromFlags(MutableMap.builder()
                 .put("symbolicName", memento.getSymbolicName())
-                .put("containingBundle", memento.getContainingBundle())
+                .put("containingBundle", possiblyUpgradedBundle(memento.getContainingBundle()))
                 .put("javaType", memento.getJavaType())
                 .put("displayName", memento.getDisplayName())
                 .put("description", memento.getDescription())
@@ -55,6 +59,10 @@ public class BasicCatalogItemRebindSupport extends AbstractBrooklynObjectRebindS
                 .put("deprecated", memento.isDeprecated())
                 .put("disabled", memento.isDisabled())
                 .build(), instance);
+    }
+
+    protected String possiblyUpgradedBundle(String bundle) {
+        return CatalogUpgrades.getBundleUpgradedIfNecessary(instance.getManagementContext(), bundle);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextImpl.java
@@ -64,7 +64,7 @@ public class RebindContextImpl implements RebindContext {
         this.mgmt = checkNotNull(mgmt, "mgmt");
         this.exceptionHandler = checkNotNull(exceptionHandler, "exceptionHandler");
         this.classLoader = checkNotNull(classLoader, "classLoader");
-        this.lookupContext = new RebindContextLookupContext(mgmt, this, exceptionHandler);
+        this.lookupContext = new RebindContextLookupContext("root-rebind-context", mgmt, this, exceptionHandler);
     }
 
     public void registerEntity(String id, Entity entity) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextLookupContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextLookupContext.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.mgmt.rebind;
 
+import java.util.Stack;
+
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
@@ -43,16 +45,38 @@ public class RebindContextLookupContext implements LookupContext {
     @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(RebindContextLookupContext.class);
     
+    protected final Stack<String> description;
+    
     @Nullable
     protected final ManagementContext managementContext;
     
     protected final RebindContextImpl rebindContext;
     protected final RebindExceptionHandler exceptionHandler;
     
+    /** @deprecated since 1.0.0 use other constructor (pass in description) */
+    @Deprecated
     public RebindContextLookupContext(ManagementContext managementContext, RebindContextImpl rebindContext, RebindExceptionHandler exceptionHandler) {
+        this("<no-context-description>", managementContext, rebindContext, exceptionHandler);
+    }
+    public RebindContextLookupContext(String description, ManagementContext managementContext, RebindContextImpl rebindContext, RebindExceptionHandler exceptionHandler) {
+        this.description = new Stack<>();
+        this.description.push(description);
         this.managementContext = managementContext;
         this.rebindContext = rebindContext;
         this.exceptionHandler = exceptionHandler;
+    }
+    public RebindContextLookupContext(String description, RebindContextLookupContext sourceToCopy) {
+        this(description, sourceToCopy.managementContext, sourceToCopy.rebindContext, sourceToCopy.exceptionHandler);
+    }
+    
+    @Override public String getContextDescription() {
+        return description.peek();
+    }
+    @Override public String popContextDescription() {
+        return description.pop();
+    }
+    @Override public void pushContextDescription(String description) {
+        this.description.push(description);
     }
     
     @Override public ManagementContext lookupManagementContext() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -101,6 +101,7 @@ import org.apache.brooklyn.core.objs.proxy.InternalLocationFactory;
 import org.apache.brooklyn.core.objs.proxy.InternalPolicyFactory;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.typereg.BasicManagedBundle;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.core.typereg.RegisteredTypeNaming;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -131,7 +132,7 @@ Multi-phase deserialization:
 <li> 1. load the manifest files and populate the summaries (ID+type) in {@link BrooklynMementoManifest}
 <li> 2. install bundles, instantiate and reconstruct catalog items
 <li> 3. instantiate entities+locations -- so that inter-entity references can subsequently 
-       be set during deserialize (and entity config/state is set).
+           be set during deserialize (and entity config/state is set).
 <li> 4. deserialize the manifests to instantiate the mementos
 <li> 5. instantiate policies+enrichers+feeds 
         (could probably merge this with (3), depending how they are implemented)
@@ -978,16 +979,33 @@ public abstract class RebindIteration {
                 String catalogItemId, List<String> searchPath, String contextSuchAsId) {
             checkNotNull(jType, "Type of %s (%s) must not be null", contextSuchAsId, bType.getSimpleName());
 
+            CatalogUpgrades.markerForCodeThatLoadsJavaTypesButShouldLoadRegisteredType();
+            
             List<String> warnings = MutableList.of();
             List<String> reboundSearchPath = MutableList.of();
             if (searchPath != null && !searchPath.isEmpty()) {
                 for (String searchItemId : searchPath) {
                     String fixedSearchItemId = null;
                     RegisteredType t1 = managementContext.getTypeRegistry().get(searchItemId);
+                    if (t1==null) {
+                        String newSearchItemId = CatalogUpgrades.getTypeUpgradedIfNecessary(managementContext, searchItemId);
+                        if (!newSearchItemId.equals(searchItemId)) {
+                            // TODO make debug
+                            logRebindingInfo("Upgrading search path entry of "+bType.getSimpleName().toLowerCase()+" "+contextSuchAsId+" from "+searchItemId+" to "+newSearchItemId);
+                            searchItemId = newSearchItemId;
+                            t1 = managementContext.getTypeRegistry().get(newSearchItemId);
+                        }
+                    }
                     if (t1!=null) fixedSearchItemId = t1.getId();
                     if (fixedSearchItemId==null) {
                         CatalogItem<?, ?> ci = findCatalogItemInReboundCatalog(bType, searchItemId, contextSuchAsId);
-                        if (ci!=null) fixedSearchItemId = ci.getCatalogItemId();
+                        if (ci!=null) {
+                            fixedSearchItemId = ci.getCatalogItemId();
+                            logRebindingWarn("Needed rebind catalog to resolve search path entry "+searchItemId+" (now "+fixedSearchItemId+") for "+bType.getSimpleName().toLowerCase()+" "+contextSuchAsId+
+                                ", persistence should remove this in future but future versions will not support this and definitions should be fixed");
+                        } else {
+                            logRebindingWarn("Could not find search path entry "+searchItemId+" for "+bType.getSimpleName().toLowerCase()+" "+contextSuchAsId+", ignoring");
+                        }
                     }
                     if (fixedSearchItemId != null) {
                         reboundSearchPath.add(fixedSearchItemId);
@@ -1003,6 +1021,19 @@ public abstract class RebindIteration {
                 Maybe<RegisteredType> registeredType = managementContext.getTypeRegistry().getMaybe(catalogItemId,
                     // ignore bType; catalog item ID gives us the search path, but doesn't need to be of the requested type
                     null );
+                if (registeredType.isAbsent()) {
+                    transformedCatalogItemId = CatalogUpgrades.getTypeUpgradedIfNecessary(managementContext, catalogItemId);
+                    if (!transformedCatalogItemId.equals(catalogItemId)) {
+                        logRebindingInfo("Upgrading catalog item ID of "+bType.getSimpleName().toLowerCase()+" "+contextSuchAsId+" from "+catalogItemId+" to "+transformedCatalogItemId);
+                        
+                        // as above
+                        registeredType = managementContext.getTypeRegistry().getMaybe(transformedCatalogItemId, null);
+                        
+                    } else {
+                        transformedCatalogItemId = null;
+                    }
+                }
+                
                 if (registeredType.isPresent()) {
                     transformedCatalogItemId = registeredType.get().getId();
                 } else {
@@ -1303,6 +1334,15 @@ public abstract class RebindIteration {
     protected void logRebindingInfo(String message, Object... args) {
         if (shouldLogRebinding()) {
             LOG.info(message, args);
+        } else {
+            LOG.trace(message, args);
+        }
+    }
+    
+    /** logs at warn, except during subsequent read-only rebinds, in which it logs trace */
+    protected void logRebindingWarn(String message, Object... args) {
+        if (shouldLogRebinding()) {
+            LOG.warn(message, args);
         } else {
             LOG.trace(message, args);
         }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -45,6 +46,7 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityDynamicType;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -180,6 +182,11 @@ public class InternalEntityFactory extends InternalFactory {
             T entity = constructEntity(clazz, spec, entityId);
             
             loadUnitializedEntity(entity, spec);
+            
+            List<NamedStringTag> upgradedFrom = BrooklynTags.findAll(BrooklynTags.UPGRADED_FROM, spec.getTags());
+            if (!upgradedFrom.isEmpty()) {
+                log.warn("Entity "+entity.getId()+" created with upgraded type "+entity.getCatalogItemId()+" "+upgradedFrom+" (in "+entity.getApplicationId()+", under "+entity.getParent()+")");
+            }
 
             entitiesByEntityId.put(entity.getId(), entity);
             specsByEntityId.put(entity.getId(), spec);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.catalog.internal.CatalogItemBuilder;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.core.typereg.RegisteredTypes.RegisteredTypeNameThenBestFirstComparator;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -82,6 +83,8 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
      * maps but coordinating that is tricky and does not seem worth it.
      */
     private ReadWriteLock localRegistryLock = new ReentrantReadWriteLock();
+
+    private CatalogUpgrades catalogUpgrades;
 
     public BasicBrooklynTypeRegistry(ManagementContext mgmt) {
         this.mgmt = mgmt;
@@ -633,5 +636,16 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
     public void clear() {
         Locks.withLock(localRegistryLock.writeLock(), () -> localRegisteredTypesAndContainingBundles.clear());
     }
+
     
+    @Beta
+    public void storeCatalogUpgradesInstructions(CatalogUpgrades catalogUpgrades) {
+        this.catalogUpgrades = catalogUpgrades;
+    }
+
+    @Beta
+    public CatalogUpgrades getCatalogUpgradesInstructions() {
+        return catalogUpgrades;
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
@@ -91,7 +91,7 @@ public class BundleUpgradeParser {
      * </ul>
      */
     @Beta
-    public static final String MANIFEST_HEADER_FORCE_REMOVE_LEGACY_ITEMS = "brooklyn-catalog-force-remove-legacy-items";
+    public static final String MANIFEST_HEADER_FORCE_REMOVE_LEGACY_ITEMS = "Brooklyn-Catalog-Force-Remove-Legacy-Items";
 
     /**
      * A header in a bundle's manifest, indicating that this bundle will force the removal of matching 
@@ -128,7 +128,7 @@ public class BundleUpgradeParser {
      * </ul>
      */
     @Beta
-    public static final String MANIFEST_HEADER_FORCE_REMOVE_BUNDLES = "brooklyn-catalog-force-remove-bundles";
+    public static final String MANIFEST_HEADER_FORCE_REMOVE_BUNDLES = "Brooklyn-Catalog-Force-Remove-Bundles";
 
     /**
      * A header in a bundle's manifest, indicating that this bundle recommends a set of upgrades.
@@ -155,14 +155,14 @@ public class BundleUpgradeParser {
      * 
      * In most use cases, one can provide a single line, e.g. if releasing a v2.0.0:
      * 
-     * {@code brooklyn-catalog-upgrade-for-bundles: *:[0,2)}
+     * {@code Brooklyn-Catalog-Upgrade-For-Bundles: *:[0,2)}
      * 
      * to indicate that this bundle is able to upgrade all instances of this bundle lower than 2.0.0,
      * and all types in this bundle will upgrade earlier types.
      * 
      * This can be used in conjunction with:
      * 
-     * {@code brooklyn-catalog-force-remove-bundles: *:[0,2)}
+     * {@code Brooklyn-Catalog-Force-Remove-Bundles: *:[0,2)}
      * 
      * to forcibly remove older bundles at an appropriate point (eg a restart) and cause all earlier instances of the bundle
      * and the type instances they contain to be upgraded with the same-named types in the 2.0.0 bundle.
@@ -171,7 +171,7 @@ public class BundleUpgradeParser {
      * or versions are not in line with previous versions of this bundle.
      */
     @Beta
-    public static final String MANIFEST_HEADER_UPGRADE_FOR_BUNDLES = "brooklyn-catalog-upgrade-for-bundles";
+    public static final String MANIFEST_HEADER_UPGRADE_FOR_BUNDLES = "Brooklyn-Catalog-Upgrade-For-Bundles";
 
     /**
      * A header in a bundle's manifest, indicating that this bundle recommends a set of upgrades.
@@ -199,17 +199,17 @@ public class BundleUpgradeParser {
      * 
      * What this is saying in most cases is that if a bundle {@code foo:1} contains {@code foo-node:1}, and 
      * bundle {@code foo:2} contains {@code foo-node:2}, then:
-     * if {@code foo:2} declares {@code brooklyn-catalog-upgrade-for-bundles: foo:1} it will also declare that
+     * if {@code foo:2} declares {@code Brooklyn-Catalog-Upgrade-For-Bundles: foo:1} it will also declare that
      * {@code foo-node:2} upgrades {@code foo-node:1};
-     * if {@code foo:2} declares {@code brooklyn-catalog-upgrade-for-bundles: *} the same thing will occur
+     * if {@code foo:2} declares {@code Brooklyn-Catalog-Upgrade-For-Bundles: *} the same thing will occur
      * (and it would also upgrade a {@code foo:0} contains {@code foo-node:0});
-     * if {@code foo:2} declares no {@code brooklyn-catalog-upgrade} manifest headers, then no advisory
+     * if {@code foo:2} declares no {@code Brooklyn-Catalog-Upgrade-*} manifest headers, then no advisory
      * upgrades will be noted.
      * 
      * As noted in {@link #MANIFEST_HEADER_UPGRADE_FOR_BUNDLES} the primary use case for this header is type renames.
      */
     @Beta
-    public static final String MANIFEST_HEADER_UPGRADE_FOR_TYPES = "brooklyn-catalog-upgrade-for-types";
+    public static final String MANIFEST_HEADER_UPGRADE_FOR_TYPES = "Brooklyn-Catalog-Upgrade-For-Types";
 
     /**
      * The result from parsing bundle(s) to find their upgrade info.

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
@@ -29,7 +29,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -311,6 +314,20 @@ public class BundleUpgradeParser {
         @Beta
         public static boolean contains(VersionRangedName range, VersionedName name) {
             return range.getSymbolicName().equals(name.getSymbolicName()) && range.getOsgiVersionRange().includes(name.getOsgiVersion());
+        }
+
+        @Beta
+        public static void storeInManagementContext(CatalogUpgrades catalogUpgrades, ManagementContext managementContext) {
+            ((BasicBrooklynTypeRegistry)managementContext.getTypeRegistry()).storeCatalogUpgradesInstructions(catalogUpgrades);
+        }
+        
+        @Beta @Nonnull
+        public static CatalogUpgrades getFromManagementContext(ManagementContext managementContext) {
+            CatalogUpgrades result = ((BasicBrooklynTypeRegistry)managementContext.getTypeRegistry()).getCatalogUpgradesInstructions();
+            if (result!=null) {
+                return result;
+            }
+            return builder().build();
         }
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
@@ -370,6 +370,10 @@ public class BundleUpgradeParser {
                 // item found (or n/a), prefer that to upgrade
                 return vName;
             }
+            // callers should use BrooklynTags.newUpgradedFromTag if creating a spec,
+            // then warn on instantiation, done only for entities currently.
+            // (yoml will allow us to have one code path for all the different creation routines.)
+            // persistence/rebind also warns.
             return getItemUpgradedIfNecessary(mgmt, vName, (cu,vn) -> cu.getUpgradesForType(vn));
         }
         
@@ -380,14 +384,19 @@ public class BundleUpgradeParser {
             Set<VersionedName> r = lookupF.lookup(getFromManagementContext(mgmt), VersionedName.fromString(vName));
             if (!r.isEmpty()) return r.iterator().next().toString();
             
-            log.warn("Could not find '"+vName+"' and no upgrades specified; subsequent failure or warning likely");
+            if (log.isTraceEnabled()) {
+                log.trace("Could not find '"+vName+"' and no upgrades specified; subsequent failure or warning possible unless that is a direct java class reference");
+            }
             return vName;
         }
         
         /** This method is used internally to mark places we need to update when we switch to persisting and loading
          *  registered type IDs instead of java types, as noted on RebindIteration.load */
         @Beta
-        public static void markerForCodeThatLoadsJavaTypesButShouldLoadRegisteredType() {}
+        public static boolean markerForCodeThatLoadsJavaTypesButShouldLoadRegisteredType() {
+            // return true if we use registered types, and update callers not to need this method
+            return false;
+        }
         
         @Beta
         CatalogUpgrades withTypeCleared(VersionedName versionedName) {

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BundleUpgradeParser.java
@@ -399,24 +399,24 @@ public class BundleUpgradeParser {
         }
         
         @Beta
-        CatalogUpgrades withTypeCleared(VersionedName versionedName) {
+        CatalogUpgrades withUpgradesProvidedByTypeCleared(VersionedName versionedName) {
             return builder().addAll(this).clearUpgradesProvidedByType(versionedName).build();
         }
         @Beta
-        CatalogUpgrades withBundleCleared(VersionedName versionedName) {
-            return builder().addAll(this).clearUpgradesProvidedByType(versionedName).build();
+        CatalogUpgrades withUpgradesProvidedByBundleCleared(VersionedName versionedName) {
+            return builder().addAll(this).clearUpgradesProvidedByBundle(versionedName).build();
         }
 
         @Beta
         public static void clearTypeInStoredUpgrades(ManagementContext mgmt, VersionedName versionedName) {
             synchronized (mgmt.getTypeRegistry()) {
-                storeInManagementContext(getFromManagementContext(mgmt).withTypeCleared(versionedName), mgmt);
+                storeInManagementContext(getFromManagementContext(mgmt).withUpgradesProvidedByTypeCleared(versionedName), mgmt);
             }
         }
         @Beta
         public static void clearBundleInStoredUpgrades(ManagementContext mgmt, VersionedName versionedName) {
             synchronized (mgmt.getTypeRegistry()) {
-                storeInManagementContext(getFromManagementContext(mgmt).withBundleCleared(versionedName), mgmt);
+                storeInManagementContext(getFromManagementContext(mgmt).withUpgradesProvidedByBundleCleared(versionedName), mgmt);
             }
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -21,8 +21,10 @@ package org.apache.brooklyn.util.core.task;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -171,9 +173,9 @@ public class Tasks {
      * 
      *   {@code Object result = resolveDeepValue(ImmutableList.of(ImmutableMap.of(1, true)), String.class, exec)} 
      *
-     * To perform a deep conversion of futures contained within Iterables or Maps without coercion of each element,
+     * To perform a deep conversion of futures contained within a {@link Collection} or {@link Map} without coercion of each element,
      * the type should normally be Object, not the type of the collection. This differs from
-     * {@link #resolveValue(Object, Class, ExecutionContext, String)} which will accept Map and Iterable
+     * {@link #resolveValue(Object, Class, ExecutionContext, String)} which will accept {@link Map} and {@link Collection}
      * as the required type.
      */
     public static <T> T resolveDeepValue(Object v, Class<T> type, ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {

--- a/core/src/test/java/org/apache/brooklyn/core/typereg/BundleUpgradeParserTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/typereg/BundleUpgradeParserTest.java
@@ -321,6 +321,18 @@ public class BundleUpgradeParserTest {
     }
     
     @Test
+    public void testParseBundleManifestUpgradesInfersTypes() throws Exception {
+        Supplier<Iterable<RegisteredType>> typeSupplier = Suppliers.ofInstance(ImmutableList.of(
+            new BasicRegisteredType(null, "foo", "2.0", null) ));
+        Bundle bundle = newMockBundle(new VersionedName("bundle", "2.0"), 
+            ImmutableMap.of(BundleUpgradeParser.MANIFEST_HEADER_UPGRADE_FOR_BUNDLES, "*"));
+        CatalogUpgrades ups = BundleUpgradeParser.parseBundleManifestForCatalogUpgrades(bundle, typeSupplier);
+        assertTypeUpgrade(ups, "foo", "1", "foo", "2.0.0");
+        assertTypeUpgrade(ups, "foo", "2", null, null);
+        assertTypeUpgrade(ups, "far", "1", null, null);
+    }
+    
+    @Test
     public void testParseBundleManifestUpgradesValidatesIfNoBundleUpgradeVersion() throws Exception {
         Supplier<Iterable<RegisteredType>> typeSupplier = Suppliers.ofInstance(ImmutableList.of(
             new BasicRegisteredType(null, "foo", "1.0", null) ));

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/TasksTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -48,7 +49,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Callables;
 
 
@@ -103,12 +103,11 @@ public class TasksTest extends BrooklynAppUnitTestSupport {
         assertResolvesValue(orig, String.class, expected);
     }
     
-    @SuppressWarnings("unchecked")
     @Test
-    public void testResolvesIterableOfMapsWithAttributeWhenReady() throws Exception {
+    public void testResolvesListOfMapsWithAttributeWhenReady() throws Exception {
         app.sensors().set(TestApplication.MY_ATTRIBUTE, "myval");
         // using Iterables.concat so that orig is of type FluentIterable rather than List etc
-        Iterable<?> orig = Iterables.concat(ImmutableList.of(ImmutableMap.of("mykey", attributeWhenReady(app, TestApplication.MY_ATTRIBUTE))));
+        List<?> orig = ImmutableList.copyOf(ImmutableList.of(ImmutableMap.of("mykey", attributeWhenReady(app, TestApplication.MY_ATTRIBUTE))));
         Iterable<Map<?,?>> expected = ImmutableList.<Map<?,?>>of(ImmutableMap.of("mykey", "myval"));
         assertResolvesValue(orig, String.class, expected);
     }

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindCatalogOsgiTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindCatalogOsgiTest.java
@@ -703,7 +703,7 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
             "        type: "+BasicEntity.class.getName());
         VersionedName bundleNameV2 = new VersionedName("org.example.testRebindGetsInitialOsgiCatalog", "2.0.0");
         Map<String,String> headers = MutableMap.of(
-            BundleUpgradeParser.MANIFEST_HEADER_FORCE_REMOVE_BUNDLES, "*"
+                BundleUpgradeParser.MANIFEST_HEADER_FORCE_REMOVE_BUNDLES, "*"
                 + (removeSourceJavaBundle ? ","+"'"+OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_COM_EXAMPLE_SYMBOLIC_NAME_FULL+":"+OsgiTestResources.BROOKLYN_TEST_OSGI_ENTITIES_VERSION+"'"
                     : ""));
         if (upgradeEntity) {
@@ -729,7 +729,7 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
     }
     
     @Test
-    public void testRebindUpgradeEntity() throws Exception {
+    public void testRebindUpgradeDeployedEntity() throws Exception {
         File initialBomFileV2 = prepForRebindRemovedItemTestReturningBomV2(false, true);
         createAndStartApplication(launcherLast.getManagementContext(), 
             "services: [ { type: 'simple-entity:1' } ]");
@@ -740,10 +740,7 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
         Entity entity = Iterables.getOnlyElement( Iterables.getOnlyElement(launcherLast.getManagementContext().getApplications()).getChildren() );
         
         // assert it was updated
-        
-        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:1.0.0");
-        // TODO when upgrades work at level of catalog item ID and bundle ID, do below instead of above
-//        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:2.0.0");
+        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:2.0.0");
         
         Assert.assertEquals(Entities.deproxy(entity).getClass().getName(), "com.example.brooklyn.test.osgi.entities.SimpleEntityImpl");
         // TODO when registered types are used to create, instead of java type,
@@ -751,8 +748,29 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
 //        Assert.assertEquals(Entities.deproxy(entity).getClass().getName(), BasicEntityImpl.class.getName());
     }
     
+//    @Test
+//    // TODO add to catalog a 'references-simple-entity' which references simple-entity:1
+//    public void testRebindUpgradeReferencedEntityFromCatalogAndDeployment() throws Exception {
+//        File initialBomFileV2 = prepForRebindRemovedItemTestReturningBomV2(false, true);
+//        createAndStartApplication(launcherLast.getManagementContext(), 
+//            "services: [ { type: references-simple-entity } ]");
+//        
+//        startT2(newLauncherForTests(initialBomFileV2.getAbsolutePath()));
+//        promoteT2IfStandby();
+//        
+//        Entity entity = Iterables.getOnlyElement( Iterables.getOnlyElement(launcherLast.getManagementContext().getApplications()).getChildren() );
+//        
+//        // assert it was updated
+//        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:2.0.0");
+//        
+//        Assert.assertEquals(Entities.deproxy(entity).getClass().getName(), "com.example.brooklyn.test.osgi.entities.SimpleEntityImpl");
+//        // TODO when registered types are used to create, instead of java type,
+//        // upgrade should cause the line below instead of the line above (see RebindIteration.load)
+////        Assert.assertEquals(Entities.deproxy(entity).getClass().getName(), BasicEntityImpl.class.getName());
+//    }
+    
     @Test(groups="WIP")
-    public void testRebindUpgradeSpec() throws Exception {
+    public void testRebindUpgradeSpecInDeployedApp() throws Exception {
         File initialBomFileV2 = prepForRebindRemovedItemTestReturningBomV2(true, true);
         Application app = createAndStartApplication(launcherLast.getManagementContext(), 
             Joiner.on("\n").join(
@@ -775,10 +793,7 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
         Entity entity = Iterables.getOnlyElement( ((DynamicCluster)cluster).getMembers() );
         
         // assert it uses the new spec
-        
-        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:1.0.0");
-        // TODO when upgrades work at level of catalog item ID and bundle ID, do below instead of above
-//        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:2.0.0");
+        Assert.assertEquals(entity.getCatalogItemId(), "simple-entity:2.0.0");
         
         Assert.assertEquals(Entities.deproxy(entity).getClass().getName(), "com.example.brooklyn.test.osgi.entities.SimpleEntityImpl");
         // TODO when registered types are used to create, instead of java type,
@@ -887,7 +902,7 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
         try {
             BrooklynLauncherRebindCatalogOsgiTest fixture = new LauncherRebindSubTests();
             fixture.setUp();
-            fixture.testRebindUpgradeEntity();
+            fixture.testRebindUpgradeDeployedEntity();
             fixture.tearDown();
         } catch (Throwable e) {
             e.printStackTrace();

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindCatalogOsgiTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherRebindCatalogOsgiTest.java
@@ -755,7 +755,8 @@ public abstract class BrooklynLauncherRebindCatalogOsgiTest extends AbstractBroo
     
     @Test
     public void testRebindUpgradeReferencedEntityFromCatalogAndDeployment() throws Exception {
-        File initialBomFileV2 = prepForRebindRemovedItemTestReturningBomV2(false, true);
+        File initialBomFileV2 = prepForRebindRemovedItemTestReturningBomV2(
+            CatalogUpgrades.markerForCodeThatLoadsJavaTypesButShouldLoadRegisteredType(), true);
         VersionedName bundleName = new VersionedName("referencer", "1.0");
         String bundleBom = Strings.lines("brooklyn.catalog:",
             "  version: 1",  // without this the type gets the osgi version, 1.0.0 (not 1.0)


### PR DESCRIPTION
Follow on from #872 which actually applies the upgrade in most places.

One known gap, and possibly some unknown gaps, but the main cases are working.

Suggest revisiting post-YOML as that will make it easier to handle upgrades due to a single instantiation path (instead of the many we currently have).