### PR TITLE
collect supertypes for registered types

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -63,7 +63,7 @@ public interface BrooklynCatalog {
     @Deprecated
     void deleteCatalogItem(String symbolicName, String version);
 
-    /** @return Deletes the item with the given {@link CatalogItem#getSymbolicName()
+    /** Deletes the item with the given {@link CatalogItem#getSymbolicName()
      * symbolicName} and version
      * @throws NoSuchElementException if not found 
      * @deprecated since introduced in 1.0.0, only used for transitioning */

--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -63,6 +63,13 @@ public interface BrooklynCatalog {
     @Deprecated
     void deleteCatalogItem(String symbolicName, String version);
 
+    /** @return Deletes the item with the given {@link CatalogItem#getSymbolicName()
+     * symbolicName} and version
+     * @throws NoSuchElementException if not found 
+     * @deprecated since introduced in 1.0.0, only used for transitioning */
+    @Deprecated
+    void deleteCatalogItem(String symbolicName, String version, boolean alsoCheckTypeRegistry, boolean failIfNotFound);
+    
     /** variant of {@link #getCatalogItem(String, String)} which checks (and casts) type for convenience
      * (returns null if type does not match)
      * @deprecated since 0.12.0 use {@link BrooklynTypeRegistry} instead */ 
@@ -155,12 +162,14 @@ public interface BrooklynCatalog {
 
     /**
      * As {@link #addItemsFromBundle(String, ManagedBundle)} with a null bundle.
+     * (Only used for legacy-mode additions.) 
      */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml);
     
     /**
      * Adds items (represented in yaml) to the catalog coming from the indicated managed bundle.
      * Fails if the same version exists in catalog (unless snapshot).
+     * (Only used for legacy-mode additions.) 
      *
      * @throws IllegalArgumentException if the yaml was invalid
      */
@@ -168,15 +177,33 @@ public interface BrooklynCatalog {
     
     /**
      * Adds items (represented in yaml) to the catalog.
+     * (Only used for legacy-mode additions.) 
      * 
      * @param forceUpdate If true allows catalog update even when an
      * item exists with the same symbolicName and version
      *
      * @throws IllegalArgumentException if the yaml was invalid
+     * 
+     * @deprecated since 1.0.0 use {@link #addItems(String)} or {@link #addItems(String, boolean, boolean)}
      */
+    @Deprecated
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate);
     
-    /** As {@link #addItems(String, ManagedBundle)} but exposing forcing option as per {@link #addItem(String, boolean)}. */
+    /**
+     * Adds items (represented in yaml) to the catalog.
+     * (Only used for legacy-mode additions.) 
+     * 
+     * @param validate Whether to validate the types (default true)
+     *
+     * @param forceUpdate If true allows catalog update even when an
+     * item exists with the same symbolicName and version
+     *
+     * @throws IllegalArgumentException if the yaml was invalid
+     */
+    Iterable<? extends CatalogItem<?,?>> addItems(String yaml, boolean validate, boolean forceUpdate);
+    
+    /** As {@link #addItems(String, ManagedBundle)} but exposing forcing option as per {@link #addItem(String, boolean)}. 
+     * (Only used for legacy-mode additions.) */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, ManagedBundle bundle, boolean forceUpdate);
     
     /**

--- a/api/src/main/java/org/apache/brooklyn/api/typereg/RegisteredType.java
+++ b/api/src/main/java/org/apache/brooklyn/api/typereg/RegisteredType.java
@@ -73,18 +73,20 @@ public interface RegisteredType extends Identifiable {
      * For specs, this should refer to the {@link BrooklynObject} type that the created spec will point at 
      * (e.g. the concrete {@link Entity}, not the {@link EntitySpec}).
      * <p>
-     * This will normally not return all ancestor classes,
-     * and it is not required even to return the most specific java class or classes:
-     * such as if the concrete type is private and callers should know only about a particular public interface,
-     * or if precise type details are unavailable and all that is known at creation is some higher level interface/supertype
-     * (e.g. this may return {@link Entity} even though the spec points at a specific subclass,
-     * for instance because the YAML has not yet been parsed or OSGi bundles downloaded).
+     * For specs, this will normally return the most specific java interface it will create (e.g. BasicEntity),
+     * then the category (e.g. Entity), then other ancestor classes/interfaces.
+     * Registered supertypes and potentially marker registered type interfaces may also be included.
      * <p>
-     * This may include other registered types such as marker interfaces.
+     * In some places, e.g. for items not yet validated or fully loaded,
+     * this list may be incomplete, but it should normally for specs include at least the category the spec will create.
      * <p>
-     * It may even include multiple interfaces but exclude the concrete subclass which implements them all
+     * This may include multiple interfaces but exclude the concrete subclass which implements them all
      * (for instance if that concrete implementation is an internal private class). 
-     * However it must be possible for the corresponding transformer to instantiate that type at runtime. 
+     * However it must be possible for the corresponding transformer to instantiate that type at runtime.
+     * (It will never return two classes which cannot have a common subclass.)
+     * <p>
+     * Any {@link RegisteredType} instances returned by this method may be stale.
+     * (TODO Currently I don't think it ever includes {@link RegisteredType} supertypes.) 
      */
     @Beta
     Set<Object> getSuperTypes();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsRebindStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsRebindStubYamlTest.java
@@ -135,6 +135,6 @@ public abstract class AbstractJcloudsRebindStubYamlTest extends JcloudsRebindStu
     }
     
     protected void addCatalogItems(String catalogYaml) {
-        mgmt().getCatalog().addItems(catalogYaml, false);
+        mgmt().getCatalog().addItems(catalogYaml);
     }
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractJcloudsStubYamlTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractJcloudsStubYamlTest extends AbstractJcloudsStubbed
     }
     
     protected void addCatalogItems(String catalogYaml) {
-        mgmt().getCatalog().addItems(catalogYaml, false);
+        mgmt().getCatalog().addItems(catalogYaml);
     }
     
     protected Entity createAndStartApplication(Reader input) throws Exception {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlRebindTest.java
@@ -209,7 +209,7 @@ public class AbstractYamlRebindTest extends RebindTestFixture<StartableApplicati
     }
 
     protected Iterable<? extends CatalogItem<?,?>> addCatalogItems(String catalogYaml) {
-        return mgmt().getCatalog().addItems(catalogYaml, forceUpdate);
+        return mgmt().getCatalog().addItems(catalogYaml);
     }
 
     protected void deleteCatalogEntity(String catalogItem) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -251,7 +251,7 @@ public abstract class AbstractYamlTest {
     }
 
     protected void addCatalogItems(String catalogYaml) {
-        mgmt().getCatalog().addItems(catalogYaml, forceUpdate);
+        mgmt().getCatalog().addItems(catalogYaml, true, forceUpdate);
     }
 
     /*

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindWithYamlDslTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsRebindWithYamlDslTest.java
@@ -77,7 +77,7 @@ public class JcloudsRebindWithYamlDslTest extends AbstractJcloudsRebindStubYamlT
             "    - name: password",
             "      default: myYamlPassword",
             "    type: "+ MachineEntity.class.getName());
-        mgmt().getCatalog().addItems(catalogYaml, true);
+        mgmt().getCatalog().addItems(catalogYaml, true, true);
 
         String yaml = Joiner.on("\n").join(
                 "location: " + LOCATION_CATALOG_ID,

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/qa/performance/CatalogPerformanceTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/qa/performance/CatalogPerformanceTest.java
@@ -85,7 +85,7 @@ public class CatalogPerformanceTest extends AbstractYamlTest {
                 "    description: My description",
                 "    item:",
                 "      type: " + TestPolicy.class.getName());
-        return ImmutableList.copyOf(mgmt().getCatalog().addItems(yaml, false));
+        return ImmutableList.copyOf(mgmt().getCatalog().addItems(yaml));
     }
     
     @Test(groups={"Integration"})

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -494,7 +494,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         while (item instanceof CatalogItemDo) item = ((CatalogItemDo<T,SpecT>)item).itemDto;
         if (item==null) return null;
         if (item instanceof CatalogItemDtoAbstract) return (CatalogItemDtoAbstract<T,SpecT>) item;
-        CatalogItem<?, ?> item2 = getCatalogItem(item.getSymbolicName(), item.getVersion());
+        CatalogItem<?, ?> item2 = getCatalogItemLegacy(item.getSymbolicName(), item.getVersion());
+        if (item2 instanceof CatalogItemDtoAbstract) return (CatalogItemDtoAbstract<T,SpecT>) item2;
         throw new IllegalStateException("Cannot unwrap catalog item '"+item+"' (type "+item.getClass()+") to restore DTO");
     }
     
@@ -1460,7 +1461,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     @Deprecated
     @Override
     public List<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate) {
-        return addItems(yaml, true, false);
+        return addItems(yaml, true, forceUpdate);
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -27,11 +27,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Queue;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -301,9 +304,13 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     }
     
     private static ThreadLocal<Boolean> deletingCatalogItem = new ThreadLocal<>();
-    @Override
+    @Override @Deprecated
     public void deleteCatalogItem(String symbolicName, String version) {
-        if (!Boolean.TRUE.equals(deletingCatalogItem.get())) {
+        deleteCatalogItem(symbolicName, version, true, true);
+    }
+    @Override @Deprecated
+    public void deleteCatalogItem(String symbolicName, String version, boolean alsoCheckTypeRegistry, boolean failIfNotFound) {
+        if (alsoCheckTypeRegistry && !Boolean.TRUE.equals(deletingCatalogItem.get())) {
             // while we switch from catalog to type registry, make sure deletion covers both;
             // thread local lets us call to other once then he calls us and we do other code path
             deletingCatalogItem.set(true);
@@ -326,10 +333,14 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (DEFAULT_VERSION.equals(version)) {
             throw new IllegalStateException("Deleting items with unspecified version (argument DEFAULT_VERSION) not supported.");
         }
-        CatalogItem<?, ?> item = getCatalogItem(symbolicName, version);
+        CatalogItem<?, ?> item = getCatalogItemLegacy(symbolicName, version);
         CatalogItemDtoAbstract<?,?> itemDto = getAbstractCatalogItem(item);
         if (itemDto == null) {
-            throw new NoSuchElementException("No catalog item found with id "+symbolicName);
+            if (failIfNotFound) {
+                throw new NoSuchElementException("No catalog item found with id "+symbolicName);
+            } else {
+                return;
+            }
         }
         if (manualAdditionsCatalog==null) loadManualAdditionsCatalog();
         manualAdditionsCatalog.deleteEntry(itemDto);
@@ -483,6 +494,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         while (item instanceof CatalogItemDo) item = ((CatalogItemDo<T,SpecT>)item).itemDto;
         if (item==null) return null;
         if (item instanceof CatalogItemDtoAbstract) return (CatalogItemDtoAbstract<T,SpecT>) item;
+        CatalogItem<?, ?> item2 = getCatalogItem(item.getSymbolicName(), item.getVersion());
         throw new IllegalStateException("Cannot unwrap catalog item '"+item+"' (type "+item.getClass()+") to restore DTO");
     }
     
@@ -1441,15 +1453,23 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
     @Override
     public List<? extends CatalogItem<?,?>> addItems(String yaml) {
-        return addItems(yaml, false);
+        return addItems(yaml, true, false);
+    }
+    
+    /** @deprecated since 1.0.0 use {@link #addItems(String)} or {@link #addItems(String, boolean, boolean)} */
+    @Deprecated
+    @Override
+    public List<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate) {
+        return addItems(yaml, true, false);
     }
     
     @Override
