### PR TITLE
Add dockerfile for CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM maven:3.5.2-jdk-8-alpine
+
+# Install necessary binaries to build brooklyn-server
+RUN apk add --no-cache git

--- a/README.md
+++ b/README.md
@@ -5,3 +5,30 @@
 
 This repo contains the core elements to run a Brooklyn server,
 from the API and utils through to the core implementation and the REST server.
+
+### Building the project
+
+2 methods are available to build this project: within a docker container or directly with maven.
+
+#### Using docker
+
+The project comes with a `Dockerfile` that contains everything you need to build this project.
+First, build the docker image:
+
+```bash
+docker build -t brooklyn:server .
+```
+
+Then run the build:
+
+```bash
+docker run -i --rm --name brooklyn-server -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn:server mvn clean install
+```
+
+### Using maven
+
+Simply run:
+
+```bash
+mvn clean install
+```


### PR DESCRIPTION
As per as the [ML discussion](https://lists.apache.org/thread.html/c97846e172d327e72eb286e3c032c26fc0d6642dc553a4b47494177c@%3Cdev.brooklyn.apache.org%3E), this adds the `Dockerfile` to build the project. It also adds instructions on how to use it.