### PR TITLE
AbstractMachineLocation base class

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractMachineLocation.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.location;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.location.MachineLocation;
+import org.apache.brooklyn.util.collections.MutableMap;
+
+public abstract class AbstractMachineLocation extends AbstractLocation implements MachineLocation {
+
+    public AbstractMachineLocation() {
+        this(MutableMap.of());
+    }
+
+    public AbstractMachineLocation(Map<?,?> properties) {
+        super(properties);
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractMachineLocation.java
@@ -26,6 +26,8 @@ import org.apache.brooklyn.api.location.OsDetails;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.mutex.MutexSupport;
+import org.apache.brooklyn.util.core.mutex.WithMutexes;
 
 import com.google.common.base.Optional;
 
@@ -45,6 +47,9 @@ public abstract class AbstractMachineLocation extends AbstractLocation implement
 
     private volatile MachineDetails machineDetails;
     private final Object machineDetailsLock = new Object();
+
+    private transient WithMutexes mutexSupport;
+    private transient final Object mutexSupportCreationLock = new Object();
 
 
     public AbstractMachineLocation() {
@@ -87,5 +92,15 @@ public abstract class AbstractMachineLocation extends AbstractLocation implement
     }
 
     protected abstract MachineDetails detectMachineDetails();
+
+    public WithMutexes mutexes() {
+        synchronized (mutexSupportCreationLock) {
+            // create on demand so that it is not null after serialization
+            if (mutexSupport == null) {
+                mutexSupport = new MutexSupport();
+            }
+            return mutexSupport;
+        }
+    }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -113,7 +113,7 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
      * @see #LocalhostMachineProvisioningLocation()
      */
     @Deprecated
-    public LocalhostMachineProvisioningLocation(Map properties) {
+    public LocalhostMachineProvisioningLocation(Map<?,?> properties) {
         super(properties);
     }
     public LocalhostMachineProvisioningLocation(String name) {
@@ -269,7 +269,7 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
                 true);
 
         private static final WithMutexes mutexSupport = new MutexSupport();
-        
+
         private final Set<Integer> portsObtained = Sets.newLinkedHashSet();
 
         public LocalhostMachine() {
@@ -277,15 +277,15 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
         }
         /** @deprecated since 0.6.0 use no-arg constructor (and spec) then configure */
         @Deprecated
-        public LocalhostMachine(Map properties) {
-            super(MutableMap.builder().putAll(properties).put("mutexSupport", mutexSupport).build());
+        public LocalhostMachine(Map<?,?> properties) {
+            super(MutableMap.builder().putAll(properties).build());
         }
-        
+
         @Override
-        protected WithMutexes getMutexSupport() {
+        public WithMutexes mutexes() {
             return mutexSupport;
         }
-        
+
         @Override
         public boolean obtainSpecificPort(int portNumber) {
             if (!isSudoAllowed() && portNumber <= 1024)

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -83,7 +83,6 @@ import org.apache.brooklyn.util.core.mutex.WithMutexes;
 import org.apache.brooklyn.util.core.task.ScheduledTask;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.task.system.internal.ExecWithLoggingHelpers;
-import org.apache.brooklyn.util.core.task.system.internal.ExecWithLoggingHelpers.ExecRunner;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.apache.brooklyn.util.guava.KeyTransformingLoadingCache.KeyTransformingSameTypeLoadingCache;
@@ -119,8 +118,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.google.common.reflect.TypeToken;
-
-import groovy.lang.Closure;
 
 /**
  * Operations on a machine that is accessible via ssh.
@@ -269,7 +266,7 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
         this(MutableMap.of());
     }
 
-    public SshMachineLocation(Map properties) {
+    public SshMachineLocation(Map<?,?> properties) {
         super(properties);
         usedPorts = (usedPorts != null) ? Sets.newLinkedHashSet(usedPorts) : Sets.<Integer>newLinkedHashSet();
     }
@@ -574,7 +571,7 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
     }
 
     protected boolean previouslyConnected = false;
-    protected SshTool connectSsh(Map props) {
+    protected SshTool connectSsh(Map<?,?> props) {
         try {
             if (!groovyTruth(user)) {
                 String newUser = getUser();

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -59,8 +59,8 @@ import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.location.AbstractLocation;
 import org.apache.brooklyn.core.location.BasicHardwareDetails;
+import org.apache.brooklyn.core.location.AbstractMachineLocation;
 import org.apache.brooklyn.core.location.BasicMachineDetails;
 import org.apache.brooklyn.core.location.BasicOsDetails;
 import org.apache.brooklyn.core.location.LocationConfigUtils;
@@ -137,7 +137,7 @@ import groovy.lang.Closure;
  * Additionally there are routines to copyTo, copyFrom; and installTo (which tries a curl, and falls back to copyTo
  * in event the source is accessible by the caller only).
  */
-public class SshMachineLocation extends AbstractLocation implements MachineLocation, PortSupplier, WithMutexes, Closeable {
+public class SshMachineLocation extends AbstractMachineLocation implements MachineLocation, PortSupplier, WithMutexes, Closeable {
 
     private static final Logger LOG = LoggerFactory.getLogger(SshMachineLocation.class);
     private static final Logger logSsh = LoggerFactory.getLogger(BrooklynLogging.SSH_IO);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -24,7 +24,6 @@ import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -45,9 +44,6 @@ import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.text.Strings;
 import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.ComputeServiceContext;
-import org.jclouds.compute.callables.RunScriptOnNode;
-import org.jclouds.compute.domain.ExecResponse;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.Image;
 import org.jclouds.compute.domain.NodeMetadata;
@@ -55,10 +51,7 @@ import org.jclouds.compute.domain.OperatingSystem;
 import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.Processor;
 import org.jclouds.compute.domain.Template;
-import org.jclouds.compute.options.RunScriptOptions;
 import org.jclouds.domain.LoginCredentials;
-import org.jclouds.scriptbuilder.domain.InterpretableStatement;
-import org.jclouds.scriptbuilder.domain.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +63,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.ListenableFuture;
 
 public class JcloudsSshMachineLocation extends SshMachineLocation implements JcloudsMachineLocation {
     

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsSshMachineLocation.java
@@ -495,7 +495,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
     }
     
     @Override
-    protected MachineDetails inferMachineDetails() {
+    protected MachineDetails detectMachineDetails() {
         Optional<String> name = Optional.absent();
         Optional<String> version = Optional.absent();
         Optional<String> architecture = Optional.absent();
@@ -539,7 +539,7 @@ public class JcloudsSshMachineLocation extends SshMachineLocation implements Jcl
                                 "arch={}, ram={}, #cpus={}",
                         new Object[]{this, name, version, architecture, ram, cpus});
             }
-            return super.inferMachineDetails();
+            return super.detectMachineDetails();
         }
     }
 

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -41,7 +41,7 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.location.AbstractLocation;
+import org.apache.brooklyn.core.location.AbstractMachineLocation;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.core.location.access.PortForwardManagerLocationResolver;
 import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
@@ -71,7 +71,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
 import com.google.common.reflect.TypeToken;
 
-public class WinRmMachineLocation extends AbstractLocation implements MachineLocation {
+public class WinRmMachineLocation extends AbstractMachineLocation implements MachineLocation {
 
     private static final Logger LOG = LoggerFactory.getLogger(WinRmMachineLocation.class);
 
@@ -485,4 +485,5 @@ public class WinRmMachineLocation extends AbstractLocation implements MachineLoc
 //                        "AAgAD0AIAAkAFIARABQAC4AUwBlAHQAQQBsAGwAbwB3AFQAUwBDAG8AbgBuAGUAYwB0AGkAbwBuAHMAKAAxACwAMQApAA=="
 //        ));
     }
+
 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -191,7 +191,13 @@ public class WinRmMachineLocation extends AbstractMachineLocation implements Mac
             }
         }
     }
-    
+
+    @Override
+    protected MachineDetails detectMachineDetails() {
+        // TODO: detect actual machine details via winRM
+        return UNKNOWN_MACHINE_DETAILS;
+    }
+
     public String getUser() {
         return config().get(USER);
     }


### PR DESCRIPTION
Introduces `AbstractMachineLocation` base class to hold responsibilities that may otherwise be duplicated between `SshMachineLocation` and `WinRmMachineLocation`.