### PR TITLE
add an /applications/details endpoint which corrects problems with /fetch

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/entity/Entity.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/Entity.java
@@ -247,6 +247,12 @@ public interface Entity extends BrooklynObject {
          * as this method will not update local values.
          */
         <T> void emit(Sensor<T> sensor, T value);
+        
+        /**
+         * @return A map of all sensors known on the entity with their values.
+         */
+        @Beta
+        Map<AttributeSensor<?>, Object> getAll();
     }
     
     public interface AdjunctSupport<T extends EntityAdjunct> extends Iterable<T> {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInternal.java
@@ -155,9 +155,6 @@ public interface EntityInternal extends BrooklynObjectInternal, EntityLocal, Reb
          * Used for rebinding.
          */
         <T> T setWithoutPublishing(AttributeSensor<T> sensor, T val);
-        
-        @Beta
-        Map<AttributeSensor<?>, Object> getAll();
 
         @Beta
         void remove(AttributeSensor<?> attribute);

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -79,7 +79,7 @@ public interface ApplicationApi {
             @QueryParam("config") String config,
             @ApiParam(value="Tree depth to traverse in children for returning detail; "
                 + "default 1 means to have detail for just applications and additional entity IDs explicitly requested, "
-                + "with references to children but not their details", required=false)
+                + "with references to children but not their details; 0 is no detail even for applications; negative is full depth", required=false)
             @DefaultValue("1")
             @QueryParam("depth") int depth);
 
@@ -92,7 +92,7 @@ public interface ApplicationApi {
                 + "(This returns the complete tree which is wasteful and not usually wanted.)"
     )
     @Deprecated
