### PR TITLE
BROOKLYN-565: fix Brooklyn:object with nested dsl

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
@@ -19,8 +19,6 @@
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
 
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 
@@ -40,16 +38,6 @@ public class DslUtils {
             if (arg instanceof DeferredSupplier<?>) {
                 allResolved = false;
                 break;
-            } else if (arg instanceof Collection) {
-                if (!resolved((Collection<?>)arg)) {
-                    allResolved = false;
-                    break;
-                }
-            } else if (arg instanceof Map) {
-                if (!(resolved(((Map<?,?>)arg).keySet()) && resolved(((Map<?,?>)arg).values()))) {
-                    allResolved = false;
-                    break;
-                }
             }
         }
         return allResolved;

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
@@ -18,27 +18,40 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
-import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 
-import com.google.common.collect.Iterables;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 
 public class DslUtils {
 
     /** true iff none of the args are deferred / tasks */
-    public static boolean resolved(Iterable<Object> args) {
-        return resolved(Iterables.toArray(args, Object.class));
-    }
-
-    /** true iff none of the args are deferred / tasks */
     public static boolean resolved(final Object... args) {
+        if (args == null) return true;
+        return resolved(Arrays.asList(args));
+    }
+    
+    /** true iff none of the args are deferred / tasks */
+    public static boolean resolved(Iterable<?> args) {
+        if (args == null) return true;
         boolean allResolved = true;
         for (Object arg: args) {
             if (arg instanceof DeferredSupplier<?>) {
                 allResolved = false;
                 break;
+            } else if (arg instanceof Collection) {
+                if (!resolved((Collection<?>)arg)) {
+                    allResolved = false;
+                    break;
+                }
+            } else if (arg instanceof Map) {
+                if (!(resolved(((Map<?,?>)arg).keySet()) && resolved(((Map<?,?>)arg).values()))) {
+                    allResolved = false;
+                    break;
+                }
             }
         }
         return allResolved;
     }
-
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
@@ -65,6 +65,7 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         private String string;
         private Integer number;
         private Object object;
+        private List<String> list;
 
         // Factory method.
         public static TestObject newTestObjectWithNoArgs() {
@@ -94,6 +95,9 @@ public class ObjectsYamlTest extends AbstractYamlTest {
 
         public Object getObject() { return object; }
         public void setObject(Object object) { this.object = object; }
+
+        public List<String> getList() { return list; }
+        public void setList(List<String> list) { this.list = list; }
 
         @Override
         public void setManagementContext(ManagementContext managementContext) {
@@ -410,7 +414,7 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         String val = (String) testEntity.getConfig(TestEntity.CONF_OBJECT);
         assertEquals(val, "1970-01-01T00:00:01");
     }
-
+    
     @Test
     public void testFieldsAsDeferredSuppliers() throws Exception {
         // all fields as deferred suppliers
@@ -424,13 +428,16 @@ public class ObjectsYamlTest extends AbstractYamlTest {
                 "        type: "+ObjectsYamlTest.class.getName()+"$TestObject",
                 "        object.fields:",
                 "          number: $brooklyn:config(\"myint\")",
-                "          string: $brooklyn:config(\"mystring\")");
+                "          string: $brooklyn:config(\"mystring\")",
+                "          list: ",
+                "          - $brooklyn:config(\"mystring\")");
     
             TestObject testObject = (TestObject) testEntity.getConfig(TestEntity.CONF_OBJECT);
             Assert.assertEquals(testObject.getNumber(), Integer.valueOf(123));
             Assert.assertEquals(testObject.getString(), "myval");
+            Assert.assertEquals(testObject.getList(), ImmutableList.of("myval"));
         }
-        
+
         // Only first field as deferred supplier
         {
             Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
@@ -468,6 +475,44 @@ public class ObjectsYamlTest extends AbstractYamlTest {
         }
     }
 
+    @Test
+    public void testFieldOfTypeListAsDeferredSuppliers() throws Exception {
+        {
+            // Using explicit `deferred: true`
+            Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
+                "  brooklyn.config:",
+                "    mystring: myval",
+                "    myint: 123",
+                "    test.confObject:",
+                "      $brooklyn:object:",
+                "        type: "+ObjectsYamlTest.class.getName()+"$TestObject",
+                "        deferred: true",
+                "        object.fields:",
+                "          list: ",
+                "          - $brooklyn:config(\"mystring\")");
+    
+            TestObject testObject = (TestObject) testEntity.getConfig(TestEntity.CONF_OBJECT);
+            Assert.assertEquals(testObject.getList(), ImmutableList.of("myval"));
+        }
+        {
+            // See https://issues.apache.org/jira/browse/BROOKLYN-565
+            // should defer evaluation automatically, and resolve config in `getConfig()`
+            Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
+                "  brooklyn.config:",
+                "    mystring: myval",
+                "    myint: 123",
+                "    test.confObject:",
+                "      $brooklyn:object:",
+                "        type: "+ObjectsYamlTest.class.getName()+"$TestObject",
+                "        object.fields:",
+                "          list: ",
+                "          - $brooklyn:config(\"mystring\")");
+    
+            TestObject testObject = (TestObject) testEntity.getConfig(TestEntity.CONF_OBJECT);
+            Assert.assertEquals(testObject.getList(), ImmutableList.of("myval"));
+        }
+    }
+    
     @Test
     public void testConfigAsDeferredSuppliers() throws Exception {
         // all fields as deferred suppliers

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ObjectsYamlTest.java
@@ -476,7 +476,7 @@ public class ObjectsYamlTest extends AbstractYamlTest {
     }
 
     @Test
-    public void testFieldOfTypeListAsDeferredSuppliers() throws Exception {
+    public void testFieldOfTypeListAsDeferredSuppliersExplicitlyDeferred() throws Exception {
         {
             // Using explicit `deferred: true`
             Entity testEntity = setupAndCheckTestEntityInBasicYamlWith(
@@ -494,6 +494,11 @@ public class ObjectsYamlTest extends AbstractYamlTest {
             TestObject testObject = (TestObject) testEntity.getConfig(TestEntity.CONF_OBJECT);
             Assert.assertEquals(testObject.getList(), ImmutableList.of("myval"));
         }
+    }
+    
+    // TODO See https://issues.apache.org/jira/browse/BROOKLYN-565
+    @Test(groups="Broken")
+    public void testFieldOfTypeListAsDeferredSuppliers() throws Exception {
         {
             // See https://issues.apache.org/jira/browse/BROOKLYN-565
             // should defer evaluation automatically, and resolve config in `getConfig()`

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtilsTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.spi.dsl;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class DslUtilsTest {
+
+    @Test
+    public void testResolved() throws Exception {
+        DeferredSupplier<String> deferredVal = new DeferredSupplier<String>() {
+            public String get() {return "myval";};
+        };
+        
+        assertTrue(DslUtils.resolved());
+        assertTrue(DslUtils.resolved((Object)null));
+        assertTrue(DslUtils.resolved((List<?>)null));
+        assertTrue(DslUtils.resolved(ImmutableList.of()));
+        assertTrue(DslUtils.resolved(MutableList.of(null)));
+        assertTrue(DslUtils.resolved(1, "a", ImmutableList.of("b"), ImmutableMap.of("c", "d")));
+        
+        assertFalse(DslUtils.resolved(deferredVal));
+        assertFalse(DslUtils.resolved(ImmutableList.of(deferredVal)));
+        assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableList.of(deferredVal))));
+        assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableMap.of(deferredVal, "myval"))));
+        assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableMap.of("mykey", deferredVal))));
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtilsTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtilsTest.java
@@ -32,12 +32,12 @@ import com.google.common.collect.ImmutableMap;
 
 public class DslUtilsTest {
 
+    private DeferredSupplier<String> deferredVal = new DeferredSupplier<String>() {
+        public String get() {return "myval";};
+    };
+
     @Test
     public void testResolved() throws Exception {
-        DeferredSupplier<String> deferredVal = new DeferredSupplier<String>() {
-            public String get() {return "myval";};
-        };
-        
         assertTrue(DslUtils.resolved());
         assertTrue(DslUtils.resolved((Object)null));
         assertTrue(DslUtils.resolved((List<?>)null));
@@ -47,6 +47,11 @@ public class DslUtilsTest {
         
         assertFalse(DslUtils.resolved(deferredVal));
         assertFalse(DslUtils.resolved(ImmutableList.of(deferredVal)));
+    }
+    
+    // TODO See https://issues.apache.org/jira/browse/BROOKLYN-565
+    @Test(groups="Broken")
+    public void testResolvedDetectionInNestedCollections() throws Exception {
         assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableList.of(deferredVal))));
         assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableMap.of(deferredVal, "myval"))));
         assertFalse(DslUtils.resolved(ImmutableList.of(ImmutableMap.of("mykey", deferredVal))));


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BROOKLYN-565?focusedCommentId=16264592&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16264592 for an explanation of why the attempted fix was reverted. Leaving the tests (marked "Broken") in this PR, because they are still useful to demonstrate the failure and the workaround.