### PR TITLE
Fix non-deterministic EffectorResourceTest

### DIFF
--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorResourceTest.java
@@ -27,12 +27,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.rest.api.EffectorApi;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.time.Duration;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Stopwatch;
@@ -50,11 +51,21 @@ public class EffectorResourceTest extends BrooklynRestResourceTest {
     BasicApplication app;
     TestEntity entity;
 
-    @BeforeMethod(alwaysRun = true)
-    public void setUpMethod() throws Exception {
+    @Override
+    public void initMethod() throws Exception {
+        super.initMethod();
         app = getManagementContext().getEntityManager().createEntity(EntitySpec.create(BasicApplication.class)
                 .child(EntitySpec.create(TestEntity.class)));
         entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
+    }
+
+    @Override
+    public void destroyMethod() throws Exception {
+        try {
+            if (app != null) Entities.destroy(app);
+        } finally {
+            super.destroyMethod();
+        }
     }
 
     @Test
@@ -114,6 +125,18 @@ public class EffectorResourceTest extends BrooklynRestResourceTest {
     
     @Test
     public void testInvokeEffectorWithTimeoutTimesOut() throws Exception {
+        /*
+         * The effector is invoked via:
+         *   Task<?> task = entity.invoke(effector.get(), parameters)
+         *   task.get(timeout)
+         * On timeout, the task is not cancelled. The effector keeps executing in the background.
+         * 
+         * The task might not yet have reached the effector body's sleep. It sometimes is
+         * still setting up the call (e.g. preparing the effector args).
+         * 
+         * The response returned is a snapshot of the task's state/stacktrace at the time
+         * of the timeout.
+         */
         String path = "/applications/"+app.getId()+"/entities/"+entity.getId()+"/effectors/"+"sleepEffector";
 
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -126,12 +149,16 @@ public class EffectorResourceTest extends BrooklynRestResourceTest {
         assertEquals(response.getStatus(), 202);
         
         String responseBody = response.readEntity(String.class);
-        assertTrue(entity.getCallHistory().contains("sleepEffector"));
+        Asserts.succeedsEventually(() -> assertTrue(entity.getCallHistory().contains("sleepEffector")));
         assertTrue(runDuration.isShorterThan(Asserts.DEFAULT_LONG_TIMEOUT), "runDuration="+runDuration);
         
         // Expect to get a task back, representing the currently executing effector
         Map<?,?> responseMap = new Gson().fromJson(responseBody, Map.class);
         assertTrue((""+responseMap.get("displayName")).contains("sleepEffector"), "responseMap="+responseMap);
-        assertTrue((""+responseMap.get("detailedStatus")).contains("In progress, thread waiting"), "responseMap="+responseMap);
+        
+        String detailedStatus = ""+responseMap.get("detailedStatus");
+        boolean taskSleeping = detailedStatus.contains("In progress, thread waiting") && detailedStatus.contains("TestEntityImpl.sleepEffector");
+        boolean taskPreparing = detailedStatus.contains("In progress (RUNNABLE)") && detailedStatus.contains("EffectorUtils.invokeMethodEffector");
+        assertTrue(taskSleeping || taskPreparing, "responseMap="+responseMap);
     }
 }


### PR DESCRIPTION
e.g. this failed in https://builds.apache.org/view/B/view/Brooklyn/job/brooklyn-server-master-docker/69/

```
Regression
org.apache.brooklyn.rest.resources.EffectorResourceTest.testInvokeEffectorWithTimeoutTimesOut

Error Message
responseMap={id=TfFAYVbX, displayName=sleepEffector, description=Invoking effector sleepEffector on TestEntity:et9d with parameters {duration=5m}, entityId=et9dfmhgbc, entityDisplayName=TestEntity:et9d, tags=[EFFECTOR, {type=org.apache.brooklyn.api.mgmt.ManagementContext}, {wrappingType=contextEntity, entity={type=org.apache.brooklyn.api.entity.Entity, id=et9dfmhgbc}}, {wrappingType=targetEntity, entity={type=org.apache.brooklyn.api.entity.Entity, id=et9dfmhgbc}}, {entityId=et9dfmhgbc, effectorName=sleepEffector}], submitTimeUtc=1.524143241939E12, startTimeUtc=1.524143241939E12, endTimeUtc=null, currentStatus=In progress, result=null, isError=false, isCancelled=false, children=[], submittedByTask=null, detailedStatus=Task[sleepEffector]@TfFAYVbX  In progress (RUNNABLE) At: org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceInternal(TypeCoercerExtensible.java:189)     org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerce(TypeCoercerExtensible.java:112)     org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.coerce(TypeCoercerExtensible.java:102)     org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.coerce(TypeCoercerExtensible.java:98)     org.apache.brooklyn.util.core.flags.TypeCoercions.coerce(TypeCoercions.java:81)     org.apache.brooklyn.core.mgmt.internal.EffectorUtils.prepareArgsForEffectorFromMap(EffectorUtils.java:167)     org.apache.brooklyn.core.mgmt.internal.EffectorUtils.prepareArgsForEffector(EffectorUtils.java:75)     org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodLocal(AbstractManagementContext.java:324)     org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodSync(AbstractManagementContext.java:366)     org.apache.brooklyn.core.mgmt.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:274)     org.apache.brooklyn.core.effector.MethodEffector.call(MethodEffector.java:153)     org.apache.brooklyn.core.effector.AbstractEffector.call(AbstractEffector.java:61)     org.apache.brooklyn.core.effector.AbstractEffector$1$1.call(AbstractEffector.java:79)     org.apache.brooklyn.util.core.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:364)     org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:565), streams={}, links={self=/activities/TfFAYVbX, children=/activities/TfFAYVbX/children, entity=/applications/gkff4d6jt1/entities/et9dfmhgbc}} expected [true] but found [false]
Stacktrace
      java.lang.AssertionError: responseMap={id=TfFAYVbX, displayName=sleepEffector, description=Invoking effector sleepEffector on TestEntity:et9d with parameters {duration=5m}, entityId=et9dfmhgbc, entityDisplayName=TestEntity:et9d, tags=[EFFECTOR, {type=org.apache.brooklyn.api.mgmt.ManagementContext}, {wrappingType=contextEntity, entity={type=org.apache.brooklyn.api.entity.Entity, id=et9dfmhgbc}}, {wrappingType=targetEntity, entity={type=org.apache.brooklyn.api.entity.Entity, id=et9dfmhgbc}}, {entityId=et9dfmhgbc, effectorName=sleepEffector}], submitTimeUtc=1.524143241939E12, startTimeUtc=1.524143241939E12, endTimeUtc=null, currentStatus=In progress, result=null, isError=false, isCancelled=false, children=[], submittedByTask=null, detailedStatus=Task[sleepEffector]@TfFAYVbX

In progress (RUNNABLE)
At: org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerceInternal(TypeCoercerExtensible.java:189)
    org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.tryCoerce(TypeCoercerExtensible.java:112)
    org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.coerce(TypeCoercerExtensible.java:102)
    org.apache.brooklyn.util.javalang.coerce.TypeCoercerExtensible.coerce(TypeCoercerExtensible.java:98)
    org.apache.brooklyn.util.core.flags.TypeCoercions.coerce(TypeCoercions.java:81)
    org.apache.brooklyn.core.mgmt.internal.EffectorUtils.prepareArgsForEffectorFromMap(EffectorUtils.java:167)
    org.apache.brooklyn.core.mgmt.internal.EffectorUtils.prepareArgsForEffector(EffectorUtils.java:75)
    org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodLocal(AbstractManagementContext.java:324)
    org.apache.brooklyn.core.mgmt.internal.AbstractManagementContext.invokeEffectorMethodSync(AbstractManagementContext.java:366)
    org.apache.brooklyn.core.mgmt.internal.EffectorUtils.invokeMethodEffector(EffectorUtils.java:274)
    org.apache.brooklyn.core.effector.MethodEffector.call(MethodEffector.java:153)
    org.apache.brooklyn.core.effector.AbstractEffector.call(AbstractEffector.java:61)
    org.apache.brooklyn.core.effector.AbstractEffector$1$1.call(AbstractEffector.java:79)
    org.apache.brooklyn.util.core.task.DynamicSequentialTask$DstJob.call(DynamicSequentialTask.java:364)
    org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:565), streams={}, links={self=/activities/TfFAYVbX, children=/activities/TfFAYVbX/children, entity=/applications/gkff4d6jt1/entities/et9dfmhgbc}} expected [true] but found [false]
	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.failNotEquals(Assert.java:513)
	at org.testng.Assert.assertTrue(Assert.java:42)
	at org.apache.brooklyn.rest.resources.EffectorResourceTest.testInvokeEffectorWithTimeoutTimesOut(EffectorResourceTest.java:135)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at org.testng.TestRunner.privateRun(TestRunner.java:756)
	at org.testng.TestRunner.run(TestRunner.java:610)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:387)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:382)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1293)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1218)
	at org.testng.TestNG.runSuites(TestNG.java:1133)
	at org.testng.TestNG.run(TestNG.java:1104)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:132)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeMulti(TestNGDirectoryTestSuite.java:193)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:94)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:147)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
```