### PR TITLE
BROOKLYN-545: Fix DynamicCluster.zoneFailureDetector default val

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicCluster.java
@@ -44,7 +44,6 @@ import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.zoneaware.BalancingNodePlacementStrategy;
-import org.apache.brooklyn.entity.group.zoneaware.ProportionalZoneFailureDetector;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
 
@@ -165,7 +164,7 @@ public interface DynamicCluster extends AbstractGroup, Cluster, MemberReplaceabl
 
     @SetFromFlag("zoneFailureDetector")
     ConfigKey<ZoneFailureDetector> ZONE_FAILURE_DETECTOR = ConfigKeys.newConfigKey(
-            ZoneFailureDetector.class, "dynamiccluster.zone.failureDetector", "Zone failure detector", new ProportionalZoneFailureDetector(2, Duration.ONE_HOUR, 0.9));
+            ZoneFailureDetector.class, "dynamiccluster.zone.failureDetector", "Zone failure detector", null);
 
     @SetFromFlag("zonePlacementStrategy")
     ConfigKey<NodePlacementStrategy> ZONE_PLACEMENT_STRATEGY = ConfigKeys.newConfigKey(

--- a/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/BalancingNodePlacementStrategy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/zoneaware/BalancingNodePlacementStrategy.java
@@ -40,6 +40,8 @@ import com.google.common.collect.Multimap;
 
 /**
  * Default node placement strategy: attempts to keep the number of nodes balanced across the available locations.
+ * <p>
+ * Instance(s) are immutable. It is safe to use this as a shared default config value.
  */
 public class BalancingNodePlacementStrategy implements NodePlacementStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(BalancingNodePlacementStrategy.class);

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesRebindTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.group;
+
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.core.location.SimulatedLocation;
+import org.apache.brooklyn.core.location.cloud.AvailabilityZoneExtension;
+import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.entity.group.DynamicCluster.ZoneFailureDetector;
+import org.apache.brooklyn.entity.group.DynamicClusterWithAvailabilityZonesTest.SimulatedAvailabilityZoneExtension;
+import org.apache.brooklyn.entity.group.zoneaware.ProportionalZoneFailureDetector;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+
+public class DynamicClusterWithAvailabilityZonesRebindTest extends RebindTestFixtureWithApp {
+    
+    // Previously, when there was a mutable default value for ZONE_FAILURE_DETECTOR, the second cluster
+    // would include failure info for the first cluster's zone-locations. When these were unmanaged,
+    // the zone-locations would become dangling referenes within the ZoneFailureDetector. This caused
+    // NPE on rebind.
+    //
+    // Config key persistence was then changed so that statically defined keys (such as ZONE_FAILURE_DETECTOR,
+    // declared on the DynamicCluster class) would not be persisted. This meant that the ZoneFailureDetector
+    // state was no longer persisted for either location. The NPE on rebind went away, but the config key
+    // default value instance was still shared between all clusters.
+    //
+    // Now the detector has a null default value. We implicitly set a transient field for the zoneFailureDetector
+    // so if using defaults then nothing is persisted. But if a custom ZoneFailureDetector is supplied, then
+    // that will be persisted and used.
+    @Test
+    public void testRebindWithDefaultZoneFailureDetector() throws Exception {
+        // Start and then unmanage a cluster (so it's detector was populated).
+        // Do this in case the ZoneFailureDetector is shared!
+        SimulatedLocation loc = mgmt().getLocationManager().createLocation(LocationSpec.create(SimulatedLocationWithZoneExtension.class)
+                .configure(SimulatedLocationWithZoneExtension.ZONE_NAMES, ImmutableList.of("zone1", "zone2"))
+                .configure(SimulatedLocationWithZoneExtension.ZONE_FAIL_CONDITIONS, ImmutableMap.of("zone1", Predicates.alwaysTrue())));
+
+        DynamicCluster cluster = app().addChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true)
+                .configure(DynamicCluster.INITIAL_SIZE, 2)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
+        
+        cluster.start(ImmutableList.of(loc));
+        
+        Entities.unmanage(cluster);
+        Locations.unmanage(loc);
+
+        // Start a second cluster
+        SimulatedLocation locUnrelated = mgmt().getLocationManager().createLocation(LocationSpec.create(SimulatedLocationWithZoneExtension.class)
+                .configure(SimulatedLocationWithZoneExtension.ZONE_NAMES, ImmutableList.of("zone3", "zone4"))
+                .configure(SimulatedLocationWithZoneExtension.ZONE_FAIL_CONDITIONS, ImmutableMap.of("zone3", Predicates.alwaysTrue())));
+        
+        DynamicCluster clusterUnrelated = app().addChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true)
+                .configure(DynamicCluster.INITIAL_SIZE, 2)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
+        clusterUnrelated.start(ImmutableList.of(locUnrelated));
+        
+        rebind();
+        
+        // Confirm that cluster is usable
+        DynamicCluster newClusterUnrelated = (DynamicCluster) mgmt().getEntityManager().getEntity(clusterUnrelated.getId());
+        newClusterUnrelated.resize(4);
+    }
+    
+    @Test
+    public void testRebindWithCustomZoneFailureDetector() throws Exception {
+        // Start and then unmanage a cluster (so it's detector was populated).
+        // Do this in case the ZoneFailureDetector is shared!
+        SimulatedLocation loc = mgmt().getLocationManager().createLocation(LocationSpec.create(SimulatedLocationWithZoneExtension.class)
+                .configure(SimulatedLocationWithZoneExtension.ZONE_NAMES, ImmutableList.of("zone1", "zone2"))
+                .configure(SimulatedLocationWithZoneExtension.ZONE_FAIL_CONDITIONS, ImmutableMap.of("zone1", Predicates.alwaysTrue())));
+
+        DynamicCluster cluster = app().addChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true)
+                .configure(DynamicCluster.INITIAL_SIZE, 2)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class))
+                .configure(DynamicCluster.ZONE_FAILURE_DETECTOR, new CustomZoneFailureDetector(2, Duration.ONE_HOUR, 0.9)));
+        
+        cluster.start(ImmutableList.of(loc));
+        ZoneFailureDetector detector = ((DynamicClusterImpl)Entities.deproxy(cluster)).getZoneFailureDetector();
+        assertTrue(detector instanceof CustomZoneFailureDetector, "detector="+detector);
+        
+        rebind();
+        
+        // Confirm that has custom detector, and is usable
+        DynamicCluster newCluster = (DynamicCluster) mgmt().getEntityManager().getEntity(cluster.getId());
+        ZoneFailureDetector newDetector = ((DynamicClusterImpl)Entities.deproxy(newCluster)).getZoneFailureDetector();
+        assertTrue(newDetector instanceof CustomZoneFailureDetector, "detector="+newDetector);
+        
+        cluster.resize(4);
+    }
+    
+    public static class CustomZoneFailureDetector extends ProportionalZoneFailureDetector {
+        public CustomZoneFailureDetector(int minDatapoints, Duration timeToConsider, double maxProportionFailures) {
+            super(minDatapoints, timeToConsider, maxProportionFailures);
+        }
+    }
+    
+    public static class SimulatedLocationWithZoneExtension extends SimulatedLocation {
+        @SuppressWarnings("serial")
+        public static final ConfigKey<List<String>> ZONE_NAMES = ConfigKeys.newConfigKey(
+                new TypeToken<List<String>>() {},
+                "zoneNames");
+        
+        @SuppressWarnings("serial")
+        public static final ConfigKey<Map<String, ? extends Predicate<? super SimulatedLocation>>> ZONE_FAIL_CONDITIONS = ConfigKeys.newConfigKey(
+                new TypeToken<Map<String, ? extends Predicate<? super SimulatedLocation>>>() {},
+                "zoneFailConditions");
+        
+        @Override
+        public void init() {
+            super.init();
+            addExtension(AvailabilityZoneExtension.class, new SimulatedAvailabilityZoneExtension(getManagementContext(), this, 
+                    config().get(ZONE_NAMES), config().get(ZONE_FAIL_CONDITIONS)));
+        }
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesTest.java
@@ -20,10 +20,13 @@ package org.apache.brooklyn.entity.group;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,6 +36,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityPredicates;
 import org.apache.brooklyn.core.entity.trait.FailingEntity;
 import org.apache.brooklyn.core.location.SimulatedLocation;
@@ -41,16 +45,19 @@ import org.apache.brooklyn.core.location.cloud.AvailabilityZoneExtension;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.entity.group.DynamicCluster.ZoneFailureDetector;
 import org.apache.brooklyn.entity.group.zoneaware.ProportionalZoneFailureDetector;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.javalang.Reflections;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -64,10 +71,7 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
-                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true)
-                .configure(DynamicCluster.INITIAL_SIZE, 0)
-                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class)));
+        cluster = app.createAndManageChild(clusterSpec());
         
         loc = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
         loc.addExtension(AvailabilityZoneExtension.class, new SimulatedAvailabilityZoneExtension(mgmt, loc, ImmutableList.of("zone1", "zone2", "zone3", "zone4")));
