### PR TITLE
Add .m2 folder in the list of ignore folders for the RAT plugin.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1104,6 +1104,8 @@
                       https://brooklyn.incubator.apache.org
                   -->
                   <exclude>docs/**</exclude>
+                  <!-- maven cache -->
+                  <exclude>**/.m2/**</exclude>
 
                 </excludes>
               </configuration>


### PR DESCRIPTION
This is required for Jenkins build as we now use a local m2 cache