### PR TITLE
Winrm hold mutex for install

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
@@ -293,9 +293,24 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     }
 
     @Override
+    public void copyPreInstallResources() {
+        final WithMutexes mutexSupport = getLocation().mutexes();
+        String mutexId = "installation lock at host";
+        mutexSupport.acquireMutex(mutexId, "pre-installation lock at host for files and templates");
+        try {
+            super.copyPreInstallResources();
+        } catch (Exception e) {
+            log.warn("Error copying pre-install resources", e);
+            throw Exceptions.propagate(e);
+        } finally {
+            mutexSupport.releaseMutex(mutexId);
+        }
+    }
+
+    @Override
     public void copyInstallResources() {
         final WithMutexes mutexSupport = getLocation().mutexes();
-        final String mutexId = "installing " + elvis(entity, this);
+        String mutexId = "installation lock at host";
         mutexSupport.acquireMutex(mutexId, "installation lock at host for files and templates");
         try {
             super.copyInstallResources();
@@ -310,7 +325,7 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     @Override
     public void copyCustomizeResources() {
         final WithMutexes mutexSupport = getLocation().mutexes();
-        final String mutexId = "customizing " + elvis(entity, this);
+        String mutexId = "installation lock at host";
         mutexSupport.acquireMutex(mutexId, "installation lock at host for files and templates");
         try {
             super.copyCustomizeResources();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -171,6 +171,20 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         }
     }
 
+    @Override
+    public void copyPreInstallResources() {
+        final WithMutexes mutexSupport = getLocation().mutexes();
+        String mutexId = "installation lock at host";
+        mutexSupport.acquireMutex(mutexId, "pre-installing " + elvis(entity, this));
+        try {
+            super.copyPreInstallResources();
+        } catch (Exception e) {
+            LOG.warn("Error copying pre-install resources", e);
+            throw Exceptions.propagate(e);
+        } finally {
+            mutexSupport.releaseMutex(mutexId);
+        }
+    }
 
     @Override
     public void copyInstallResources() {
@@ -180,7 +194,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         try {
             super.copyInstallResources();
         } catch (Exception e) {
-//            log.warn("Error copying install resources", e);
+            LOG.warn("Error copying install resources", e);
             throw Exceptions.propagate(e);
         } finally {
             mutexSupport.releaseMutex(mutexId);
@@ -190,13 +204,12 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     @Override
     public void copyCustomizeResources() {
         final WithMutexes mutexSupport = getLocation().mutexes();
-        final String description = "customizing " + elvis(entity, this);
         String mutexId = "installation lock at host";
-        mutexSupport.acquireMutex(mutexId, description);
+        mutexSupport.acquireMutex(mutexId, "customizing " + elvis(entity, this));
         try {
             super.copyCustomizeResources();
         } catch (Exception e) {
-//            log.warn("Error copying customize resources", e);
+            LOG.warn("Error copying customize resources", e);
             throw Exceptions.propagate(e);
         } finally {
             mutexSupport.releaseMutex(mutexId);

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.entity.software.base;
 
+import static org.apache.brooklyn.util.JavaGroovyEquivalents.elvis;
+
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.entity.software.base.lifecycle.WinRmExecuteHelper;
@@ -58,11 +60,11 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
 
         // TODO: Follow install path of VanillaSoftwareProcessSshDriver
         if(Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND))) {
-            executeCommandInTask(
-                    getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND),
-                    getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND),
-                    "install-command",
-                    hostname);
+            String cmd = getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND);
+            String psCmd = getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND);
+            newScript(cmd, psCmd, "install-command", hostname)
+                    .useMutex(getLocation().mutexes(), "installation lock at host", "installing "+elvis(entity,this))
+                    .execute();
         }
         if (entity.getConfig(VanillaWindowsProcess.INSTALL_REBOOT_REQUIRED)) {
             rebootAndWait(hostname);

--- a/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
@@ -21,6 +21,8 @@ package org.apache.brooklyn.util.core.internal.winrm;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,7 +32,6 @@ import org.apache.brooklyn.util.stream.Streams;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * For stubbing out the {@link WinRmTool}, so that no real winrm commands are executed.
@@ -98,7 +99,7 @@ public class RecordingWinRmTool implements WinRmTool {
     
     public static List<ExecParams> execs = Lists.newCopyOnWriteArrayList();
     public static List<Map<?,?>> constructorProps = Lists.newCopyOnWriteArrayList();
-    public static Map<String, CustomResponseGenerator> customResponses = Maps.newConcurrentMap();
+    public static Map<String, CustomResponseGenerator> customResponses = Collections.synchronizedMap(new LinkedHashMap<>());
     
     public static void clear() {
         execs.clear();
@@ -163,8 +164,12 @@ public class RecordingWinRmTool implements WinRmTool {
     }
     
     protected WinRmToolResponse generateResponse(ExecParams execParams) {
+        LinkedHashMap<String, CustomResponseGenerator> customResponsesCopy;
+        synchronized (customResponses) {
+            customResponsesCopy = new LinkedHashMap<>(customResponses);
+        }
         for (String cmd : execParams.commands) {
-            for (Entry<String, CustomResponseGenerator> entry : customResponses.entrySet()) {
+            for (Entry<String, CustomResponseGenerator> entry : customResponsesCopy.entrySet()) {
                 if (cmd.matches(entry.getKey())) {
                     CustomResponseGenerator responseGenerator = entry.getValue();
                     CustomResponse response = responseGenerator.generate(execParams);

--- a/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/util/core/internal/winrm/RecordingWinRmTool.java
@@ -153,8 +153,9 @@ public class RecordingWinRmTool implements WinRmTool {
 
     @Override
     public WinRmToolResponse copyToServer(InputStream source, String destination) {
-        execs.add(new ExecParams(ExecType.COPY_TO_SERVER, ownConstructorProps, ImmutableList.of(new String(Streams.readFully(source)))));
-        return new WinRmToolResponse("", "", 0);
+        ExecParams execParams = new ExecParams(ExecType.COPY_TO_SERVER, ownConstructorProps, ImmutableList.of(new String(Streams.readFully(source))));
+        execs.add(execParams);
+        return generateResponse(execParams);
     }
 
     @Override


### PR DESCRIPTION
This PR prevents processes concurrently trying to install items on the same winrm location.  It is as similar as possible to how we handle ssh.