-    public List<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate) {
+    public List<? extends CatalogItem<?,?>> addItems(String yaml, boolean validate, boolean forceUpdate) {
         Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)mgmt).getOsgiManager();
         if (osgiManager.isPresent() && AUTO_WRAP_CATALOG_YAML_AS_BUNDLE) {
             // wrap in a bundle to be managed; need to get bundle and version from yaml
             OsgiBundleInstallationResult result = addItemsOsgi(yaml, forceUpdate, osgiManager.get());
+            // above will have done validation and supertypes recorded
             return toLegacyCatalogItems(result.getTypesInstalled());
 
             // if all items pertaining to an older anonymous catalog.bom bundle have been overridden
@@ -1560,6 +1580,18 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 item.setContainingBundle(bundle.getVersionedName());
             }
             addItemDto(item, forceUpdate);
+        }
+        // do type validation so supertypes are populated and errors are at least logged in legacy mode (only time this is used)
+        // (validation normally done by osgi load routines)
+        Map<String,Collection<Throwable>> errors = MutableMap.of();
+        for (CatalogItemDtoAbstract<?, ?> item: result) {
+            Collection<Throwable> errorsInItem = validateType(RegisteredTypes.of(item), null);
+            if (!errorsInItem.isEmpty()) {
+                errors.put(item.getCatalogItemId(), errorsInItem);
+            }
+        }
+        if (!errors.isEmpty()) {
+            log.warn("Error adding YAML"+(bundle!=null ? " for bundle "+bundle : "")+" (ignoring, but types will not be usable): "+errors);
         }
         return result;
     }
