### PR TITLE
Config on entity dynamic goes on type after persistence

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
@@ -404,7 +404,8 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
         if (ownKey1==null) ownKey1 = queryKey;
         final ConfigKey<T> ownKey = ownKey1;
         @SuppressWarnings("unchecked")
-        final Class<T> type = (Class<T>) moreSpecificOrWarningPreferringFirst(ownKey, queryKey, ""+getContainer());
+        // NB: can't use ""+getContainerImpl() as this can loop in the case of locations looking up ports
+        final Class<T> type = (Class<T>) moreSpecificOrWarningPreferringFirst(ownKey, queryKey, ""+getContainer().getId()+"["+getContainer().getDisplayName()+"]");
 
         // takes type of own key (or query key if own key not available)
         // takes default of own key if available and has default, else of query key

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
@@ -36,11 +36,13 @@ import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.objs.BrooklynTypes;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -78,6 +80,7 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
         protected List<String> members = Lists.newArrayList();
         protected List<Effector<?>> effectors = Lists.newArrayList();
         
+        /** @deprecated since 1.0.0 not used, and incomplete (eg doesn't copy configKeys) */
         public Builder from(EntityMemento other) {
             super.from((TreeNode)other);
             isTopLevelApp = other.isTopLevelApp();
@@ -163,8 +166,23 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
         if (configByKey != null) {
             for (Map.Entry<ConfigKey<?>, Object> entry : configByKey.entrySet()) {
                 ConfigKey<?> key = entry.getKey();
-                if (!configKeys.containsKey(key.getName()) && key != staticConfigKeys.get(key.getName())) {
-                    configKeys.put(key.getName(), key);
+                ConfigKey<?> staticKey = staticConfigKeys.get(key.getName());
+                if (!configKeys.containsKey(key.getName()) && key != staticKey) {
+                    // added a key (programmatically) not declared on the type; add if not anonymous
+                    if (isAnonymous(key)) {
+                        // 2017-11 no longer persist these, wasteful and unhelpful, 
+                        // (can hurt if someone expects declared key to be meaningful) 
+                        log.debug("Skipping persistence of "+key+" on "+getId()+" because it is anonymous");
+                    } else {
+                        if (log.isTraceEnabled()) {
+                            if (staticKey!=null) {
+                                log.trace("Persisting dynamic config key "+key+" on "+getId()+", overriding key on type "+staticKey);
+                            } else {
+                                log.trace("Persisting dynamic config key "+key+" on "+getId());
+                            }
+                        }
+                        configKeys.put(key.getName(), key);
+                    }
                 }
                 config.put(key.getName(), entry.getValue());
             }
@@ -188,6 +206,16 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
         config = toPersistedMap(config);
         attributeKeys = toPersistedMap(attributeKeys);
         attributes = toPersistedMap(attributes);
+    }
+
+    private static boolean isAnonymous(ConfigKey<?> key) {
+        Preconditions.checkNotNull(key, "key");
+        if (!Object.class.equals(key.getType())) return false;
+        if (!Strings.isBlank(key.getDescription())) return false;
+        if (key.getDefaultValue()!=null) return false;
+        // inheritance, constraints, reconfigurability could also be checked - but above should catch any such
+        // (not even sure we need this method at all - see caller)
+        return true;
     }
 
     protected synchronized Map<String, ConfigKey<?>> getStaticConfigKeys() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
@@ -168,7 +168,11 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
                 ConfigKey<?> key = entry.getKey();
                 ConfigKey<?> staticKey = staticConfigKeys.get(key.getName());
                 if (!configKeys.containsKey(key.getName()) && key != staticKey) {
-                    // added a key (programmatically) not declared on the type; add if not anonymous
+                    // user added a key (programmatically) not declared on the type; persist if not anonymous.
+                    // on rebind this shows up in getEntityType() which is still a difference in the pre-rebind entity,
+                    // but that's more understandable and has been the case for a long time. 
+                    // (the entity type is unclear in the yaml era anyway.)
+                    // see RebindEntityTest.test*Key*
                     if (isAnonymous(key)) {
                         // 2017-11 no longer persist these, wasteful and unhelpful, 
                         // (can hurt if someone expects declared key to be meaningful) 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
@@ -31,7 +31,6 @@ import org.apache.brooklyn.api.mgmt.rebind.mementos.TreeNode;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.objs.BrooklynTypes;
@@ -231,6 +230,7 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
         return staticConfigKeys;
     }
 
+    // no longer used for writing, see comments near usage; may be useful for understanding rebinded state however
     final static String LEGACY_KEY_DESCRIPTION = "This item was defined in a different version of this blueprint; metadata unavailable here.";
     
     protected ConfigKey<?> getConfigKey(String key) {
@@ -243,11 +243,15 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
         ConfigKey<?> resultStatic = getStaticConfigKeys().get(key);
         if (resultStatic!=null) return resultStatic;
         if (result!=null) return result;
-        // can come here on rebind if a key has gone away in the class, so create a generic one; 
-        // but if it was previously found to a legacy key (below) which is added back after a regind, 
-        // gnore the legacy description (several lines above) and add the key back from static (code just above)
-        log.warn("Config key "+key+": "+LEGACY_KEY_DESCRIPTION);
-        return ConfigKeys.newConfigKey(Object.class, key, LEGACY_KEY_DESCRIPTION);
+        // can come here on rebind if a key has gone away in the class,
+        // or now if we had an anonymous key originally which is not persisted.
+        // cannot distinguish as we previously did unless we revert some of 
+        // https://github.com/apache/brooklyn-server/pull/887
+        // (maybe we _should_ persist anonymous keys - although there is also the 
+        // idea we have provenance for dealing with upgrades, probably even cleaner)
+        // now just return, not an anonymous key with LEGACY_KEY_DESCRIPTION,
+        // so caller will probably use simple anonymous key
+        return null;
     }
 
     protected synchronized Map<String, Sensor<?>> getStaticSensorKeys() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicEntityMemento.java
@@ -174,8 +174,8 @@ public class BasicEntityMemento extends AbstractTreeNodeMemento implements Entit
                     // see RebindEntityTest.test*Key*
                     if (isAnonymous(key)) {
                         // 2017-11 no longer persist these, wasteful and unhelpful, 
-                        // (can hurt if someone expects declared key to be meaningful) 
-                        log.debug("Skipping persistence of "+key+" on "+getId()+" because it is anonymous");
+                        // (can hurt if someone expects declared key to be meaningful)
+                        log.trace("Skipping persistence of "+key+" on "+getId()+" because it is anonymous");
                     } else {
                         if (log.isTraceEnabled()) {
                             if (staticKey!=null) {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -675,10 +675,12 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         Asserts.assertInstanceOf(origApp.config().get(keyAsDouble), Double.class);
         
         newApp = rebind();
-        // currently both these fail because the anonymous key definition is persisted
+        // now (2017-11) this works because we check both types on lookup
+        Asserts.assertInstanceOf(newApp.config().get(keyAsDouble), Double.class);
+        
+        // but this still fails because the anonymous key definition is persisted
         Optional<ConfigKey<?>> persistedKey = Iterables.tryFind(newApp.config().findKeysDeclared(Predicates.alwaysTrue()), (k) -> k.getName().equals(doubleKeyName));
         if (persistedKey.isPresent()) Assert.fail("Shouldn't have persisted anonymous key, but had: "+persistedKey.get());
-        Asserts.assertInstanceOf(newApp.config().get(keyAsDouble), Double.class);
     }
     
     /**

--- a/utils/common/src/main/java/org/apache/brooklyn/config/ConfigMap.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/config/ConfigMap.java
@@ -92,6 +92,7 @@ public interface ConfigMap {
     /** returns all keys present in the map matching the given filter predicate; see ConfigPredicates for common predicates.
      * if the map is associated with a container or type context where reference keys are defined,
      * those keys are included in the result whether or not present in the map (unlike {@link #findKeysPresent(Predicate)}) */
+    // TODO should be findKeysDeclaredOrPresent - if you want just the declared ones, look up the type
     public Set<ConfigKey<?>> findKeysDeclared(Predicate<? super ConfigKey<?>> filter);
 
     /** as {@link #findKeysDeclared(Predicate)} but restricted to keys actually present in the map


### PR DESCRIPTION
Fixes two issues noted with rebind of dynamic config.  See first commit first for failing test, then the others which fix it and comment.