### PR TITLE
Misc enhancements - warnings and more lookup conveniences

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Predicate;
 
 /**
  * This is the entry point for accessing and interacting with a realm of applications and their entities in Brooklyn.
@@ -309,8 +310,14 @@ public interface ManagementContext {
     /** As {@link #lookup(String, Class)} but not constraining the return type */
     public BrooklynObject lookup(String id);
     
-    /** Finds an entity with the given ID known at this management context */
-    // TODO in future support policies etc
+    /** As {@link #lookup(Predicate)} comparing the ID of the object with the given string */
     public <T extends BrooklynObject> T lookup(String id, Class<T> type); 
 
+    /** Finds a {@link BrooklynObject} known in this management context 
+     * satisfying the given predicate, or null */
+    public <T extends BrooklynObject> T lookup(Predicate<? super T> filter);
+    
+    /** As {@link #lookup(Predicate)} but returning all such instances */
+    public <T extends BrooklynObject> Collection<T> lookupAll(Predicate<? super T> filter);
+    
 }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
@@ -100,10 +100,7 @@ public abstract class BrooklynDslDeferredSupplier<T> implements DeferredSupplier
         if (log.isDebugEnabled())
             log.debug("Queuing task to resolve "+dsl+", called by "+Tasks.current());
 
-        EntityInternal entity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-        ExecutionContext exec =
-                (entity != null) ? entity.getExecutionContext()
-                                 : BasicExecutionContext.getCurrentExecutionContext();
+        ExecutionContext exec = BrooklynTaskTags.getCurrentExecutionContext();
         if (exec == null) {
             throw new IllegalStateException("No execution context available to resolve " + dsl);
         }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -46,7 +46,6 @@ import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
-import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.ImmediateSupplier;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
@@ -339,10 +338,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
     }
 
     static ExecutionContext findExecutionContext(Object callerContext) {
-        EntityInternal contextEntity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-        ExecutionContext execContext =
-                (contextEntity != null) ? contextEntity.getExecutionContext()
-                                        : BasicExecutionContext.getCurrentExecutionContext();
+        ExecutionContext execContext = BrooklynTaskTags.getCurrentExecutionContext();
         if (execContext == null) {
             throw new IllegalStateException("No execution context available to resolve " + callerContext);
         }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
@@ -230,7 +230,6 @@ public class EntityAsserts {
      * Setting these sensors is common behaviour for entities, but depends on the particular entity
      * implementation.
      */
-    @Beta
     public static void assertEntityHealthy(Entity entity) {
         assertAttributeEquals(entity, SERVICE_UP, true);
         assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
@@ -240,6 +239,9 @@ public class EntityAsserts {
                 return Lifecycle.RUNNING.equals(transition.getState());
             }
         });
+    }
+    public static void assertEntityHealthyEventually(Entity entity) {
+        Asserts.succeedsEventually(() -> assertEntityHealthy(entity));
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -503,6 +504,18 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
         return initialManagementContext.lookup(id, type);
     }
 
+    @Override
+    public <T extends BrooklynObject> T lookup(Predicate<? super T> filter) {
+        checkInitialManagementContextReal();
+        return initialManagementContext.lookup(filter);
+    }
+
+    @Override
+    public <T extends BrooklynObject> Collection<T> lookupAll(Predicate<? super T> filter) {
+        checkInitialManagementContextReal();
+        return initialManagementContext.lookupAll(filter);
+    }
+    
     @Override
     public List<Throwable> errors() {
         checkInitialManagementContextReal();

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicExecutionContext.java
@@ -56,6 +56,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
@@ -69,7 +70,6 @@ public class BasicExecutionContext extends AbstractExecutionContext {
     private static final Logger log = LoggerFactory.getLogger(BasicExecutionContext.class);
     
     static final ThreadLocal<BasicExecutionContext> perThreadExecutionContext = new ThreadLocal<BasicExecutionContext>();
-    
     public static BasicExecutionContext getCurrentExecutionContext() { return perThreadExecutionContext.get(); }
 
     final ExecutionManager executionManager;
@@ -448,6 +448,16 @@ public class BasicExecutionContext extends AbstractExecutionContext {
     }
 
     private void registerPerThreadExecutionContext() { perThreadExecutionContext.set(this); }
+    /** For use if external code wants to subsequently use an {@link ExecutionContext} but cannot submit via one. 
+     * Caller should store the result and reset it back afterwards, in case a task may be running 
+     * in the same thread as a synchronous submitter. */
+    // only LocalSubscriptionManager needs to do that; and it could be refactored to take the execution context rather than tags. 
+    @Beta
+    public static BasicExecutionContext setPerThreadExecutionContext(BasicExecutionContext ec) {
+        BasicExecutionContext old = perThreadExecutionContext.get();
+        perThreadExecutionContext.set(ec); 
+        return old;
+    }
 
     private void clearPerThreadExecutionContext() { perThreadExecutionContext.remove(); }
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -808,10 +809,10 @@ public class BasicTask<T> implements TaskInternal<T> {
                 return;
             }
             if (!t.isDone()) {
-                // shouldn't happen
-                // TODO But does happen if management context was terminated (e.g. running test suite).
-                //      Should check if Execution Manager is running, and only log if it was not terminated?
-                log.warn("Task "+t+" is being finalized before completion");
+                if (!BrooklynTaskTags.getExecutionContext(t).isShutdown()) {
+                    // not sure how this could happen
+                    log.warn("Task "+t+" was submitted but forgotten before it was run (finalized before completion)");
+                }
                 return;
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -357,7 +357,10 @@ public class Tasks {
         } }).build();
     }
     public static Task<Void> warning(final String message, final Throwable optionalError) {
-        log.warn(message);
+        return warning(message, optionalError, true);
+    }
+    public static Task<Void> warning(final String message, final Throwable optionalError, boolean logWarning) {
+        if (logWarning) log.warn(message);
         return TaskTags.markInessential(fail(message, optionalError));
     }
 

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
@@ -85,6 +85,17 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
+    public void testLookup() {
+        Enricher enr = entity.enrichers().add(Enrichers.builder()
+                .combining(NUM1, NUM2)
+                .publishing(NUM3)
+                .computingSum()
+                .build());
+        
+        Assert.assertEquals(mgmt.lookup(enr.getId()), enr);
+    }
+    
+    @Test
     public void testAdding() {
         Enricher enr = entity.enrichers().add(Enrichers.builder()
                 .combining(NUM1, NUM2)

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
@@ -23,14 +23,9 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.mgmt.Task;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.MethodCoercions;
-import org.apache.brooklyn.util.core.task.BasicExecutionContext;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -53,10 +48,7 @@ public class TemplateOptionsOption implements TemplateOptionCustomizer {
             if (optionValue != null) {
 
                 try {
-                    final EntityInternal entity = (EntityInternal) BrooklynTaskTags.getTargetOrContextEntity(Tasks.current());
-                    final ExecutionContext exec = (null != entity
-                        ? entity.getExecutionContext()
-                        : BasicExecutionContext.getCurrentExecutionContext());
+                    final ExecutionContext exec = BrooklynTaskTags.getCurrentExecutionContext();
                     if (exec != null) {
                         optionValue = Tasks.resolveDeepValue(optionValue, Object.class, exec);
                     }


### PR DESCRIPTION
Builds on #875 (review that first) adding just:

* a `Task.warning(msg, false)` that doesn't `LOG.warning`
* `mgmt.lookup(...)` methods supporting adjuncts and more predicates
* removing unnecessary task finalization warnings
* routine to `assertEntityHealthyEventually`