### PR TITLE
disable jclouds authorizePublicKey for extra ssh public key data

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/ExtraPublicKeyDataToAuthOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/ExtraPublicKeyDataToAuthOption.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.location.jclouds.templates.customize;
 
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.internal.BrooklynSystemProperties;
 import org.jclouds.compute.options.TemplateOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 class ExtraPublicKeyDataToAuthOption implements TemplateOptionCustomizer {
     private static final Logger LOG = LoggerFactory.getLogger(ExtraPublicKeyDataToAuthOption.class);
 
+    @SuppressWarnings("deprecation")
     @Override
     public void apply(TemplateOptions t, ConfigBag props, Object v) {
         // this is unreliable:
@@ -43,8 +45,13 @@ class ExtraPublicKeyDataToAuthOption implements TemplateOptionCustomizer {
         // we also do it here for legacy reasons though i (alex) can't think of any situations it's needed
         // --
         // also we warn on exceptions in case someone is dumping comments or something else
+        //
+        // TODO remove in 1.1 or later, if we confirm there is no need for this
         try {
-            t.authorizePublicKey(v.toString());
+            if (BrooklynSystemProperties.JCLOUDS_AUTHORIZE_EXTRA_SSH_PUBLIC_KEY_DATA.isEnabled()) {
+                // May 2018 - disabled this unless explicitly enabled as it breaks the use of key pairs
+                t.authorizePublicKey(v.toString());
+            }
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
             LOG.warn("Error trying jclouds authorizePublicKey; will run later: " + e, e);

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AbstractJcloudsLocationTest.java
@@ -48,7 +48,7 @@ import com.google.common.collect.Maps;
 public abstract class AbstractJcloudsLocationTest {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractJcloudsLocationTest.class);
 
-    private final String provider;
+    protected final String provider;
 
     protected JcloudsLocation loc;
     protected List<SshMachineLocation> machines = MutableList.of();

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AwsEc2LocationLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/provider/AwsEc2LocationLiveTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.location.jclouds.provider;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -28,6 +30,8 @@ import org.testng.annotations.Test;
  */
 public class AwsEc2LocationLiveTest extends AbstractJcloudsLocationTest {
 
+    private static final Logger log = LoggerFactory.getLogger(AwsEc2LocationLiveTest.class);
+    
     private static final String PROVIDER = "aws-ec2";
     private static final String EUWEST_REGION_NAME = "eu-west-1";
     private static final String USEAST_REGION_NAME = "us-east-1";
@@ -68,4 +72,29 @@ public class AwsEc2LocationLiveTest extends AbstractJcloudsLocationTest {
 
     @Test(enabled = false)
     public void noop() { } /* just exists to let testNG IDE run the test */
+    
+    // outline of test which can be used to assert combos of keys etc
+    // currently uses my (alex's) hardcoded keys and preexisting pair;
+    // should refactor to generate keys and the keypair and make a real test,
+    // but for now keeping it commented out as a template for people to do manual testing
+//    @Test(groups = "Live")
+//    public void testProvisionVmAndAuthPublicKey() {
+//        String regionName = USEAST_REGION_NAME;
+//        loc = (JcloudsLocation) mgmt().getLocationRegistry().getLocationManaged(provider + (regionName == null ? "" : ":" + regionName));
+//        SshMachineLocation machine = obtainMachine(MutableMap.of(
+//            JcloudsLocationConfig.KEY_PAIR, "alex-aws-2",
+//            JcloudsLocationConfig.LOGIN_USER_PRIVATE_KEY_FILE, "~/.ssh/alex-aws-2-id_rsa",
+//            
+//            JcloudsLocationConfig.PRIVATE_KEY_FILE, "~/.ssh/aws-cloudera_rsa",
+//            JcloudsLocationConfig.PUBLIC_KEY_FILE, "~/.ssh/aws-cloudera_rsa.pub",
+//            JcloudsLocationConfig.EXTRA_PUBLIC_KEY_DATA_TO_AUTH,
+//                aws-whirr
+//                "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw9R7FG0pOpZ7MR+KYty+UzHerEtW9NVBJj+NmznT4zg57klqDAxitahe6cJpj8Nbt0Rmp9G4TZQzAWuoSH5ZUJpFpcVP75tMYWOP6ZymH7MZ5hXLjLHTicNyQ/EB9H2eXSK2xLnq/8oDnzKgnhIXL7tbcC7hOY9Yzu25UrO+xQDbzM3nuwlr38JJwo1fLsIiEVI3uutZW9ANZgcZg0USlFFvxGcAA2KZ322tqtQtP3YYE0IogYUjTSFj5xexFDzIcN5V2Z2tHYKW+Jl/jR98EAsq4By1L+whoX142NJGZsB1GKm4zZTh3vjfzpeGNmxrrHDGp2TOCGFJjk2seHqyyw== alex@almac.rocklynn.cognetics.org",
+//            JcloudsLocationConfig.IMAGE_ID, "us-east-1/ami-5492ba3c"
+//        ));
+//        
+//        log.info("Provisioned {} vm {}; checking if ssh'able", provider, machine);
+//        assertTrue(machine.isSshable());
+//    }
+
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/internal/BrooklynSystemProperties.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/internal/BrooklynSystemProperties.java
@@ -23,11 +23,12 @@ package org.apache.brooklyn.util.internal;
  */
 public class BrooklynSystemProperties {
 
-    // TODO should these become ConfigKeys ?
-    
+    // FIXME not used
     public static BooleanSystemProperty DEBUG = new BooleanSystemProperty("brooklyn.debug");
+    // FIXME not used
     public static BooleanSystemProperty EXPERIMENTAL = new BooleanSystemProperty("brooklyn.experimental");
     
+    // FIXME not used
     /** controls how long jsch delays between commands it issues */
     // -Dbrooklyn.jsch.exec.delay=100
     public static IntegerSystemProperty JSCH_EXEC_DELAY = new IntegerSystemProperty("brooklyn.jsch.exec.delay");
@@ -39,4 +40,15 @@ public class BrooklynSystemProperties {
 
     /** Allows the use of YAML tags to create arbitrary types known to Java. */
     public static BooleanSystemProperty YAML_TYPE_INSTANTIATION = new BooleanSystemProperty("org.apache.brooklyn.unsafe.YamlTypeInstantiation");
+    
+    /** Since 1.0.0 we no longer ask jclouds to authorizePublicKey for data in extraSshPublicKeyData; we do this ourselves, and the jclouds behaviour
+     * interferes with the use of key pairs.
+     * <p> 
+     * Set -Dbrooklyn.jclouds.authorizePublicKey.extraSshPublicKeyData=true to enable the jclouds call and revert to previous behaviour.
+     * 
+     * @deprecated since introduction in 1.0.0, to be removed in 1.1 or later unless there is a need for this
+     */
+    @Deprecated
+    public static BooleanSystemProperty JCLOUDS_AUTHORIZE_EXTRA_SSH_PUBLIC_KEY_DATA = new BooleanSystemProperty("brooklyn.jclouds.authorizePublicKey.extraSshPublicKeyData");
+    
 }


### PR DESCRIPTION
we install this ourselves in addition so no need, and if we ask jclouds to do it, it seems to break sometimes (eg when keyPair is set).
there is a system property that can be set to revert for legacy behaviour.