@@ -143,10 +147,12 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
             }
         };
         
-        cluster.config().set(DynamicCluster.ZONE_FAILURE_DETECTOR, new ProportionalZoneFailureDetector(2, Duration.ONE_HOUR, 0.9, ticker));
-        cluster.config().set(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"));
-        cluster.config().set(DynamicCluster.MEMBER_SPEC, EntitySpec.create(FailingEntity.class)
-                .configure(FailingEntity.FAIL_ON_START_CONDITION, failurePredicate));
+        // Don't change zoneFailureDetector on-the-fly; create a new cluster
+        cluster = app.createAndManageChild(clusterSpec()
+                .configure(DynamicCluster.ZONE_FAILURE_DETECTOR, new ProportionalZoneFailureDetector(2, Duration.ONE_HOUR, 0.9, ticker))
+                .configure(DynamicCluster.AVAILABILITY_ZONE_NAMES, ImmutableList.of("zone1", "zone2"))
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(FailingEntity.class)
+                        .configure(FailingEntity.FAIL_ON_START_CONDITION, failurePredicate)));
         cluster.start(ImmutableList.of(loc));
         
         cluster.resize(1);
@@ -172,6 +178,48 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
         Asserts.assertEqualsIgnoringOrder(locsUsed, ImmutableList.of(locUsed, locUsed, locUsed, otherLoc));
     }
     
