### PR TITLE
BROOKLYN-549: fix policy rebind's execution context

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindExceptionHandlerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindExceptionHandlerImpl.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.QuorumCheck;
+import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
@@ -94,6 +95,15 @@ public class RebindExceptionHandlerImpl implements RebindExceptionHandler {
         private RebindManager.RebindFailureMode deserializePolicyFailureMode = RebindManager.RebindFailureMode.CONTINUE;
         private QuorumCheck danglingRefsQuorumRequiredHealthy = RebindManagerImpl.DANGLING_REFERENCES_MIN_REQUIRED_HEALTHY.getDefaultValue();
 
+        public Builder strict() {
+            danglingRefFailureMode = RebindManager.RebindFailureMode.FAIL_AT_END;
+            rebindFailureMode = RebindManager.RebindFailureMode.FAIL_AT_END;
+            addConfigFailureMode = RebindManager.RebindFailureMode.FAIL_AT_END;
+            addPolicyFailureMode = RebindManager.RebindFailureMode.FAIL_AT_END;
+            deserializePolicyFailureMode = RebindManager.RebindFailureMode.FAIL_AT_END;
+            danglingRefsQuorumRequiredHealthy = QuorumChecks.all();
+            return this;
+        }
         public Builder danglingRefFailureMode(RebindManager.RebindFailureMode val) {
             danglingRefFailureMode = val;
             return this;


### PR DESCRIPTION
Adds test, marked as "Broken" so not run by jenkins, which demonstrates the bug reported at https://issues.apache.org/jira/browse/BROOKLYN-549