### PR TITLE
Fix icons in catalog, and a few misc

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -907,7 +907,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         description = setFromItemIfUnset(description, itemAsMap, "description");
 
         // icon.url is discouraged (using '.'), but kept for legacy compatibility; should deprecate this
-        final String catalogIconUrl = getFirstAs(catalogMetadata, String.class, "iconUrl", "icon_url", "icon.url").orNull();
+        String catalogIconUrl = getFirstAs(catalogMetadata, String.class, "iconUrl", "icon_url", "icon.url").orNull();
+        catalogIconUrl = setFromItemIfUnset(catalogIconUrl, itemAsMap, "iconUrl", "icon_url", "icon.url");
 
         final String deprecated = getFirstAs(catalogMetadata, String.class, "deprecated").orNull();
         final Boolean catalogDeprecated = Boolean.valueOf(deprecated);
@@ -1088,12 +1089,15 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         throw new UserFacingException("Expected "+JavaClassNames.superSimpleClassName(type)+" for "+description+", not "+JavaClassNames.superSimpleClassName(x));
     }
 
-    private String setFromItemIfUnset(String oldValue, Map<?,?> item, String fieldAttr) {
+    private String setFromItemIfUnset(String oldValue, Map<?,?> item, String ...fieldAttrs) {
         if (Strings.isNonBlank(oldValue)) return oldValue;
         if (item!=null) {
-            Object newValue = item.get(fieldAttr);
-            if (newValue instanceof String && Strings.isNonBlank((String)newValue)) 
-                return (String)newValue;
+            for (String fieldAttr: fieldAttrs) {
+                Object newValue = item.get(fieldAttr);
+                if (newValue instanceof String && Strings.isNonBlank((String)newValue)) { 
+                    return (String)newValue;
+                }
+            }
         }
         return oldValue;
     }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicFabric.java
@@ -55,14 +55,14 @@ public interface DynamicFabric extends AbstractGroup, Startable, Fabric {
     @SetFromFlag("memberSpec")
     ConfigKey<EntitySpec<?>> MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() {}, 
-            "dynamiccfabric.memberspec", 
+            "dynamicfabric.memberspec", 
             "Entity spec for creating new members (one per location)", 
             null);
 
     @SetFromFlag("firstMemberSpec")
     ConfigKey<EntitySpec<?>> FIRST_MEMBER_SPEC = ConfigKeys.newConfigKey(
             new TypeToken<EntitySpec<?>>() {}, 
-            "dynamiccfabric.firstmemberspec", 
+            "dynamicfabric.firstmemberspec", 
             "Entity spec for the first member", 
             null);
 

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
@@ -280,7 +280,6 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
         String yaml = Joiner.on("\n").join(
                 "brooklyn.catalog:",
                 "  id: " + catalogItemId,
-                "  version: " + TEST_VERSION,
                 "  itemType: " + checkNotNull(itemType),
                 "  name: My Catalog App",
                 "  description: My description",


### PR DESCRIPTION
icons set on catalog items previously could only come in metadata, unlike name and description which could be in metadata _or_ in the `item` yaml.  as setting an `iconUrl` in the item yaml is valid (like `description` and display `name`), we should also special case check this when preparing catalog item metadata, treating all three the same.  see the most recent commit.

this fixes a bug where the icons in `policy/src/main/resource/catalog.bom` weren't getting picked up in the catalog (but they were being seen when instances were deployed).

two tiny other commits which i've noticed in the course of debugging also