@@ -1752,12 +1784,21 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 // if it was a bean that points at a BO then switch it to a spec and try to re-validate
                 return resolve(RegisteredTypes.copyResolved(RegisteredTypeKind.SPEC, typeToValidate), constraint);
             }
-            RegisteredTypes.cacheActualJavaType(resultT, resultO.getClass());
+            Class<?> resultS;
+            if (resultT.getKind() == RegisteredTypeKind.SPEC) {
+                resultS = ((AbstractBrooklynObjectSpec<?,?>)resultO).getType();
+            } else {
+                resultS = resultO.getClass();
+            }
+            RegisteredTypes.cacheActualJavaType(resultT, resultS);
             
-            supers = MutableSet.copyOf(supers);
-            supers.add(resultO.getClass());
-            supers.add(BrooklynObjectType.of(resultO.getClass()).getInterfaceType());
-            RegisteredTypes.addSuperTypes(resultT, supers);
+            Set<Object> newSupers = MutableSet.of();
+            // TODO collect registered type name supertypes, as strings
+            newSupers.add(resultS);
+            newSupers.addAll(supers);
+            newSupers.add(BrooklynObjectType.of(resultO.getClass()).getInterfaceType());
+            collectSupers(newSupers);
+            RegisteredTypes.addSuperTypes(resultT, newSupers);
 
             return ReferenceWithError.newInstanceWithoutError(resultT);
         }
