### PR TITLE
DynamicCluster's max size applies to all calls to grow

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -1398,14 +1398,18 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
     public void testClusterMaxSize() {
         DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
                 .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class))
-                .configure(DynamicCluster.INITIAL_SIZE, 2)
-                .configure(DynamicCluster.MAX_SIZE, 6));
+                .configure(DynamicCluster.INITIAL_SIZE, 1)
+                .configure(DynamicCluster.MAX_SIZE, 1));
         cluster.start(ImmutableList.of(loc));
-
-        cluster.resize(4);
-        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicCluster.GROUP_SIZE, 4);
         try {
-            cluster.resize(8);
+            cluster.resize(3);
+            Asserts.shouldHaveFailedPreviously("Cluster resize should have failed because max size was exceeded");
+        } catch (Exception e) {
+            assertNotNull(Exceptions.getFirstThrowableOfType(e, Resizable.InsufficientCapacityException.class), "Expected InsufficientCapacityException");
+        }
+        // resizeByDelta should also fail.
+        try {
+            cluster.resizeByDelta(2);
             Asserts.shouldHaveFailedPreviously("Cluster resize should have failed because max size was exceeded");
         } catch (Exception e) {
             assertNotNull(Exceptions.getFirstThrowableOfType(e, Resizable.InsufficientCapacityException.class), "Expected InsufficientCapacityException");


### PR DESCRIPTION
Previously the limit was ignored by resizeByDelta.