### PR TITLE
ElectPrimaryTest: decrease race

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
@@ -63,6 +63,7 @@ import org.testng.reporters.FailedReporter;
 
 import com.google.common.base.Predicates;
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
 
 // TODO this test is in the CAMP package because YAML not available in policies package
 public class ElectPrimaryTest extends AbstractYamlRebindTest {
@@ -287,6 +288,12 @@ public class ElectPrimaryTest extends AbstractYamlRebindTest {
         runSelectionModeTest(SelectionMode.BEST, false);
     }
 
+    /**
+     * TODO Non-deterministic test failure. Policy invokes effector (due to sensor-changed)
+     * at same time as test explicitly invokes effector: it fails over to 'b' and then back
+     * to 'a'. See https://github.com/apache/brooklyn-server/pull/931 to reduce this race,
+     * and for more details.
+     */
     @Test
     public void testSelectionModeFailoverReelectWithPreference() throws Exception {
         runSelectionModeTest(SelectionMode.FAILOVER, false);
@@ -396,7 +403,7 @@ public class ElectPrimaryTest extends AbstractYamlRebindTest {
         if (integration) {
             EntityAsserts.assertAttributeEqualsContinually(app, PRIMARY, a);
         } else {
-            EntityAsserts.assertAttributeEquals(app, PRIMARY, a);
+            EntityAsserts.assertAttributeEqualsContinually(ImmutableMap.of("timeout", Duration.millis(100)), app, PRIMARY, a);
         }
     }
 


### PR DESCRIPTION
`ElectPrimaryTest.testSelectionModeFailoverReelectWithPreference` sometimes fails in apache jenkins. This reduces the race by us waiting for 100ms after changing the sensor, before we invoke the effector manually!

The race happens in `testSelectionModeFailoverReelectWithPreference` when the `ElectPrimaryPolicy` invokes the effector (because the child's WEIGHT_SENSOR has changed), and at the same  time the test explicitly invokes the `ElectPrimaryEffector`.
 
 There are two threads concurrently executing the effector: the policy's invocation is using `SelectionMode.FAILOVER` and the test's invocation is using `SelectionMode.BEST`. The first   thread calculates `newPrimary=a` (because that is the current primary, and it is still ok). We then context switch to the second thread which calculates `newPrimary=b`,                  `currentActive=a`, changes the primary sensor to `b` and invokes the promote/demote effectors. At some point after setting the 
 primary sensor to `b`, we context switch back to the first thread. This now looks up `currentActive=b`, which does not match its `newPrimary=a`. It therefore sets the primary sensor to
 `a` and begins to call the promote/demote effectors. Our test fails because the primary sensor finishes with the value `a`.

A bigger fix would be to think more carefully about how the effector can execute concurrently such that its results are more predictable, or to add some kind of synchronization so that the effector can only be executing once at a time.