### PR TITLE
avoid UpdatingMapTest non-det failure

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/entity/RecordingSensorEventListener.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/RecordingSensorEventListener.java
@@ -142,6 +142,10 @@ public class RecordingSensorEventListener<T> implements SensorEventListener<T>, 
         tasks.clear();
         lastValue = null;
     }
+    
+    public SensorEvent<T> removeEvent(int i) {
+        return events.remove(i);
+    }
 
     @Override
     public Iterator<SensorEvent<T>> iterator() {

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/UpdatingMapTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/UpdatingMapTest.java
@@ -123,7 +123,14 @@ public class UpdatingMapTest extends BrooklynAppUnitTestSupport {
         EntityAsserts.assertAttributeEqualsEventually(entity, mapSensor, ImmutableMap.of("myKey", "valIsV1"));
         
         listener.assertHasEventEventually(Predicates.alwaysTrue());
-        assertEquals(Iterables.getOnlyElement(listener.getEventValues()), ImmutableMap.of("myKey", "valIsV1"));
+        Map<String, Object> ev = listener.removeEvent(0).getValue();
+        if (ev.equals(ImmutableMap.of("myKey", "myDefault"))) {
+            // possible on slow machine for this to pick up myDefault computed late; get next
+            listener.assertHasEventEventually(Predicates.alwaysTrue());
+            ev = listener.removeEvent(0).getValue();
+        }
+        assertEquals(ev, ImmutableMap.of("myKey", "valIsV1"));
+        Asserts.assertSize(listener.getEventValues(), 0);
     }
     
     @Test


### PR DESCRIPTION
need to allow a first default event as that transformation may be running slowly