### PR TITLE
Revert @JsonInclude annotations to what it was in 0.12.0 for backward compatibility

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSpec.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ApplicationSpec.java
@@ -90,7 +90,6 @@ public class ApplicationSpec implements HasName, Serializable {
     private final String type;
     @JsonInclude(Include.NON_NULL)
     private final Set<EntitySpec> entities;
-    @JsonInclude(Include.NON_NULL)
     private final Set<String> locations;
     @JsonInclude(Include.NON_EMPTY)
     private final Map<String, String> config;

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ConfigSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/ConfigSummary.java
@@ -57,14 +57,14 @@ public class ConfigSummary implements HasName, Serializable {
     private final String label;
     @JsonInclude(Include.NON_NULL)
     private final Double priority;
-    @JsonInclude(Include.NON_EMPTY)
+    @JsonInclude(Include.NON_NULL)
     private final List<Map<String, String>> possibleValues;
     @JsonInclude(Include.NON_NULL)
     private final Boolean pinned;
-    @JsonInclude(Include.NON_EMPTY)
+    @JsonInclude(Include.NON_NULL)
     private final List<String> constraints;
 
-    @JsonInclude(Include.NON_EMPTY)
+    @JsonInclude(Include.NON_NULL)
     private final Map<String, URI> links;
 
     // json deserialization


### PR DESCRIPTION
As per as [the discussion on the ML](https://lists.apache.org/thread.html/274c9b60e5fc15a7f25f0311dd0139667d0c7a5536ff86523010089d@%3Cdev.brooklyn.apache.org%3E), this revert the use of `@JsonInclude` annotation for certain fields of domain objects to insure backward compatibility. 