+    // If default config value for ZoneFailureDetector is mutable, causes problems where apps interfere.
+    // Worse, it can cause rebind issues - if the original app and its location have been deleted,
+    // another cluster might still have a ZoneFailureDetector whose default value references th
+    // unmanaged location!
+    @Test
+    public void testZoneFailureDetectorNotShared() throws Exception {
+        SimulatedLocation locWithFailures = mgmt.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
+        locWithFailures.addExtension(AvailabilityZoneExtension.class, new SimulatedAvailabilityZoneExtension(mgmt, loc, 
+                ImmutableList.of("zone1", "zone2"),
+                ImmutableMap.of("zone1", Predicates.alwaysTrue())));
+
+        cluster.config().set(DynamicCluster.INITIAL_SIZE, 2);
+        cluster.start(ImmutableList.of(loc));
+        ZoneFailureDetector zoneFailureDetector = ((DynamicClusterImpl)Entities.deproxy(cluster)).getZoneFailureDetector();
+        assertZoneHistoriesNotEmpty(zoneFailureDetector);
+        
+        DynamicCluster unrelatedCluster = app.addChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true));
+        ZoneFailureDetector unrelatedZoneFailureDetector = ((DynamicClusterImpl)Entities.deproxy(unrelatedCluster)).getZoneFailureDetector();
+        assertZoneHistoriesEmpty(unrelatedZoneFailureDetector);
+    }
+
+    protected EntitySpec<DynamicCluster> clusterSpec() {
+        return EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.ENABLE_AVAILABILITY_ZONES, true)
+                .configure(DynamicCluster.INITIAL_SIZE, 0)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class));
+    }
+
+    private void assertZoneHistoriesEmpty(ZoneFailureDetector zoneFailureDetector) {
+        // Poke inside ProportionalZoneFailureDetector, to make sure it is empty.
+        // Live with the reflection for the test; it's in a .zoneaware sub-package,
+        // so can't just make it package-private either.
+        Map<?,?> zoneHistories = (Map<?,?>) Reflections.getFieldValueMaybe((ProportionalZoneFailureDetector)zoneFailureDetector, "zoneHistories").get();
+        assertTrue(zoneHistories.isEmpty(), "zoneHistories="+zoneHistories);
+    }
+
+    private void assertZoneHistoriesNotEmpty(ZoneFailureDetector zoneFailureDetector) {
+        Map<?,?> zoneHistories = (Map<?,?>) Reflections.getFieldValueMaybe((ProportionalZoneFailureDetector)zoneFailureDetector, "zoneHistories").get();
+        assertFalse(zoneHistories.isEmpty(), "zoneHistories="+zoneHistories);
+    }
+
     protected List<String> getLocationNames(Iterable<? extends Location> locs) {
         List<String> result = Lists.newArrayList();
         for (Location subLoc : locs) {
@@ -193,11 +241,19 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
     public static class SimulatedAvailabilityZoneExtension extends AbstractAvailabilityZoneExtension implements AvailabilityZoneExtension {
         private final SimulatedLocation loc;
         private final List<String> subLocNames;
+        private final Map<String, ? extends Predicate<? super SimulatedLocation>> subLocFailConditions;
+
+        public SimulatedAvailabilityZoneExtension(ManagementContext managementContext, SimulatedLocation loc, 
+                List<String> subLocNames) {
+            this(managementContext, loc, subLocNames, ImmutableMap.of());
+        }
         
-        public SimulatedAvailabilityZoneExtension(ManagementContext managementContext, SimulatedLocation loc, List<String> subLocNames) {
+        public SimulatedAvailabilityZoneExtension(ManagementContext managementContext, SimulatedLocation loc, 
+                List<String> subLocNames, Map<String, ? extends Predicate<? super SimulatedLocation>> subLocFailCondition) {
             super(managementContext);
             this.loc = checkNotNull(loc, "loc");
             this.subLocNames = subLocNames;
+            this.subLocFailConditions = subLocFailCondition;
         }
 
         @Override
@@ -214,11 +270,12 @@ public class DynamicClusterWithAvailabilityZonesTest extends BrooklynAppUnitTest
             return namePredicate.apply(loc.getDisplayName());
         }
         
-        protected SimulatedLocation newSubLocation(Location parent, String displayName) {
+        protected SimulatedLocation newSubLocation(Location parent, String subLocName) {
             return managementContext.getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class)
                     .parent(parent)
                     .configure(((LocationInternal)parent).config().getBag().getAllConfig())
-                    .displayName(displayName));
+                    .configure(SimulatedLocation.FAIL_ON_PROVISION_CONDITION, subLocFailConditions.get(subLocName))
+                    .displayName(subLocName));
         }
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BROOKLYN-545

Below is an extract from the comments in the code, explaining it - see other code comments for more info:
```
    // Previously, when there was a mutable default value for ZONE_FAILURE_DETECTOR, the second cluster
    // would include failure info for the first cluster's zone-locations. When these were unmanaged,
    // the zone-locations would become dangling referenes within the ZoneFailureDetector. This caused
    // NPE on rebind.
    //
    // Config key persistence was then changed so that statically defined keys (such as ZONE_FAILURE_DETECTOR,
    // declared on the DynamicCluster class) would not be persisted. This meant that the ZoneFailureDetector
    // state was no longer persisted for either location. The NPE on rebind went away, but the config key
    // default value instance was still shared between all clusters.
    //
    // Now the detector has a null default value. We implicitly set a transient field for the zoneFailureDetector
    // so if using defaults then nothing is persisted. But if a custom ZoneFailureDetector is supplied, then
    // that will be persisted and used.
```