### PR TITLE
REST `/applications/fetch` can request selected sensors

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ManagementContext.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Predicate;
 
 /**
  * This is the entry point for accessing and interacting with a realm of applications and their entities in Brooklyn.
@@ -309,8 +310,14 @@ public interface ManagementContext {
     /** As {@link #lookup(String, Class)} but not constraining the return type */
     public BrooklynObject lookup(String id);
     
-    /** Finds an entity with the given ID known at this management context */
-    // TODO in future support policies etc
+    /** As {@link #lookup(Predicate)} comparing the ID of the object with the given string */
     public <T extends BrooklynObject> T lookup(String id, Class<T> type); 
 
+    /** Finds a {@link BrooklynObject} known in this management context 
+     * satisfying the given predicate, or null */
+    public <T extends BrooklynObject> T lookup(Predicate<? super T> filter);
+    
+    /** As {@link #lookup(Predicate)} but returning all such instances */
+    public <T extends BrooklynObject> Collection<T> lookupAll(Predicate<? super T> filter);
+    
 }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAsserts.java
@@ -230,7 +230,6 @@ public class EntityAsserts {
      * Setting these sensors is common behaviour for entities, but depends on the particular entity
      * implementation.
      */
-    @Beta
     public static void assertEntityHealthy(Entity entity) {
         assertAttributeEquals(entity, SERVICE_UP, true);
         assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
@@ -240,6 +239,9 @@ public class EntityAsserts {
                 return Lifecycle.RUNNING.equals(transition.getState());
             }
         });
+    }
+    public static void assertEntityHealthyEventually(Entity entity) {
+        Asserts.succeedsEventually(() -> assertEntityHealthy(entity));
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -77,6 +77,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -503,6 +504,18 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
         return initialManagementContext.lookup(id, type);
     }
 
