### PR TITLE
Update Reflections dependency

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogic.java
@@ -374,7 +374,6 @@ public class ServiceStateLogic {
         return newEnricherForServiceState(ComputeServiceState.class);
     }
     public static final EnricherSpec<?> newEnricherForServiceState(Class<? extends Enricher> type) {
-        newEnricherForServiceUpFromChildren();
         return EnricherSpec.create(type);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/javalang/ReflectionScanner.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/javalang/ReflectionScanner.java
@@ -106,17 +106,19 @@ public class ReflectionScanner {
     public Store getStore() {
         return reflections.getStore();
     }
-    
+
     /** overrides delegate so as to log rather than throw exception if a class cannot be loaded */
     public <T> Set<Class<? extends T>> getSubTypesOf(final Class<T> type) {
-        Set<String> subTypes = getStore().getSubTypesOf(type.getName());
-        return ImmutableSet.copyOf(this.<T>forNames(subTypes, "sub-type of "+type));
+        return ImmutableSet.copyOf(reflections.getSubTypesOf(type));
     }
     
     /** overrides delegate so as to log rather than throw exception if a class cannot be loaded */
     public Set<Class<?>> getTypesAnnotatedWith(Class<? extends Annotation> annotation) {
-        Set<String> annotatedWith = getStore().getTypesAnnotatedWith(annotation.getName());
-        return ImmutableSet.copyOf(this.forNames(annotatedWith, "annotated "+annotation.getName()));
+        // Second parameter to getTypesAnnotatedWith instructs reflections to honour the
+        // Inherited meta-annotation. When `false` the returned set includes unannotated
+        // classes that implement annotated interfaces. In practice this means that the
+        // Brooklyn catalog would include entity implementations.
+        return ImmutableSet.copyOf(reflections.getTypesAnnotatedWith(annotation, true));
     }
 
     @SuppressWarnings("unchecked")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -373,6 +373,12 @@
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <bouncycastle.version>1.51</bouncycastle.version>
         <sshj.version>0.12.0</sshj.version>
         <felix.framework.version>5.6.1</felix.framework.version>
-        <reflections.version>0.9.9-RC1</reflections.version>
+        <reflections.version>0.9.10</reflections.version>
         <jetty.version>9.3.14.v20161028</jetty.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
@@ -237,16 +237,16 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
         List<TypeSummary> entities = client().path("/catalog/types")
                 .query("fragment", "vaNIllasOFTWAREpROCESS").get(new GenericType<List<TypeSummary>>() {});
         log.info("Matching entities: " + entities);
-        assertEquals(entities.size(), 1);
+        Asserts.assertSize(entities, 1);
 
         entities = client().path("/catalog/types").query("supertype", "entity")
                 .query("fragment", "vaNIllasOFTWAREpROCESS").get(new GenericType<List<TypeSummary>>() {});
         log.info("Matching entities: " + entities);
-        assertEquals(entities.size(), 1);
+        Asserts.assertSize(entities, 1);
 
         List<TypeSummary> entities2 = client().path("/catalog/types")
                 .query("regex", "[Vv]an.[alS]+oftware\\w+").get(new GenericType<List<TypeSummary>>() {});
-        assertEquals(entities2.size(), 1);
+        Asserts.assertSize(entities2, 1);
 
         assertEquals(entities, entities2);
     

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
@@ -226,21 +226,21 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
         List<CatalogEntitySummary> entities = client().path("/catalog/entities")
                 .query("fragment", "vaNIllasOFTWAREpROCESS").get(new GenericType<List<CatalogEntitySummary>>() {});
         log.info("Matching entities: " + entities);
-        assertEquals(entities.size(), 1);
+        Asserts.assertSize(entities, 1);
 
         List<CatalogEntitySummary> entities2 = client().path("/catalog/entities")
                 .query("regex", "[Vv]an.[alS]+oftware\\w+").get(new GenericType<List<CatalogEntitySummary>>() {});
-        assertEquals(entities2.size(), 1);
+        Asserts.assertSize(entities2, 1);
 
         assertEquals(entities, entities2);
     
         List<CatalogEntitySummary> entities3 = client().path("/catalog/entities")
                 .query("fragment", "bweqQzZ").get(new GenericType<List<CatalogEntitySummary>>() {});
-        assertEquals(entities3.size(), 0);
+        Asserts.assertSize(entities3, 0);
 
         List<CatalogEntitySummary> entities4 = client().path("/catalog/entities")
                 .query("regex", "bweq+z+").get(new GenericType<List<CatalogEntitySummary>>() {});
-        assertEquals(entities4.size(), 0);
+        Asserts.assertSize(entities4, 0);
     }
 
     @Test

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ClassFinder.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/lister/ClassFinder.java
@@ -142,11 +142,10 @@ public class ClassFinder {
     public static <T extends BrooklynObject> Set<Class<? extends T>> findClasses(Collection<URL> urls, Class<T> clazz) {
         ClassLoader classLoader = new UrlClassLoader(urls.toArray(new URL[urls.size()]));
         
-        Reflections reflections = new ConfigurationBuilder()
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
                 .addClassLoader(classLoader)
                 .addScanners(new SubTypesScanner(), new TypeAnnotationsScanner(), new FieldAnnotationsScanner())
-                .addUrls(urls)
-                .build();
+                .addUrls(urls));
         
         Set<Class<? extends T>> types = reflections.getSubTypesOf(clazz);
         


### PR DESCRIPTION
0.9.9-RC1 is unable to read classes containing lambda functions. This meant that `brooklyn list-objects` did not output all classes. Refer to ronmamo/reflections#15 for futher context.

There is a more recent release of reflections that I think fixes further issues (see GitHub) but it relies on Guava v20. ronmamo/reflections#194

Reflections' dependency on com.google.code.findbugs:annotations is excluded because it clashes with a version from airline and should only be needed at compile time anyway.