### PR TITLE
Add RecordingSshTool clears to selected tests

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshCommandSensorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricSshCommandSensorTest.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool.ExecCmd;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -41,8 +42,18 @@ public class RebindHistoricSshCommandSensorTest extends AbstractRebindHistoricTe
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         super.setUp();
+        RecordingSshTool.clear();
     }
 
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            RecordingSshTool.clear();
+        }
+    }
     /**
      * The persisted state was generated when SshCommandSensor used fields for 'command' etc, populating
      * them during init. Now it populates them lazily (thus handling deferred config suppliers).

--- a/core/src/test/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicyTest.java
@@ -56,6 +56,7 @@ public class SshCommandMembershipTrackingPolicyTest extends BrooklynAppUnitTestS
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        RecordingSshTool.clear();
 
         machine = LocationSpec.create(SshMachineLocation.class)
                 .configure("address", "1.2.3.4")


### PR DESCRIPTION
Noticed test output from SCMTPT failing with
the tool output referring to the commands from RHSCST in a
brooklyn-server build failure.