-    /** @deprecated since 1.0.0 use {@link #details(String, String, int)} */
+    /** @deprecated since 1.0.0 use {@link #details(String, boolean, String, String, int)} */
     public List<EntityDetail> fetch(
             @ApiParam(value="Any additional entity ID's to include, as JSON or comma-separated list", required=false)
             @DefaultValue("")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -54,11 +54,45 @@ import io.swagger.annotations.ApiResponses;
 public interface ApplicationApi {
 
     @GET
+    @Path("/details")
+    @ApiOperation(
+            value = "Get details for all applications and optionally selected additional entity items, "
+                + "including tags, values for selected sensor and config glob patterns, "
+                + "and recursively this info for children, up to a given depth."
+    )
+    public List<EntitySummary> details(
+            @ApiParam(value="Any additional entity ID's to include, as JSON or comma-separated list; ancestors will also be included", required=false)
+            @DefaultValue("")
+            @QueryParam("items") String items,
+            @ApiParam(value="Whether to include all applications in addition to any explicitly requested IDs; "
+                + "default is true so no items need to be listed; "
+                + "set false to return only info for entities whose IDs are listed in `items` and their ancestors", required=false)
+            @DefaultValue("true")
+            @QueryParam("includeAllApps") boolean includeAllApps,
+            @ApiParam(value="Any additional sensors to include, as JSON or comma-separated list, accepting globs (* and ?); "
+                + "current sensor values if present are returned for each entity in a name-value map under the 'sensors' key", required=false)
+            @DefaultValue("")
+            @QueryParam("sensors") String sensors,
+            @ApiParam(value="Any config to include, as JSON or comma-separated list, accepting globs (* and ?); "
+                + "current config values if present are returned for each entity in a name-value map under the 'config' key", required=false)
+            @DefaultValue("")
+            @QueryParam("config") String config,
+            @ApiParam(value="Tree depth to traverse in children for returning detail; "
+                + "default 1 means to have detail for just applications and additional entity IDs explicitly requested, "
+                + "with references to children but not their details", required=false)
+            @DefaultValue("1")
+            @QueryParam("depth") int depth);
+
+    @GET
     @Path("/fetch")
     @ApiOperation(
             value = "Fetch details for all applications and optionally selected additional entity items, "
-                + "optionally also with the values for selected sensors"
+                + "optionally also with the values for selected sensors. "
+                + "Deprecated since 1.0.0. Use the '/details' endpoint with better semantics. "
+                + "(This returns the complete tree which is wasteful and not usually wanted.)"
     )
+    @Deprecated
+    /** @deprecated since 1.0.0 use {@link #details(String, String, int)} */
     public List<EntityDetail> fetch(
             @ApiParam(value="Any additional entity ID's to include, as JSON or comma-separated list", required=false)
             @DefaultValue("")
@@ -67,10 +101,11 @@ public interface ApplicationApi {
                 + "current sensor values if present are returned for each entity in a name-value map under the 'sensors' key", required=false)
             @DefaultValue("")
             @QueryParam("sensors") String sensors);
-
+    
     @GET
     @ApiOperation(
-            value = "Fetch the list of applications managed here",
+            value = "List a summary object for applications managed here, optionally filtered by a type regex. "
+                + "The `details` endpoint returns a more informative record of applications.",
             response = org.apache.brooklyn.rest.domain.ApplicationSummary.class
     )
     public List<ApplicationSummary> list(

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityDetail.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/EntityDetail.java
@@ -44,6 +44,8 @@ public class EntityDetail extends EntitySummary {
     private final Lifecycle serviceState;
     private final String iconUrl;
 
+    /** @deprecated since 1.0.0, supply links */
+    @Deprecated
     public EntityDetail(
             @JsonProperty("applicationId") String applicationId,
             @JsonProperty("id") String id,
@@ -57,16 +59,34 @@ public class EntityDetail extends EntitySummary {
             @JsonProperty("children") List<EntitySummary> children,
             @JsonProperty("groupIds") List<String> groupIds,
             @JsonProperty("members") List<Map<String, String>> members) {
-        super(id, name, type, catalogItemId, Collections.<String, URI>emptyMap());
-        this.applicationId = applicationId;
-        this.iconUrl = iconUrl;
-        this.parentId = parentId;
-        this.children = (children == null) ? ImmutableList.<EntitySummary>of() : ImmutableList.copyOf(children);
-        this.groupIds = (groupIds == null) ? ImmutableList.<String>of() : ImmutableList.copyOf(groupIds);
-        this.members = (members == null) ? ImmutableList.<Map<String, String>>of() : ImmutableList.copyOf(members);
-        this.serviceState = serviceState;
-        this.serviceUp = serviceUp;
+        this(applicationId, id, parentId, name, type, serviceUp, serviceState, iconUrl, catalogItemId, children, groupIds, members, 
+            Collections.<String, URI>emptyMap());
     }
+    
+    public EntityDetail(
+        @JsonProperty("applicationId") String applicationId,
+        @JsonProperty("id") String id,
+        @JsonProperty("parentId") String parentId,
+        @JsonProperty("name") String name,
+        @JsonProperty("type") String type,
+        @JsonProperty("serviceUp") Boolean serviceUp,
+        @JsonProperty("serviceState") Lifecycle serviceState,
+        @JsonProperty("iconUrl") String iconUrl,
+        @JsonProperty("catalogItemId") String catalogItemId,
+        @JsonProperty("children") List<EntitySummary> children,
+        @JsonProperty("groupIds") List<String> groupIds,
+        @JsonProperty("members") List<Map<String, String>> members,
+        @JsonProperty("links") Map<String, URI> links) {
+    super(id, name, type, catalogItemId, links);
+    this.applicationId = applicationId;
+    this.iconUrl = iconUrl;
+    this.parentId = parentId;
+    this.children = (children == null) ? ImmutableList.<EntitySummary>of() : ImmutableList.copyOf(children);
+    this.groupIds = (groupIds == null) ? ImmutableList.<String>of() : ImmutableList.copyOf(groupIds);
+    this.members = (members == null) ? ImmutableList.<Map<String, String>>of() : ImmutableList.copyOf(members);
+    this.serviceState = serviceState;
+    this.serviceUp = serviceUp;
+}
 
     public static long getSerialVersionUID() {
         return serialVersionUID;


### PR DESCRIPTION
and adds some new features:

noticed that fetch actually recurses through all children entities which was never the intention and is wasteful at scale.  also for usability it would be nice to include tags and all/regex sensors and config values.  this adds support for that.

i've deprecated the existing `/fetch` call but left its behaviour unchanged.  have also expanded description of `/list` endpoint.

to make this easier i've promoted `getAll()` from SensorSupportInternal. previously we had no way on the public API to list all sensors for an entity.
it is still @Beta.