### PR TITLE
Fix VSP stop/start when ssh monitoring disabled

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessImpl.java
@@ -49,7 +49,15 @@ public class VanillaSoftwareProcessImpl extends SoftwareProcessImpl implements V
             ServiceNotUpLogic.clearNotUpIndicator(this, SERVICE_PROCESS_IS_RUNNING);
         }
     }
-    
+
+    @Override
+    protected void postStop() {
+        super.postStop();
+        if (!isSshMonitoringEnabled()) {
+            ServiceNotUpLogic.updateNotUpIndicator(this, SERVICE_PROCESS_IS_RUNNING, "This service was stopped");
+        }
+    }
+
     @Override
     protected void disconnectSensors() {
         disconnectServiceUpIsRunning();

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
@@ -367,5 +367,9 @@ public class VanillaSoftwareProcessTest extends BrooklynAppUnitTestSupport {
         // Restart (see https://issues.apache.org/jira/browse/BROOKLYN-547)
         entity.restart();
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        entity.stop();
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        entity.start(ImmutableList.of());
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessTest.java
@@ -18,14 +18,7 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecContains;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecHasAtLeastOnce;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecHasNever;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecHasOnlyOnce;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecSatisfies;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecsContain;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecsNotContains;
-import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.assertExecsSatisfy;
+import static org.apache.brooklyn.util.core.internal.ssh.ExecCmdAsserts.*;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -150,6 +143,18 @@ public class VanillaSoftwareProcessTest extends BrooklynAppUnitTestSupport {
                 "checkRunningCommand", "stopCommand",  
                 "preLaunchCommand", "launchCommand", "postLaunchCommand", 
                 "checkRunningCommand"));
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+
+        Entities.invokeEffector(app, entity, SoftwareProcess.STOP, ImmutableMap.of(
+                SoftwareProcess.StopSoftwareParameters.STOP_MACHINE_MODE.getName(), SoftwareProcess.StopSoftwareParameters.StopMode.NEVER))
+                .get();
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+
+        entity.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
     }
 
     
@@ -309,7 +314,7 @@ public class VanillaSoftwareProcessTest extends BrooklynAppUnitTestSupport {
         assertExecHasOnlyOnce(RecordingSshTool.getExecCmds(), "preInstallCommand");
         assertExecHasOnlyOnce(RecordingSshTool.getExecCmds(), "launchCommand");
     }
-    
+
     @Test
     public void testUseSshMonitoringDisabled() throws Exception {
         // Setup a custom health-check that returns true after launch is called, 
@@ -367,8 +372,12 @@ public class VanillaSoftwareProcessTest extends BrooklynAppUnitTestSupport {
         // Restart (see https://issues.apache.org/jira/browse/BROOKLYN-547)
         entity.restart();
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
-        entity.stop();
+
+        Entities.invokeEffector(app, entity, SoftwareProcess.STOP, ImmutableMap.of(
+                SoftwareProcess.StopSoftwareParameters.STOP_MACHINE_MODE.getName(), SoftwareProcess.StopSoftwareParameters.StopMode.NEVER))
+                .get();
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+
         entity.start(ImmutableList.of());
         EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
     }


### PR DESCRIPTION
When stop / starting a VanillaSoftwareProcess with ssh monitoring the
process will never be marked as healthy after a stop start.

On a restart the feeds are not disconnected so a service.notup.indicator
is set.  When this is cleared on start the ServiceNotUpLogic will detect
the change and set the isUp sensor true.  However when stopping the
process feeds are disconnected so no service.notup indicators are set.
This means the ServiceNotUp logic will not detect a change on start and
won't set the service isUp sensor to true.

Fixed by setting a service.notUp.indicator on stop.