@@ -1768,6 +1809,22 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             .appendIfNotNull(beanError)
             .appendIfNotNull(specError);
         return ReferenceWithError.newInstanceThrowingError(null, Exceptions.create("Could not resolve "+typeToValidate, errors));
+    }
+
+    private void collectSupers(Set<Object> s) {
+        Queue<Object> remaining = new LinkedList<>();
+        remaining.addAll(s);
+        s.clear();
+        while (!remaining.isEmpty()) {
+            Object next = remaining.remove();
+            if (next instanceof Class<?>) {
+                if (!s.contains(next)) {
+                    s.add(next);
+                    remaining.add( ((Class<?>)next).getSuperclass() );
+                    remaining.addAll( Arrays.asList( ((Class<?>)next).getInterfaces() ) );
+                }
+            }
+        }
     }
 
     private CatalogItem<?,?> addItemDto(CatalogItemDtoAbstract<?, ?> itemDto, boolean forceUpdate) {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -346,11 +346,13 @@ public class CatalogUtils {
         if (item!=null) {
             item.setDeprecated(newValue);
             mgmt.getCatalog().persist(item);
+        }
+        RegisteredType type = mgmt.getTypeRegistry().get(symbolicName, version);
+        if (type!=null) {
+            // won't be persisted
+            RegisteredTypes.setDeprecated(type, newValue);
         } else {
-            RegisteredType type = mgmt.getTypeRegistry().get(symbolicName, version);
-            if (type!=null) {
-                RegisteredTypes.setDeprecated(type, newValue);
-            } else {
+            if (item==null) {
                 throw new NoSuchElementException(symbolicName+":"+version);
             }
         }
@@ -363,11 +365,13 @@ public class CatalogUtils {
         if (item!=null) {
             item.setDisabled(newValue);
             mgmt.getCatalog().persist(item);
+        }
+        RegisteredType type = mgmt.getTypeRegistry().get(symbolicName, version);
+        if (type!=null) {
+            // won't be persisted
+            RegisteredTypes.setDisabled(type, newValue);
         } else {
-            RegisteredType type = mgmt.getTypeRegistry().get(symbolicName, version);
-            if (type!=null) {
-                RegisteredTypes.setDisabled(type, newValue);
-            } else {
+            if (item==null) {
                 throw new NoSuchElementException(symbolicName+":"+version);
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -589,22 +589,23 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 }
                 return changed;
             });
-        if (changedLocally) {
-            return;
-        }
-        legacyDelete(type);
+        legacyDelete(type, changedLocally);
     }
     
     @SuppressWarnings("deprecation")
-    private void legacyDelete(VersionedName type) {
-        // when we delete this, we should simply do the following (as contract is to throw if can't delete)
+    private void legacyDelete(VersionedName type, boolean alreadyDeletedLocally) {
+        // when we delete the legacy basic catalog, this method should simply do the following (as contract is to throw if can't delete)
+//        if (alreadyDeletedLocally) return;
 //        if (Strings.isBlank(type.getVersionString()) || BrooklynCatalog.DEFAULT_VERSION.equals(type.getVersionString())) {
 //            throw new IllegalStateException("Deleting items with unspecified version (argument DEFAULT_VERSION) not supported.");
 //        }
 //        throw new NoSuchElementException("No catalog item found with id "+type);
         
-        // NB the call below may call back to us, but max once)
-        mgmt.getCatalog().deleteCatalogItem(type.getSymbolicName(), type.getVersionString());
+        // but for now we should delete the CI - if it's a RT then CI deletion is optional
+        // (note that if a CI is added and validated, there is an RT created so there are both)
+        // if it was an RT that was added there is no CI.  (and if the CI was added without vbalidation,
+        // there is no RT, and in this case we have to fail if the CI is not found.)
+        mgmt.getCatalog().deleteCatalogItem(type.getSymbolicName(), type.getVersionString(), false, !alreadyDeletedLocally);
     }
     
     /** removes the given registered type in the noted bundle; 
@@ -626,11 +627,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 }
                 return true;
             });
-        if (changedLocally) {
-            return;
-        }
-        
-        legacyDelete(type.getVersionedName());
+        legacyDelete(type.getVersionedName(), changedLocally);
     }
     
     /** as {@link #delete(VersionedName)} */

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
@@ -109,7 +109,8 @@ public class RegisteredTypes {
             throw new IllegalStateException("Unsupported catalog item "+item+" when trying to create RegisteredType");
         }
         
-        BasicRegisteredType type = (BasicRegisteredType) spec(item.getSymbolicName(), item.getVersion(), impl, item.getCatalogItemJavaType());
+        BasicRegisteredType type = (BasicRegisteredType) RegisteredTypes.spec(item.getSymbolicName(), item.getVersion(), impl);
+        RegisteredTypes.addSuperType(type, item.getCatalogItemJavaType());
         type.containingBundle = item.getContainingBundle();
         type.displayName = item.getDisplayName();
         type.description = item.getDescription();
@@ -175,7 +176,10 @@ public class RegisteredTypes {
         if (symbolicName==null || version==null) log.warn("Deprecated use of RegisteredTypes API passing null name/version", new Exception("Location of deprecated use, wrt "+plan));
         return new BasicRegisteredType(RegisteredTypeKind.BEAN, symbolicName, version, plan);
     }
-    /** Convenience for {@link #bean(String, String, TypeImplementationPlan)} when there is a single known java signature/super type */
+    /** Convenience for {@link #bean(String, String, TypeImplementationPlan)} when there is a single known java signature/super type
+     * @deprecated since 1.0.0 no need for method which adds one explicit supertype; you can do it if you need with {@link #bean(String, String, TypeImplementationPlan)} then {@link #addSuperType(RegisteredType, Class)}
+     * but the type creation should set supertypes */
+    @Deprecated
     public static RegisteredType bean(@Nonnull String symbolicName, @Nonnull String version, @Nonnull TypeImplementationPlan plan, @Nonnull Class<?> superType) {
         if (superType==null) log.warn("Deprecated use of RegisteredTypes API passing null supertype", new Exception("Location of deprecated use, wrt "+symbolicName+":"+version+" "+plan));
         return addSuperType(bean(symbolicName, version, plan), superType);
@@ -187,7 +191,9 @@ public class RegisteredTypes {
         if (symbolicName==null || version==null) log.warn("Deprecated use of RegisteredTypes API passing null supertype", new Exception("Location of deprecated use, wrt "+plan));
         return new BasicRegisteredType(RegisteredTypeKind.SPEC, symbolicName, version, plan);
     }
-    /** Convenience for {@link #spec(String, String, TypeImplementationPlan)} when there is a single known java signature/super type */
+    /** Convenience for {@link #spec(String, String, TypeImplementationPlan)} when there is a single known java signature/super type
+     * @deprecated since 1.0.0 no need for method which adds one explicit supertype; you can do it if you need with {@link #spec(String, String, TypeImplementationPlan)} then {@link #addSuperType(RegisteredType, Class)}
+     * but the type creation should set supertypes */
     public static RegisteredType spec(@Nonnull String symbolicName, @Nonnull String version, @Nonnull TypeImplementationPlan plan, @Nonnull Class<?> superType) {
         if (superType==null) log.warn("Deprecated use of RegisteredTypes API passing null supertype", new Exception("Location of deprecated use, wrt "+symbolicName+":"+version+" "+plan));
         return addSuperType(spec(symbolicName, version, plan), superType);

--- a/core/src/test/java/org/apache/brooklyn/core/catalog/internal/StaticTypePlanTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/catalog/internal/StaticTypePlanTransformerTest.java
@@ -52,7 +52,7 @@ public class StaticTypePlanTransformerTest extends BrooklynMgmtUnitTestSupport {
     @Test
     public void testCreateSpec() {
         EntitySpec<?> spec = mgmt.getTypeRegistry().createSpec(
-            RegisteredTypes.spec(specId, "1", new BasicTypeImplementationPlan(StaticTypePlanTransformer.FORMAT, null), Entity.class),
+            RegisteredTypes.addSuperType(RegisteredTypes.spec(specId, "1", new BasicTypeImplementationPlan(StaticTypePlanTransformer.FORMAT, null)), Entity.class),
             null, EntitySpec.class);
         Assert.assertEquals(spec.getDisplayName(), DISPLAY_NAME);
         Assert.assertEquals(spec.getType(), BasicEntity.class);

--- a/core/src/test/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistryTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistryTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.brooklyn.core.typereg;
 
+import javax.annotation.Nonnull;
+
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.api.typereg.RegisteredType.TypeImplementationPlan;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -42,8 +45,12 @@ public class BasicBrooklynTypeRegistryTest extends BrooklynMgmtUnitTestSupport {
         registry().addToLocalUnpersistedTypeRegistry(type, canForce);
     }
     
-    private final static RegisteredType SAMPLE_TYPE = RegisteredTypes.bean("item.A", "1", new BasicTypeImplementationPlan("ignore", null), String.class);
-    private final static RegisteredType SAMPLE_TYPE2 = RegisteredTypes.bean("item.A", "2", new BasicTypeImplementationPlan("ignore", null), String.class);
+    private static RegisteredType beanWithSuper(@Nonnull String symbolicName, @Nonnull String version, @Nonnull TypeImplementationPlan plan, @Nonnull Class<?> superType) {
+        return RegisteredTypes.addSuperType(RegisteredTypes.bean(symbolicName, version, plan), superType);
+    }
+    
+    private final static RegisteredType SAMPLE_TYPE = beanWithSuper("item.A", "1", new BasicTypeImplementationPlan("ignore", null), String.class);
+    private final static RegisteredType SAMPLE_TYPE2 = beanWithSuper("item.A", "2", new BasicTypeImplementationPlan("ignore", null), String.class);
     
     @Test
     public void testAddAndGet() {
@@ -63,7 +70,7 @@ public class BasicBrooklynTypeRegistryTest extends BrooklynMgmtUnitTestSupport {
     @Test
     public void testCantAddSameIdUnlessSameInstanceOrForced() {
         add(SAMPLE_TYPE);
-        RegisteredType sampleTypeDifferent = RegisteredTypes.bean("item.A", "1", new BasicTypeImplementationPlan("ignore2", null), String.class);
+        RegisteredType sampleTypeDifferent = beanWithSuper("item.A", "1", new BasicTypeImplementationPlan("ignore2", null), String.class);
         add(sampleTypeDifferent, true);
         Assert.assertSame( registry().get(SAMPLE_TYPE.getId()), sampleTypeDifferent );
         Assert.assertNotSame( registry().get(SAMPLE_TYPE.getId()), SAMPLE_TYPE );
@@ -132,7 +139,7 @@ public class BasicBrooklynTypeRegistryTest extends BrooklynMgmtUnitTestSupport {
         add(SAMPLE_TYPE2);
         
         RegisteredType sampleType15WithAliases = RegisteredTypes.addAliases(
-            RegisteredTypes.bean("item.A", "1.1", new BasicTypeImplementationPlan("ignore", null), String.class),
+            beanWithSuper("item.A", "1.1", new BasicTypeImplementationPlan("ignore", null), String.class),
             MutableList.of("my_a", "the_a"));
         add(sampleType15WithAliases);
         Assert.assertEquals(sampleType15WithAliases.getAliases(), MutableSet.of("my_a", "the_a"));
@@ -162,7 +169,7 @@ public class BasicBrooklynTypeRegistryTest extends BrooklynMgmtUnitTestSupport {
         add(SAMPLE_TYPE2);
         
         RegisteredType sampleType15WithTags = RegisteredTypes.addTags(
-            RegisteredTypes.bean("item.A", "1.1", new BasicTypeImplementationPlan("ignore", null), String.class),
+            beanWithSuper("item.A", "1.1", new BasicTypeImplementationPlan("ignore", null), String.class),
             MutableList.of("my_a", "the_a"));
         add(sampleType15WithTags);
         Assert.assertEquals(sampleType15WithTags.getTags(), MutableSet.of("my_a", "the_a"));

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -137,7 +137,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         }
 
         try {
-            final Iterable<? extends CatalogItem<?, ?>> items = brooklyn().getCatalog().addItems(yaml, forceUpdate);
+            final Iterable<? extends CatalogItem<?, ?>> items = brooklyn().getCatalog().addItems(yaml, true, forceUpdate);
             List<RegisteredType> itemsRT = MutableList.of();
             for (CatalogItem<?, ?> ci: items) {
                 RegisteredType rt = brooklyn().getTypeRegistry().get(ci.getId());

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourcePerformanceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourcePerformanceTest.java
@@ -105,7 +105,7 @@ public class CatalogResourcePerformanceTest extends BrooklynRestResourcePerforma
                     "    description: My description",
                     "    item:",
                     "      type: " + Aggregator.class.getName());
-            getManagementContext().getCatalog().addItems(yaml, false);
+            getManagementContext().getCatalog().addItems(yaml);
         }
     }
 


### PR DESCRIPTION
this populates the `supertypes` field of `RegisteredType` instances better, now including all java supertypes (and for specs only including what it's a spec for, ie `Entity`, now excluding the `EntitySpec` class).

this is WIP as i'd also like to include declared `RegisteredType` supers.

this is slightly messy on the API however.  specifically consider a YAML type `b` declaring its super as a java `type: a.A`, and a YAML type `c` declaring super `type: b`.  in java, the supers of `c` would then be `[ RegisteredType[b], Class[a.A] ]` (plus any supers of `a.A`).  what should this look like in REST?

currently we return a list of strings for all supers so the json response in `TypeSummary` will include `supertypes: [ b:0.0.0_SNAPSHOT, a.A ]`.

other options are available to better distinguish registered types (yaml types) from java types.  we could have eg `supertypesJava: [ a.A ]` and `supertypesYaml: [ b:0.0.0_SNAPSHOT ]`.  or we could have objects eg `supertypes: [ { kind: registered-type, name: b:0.0.0_SNAPSHOT }, { kind: java, name: a.A } ]`.

i think it's best to leave it as is and rely on the `:` character to distinguish yaml supertypes.  otherwise we're breaking the API and making the object seem more complex.  but i want to flag this bit of complexity in the semantics of the json `supertypes` field.

(opening this PR now for early review of code and to see whether anyone has strong feelings on the above.)
