### PR TITLE
Stop memberSpecs being inherited

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -35,6 +35,7 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
+import org.apache.brooklyn.core.config.BasicConfigInheritance;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -138,16 +139,18 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
 
     @CatalogConfig(label = "Member spec")
     @SetFromFlag("memberSpec")
-    ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
-            new TypeToken<EntitySpec<?>>() { },
-            "dynamiccluster.memberspec", "entity spec for creating new cluster members", null);
+    ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.builder(new TypeToken<EntitySpec<?>>(){}, "dynamiccluster.memberspec")
+            .description("entity spec for creating new cluster members")
+            .defaultValue(null)
+            .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
+            .build();
 
     @SetFromFlag("firstMemberSpec")
-    ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.newConfigKey(
-            new TypeToken<EntitySpec<?>>() { },
-            "dynamiccluster.firstmemberspec", 
-            "entity spec for creating the first member of the cluster (if unset, will use the member spec for all)", 
-            null);
+    ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.builder(new TypeToken<EntitySpec<?>>(){}, "dynamiccluster.firstmemberspec")
+            .description("entity spec for creating the first member of the cluster (if unset, will use the member spec for all)")
+            .defaultValue(null)
+            .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
+            .build();
 
     @SetFromFlag("removalStrategy")
     ConfigKey<Function<Collection<Entity>, Entity>> REMOVAL_STRATEGY = ConfigKeys.newConfigKey(

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -171,6 +171,26 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
     }
 
     @Test
+    public void testMemberSpecNotInherited() throws Exception {
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
+        DynamicCluster child = cluster.addChild(EntitySpec.create(DynamicCluster.class));
+        Asserts.assertNull(child.getConfig(DynamicCluster.MEMBER_SPEC));
+        DynamicCluster memberChild = cluster.addMemberChild(EntitySpec.create(DynamicCluster.class));
+        Asserts.assertNull(memberChild.getConfig(DynamicCluster.MEMBER_SPEC));
+    }
+
+    @Test
+    public void testFirstMemberSpecNotInherited() throws Exception {
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.FIRST_MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
+        DynamicCluster child = cluster.addChild(EntitySpec.create(DynamicCluster.class));
+        Asserts.assertNull(child.getConfig(DynamicCluster.FIRST_MEMBER_SPEC));
+        DynamicCluster memberChild = cluster.addMemberChild(EntitySpec.create(DynamicCluster.class));
+        Asserts.assertNull(memberChild.getConfig(DynamicCluster.FIRST_MEMBER_SPEC));
+    }
+
+    @Test
     public void testClusterHasOneLocationAfterStarting() throws Exception {
         DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
                 .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));


### PR DESCRIPTION
If I create a cluster inside a cluster currently the memberSpec is inherited by the second cluster. When that memberSpec is inherited it loops creating an infinite structure. This isn't useful and therefore memberSpecs shouldn't be inherited.