### PR TITLE
BROOKLYN-576: decrease debug logging for resolved DSL

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
@@ -117,12 +117,12 @@ public abstract class BrooklynDslDeferredSupplier<T> implements DeferredSupplier
             throw Exceptions.propagate(e);
         }
 
-        if (log.isDebugEnabled()) {
+        if (log.isTraceEnabled()) {
             // https://issues.apache.org/jira/browse/BROOKLYN-269
             // We must not log sensitve data, such as from $brooklyn:external, or if the value
             // is to be used as a password etc. Unfortunately we don't know the context, so can't
             // use Sanitizer.sanitize.
-            log.debug("Resolved "+dsl);
+            log.trace("Resolved "+dsl);
         }
         return result;
     }


### PR DESCRIPTION
We ran a test in QA that lasted 1 hour. There were 98,275 of these debug log messages (out of 226,712 total log messages at debug or above).