+    @Override
+    public <T extends BrooklynObject> T lookup(Predicate<? super T> filter) {
+        checkInitialManagementContextReal();
+        return initialManagementContext.lookup(filter);
+    }
+
+    @Override
+    public <T extends BrooklynObject> Collection<T> lookupAll(Predicate<? super T> filter) {
+        checkInitialManagementContextReal();
+        return initialManagementContext.lookupAll(filter);
+    }
+    
     @Override
     public List<Throwable> errors() {
         checkInitialManagementContextReal();

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -808,10 +809,10 @@ public class BasicTask<T> implements TaskInternal<T> {
                 return;
             }
             if (!t.isDone()) {
-                // shouldn't happen
-                // TODO But does happen if management context was terminated (e.g. running test suite).
-                //      Should check if Execution Manager is running, and only log if it was not terminated?
-                log.warn("Task "+t+" is being finalized before completion");
+                if (!BrooklynTaskTags.getExecutionContext(t).isShutdown()) {
+                    // not sure how this could happen
+                    log.warn("Task "+t+" was submitted but forgotten before it was run (finalized before completion)");
+                }
                 return;
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -359,7 +359,10 @@ public class Tasks {
         } }).build();
     }
     public static Task<Void> warning(final String message, final Throwable optionalError) {
-        log.warn(message);
+        return warning(message, optionalError, true);
+    }
+    public static Task<Void> warning(final String message, final Throwable optionalError, boolean logWarning) {
+        if (logWarning) log.warn(message);
         return TaskTags.markInessential(fail(message, optionalError));
     }
 

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/EnrichersTest.java
@@ -85,6 +85,17 @@ public class EnrichersTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
+    public void testLookup() {
+        Enricher enr = entity.enrichers().add(Enrichers.builder()
+                .combining(NUM1, NUM2)
+                .publishing(NUM3)
+                .computingSum()
+                .build());
+        
+        Assert.assertEquals(mgmt.lookup(enr.getId()), enr);
+    }
+    
+    @Test
     public void testAdding() {
         Enricher enr = entity.enrichers().add(Enrichers.builder()
                 .combining(NUM1, NUM2)

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -56,16 +56,21 @@ public interface ApplicationApi {
     @GET
     @Path("/fetch")
     @ApiOperation(
-            value = "Fetch display details for all applications and optionally selected additional entities"
+            value = "Fetch details for all applications and optionally selected additional entity items, "
+                + "optionally also with the values for selected sensors"
     )
     public List<EntityDetail> fetch(
-            @ApiParam(value="Selected additional entity ID's to include, comma-separated", required=false)
+            @ApiParam(value="Any additional entity ID's to include, as JSON or comma-separated list", required=false)
             @DefaultValue("")
-            @QueryParam("items") String items);
+            @QueryParam("items") String items,
+            @ApiParam(value="Any additional sensors to include, as JSON or comma-separated list; "
+                + "current sensor values if present are returned for each entity in a name-value map under the 'sensors' key", required=false)
+            @DefaultValue("")
+            @QueryParam("sensors") String sensors);
 
     @GET
     @ApiOperation(
-            value = "Fetch list of applications, as ApplicationSummary objects",
+            value = "Fetch the list of applications managed here",
             response = org.apache.brooklyn.rest.domain.ApplicationSummary.class
     )
     public List<ApplicationSummary> list(
@@ -82,7 +87,7 @@ public interface ApplicationApi {
     @GET
     @Path("/{application}")
     @ApiOperation(
-            value = "Fetch a specific application",
+            value = "Fetch details of an application",
             response = org.apache.brooklyn.rest.domain.ApplicationSummary.class
     )
     @ApiResponses(value = {

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/EntityApi.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public interface EntityApi {
 
     @GET
-    @ApiOperation(value = "Fetch the list of entities for a given application",
+    @ApiOperation(value = "Fetch the list of children entities directly under the root of an application",
             response = org.apache.brooklyn.rest.domain.EntitySummary.class,
             responseContainer = "List")
     @ApiResponses(value = {
@@ -54,7 +54,7 @@ public interface EntityApi {
 
     @GET
     @Path("/{entity}")
-    @ApiOperation(value = "Fetch details about a specific application entity",
+    @ApiOperation(value = "Fetch details of an entity",
             response = org.apache.brooklyn.rest.domain.EntitySummary.class)
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Application or entity missing")
@@ -67,7 +67,7 @@ public interface EntityApi {
 
     // TODO rename as "/children" ?
     @GET
-    @ApiOperation(value = "Fetch details about a specific application entity's children",
+    @ApiOperation(value = "Fetch the list of children of an entity",
             response = org.apache.brooklyn.rest.domain.EntitySummary.class)
     @Path("/{entity}/children")
     public List<EntitySummary> getChildren(

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntitySummary.java
@@ -23,6 +23,12 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,6 +44,11 @@ public class EntitySummary implements HasId, HasName, Serializable {
     @JsonInclude(Include.NON_NULL)
     private final String catalogItemId;
     private final Map<String, URI> links;
+
+    // not exported directly, but used to provide other top-level json fields
+    // for specific types
+    @JsonIgnore
+    private final Map<String,Object> others = MutableMap.of();
 
     public EntitySummary(
             @JsonProperty("id") String id,
@@ -74,6 +85,16 @@ public class EntitySummary implements HasId, HasName, Serializable {
         return links;
     }
 
+    /** Mutable map of other top-level metadata included on this DTO (eg listing config keys or effectors) */ 
+    @JsonAnyGetter 
+    public Map<String,Object> getExtraFields() {
+        return others;
+    }
+    @JsonAnySetter
+    public void setExtraField(String name, Object value) {
+        others.put(name, value);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -93,11 +114,12 @@ public class EntitySummary implements HasId, HasName, Serializable {
 
     @Override
     public String toString() {
-        return "EntitySummary{" +
+        return JavaClassNames.simpleClassName(this)+"{" +
                 "id='" + id + '\'' +
                 ", name='" + name + '\'' +
                 ", type='" + type + '\'' +
                 ", catalogItemId='" + catalogItemId + '\'' +
+                (!getExtraFields().isEmpty() ? ", others='"+getExtraFields()+"'" : "")+
                 ", links=" + links +
                 '}';
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
@@ -29,6 +29,8 @@ import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements.EntityAndItem;
 import org.apache.brooklyn.rest.api.EntityConfigApi;
@@ -88,7 +90,9 @@ public class EntityConfigResource extends AbstractBrooklynRestResource implement
         }
 
         // wrap in a task for better runtime view
-        return Entities.submit(entity, Tasks.<Map<String,Object>>builder().displayName("REST API batch config read").body(new BatchConfigRead(mgmt(), this, entity, raw)).build()).getUnchecked();
+        return Entities.submit(entity, Tasks.<Map<String,Object>>builder().displayName("REST API batch config read")
+            .tag(BrooklynTaskTags.TRANSIENT_TASK_TAG)
+            .body(new BatchConfigRead(mgmt(), this, entity, raw)).build()).getUnchecked();
     }
     
     private static class BatchConfigRead implements Callable<Map<String,Object>> {


### PR DESCRIPTION
This allows clients to efficiently get selected sensors they are interested in.

Does this by adding a `@JsonAnyGetter` map to `EntitySummary`, as done for `TypeSummary` and elsewhere, returning data in `sensors` key.

Re-enables the `fetch` test (disabled in #156) to assert this, but with better logging if the problem recurs.

Also sets batch config read task as transient so it doesn't clutter the activities view.