### PR TITLE
DynamicCluster: resize to maxSize, before throwing InsufficientCapacity

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicClusterImpl.java
@@ -797,10 +797,16 @@ public class DynamicClusterImpl extends AbstractGroupImpl implements DynamicClus
         Preconditions.checkArgument(delta > 0, "Must call grow with positive delta.");
         Integer maxSize = config().get(MAX_SIZE);
         if (maxSize != null) {
-            final int desiredSize = getCurrentSize() + delta;
-            if (desiredSize > maxSize) {
+            Integer currentSize = getCurrentSize();
+            final int desiredSize = currentSize + delta;
+            if (currentSize >= maxSize) {
                 throw new Resizable.InsufficientCapacityException(
-                        "Desired cluster size " + desiredSize + " exceeds maximum size of " + maxSize);
+                        "Current cluster size " + currentSize + " already at maximum permitted");
+            } else if (desiredSize > maxSize) {
+                int allowedDelta = (maxSize - currentSize);
+                LOG.warn("Desired cluster size " + desiredSize + " exceeds maximum size of " + maxSize
+                        + "; will only grow by " + allowedDelta + " instead of " + delta + " for " + this);
+                delta = allowedDelta;
             }
         }
 

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterTest.java
@@ -1416,6 +1416,24 @@ public class DynamicClusterTest extends AbstractDynamicClusterOrFabricTest {
         }
     }
 
+    @Test
+    public void testGrowsToClusterMaxSize() {
+        DynamicCluster cluster = app.createAndManageChild(EntitySpec.create(DynamicCluster.class)
+                .configure(DynamicCluster.MEMBER_SPEC, EntitySpec.create(TestEntity.class))
+                .configure(DynamicCluster.INITIAL_SIZE, 1)
+                .configure(DynamicCluster.MAX_SIZE, 3));
+        cluster.start(ImmutableList.of(loc));
+
+        cluster.resize(4);
+        Assert.assertEquals(cluster.getCurrentSize(), Integer.valueOf(3));
+        Assert.assertEquals(Iterables.size(Iterables.filter(Entities.descendantsAndSelf(app), TestEntity.class)), 3);
+        
+        cluster.resize(1);
+        cluster.resizeByDelta(3);
+        Assert.assertEquals(cluster.getCurrentSize(), Integer.valueOf(3));
+        Assert.assertEquals(Iterables.size(Iterables.filter(Entities.descendantsAndSelf(app), TestEntity.class)), 3);
+    }
+
     @ImplementedBy(ThrowOnAsyncStartEntityImpl.class)
     public interface ThrowOnAsyncStartEntity extends TestEntity {
         ConfigKey<Integer> MAX_CONCURRENCY = ConfigKeys.newConfigKey(Integer.class, "concurrency", "max concurrency", 1);


### PR DESCRIPTION
Building on PR #916 and the conversation in https://github.com/apache/brooklyn-server/pull/916#discussion_r157902790, this changes the behaviour of resize so that it will grow to the maxSize.

For example, imaging the extreme case where we have `initialSize=1, maxSize=10`, and an auto-scaler policy decides that the cluster should be resized to 11. Instead of throwing an exception, the behaviour now will be that the first call to `resize(11)` will cause us to resize to the max of 10 (logging a warning). A subsequent call to `resize(11)` by the policy will throw the `InsufficientCapacityException`.