### PR TITLE
Add brooklyn-cli as a feature to karaf

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -327,11 +327,16 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-test-framework/${project.version}</bundle>
     </feature>
 
+    <feature name="brooklyn-cli" version="${project.version}" description="Brooklyn CLI" >
+        <bundle>mvn:org.apache.brooklyn/brooklyn-cli/${project.version}</bundle>
+    </feature>
+
     <feature name="brooklyn-server-software-all" version="${project.version}" description="Brooklyn All Core Entities">
         <feature>brooklyn-software-base</feature>
         <feature>brooklyn-jmxmp-agent</feature>
         <feature>brooklyn-jmxrmi-agent</feature>
         <feature>brooklyn-test-framework</feature>
+        <feature>brooklyn-cli</feature>
     </feature>
 
     <feature name="brooklyn-osgi-launcher" version="${project.version}" description="Brooklyn init">


### PR DESCRIPTION
https://github.com/apache/brooklyn-server/pull/882 added brooklyn-cli to a catalog.bom. This causes brooklyn to fail to start, as karaf can't find brooklyn-cli. This PR adds brooklyn-cli to karaf