### PR TITLE
WithMutexes cleanup

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -84,7 +84,6 @@ import org.apache.brooklyn.util.core.task.ScheduledTask;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.task.system.internal.ExecWithLoggingHelpers;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.apache.brooklyn.util.guava.KeyTransformingLoadingCache.KeyTransformingSameTypeLoadingCache;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.pool.BasicPool;
@@ -1016,12 +1015,8 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
     /** @deprecated since 1.0.0; mutex-related methods are now accessible via {@link #mutexes()} */
     @Override
     @Deprecated
-    public void acquireMutex(String mutexId, String description) throws RuntimeInterruptedException {
-        try {
-            mutexes().acquireMutex(mutexId, description);
-        } catch (InterruptedException ie) {
-            throw new RuntimeInterruptedException("Interrupted waiting for mutex: " + mutexId, ie);
-        }
+    public void acquireMutex(String mutexId, String description) {
+        mutexes().acquireMutex(mutexId, description);
     }
 
     /** @deprecated since 1.0.0; mutex-related methods are now accessible via {@link #mutexes()} */

--- a/core/src/main/java/org/apache/brooklyn/util/core/mutex/WithMutexes.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/mutex/WithMutexes.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.util.core.mutex;
 
+import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
+
 /** interface which allows multiple callers to co-operate using named mutexes, inspectably,
  * and containing implementation as inner class
  * <p>
@@ -31,8 +33,10 @@ public interface WithMutexes {
     public boolean hasMutex(String mutexId);
     
     /** acquires a mutex, if available, otherwise blocks on its becoming available;
-     * caller must release after use */
-    public void acquireMutex(String mutexId, String description) throws InterruptedException;
+     * caller must release after use
+     * @throws RuntimeInterruptedException if the thread was interrupted waiting for the underlying mutex
+     */
+    public void acquireMutex(String mutexId, String description);
 
     /** acquires a mutex and returns true, if available; otherwise immediately returns false;
      * caller must release after use if this returns true */

--- a/core/src/test/java/org/apache/brooklyn/util/core/mutex/WithMutexesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/mutex/WithMutexesTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.brooklyn.util.core.mutex.MutexSupport;
 import org.apache.brooklyn.util.core.mutex.SemaphoreWithOwners;
 import org.apache.brooklyn.util.core.mutex.WithMutexes;
+import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -70,7 +71,7 @@ public class WithMutexesTest {
             public void run() {
                 try {
                     m.acquireMutex("foo", "thread 2 foo");
-                } catch (InterruptedException e) {
+                } catch (RuntimeInterruptedException e) {
                     e.printStackTrace();
                 }
                 m.releaseMutex("foo");
@@ -92,13 +93,13 @@ public class WithMutexesTest {
 
     
     public static class SampleWithMutexesDelegatingMixin implements WithMutexes {
-        
+
         /* other behaviour would typically go here... */
-        
+
         WithMutexes mutexSupport = new MutexSupport();
-        
+
         @Override
-        public void acquireMutex(String mutexId, String description) throws InterruptedException {
+        public void acquireMutex(String mutexId, String description) {
             mutexSupport.acquireMutex(mutexId, description);
         }
 
@@ -117,7 +118,7 @@ public class WithMutexesTest {
             return mutexSupport.hasMutex(mutexId);
         }
     }
-    
+
     @Test
     public void testDelegatingMixinPattern() throws InterruptedException {
         WithMutexes m = new SampleWithMutexesDelegatingMixin();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.base.Joiner;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.drivers.downloads.DownloadResolver;
 import org.apache.brooklyn.config.ConfigKey;
@@ -46,6 +45,7 @@ import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.core.internal.ssh.sshj.SshjTool;
 import org.apache.brooklyn.util.core.json.ShellEnvironmentSerializer;
+import org.apache.brooklyn.util.core.mutex.WithMutexes;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
@@ -60,6 +60,7 @@ import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -293,27 +294,31 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
 
     @Override
     public void copyInstallResources() {
-        getLocation().acquireMutex("installing " + elvis(entity, this), "installation lock at host for files and templates");
+        final WithMutexes mutexSupport = getLocation().mutexes();
+        final String mutexId = "installing " + elvis(entity, this);
+        mutexSupport.acquireMutex(mutexId, "installation lock at host for files and templates");
         try {
             super.copyInstallResources();
         } catch (Exception e) {
             log.warn("Error copying install resources", e);
             throw Exceptions.propagate(e);
         } finally {
-            getLocation().releaseMutex("installing " + elvis(entity, this));
+            mutexSupport.releaseMutex(mutexId);
         }
     }
 
     @Override
     public void copyCustomizeResources() {
-        getLocation().acquireMutex("customizing " + elvis(entity, this), "installation lock at host for files and templates");
+        final WithMutexes mutexSupport = getLocation().mutexes();
+        final String mutexId = "customizing " + elvis(entity, this);
+        mutexSupport.acquireMutex(mutexId, "installation lock at host for files and templates");
         try {
             super.copyCustomizeResources();
         } catch (Exception e) {
             log.warn("Error copying customize resources", e);
             throw Exceptions.propagate(e);
         } finally {
-            getLocation().releaseMutex("customizing " + elvis(entity, this));
+            mutexSupport.releaseMutex(mutexId);
         }
     }
 
@@ -565,7 +570,8 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
             }
             if (INSTALLING.equals(phase)) {
                 // mutexId should be global because otherwise package managers will contend with each other
-                s.useMutex(getLocation(), "installation lock at host", "installing "+elvis(entity,this));
+                final String mutexId = "installation lock at host";
+                s.useMutex(getLocation().mutexes(), mutexId, "installing "+elvis(entity,this));
                 s.header.append(
                         "export INSTALL_DIR=\""+getInstallDir()+"\"",
                         "mkdir -p $INSTALL_DIR",

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/ScriptHelper.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.entity.software.base.lifecycle;
 
 import static java.lang.String.format;
-import groovy.lang.Closure;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -54,6 +53,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+
+import groovy.lang.Closure;
 
 public class ScriptHelper {
 
@@ -216,11 +217,7 @@ public class ScriptHelper {
         mutexAcquire = new Runnable() {
             @Override
             public void run() {
-                try {
-                    mutexSupport.acquireMutex(mutexId, description);
-                } catch (InterruptedException e) {
-                    throw new RuntimeInterruptedException(e);
-                }
+                mutexSupport.acquireMutex(mutexId, description);
             }
         };
 


### PR DESCRIPTION
Modifies signature of `WithMutexes.acquireMutex()` to throw unchecked `RuntimeInterruptedException` to ease the burden on callers.