### PR TITLE
Fix execution context on subscriptions

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
@@ -100,10 +100,7 @@ public abstract class BrooklynDslDeferredSupplier<T> implements DeferredSupplier
         if (log.isDebugEnabled())
             log.debug("Queuing task to resolve "+dsl+", called by "+Tasks.current());
 
-        EntityInternal entity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-        ExecutionContext exec =
-                (entity != null) ? entity.getExecutionContext()
-                                 : BasicExecutionContext.getCurrentExecutionContext();
+        ExecutionContext exec = BrooklynTaskTags.getCurrentExecutionContext();
         if (exec == null) {
             throw new IllegalStateException("No execution context available to resolve " + dsl);
         }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -46,7 +46,6 @@ import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
-import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.ImmediateSupplier;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
@@ -339,10 +338,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
     }
 
     static ExecutionContext findExecutionContext(Object callerContext) {
-        EntityInternal contextEntity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-        ExecutionContext execContext =
-                (contextEntity != null) ? contextEntity.getExecutionContext()
-                                        : BasicExecutionContext.getCurrentExecutionContext();
+        ExecutionContext execContext = BrooklynTaskTags.getCurrentExecutionContext();
         if (execContext == null) {
             throw new IllegalStateException("No execution context available to resolve " + callerContext);
         }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
@@ -56,6 +56,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
@@ -69,7 +70,6 @@ public class BasicExecutionContext extends AbstractExecutionContext {
     private static final Logger log = LoggerFactory.getLogger(BasicExecutionContext.class);
     
     static final ThreadLocal<BasicExecutionContext> perThreadExecutionContext = new ThreadLocal<BasicExecutionContext>();
-    
     public static BasicExecutionContext getCurrentExecutionContext() { return perThreadExecutionContext.get(); }
 
     final ExecutionManager executionManager;
@@ -448,6 +448,16 @@ public class BasicExecutionContext extends AbstractExecutionContext {
     }
 
     private void registerPerThreadExecutionContext() { perThreadExecutionContext.set(this); }
+    /** For use if external code wants to subsequently use an {@link ExecutionContext} but cannot submit via one. 
+     * Caller should store the result and reset it back afterwards, in case a task may be running 
+     * in the same thread as a synchronous submitter. */
+    // only LocalSubscriptionManager needs to do that; and it could be refactored to take the execution context rather than tags. 
+    @Beta
+    public static BasicExecutionContext setPerThreadExecutionContext(BasicExecutionContext ec) {
+        BasicExecutionContext old = perThreadExecutionContext.get();
+        perThreadExecutionContext.set(ec); 
+        return old;
+    }
 
     private void clearPerThreadExecutionContext() { perThreadExecutionContext.remove(); }
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
@@ -23,14 +23,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.mgmt.Task;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.MethodCoercions;
-import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -53,10 +48,7 @@ public class TemplateOptionsOption implements TemplateOptionCustomizer {
             if (optionValue != null) {
 
                 try {
-                    final EntityInternal entity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-                    final ExecutionContext exec = (null != entity
-                        ? entity.getExecutionContext()
-                        : BasicExecutionContext.getCurrentExecutionContext());
+                    final ExecutionContext exec = BrooklynTaskTags.getCurrentExecutionContext();
                     if (exec != null) {
                         optionValue = Tasks.resolveDeepValue(optionValue, Object.class, exec);
                     }


### PR DESCRIPTION
Execution contexts weren't getting set on subscriptions.  Seems this has always been the case, and I guess subscribers weren't relying on having an execution context, but they should be able to, so policies don't always have to use their own (although they probably should for anything long-running, for cleaner task separation).  This adds a test that shows the problem, then the solution which specially sets the execution context.  (Pretty much everywhere else this isn't a problem because we submit via EC rather than ExecutionManager; but in subscriptions we can't do that given how task tags are passed in.  Ideally should refactor LSM so that it takes the EC not the tags -- but this is easier and works just as well.)