### PR TITLE
Improve JcloudsWinrmingLiveTest coverage

### DIFF
--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/AbstractJcloudsLiveTest.java
@@ -66,7 +66,10 @@ public class AbstractJcloudsLiveTest {
     
     public static final String GCE_PROVIDER = "google-compute-engine";
     public static final String GCE_USCENTRAL_REGION_NAME = "us-central1-a";
-    
+
+    public static final String AZURE_ARM_PROVIDER = "azurecompute-arm";
+    public static final String AZURE_ARM_REGION_NAME = "westeurope";
+
     protected BrooklynProperties brooklynProperties;
     protected LocalManagementContext managementContext;
     

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsWinrmingLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsWinrmingLiveTest.java
@@ -21,12 +21,17 @@ package org.apache.brooklyn.location.jclouds;
 import java.util.Map;
 
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.jclouds.Constants;
+import org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions;
+import org.jclouds.azurecompute.compute.options.AzureComputeTemplateOptions;
 import org.jclouds.compute.domain.OsFamily;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import static org.apache.brooklyn.core.location.LocationConfigKeys.OAUTH_ENDPOINT;
 
 /**
  * Tests the initial WinRM command execution, for a VM provisioned through jclouds.
@@ -49,12 +54,26 @@ public class JcloudsWinrmingLiveTest extends AbstractJcloudsLiveTest {
     public static final String GCE_LOCATION_SPEC = "jclouds:" + GCE_PROVIDER + ":" + GCE_USCENTRAL_REGION_NAME;
     public static final String GCE_IMAGE_NAME_REGEX = "windows-server-2012-r2-.*";
 
+    public static final String AZURE_ARM_LOCATION_SPEC = "jclouds:" + AZURE_ARM_PROVIDER + ":" + AZURE_ARM_REGION_NAME;
+    public static final String AZURE_ARM_NAME_REGEX = "WindowsServer";
+
     public static final String SOFTLAYER_LOCATION_SPEC = "jclouds:" + SOFTLAYER_PROVIDER;
     public static final String SOFTLAYER_IMAGE_ID = "WIN_2012-STD-R2_64";
 
     @DataProvider(name = "cloudAndImageNames")
     public Object[][] cloudAndImageNames() {
         return new Object[][] {
+                new Object[] { AZURE_ARM_LOCATION_SPEC, AZURE_ARM_NAME_REGEX, ImmutableMap.builder()
+                        .put(Constants.PROPERTY_ENDPOINT, "https://management.azure.com/subscriptions/012e832d-7b27-4c30-9f21-22cdd9159d12")
+                        .put(OAUTH_ENDPOINT.getName(), "https://login.microsoftonline.com/ba85e8cd-8c83-486e-a7e3-0d7666169d34/oauth2/token")
+                        .put(JcloudsLocation.IMAGE_ID.getName(), "westeurope/MicrosoftWindowsServer/WindowsServer/2016-Datacenter")
+                        .put("jclouds.azurecompute.arm.publishers", "MicrosoftWindowsServer")
+                        .put("azure.arm.default.network.enabled", false)
+                        .put("vmNameMaxLength", 15)
+                        .put("destroyOnFailure", false)
+                        .put("useJcloudsSshInit", false)
+                        .build()
+                },
                 new Object[] { AWS_EC2_LOCATION_SPEC, AWS_EC2_IMAGE_NAME_REGEX, ImmutableMap.of() },
                 new Object[] { GCE_LOCATION_SPEC, GCE_IMAGE_NAME_REGEX, ImmutableMap.of(JcloudsLocation.LOGIN_USER.getName(), "myname") },
             };


### PR DESCRIPTION
- add Azure ARM live test
- improve error message for DefaultConnectivityResolver

---

When `DefaultConnectivityResolver.getReachableAddresses` now fails when no reachable address are found with this error message
```
2018-02-21 11:47:15,502 ERROR None of the addresses [168.63.120.198, 10.0.0.4] of node {id=brp4hwrr/brp4hwrr-9f7, providerId=/subscriptions/012e832d-7b27-4c30-9f21-22cdd9159d12/resourceGroups/brp4hwrr/providers/Microsoft.Compute/virtualMachines/brp4hwrr-9f7, name=brp4hwrr-9f7, location={scope=REGION, id=westeurope, description=West Europe, parent=azurecompute-arm, iso3166Codes=[NL]}, group=brp4hwrr, imageId=westeurope/MicrosoftWindowsServer/WindowsServer/2016-Datacenter, os={family=windows, version=2016-Datacenter, description=2016-Datacenter, is64Bit=true}, status=RUNNING[ProvisioningState/succeeded,PowerState/running], loginPort=5985, hostname=brp4hwrr-9f7, privateAddresses=[10.0.0.4], publicAddresses=[168.63.120.198], hardware={id=westeurope/Standard_B1s, providerId=Standard_B1s, name=Standard_B1s, location={scope=REGION, id=westeurope, description=West Europe, parent=azurecompute-arm, iso3166Codes=[NL]}, processors=[{cores=1.0, speed=2.0}], ram=1024, volumes=[{type=LOCAL, size=2048.0, bootDevice=false, durable=false}, {type=LOCAL, size=1047552.0, bootDevice=false, durable=false}], supportsImage=Predicates.alwaysTrue(), userMetadata={maxDataDiskCount=2}}, loginUser=jclouds, userMetadata={Name=brp4hwrr-idg4, brooklyn-user=andrea, jclouds_group=brp4hwrr}} are reachable in mode PREFER_PUBLIC
```
instead of the IllegalStateException 
```
jclouds did not return any IP addresses matching " + getNetworkMode() + " in " + location
```