### PR TITLE
Allow deprecation as the catalog item level

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -911,7 +911,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         catalogIconUrl = setFromItemIfUnset(catalogIconUrl, itemAsMap, "iconUrl", "icon_url", "icon.url");
 
         final String deprecated = getFirstAs(catalogMetadata, String.class, "deprecated").orNull();
-        final Boolean catalogDeprecated = Boolean.valueOf(deprecated);
+        final Boolean catalogDeprecated = Boolean.valueOf(setFromItemIfUnset(deprecated, itemAsMap, "deprecated"));
 
         // run again now that we know the ID to catch recursive definitions and possibly other mistakes (itemType inconsistency?)
         planInterpreter = new PlanInterpreterGuessingType(id, item, sourceYaml, itemType, libraryBundles, resultLegacyFormat).reconstruct();
@@ -1094,8 +1094,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (item!=null) {
             for (String fieldAttr: fieldAttrs) {
                 Object newValue = item.get(fieldAttr);
-                if (newValue instanceof String && Strings.isNonBlank((String)newValue)) { 
+                if (newValue instanceof String && Strings.isNonBlank((String)newValue)) {
                     return (String)newValue;
+                } else if (newValue instanceof Number || newValue instanceof Boolean) {
+                    return newValue.toString();
                 }
             }
         }

--- a/policy/src/main/resources/catalog.bom
+++ b/policy/src/main/resources/catalog.bom
@@ -114,6 +114,7 @@ brooklyn.catalog:
         type: org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
         name: "[DEPRECATED] Rolling Mean in Time Window"
         description: "[DEPRECATED] Prefer YamlRollingTimeWindowMeanEnricher"
+        deprecated: true
     - id: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
       item:
         type: org.apache.brooklyn.policy.enricher.TimeFractionDeltaEnricher
@@ -126,6 +127,7 @@ brooklyn.catalog:
         type: org.apache.brooklyn.policy.enricher.TimeWeightedDeltaEnricher
         name: "[DEPRECATED] Time Weighted Delta"
         description: "[DEPRECATED] prefer 'YamlTimeWeightedDeltaEnricher'"
+        deprecated: true
     - id: org.apache.brooklyn.policy.ha.ServiceFailureDetector
       item:
         type: org.apache.brooklyn.policy.ha.ServiceFailureDetector

--- a/test-framework/src/main/resources/catalog.bom
+++ b/test-framework/src/main/resources/catalog.bom
@@ -28,6 +28,7 @@ brooklyn.catalog:
         type: org.apache.brooklyn.test.framework.SimpleShellCommandTest
         name: "[DEPRECATED] Simple Shell Command Test"
         description:  "[DEPRECATED] Instead use TestSshCommand"
+        deprecated: true
     - id: org.apache.brooklyn.test.framework.ParallelTestCase
       item:
         type: org.apache.brooklyn.test.framework.ParallelTestCase


### PR DESCRIPTION
In YAML, one can mark a catalog item as `deprecated` but it works only when the flag it set as the `brooklyn.catalog` level.

This allows each catalog item to use the deprecated flag as one see fit. For example, I used it for the deprecated policies/enrichers we have within Brooklyn (see changes in bom files)