### PR TITLE
Fix reporting of master ID when web API used before persistence is ready

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -234,7 +234,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
      * Defaults to null which means to use the remote timestamp. 
      * Only for testing as this records the remote timestamp in the object.
      * <p>
-     * If this is supplied, one must also set {@link ManagementPlaneSyncRecordPersisterToObjectStore#useRemoteTimestampInMemento()}. */
+     * If this is supplied, one must also set {@link ManagementPlaneSyncRecordPersisterToObjectStore#preferRemoteTimestampInMemento()}. */
     @VisibleForTesting
     public HighAvailabilityManagerImpl setRemoteTicker(Ticker val) {
         this.optionalRemoteTickerUtc = val;
@@ -570,11 +570,6 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         return myNodeState;
     }
 
-    @Override
-    public ManagementPlaneSyncRecord getLastManagementPlaneSyncRecord() {
-        return lastSyncRecord;
-    }
-    
     protected void registerPollTask() {
         final Runnable job = new Runnable() {
             private boolean lastFailed;
@@ -1003,6 +998,11 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         lastSyncRecord = record;
         return record; 
     }
+
+    @Override
+    public ManagementPlaneSyncRecord getLastManagementPlaneSyncRecord() {
+        return lastSyncRecord;
+    }
     
     private ManagementPlaneSyncRecord loadManagementPlaneSyncRecordInternal(boolean useLocalKnowledgeForThisNode) {
         if (disabled) {
@@ -1020,7 +1020,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             LOG.debug("High availablity manager has no persister; returning empty record");
             return ManagementPlaneSyncRecordImpl.builder().build();
         }
-        
+
         int maxLoadAttempts = 5;
         Exception lastException = null;
         Stopwatch timer = Stopwatch.createStarted();


### PR DESCRIPTION
ServerResource#getHighAvailabilityPlaneStates obtains a new plane sync
record when the master node ID in the first one it obtained is null.
This generally only happens when the web-console tries to obtain the
HA status before the server has started up.

Fixes https://issues.apache.org/jira/browse/BROOKLYN-167.