### PR TITLE
BROOKLYN-461: coerce empty string to URI as null

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/CommonAdaptorTypeCoercions.java
@@ -148,7 +148,7 @@ public class CommonAdaptorTypeCoercions {
         registerAdapter(String.class, URI.class, new Function<String,URI>() {
             @Override
             public URI apply(String input) {
-                return URI.create(input);
+                return Strings.isNonBlank(input) ? URI.create(input) : null;
             }
         });
         registerAdapter(URI.class, String.class, new Function<URI,String>() {

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
@@ -399,6 +399,15 @@ public class TypeCoercionsTest {
     }
 
     @Test
+    public void testStringToUriCoercion() {
+        Assert.assertEquals(coerce("http://localhost:1234/", URI.class), URI.create("http://localhost:1234/"));
+        
+        // Empty string is coerced to null; in contrast, `URI.create("")` gives a URI
+        // with null scheme, host, etc (which would be very surprising for Brooklyn users!).
+        Assert.assertEquals(coerce("", URI.class), null);
+    }
+
+    @Test
     public void testURLtoStringCoercion() throws MalformedURLException {
         String s = coerce(new URL("http://localhost:1234/"), String.class);
         Assert.assertEquals(s, "http://localhost:1234/");


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/BROOKLYN-561