### PR TITLE
BROOKLYN-566: fix SaltEntity rebind to historic state

### DIFF
--- a/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties
+++ b/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties
@@ -1452,3 +1452,10 @@ org.apache.brooklyn.feed.ssh.SshFeed$SshPollIdentifier                          
 org.apache.brooklyn.feed.ssh.SshPollConfig$CombiningEnvSupplier                  : org.apache.brooklyn.feed.CommandPollConfig$CombiningEnvSupplier
 
 com.usharesoft.cloudsoft.SoftwareFromStack : com.usharesoft.cloudsoft.entities-from-uforge:com.usharesoft.cloudsoft.SoftwareFromStack
+
+org.apache.brooklyn.entity.cm.salt.impl.SaltEntityImpl                           : org.apache.brooklyn.entity.cm.salt.SaltEntityImpl
+org.apache.brooklyn.entity.cm.salt.impl.SaltHighstate                            : org.apache.brooklyn.entity.cm.salt.SaltHighstate
+org.apache.brooklyn.entity.cm.salt.impl.SaltUtils                                : org.apache.brooklyn.entity.cm.salt.SaltUtils
+org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.impl.SaltEntityImpl  : org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.SaltEntityImpl
+org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.impl.SaltHighstate   : org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.SaltHighstate
+org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.impl.SaltUtils       : org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.SaltUtils


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BROOKLYN-566

These were renamed in https://github.com/apache/brooklyn-library/pull/123, which broke rebind if the persisted state contained a SaltEntity from 0.11.0.

Also see https://github.com/apache/brooklyn-library/pull/144