### PR TITLE
Bundle type endpoint

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
@@ -35,6 +35,8 @@ import javax.ws.rs.core.Response;
 
 import org.apache.brooklyn.rest.domain.BundleInstallationRestResult;
 import org.apache.brooklyn.rest.domain.BundleSummary;
+import org.apache.brooklyn.rest.domain.TypeDetail;
+import org.apache.brooklyn.rest.domain.TypeSummary;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -88,6 +90,51 @@ public interface BundleApi {
         @PathParam("version")
         String version);
 
+
+    @Path("/{symbolicName}/{version}/types")
+    @GET
+    @ApiOperation(value = "Get all types declared in a given bundle", 
+            response = TypeDetail.class)
+    public List<TypeSummary> getTypes(
+        @ApiParam(name = "symbolicName", value = "Bundle name to query", required = true)
+        @PathParam("symbolicName")
+        String symbolicName,
+        @ApiParam(name = "version", value = "Version of bundle and of type to query", required = true)
+        @PathParam("version")
+        String version);
+    
+    @Path("/{symbolicName}/{version}/types/{typeSymbolicName}")
+    @GET
+    @ApiOperation(value = "Get detail on a given type in a given bundle", 
+            response = TypeDetail.class)
+    public TypeDetail getType(
+        @ApiParam(name = "symbolicName", value = "Bundle name to query", required = true)
+        @PathParam("symbolicName")
+        String symbolicName,
+        @ApiParam(name = "version", value = "Version of bundle and of type to query", required = true)
+        @PathParam("version")
+        String version,
+        @ApiParam(name = "typeSymbolicName", value = "Type name to query", required = true)
+        @PathParam("typeSymbolicName")
+        String typeSymbolicName);
+    
+    @Path("/{symbolicName}/{version}/types/{typeSymbolicName}/{typeVersion}")
+    @GET
+    @ApiOperation(value = "Get detail on a given type and version in a bundle (special method for unusual cases where type has different version)", 
+            response = TypeDetail.class)
+    public TypeDetail getTypeExplicitVersion(
+        @ApiParam(name = "symbolicName", value = "Bundle name to query", required = true)
+        @PathParam("symbolicName")
+        String symbolicName,
+        @ApiParam(name = "version", value = "Bundle version to query", required = true)
+        @PathParam("version")
+        String version,
+        @ApiParam(name = "typeSymbolicName", value = "Type name to query", required = true)
+        @PathParam("typeSymbolicName")
+        String typeSymbolicName,
+        @ApiParam(name = "typeVersion", value = "Version to query (if different to bundle version)", required = true)
+        @PathParam("typeVersion")
+        String typeVersion);
     
     @Path("/{symbolicName}/{version}")
     @DELETE

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/TypeDetail.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/TypeDetail.java
@@ -23,6 +23,7 @@ import org.apache.brooklyn.api.typereg.RegisteredType.TypeImplementationPlan;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.google.common.base.Objects;
 
 /** As {@link TypeSummary} but including plan information. */
 public class TypeDetail extends TypeSummary {
@@ -42,7 +43,22 @@ public class TypeDetail extends TypeSummary {
         public Object getData() {
             return data;
         }
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(format, data);
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            TypeImplementationPlanSummary other = (TypeImplementationPlanSummary) obj;
+            if (!Objects.equal(data, other.data)) return false;
+            if (!Objects.equal(format, other.format)) return false;
+            return true;
+        }
     }
+    
     private TypeImplementationPlanSummary plan;
     
     /** Constructor for JSON deserialization use only. */


### PR DESCRIPTION
It was noted that if the same type is defined in two different bundles, the API does not let you distinguish between the two.  This adds `/catalog/bundles/{symbolicName}/{version}/types/{typeSymbolicName}/{typeVersion}` to resolve that.  (It also adds the two immediate ancestor paths, with `../types` listing types in the bundle and `../types/{typeSymbolicName}` giving `TypeDetail` assuming `typeVersion==version`).

It also adds a bunch of tests for behaviour when adding the same type ID:

```
testAddSameTypeTwiceInSameBundle_SilentlyDeduped()
testAddSameTypeTwiceInSameBundleDifferentDisplayName_LastOneWins()
testAddSameTypeTwiceInSameBundleDifferentDefinition_Disallowed()
testAddSameTypeTwiceInDifferentBundleDifferentDefinition_Disallowed()
testAddSameTypeTwiceInDifferentBundleSameDefinition_AllowedAndApiMakesTheDifferentOnesClear()
```

the final test above fails after the first commit but is fixed by the second commit here, by changing the type's `self` link to use the unambiguous `bundles/.../types/...` endpoint.