### PR TITLE
Persistence efficient: unchanged and transient attributes

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindManager.java
@@ -113,6 +113,12 @@ public interface RebindManager {
     /** waits for any needed or pending writes to complete */
     public void waitForPendingComplete(Duration duration, boolean canTrigger) throws InterruptedException, TimeoutException;
 
+    @VisibleForTesting
+    /**
+     * whether there are any needed or pending writes.
+     */
+    public boolean hasPending();
+
     /** Forcibly performs persistence, in the foreground, either full (all entities) or incremental;
      * if no exception handler specified, the default one from the persister is used.
      * <p>

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
@@ -111,6 +111,9 @@ public interface BrooklynMementoPersister {
     @VisibleForTesting
     void waitForWritesCompleted(Duration timeout) throws InterruptedException, TimeoutException;
 
+    @VisibleForTesting
+    public boolean isWriting();
+
     String getBackingStoreDescription();
     
     /** All methods on this interface are unmodifiable by the caller. Sub-interfaces may introduce modifiers. */

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -974,7 +974,10 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
                 entityType.addSensorIfAbsent(attribute);
             }
             
-            getManagementSupport().getEntityChangeListener().onAttributeChanged(attribute);
+            if (!Objects.equal(result, val)) {
+                getManagementSupport().getEntityChangeListener().onAttributeChanged(attribute);
+            }
+            
             return result;
         }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
+import org.apache.brooklyn.api.sensor.AttributeSensor.SensorPersistenceMode;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Entities;
@@ -467,10 +468,9 @@ public class EntityManagementSupport {
         }
         @Override
         public void onAttributeChanged(AttributeSensor<?> attribute) {
-            // TODO Could make this more efficient by inspecting the attribute to decide if needs persisted
-            // immediately, or not important, or transient (e.g. do we really need to persist 
-            // request-per-second count for rebind purposes?!)
-            getManagementContext().getRebindManager().getChangeListener().onChanged(entity);
+            if (attribute.getPersistenceMode() != SensorPersistenceMode.NONE) {
+                getManagementContext().getRebindManager().getChangeListener().onChanged(entity);
+            }
         }
         @Override
         public void onConfigChanged(ConfigKey<?> key) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -612,6 +612,10 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }
         @Override
+        public boolean hasPending() {
+            throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
+        }
+        @Override
         public void forcePersistNow(boolean full, PersistenceExceptionHandler exceptionHandler) {
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/PersistenceObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/PersistenceObjectStore.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.mgmt.ha.HighAvailabilityMode;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteSource;
 
 /**
@@ -59,6 +60,12 @@ public interface PersistenceObjectStore {
          * for more complex uses, readers should <code>getLockObject().readLock().lockInterruptibly()</code> 
          * and ensure they subsequently <code>unlock()</code> it of course. see {@link #getLockObject()}. */
         void waitForCurrentWrites(Duration timeout) throws InterruptedException, TimeoutException;
+        
+        /**
+         * Whether there are any scheduled write lock operations, either queued or executing.
+         */
+        @VisibleForTesting
+        boolean isWriting();
         
         /** returns the underlying lock in case callers need more complex synchronization control */ 
         ReadWriteLock getLockObject();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/StoreObjectAccessorLocking.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/StoreObjectAccessorLocking.java
@@ -226,6 +226,21 @@ public class StoreObjectAccessorLocking implements PersistenceObjectStore.StoreO
     }
     
     @Override
