### PR TITLE
BROOKLYN-573: repeater not log stacktrace repeatedly

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/repeat/Repeater.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/repeat/Repeater.java
@@ -400,7 +400,7 @@ public class Repeater implements Callable<Boolean> {
                     hasLoggedTransientException = false;
                 } catch (Throwable e) {
                     if (hasLoggedTransientException) {
-                        log.debug("{}: repeated failure; excluding stacktrace: {}", description, e);
+                        log.debug("{}: repeated failure; excluding stacktrace: {}", description, e.toString());
                     } else {
                         log.debug(description, e);
                         hasLoggedTransientException = true;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BROOKLYN-573