### PR TITLE
ShellEnvSerializer: handle Duration

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BrooklynObjectsJsonMapper.java
@@ -16,6 +16,7 @@
 package org.apache.brooklyn.util.core.json;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.time.Duration;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,6 +42,7 @@ public class BrooklynObjectsJsonMapper {
         new BidiSerialization.TaskSerialization(mgmt).install(mapperModule);
         new BidiSerialization.ClassLoaderSerialization(mgmt).install(mapperModule);
 
+        mapperModule.addSerializer(Duration.class, new DurationSerializer());
         mapperModule.addSerializer(new MultimapSerializer());
         mapper.registerModule(mapperModule);
         return mapper;

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/DurationSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/DurationSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.json;
+
+import java.io.IOException;
+
+import org.apache.brooklyn.util.time.Duration;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.NonTypedScalarSerializerBase;
+
+public class DurationSerializer extends NonTypedScalarSerializerBase<Object> {
+    private static final long serialVersionUID = 1L;
+
+    public DurationSerializer() { super(Duration.class, false); }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(((Duration) value).toString());
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.util.core.json.ShellEnvironmentSerializer;
+import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -42,7 +43,7 @@ public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testSerialize() {
         String str = "some string \" with ' special; characters {}[]";
-        Date dt = new Date();
+        Date date = new Date();
         String appExpected = "{\"type\":\"org.apache.brooklyn.api.entity.Entity\",\"id\":\"" + app.getId() + "\"}";
         assertSerialize(str, str);
         assertSerialize(3.14, "3.14");
@@ -51,7 +52,8 @@ public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
         assertSerialize(0.140, "0.14");
         assertSerialize(Boolean.TRUE, "true");
         assertSerialize(Boolean.FALSE, "false");
-        assertSerialize(dt, Long.toString(dt.getTime()));
+        assertSerialize(date, Long.toString(date.getTime()));
+        assertSerialize(Duration.FIVE_MINUTES, "5m");
         assertSerialize(null, null);
         assertSerialize(ImmutableList.of(str, 3.14, 0.14));
         assertSerialize(ImmutableMap.of("string", str, "num1", 3.14, "num2", 0.14));

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessShellEnvironmentTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessShellEnvironmentTest.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
+import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -40,15 +41,18 @@ public class SoftwareProcessShellEnvironmentTest extends BrooklynAppUnitTestSupp
         VanillaSoftwareProcess entity = app.createAndManageChild(EntitySpec.create(VanillaSoftwareProcess.class));
         Date dt = new Date();
         Integer someInt = 12;
+        Duration someDuration = Duration.FIVE_MINUTES;
         String someString = "simple string";
         String specialString = "some \"\\\" escaped string ' ; to\" [] {}";
         entity.config().set(VanillaSoftwareProcess.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>builder()
                 .put("some_int", someInt)
+                .put("some_duration", someDuration.toString())
                 .put("some_string", someString)
                 .put("some_boolean", Boolean.TRUE)
                 .put("some_map", ImmutableMap.of(
                         "more_keys", "more_values",
                         "some_more_keys", "some_more_values",
+                        "some_duration", someDuration,
                         "special_value", specialString))
                 .put("some_list", ImmutableList.of(
                         "idx1",
@@ -66,7 +70,12 @@ public class SoftwareProcessShellEnvironmentTest extends BrooklynAppUnitTestSupp
         assertEquals(env.get("some_int"), someInt.toString());
         assertEquals(env.get("some_string"), someString);
         assertEquals(env.get("some_boolean"), Boolean.TRUE.toString());
-        assertEquals(env.get("some_map"), "{\"more_keys\":\"more_values\",\"some_more_keys\":\"some_more_values\",\"special_value\":" + escapedString + "}");
+        assertEquals(env.get("some_map"), "{"
+                + "\"more_keys\":\"more_values\","
+                + "\"some_more_keys\":\"some_more_values\","
+                + "\"some_duration\":\""+someDuration.toString()+"\","
+                + "\"special_value\":" + escapedString
+                + "}");
         assertEquals(env.get("some_list"), "[\"idx1\",\"idx2\"," + escapedString + "]");
         assertEquals(env.get("some_time"), Long.toString(dt.getTime()));
         assertEquals(env.get("some_bean"), "{\"propString\":\"bean-string\",\"propInt\":-1}");


### PR DESCRIPTION
This change is useful when generating environment variables.

The use-case was a blueprint that took a map of values, turning it into an env variable that is a json string. If that map contained a `Duration`, then the env variable would contain something like `{"delay": {"nanos": 30000000}}`. With this change, it will instead generate `{"delay": "5m"}`.