+    public boolean isWriting() {
+        try {
+            boolean locked = lock.readLock().tryLock(0, TimeUnit.MILLISECONDS);
+            if (locked) {
+                lock.readLock().unlock();
+                return false;
+            } else {
+                return true;
+            }
+        } catch (InterruptedException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+    
+    @Override
     public Date getLastModifiedDate() {
         return delegate.getLastModifiedDate();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -460,6 +460,13 @@ public class RebindManagerImpl implements RebindManager {
 
     @Override
     @VisibleForTesting
+    public boolean hasPending()  {
+        if (persistenceStoreAccess == null || !persistenceRunning) return false;
+        return persistenceRealChangeListener.hasPending() || persistenceStoreAccess.isWriting();
+    }
+
+    @Override
+    @VisibleForTesting
     public void forcePersistNow(boolean full, PersistenceExceptionHandler exceptionHandler) {
         if (persistenceStoreAccess == null || persistenceRealChangeListener == null) {
             LOG.info("Skipping forced persist; no persistence mechanism available");

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -770,6 +770,17 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         assertFalse(RebindTestUtils.hasPendingPersists(mgmt()));
     }
     
+    @Test
+    public void testDoNotRepersistOnSetAttributeWithSameValue() throws Exception {
+        final AttributeSensor<String> MY_ATTRIBUTE = Sensors.builder(String.class, "myAttribute").build();
+        
+        origApp.sensors().set(MY_ATTRIBUTE, "myval");
+        RebindTestUtils.waitForPersisted(mgmt());
+        
+        origApp.sensors().set(MY_ATTRIBUTE, "myval");
+        assertFalse(RebindTestUtils.hasPendingPersists(mgmt()));
+    }
+    
     @ImplementedBy(EntityChecksIsRebindingImpl.class)
     public static interface EntityChecksIsRebinding extends TestEntity {
         boolean isRebindingValWhenRebinding();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindEntityTest.java
@@ -757,6 +757,19 @@ public class RebindEntityTest extends RebindTestFixtureWithApp {
         assertFalse(newE.isRebinding());
     }
     
+    @Test
+    public void testDoNotRepersistOnTransientAttributeChanged() throws Exception {
+        final AttributeSensor<String> MY_TRANSIENT_ATTRIBUTE = Sensors.builder(String.class, "myTransientAttribute")
+                .persistence(SensorPersistenceMode.NONE)
+                .build();
+        
+        RebindTestUtils.waitForPersisted(mgmt());
+        assertFalse(RebindTestUtils.hasPendingPersists(mgmt()));
+
+        origApp.sensors().set(MY_TRANSIENT_ATTRIBUTE, "myval");
+        assertFalse(RebindTestUtils.hasPendingPersists(mgmt()));
+    }
+    
     @ImplementedBy(EntityChecksIsRebindingImpl.class)
     public static interface EntityChecksIsRebinding extends TestEntity {
         boolean isRebindingValWhenRebinding();

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestUtils.java
@@ -443,6 +443,10 @@ public class RebindTestUtils {
         managementContext.getRebindManager().waitForPendingComplete(TIMEOUT, true);
     }
 
+    public static boolean hasPendingPersists(ManagementContext managementContext) {
+        return managementContext.getRebindManager().hasPending();
+    }
+
     public static void stopPersistence(Application origApp) throws InterruptedException, TimeoutException {
         stopPersistence(origApp.getManagementContext());
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineAttributes.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/machine/MachineAttributes.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.AttributeSensor.SensorPersistenceMode;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.guava.Functionals;
@@ -43,21 +44,60 @@ public class MachineAttributes {
      * Sensor attributes for machines.
      */
 
-    public static final AttributeSensor<Duration> UPTIME = Sensors.newSensor(Duration.class, "machine.uptime", "Current uptime");
-    public static final AttributeSensor<Double> LOAD_AVERAGE = Sensors.newDoubleSensor("machine.loadAverage", "Current load average");
+    public static final AttributeSensor<Duration> UPTIME = Sensors.builder(Duration.class, "machine.uptime")
+            .description("Current uptime")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
 
-    public static final AttributeSensor<Double> CPU_USAGE = Sensors.newDoubleSensor("machine.cpu", "Current CPU usage");
-    public static final AttributeSensor<Double> AVERAGE_CPU_USAGE = Sensors.newDoubleSensor("cpu.average", "Average CPU usage across the cluster");
+    public static final AttributeSensor<Double> LOAD_AVERAGE = Sensors.builder(Double.class, "machine.loadAverage")
+            .description("Current load average")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
 
-    public static final AttributeSensor<Long> FREE_MEMORY = Sensors.newLongSensor("machine.memory.free", "Current free memory");
-    public static final AttributeSensor<Long> TOTAL_MEMORY = Sensors.newLongSensor("machine.memory.total", "Total memory");
-    public static final AttributeSensor<Long> USED_MEMORY = Sensors.newLongSensor("machine.memory.used", "Current memory usage");
+    public static final AttributeSensor<Double> CPU_USAGE = Sensors.builder(Double.class, "machine.cpu")
+            .description("Current CPU usage")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
 
-    public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_LAST = Sensors.newDoubleSensor("memory.used.delta", "Change in memory usage per second");
-    public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_IN_WINDOW = Sensors.newDoubleSensor("memory.used.windowed", "Average change in memory usage over 30s");
+    public static final AttributeSensor<Double> AVERAGE_CPU_USAGE = Sensors.builder(Double.class, "cpu.average")
+            .description("Average CPU usage across the cluster")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
 
-    public static final AttributeSensor<Double> USED_MEMORY_PERCENT = Sensors.newDoubleSensor("memory.used.percent", "The percentage of memory used");
-    public static final AttributeSensor<Double> AVERAGE_USED_MEMORY_PERCENT = Sensors.newDoubleSensor("memory.used.percent.average", "Average percentage of memory used across the cluster");
+    public static final AttributeSensor<Long> FREE_MEMORY = Sensors.builder(Long.class, "machine.memory.free")
+            .description("Current free memory")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+
+    public static final AttributeSensor<Long> TOTAL_MEMORY = Sensors.builder(Long.class, "machine.memory.total")
+            .description("Total memory")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+
+    public static final AttributeSensor<Long> USED_MEMORY = Sensors.builder(Long.class, "machine.memory.used")
+            .description("Current memory usage")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+
+    public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_LAST = Sensors.builder(Double.class, "memory.used.delta")
+            .description("Change in memory usage per second")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+    
+    public static final AttributeSensor<Double> USED_MEMORY_DELTA_PER_SECOND_IN_WINDOW = Sensors.builder(Double.class, "memory.used.windowed")
+            .description("Average change in memory usage over 30s")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+
+    public static final AttributeSensor<Double> USED_MEMORY_PERCENT = Sensors.builder(Double.class, "memory.used.percent")
+            .description("The percentage of memory used")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
+
+    public static final AttributeSensor<Double> AVERAGE_USED_MEMORY_PERCENT = Sensors.builder(Double.class, "memory.used.percent.average")
+            .description("Average percentage of memory used across the cluster")
+            .persistence(SensorPersistenceMode.NONE)
+            .build();
 
     private static AtomicBoolean initialized = new AtomicBoolean(false);
 


### PR DESCRIPTION
Most of the changes are to allow us to write tests, and the tests themselves. The actual important production-code changes is really just two if statements wrapping the calls to `onAttributeChanged(attribute)` and `onChanged(entity)`!