### PR TITLE
Add registered types test

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
@@ -50,6 +50,7 @@ import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer.JavaClassNameTypeImplementationPlan;
+import org.apache.brooklyn.util.collections.Jsonya;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.guava.Maybe.Absent;
@@ -682,27 +683,65 @@ public class RegisteredTypes {
         // it does mean a format change will be ignored
         return "equivalent-plan("+Streams.getMd5Checksum(Streams.newInputStreamWithContents(input.trim()))+")";
     }
-    
+
+    /** parse the plan as yaml/json, re-serialize it, and take that checksum.
+     * this allows plans that are equivalent post-parse to be treated as equivalent.
+     * returns {@link Absent} if the input is not valid yaml.
+     */
+    private static Maybe<String> tagForEquivalentYamlPlan(String input) {
+        // plans may be trimmed by yaml parser so do that before checking equivalence
+        // it does mean a format change will be ignored
+        try {
+            Iterator<Object> plansI = Yamls.parseAll(input).iterator();
+            if (!plansI.hasNext()) {
+                return Maybe.absent("No data found");
+            }
+            String planOut = "";
+            while (plansI.hasNext()) {
+                Object plan = plansI.next();
+                if (!planOut.isEmpty()) planOut += "\n";
+                planOut += Jsonya.render(plan);
+            }
+            return Maybe.of(tagForEquivalentPlan(planOut));
+        } catch (Exception e) {
+            return Maybe.absent(e);
+        }
+    }
+
     @Beta
     public static void notePlanEquivalentToThis(RegisteredType type, TypeImplementationPlan plan) {
         Object data = plan.getPlanData();
         if (data==null) throw new IllegalStateException("No plan data for "+plan+" noted equivalent to "+type);
         if (!(data instanceof String)) throw new IllegalStateException("Expected plan for equivalent to "+type+" to be a string; was "+data);
         ((BasicRegisteredType)type).tags.add(tagForEquivalentPlan((String)data));
+        Maybe<String> reserializeEquivalenceTag = tagForEquivalentYamlPlan((String)data);
+        if (reserializeEquivalenceTag.isPresent()) ((BasicRegisteredType)type).tags.add(reserializeEquivalenceTag.get());
     }
 
+    /** Checks whether two types have plans which are identical, or identical after a YAML parse,
+     * or if either has an "equivalent-plan" tag indicating its equivalence to the other plan
+     * (as set by {@link #notePlanEquivalentToThis(RegisteredType, TypeImplementationPlan)}). 
+     */
     @Beta
     public static boolean arePlansEquivalent(RegisteredType type1, RegisteredType type2) {
         String plan1 = getImplementationDataStringForSpec(type1);
         String plan2 = getImplementationDataStringForSpec(type2);
         if (Strings.isNonBlank(plan1) && Strings.isNonBlank(plan2)) {
-            String p2tag = tagForEquivalentPlan(plan2);
             String p1tag = tagForEquivalentPlan(plan1);
-            // allow same plan under trimming,
-            // or any recorded tag in either direction
+            String p2tag = tagForEquivalentPlan(plan2);
+            
             if (Objects.equal(p1tag, p2tag)) return true;
+            
             if (type1.getTags().contains(p2tag)) return true;
             if (type2.getTags().contains(p1tag)) return true;
+            
+            Maybe<String> rp2tag = tagForEquivalentYamlPlan(plan2);
+            if (rp2tag.isPresent() && type1.getTags().contains(rp2tag.get())) return true;
+            
+            Maybe<String> rp1tag = tagForEquivalentYamlPlan(plan1);
+            if (rp1tag.isPresent() && type2.getTags().contains(rp1tag.get())) return true;
+            
+            if (rp1tag.isPresent() && rp2tag.isPresent() && rp1tag.get().equals(rp2tag.get())) return true; 
         }
         return Objects.equal(type1.getPlan(), type2.getPlan());
     }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/RegisteredTypes.java
@@ -25,10 +25,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.common.collect.Iterators;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogItemType;
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;

--- a/core/src/test/java/org/apache/brooklyn/core/typereg/RegisteredTypesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/typereg/RegisteredTypesTest.java
@@ -1,0 +1,123 @@
+package org.apache.brooklyn.core.typereg;
+
+import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
+
+import static org.testng.Assert.*;
+
+public class RegisteredTypesTest {
+
+    public static final String DRBD_YAML = "brooklyn.catalog:\n" +
+            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION\n" +
+            "  publish:\n" +
+            "    description: |\n" +
+            "      DRBD is a distributed replicated storage system for the Linux platform. It is implemented as a kernel driver, \n" +
+            "      several userspace management applications, and some shell scripts. DRBD is traditionally used in high availability (HA) computer clusters to provide a\n" +
+            "      RAID 1 like configuration over a network.\n" +
+            "    license_code: Apache-2.0\n" +
+            "    defaults:\n" +
+            "      drbdIconUrl: \"https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\"\n" +
+            "      classpathIconUrl: &drbdIconUrl 'classpath://io.brooklyn.drbd.brooklyn-drbd:drbd.png'\n" +
+            "  items:\n" +
+            "  - \"https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom\"\n" +
+            "  - id: drbd-node\n";
+
+    public static final String DRBD_TESTS_YAML = "brooklyn.catalog:\n" +
+            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION\n" +
+            "  items:\n" +
+            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom\n" +
+            "  - id: drbd-test\n" +
+            "    name: DRBD Test\n" +
+            "    itemType: template\n" +
+            "    iconUrl: https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\n" +
+            "    license: Apache-2.0\n" +
+            "    item:\n" +
+            "      booklyn.config:\n" +
+            "        defaultDisplayName: DRBD Test\n" +
+            "      services:\n" +
+            "      - type: drbd-webapp\n";
+
+    public static final String DRBR_YAML_WITH_COMMENTS = DRBD_YAML + "\n" +
+            "# this is a comment";
+    private static final String DRBR_YAML_WITHOUT_QUOTES = "brooklyn.catalog:\n" +
+            "  version: 1.0.0-SNAPSHOT # BROOKLYN_DRBD_VERSION\n" +
+            "  publish:\n" +
+            "    description: |\n" +
+            "      DRBD is a distributed replicated storage system for the Linux platform. It is implemented as a kernel driver, \n" +
+            "      several userspace management applications, and some shell scripts. DRBD is traditionally used in high availability (HA) computer clusters to provide a\n" +
+            "      RAID 1 like configuration over a network.\n" +
+            "    license_code: Apache-2.0\n" +
+            "    defaults:\n" +
+            "      drbdIconUrl: https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\n" +
+            "      classpathIconUrl: &drbdIconUrl 'classpath://io.brooklyn.drbd.brooklyn-drbd:drbd.png'\n" +
+            "  items:\n" +
+            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom\n" +
+            "  - id: drbd-node\n";
+
+    @Test
+    public void testIdenticalPlansAreEquivalent() {
+        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+
+        BasicRegisteredType b = makeTypeWithYaml(DRBD_YAML);
+
+        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
+                a, b);
+        assertTrue(plansEquivalent);
+    }
+
+    @Test
+    public void testDifferentPlansAreNotEquivalent() {
+        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType b = makeTypeWithYaml(DRBD_TESTS_YAML);
+
+        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
+                a, b);
+        assertFalse(plansEquivalent);
+    }
+
+    @Test
+    public void testComparisonIgnoresComments() {
+        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+
+        BasicRegisteredType b = makeTypeWithYaml(DRBR_YAML_WITH_COMMENTS);
+
+        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
+                a, b);
+        assertTrue(plansEquivalent);
+    }
+
+    @Test
+    public void testComparisonIgnoresQuotedStrings() {
+        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+
+        BasicRegisteredType b = makeTypeWithYaml(DRBR_YAML_WITHOUT_QUOTES);
+
+        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
+                a, b);
+        assertTrue(plansEquivalent);
+    }
+
+    BasicRegisteredType makeTypeWithYaml(final String yaml) {
+        return new BasicRegisteredType(
+                BrooklynTypeRegistry.RegisteredTypeKind.SPEC,
+                "B",
+                "1",
+                new RegisteredType.TypeImplementationPlan() {
+                    @Nullable
+                    @Override
+                    public String getPlanFormat() {
+                        return null;
+                    }
+
+                    @Override
+                    public Object getPlanData() {
+                        return yaml;
+                    }
+                });
+    }
+
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/typereg/RegisteredTypesTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/typereg/RegisteredTypesTest.java
@@ -1,7 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.brooklyn.core.typereg;
 
 import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nullable;
@@ -10,94 +30,75 @@ import static org.testng.Assert.*;
 
 public class RegisteredTypesTest {
 
-    public static final String DRBD_YAML = "brooklyn.catalog:\n" +
-            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION\n" +
-            "  publish:\n" +
-            "    description: |\n" +
-            "      DRBD is a distributed replicated storage system for the Linux platform. It is implemented as a kernel driver, \n" +
-            "      several userspace management applications, and some shell scripts. DRBD is traditionally used in high availability (HA) computer clusters to provide a\n" +
-            "      RAID 1 like configuration over a network.\n" +
-            "    license_code: Apache-2.0\n" +
-            "    defaults:\n" +
-            "      drbdIconUrl: \"https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\"\n" +
-            "      classpathIconUrl: &drbdIconUrl 'classpath://io.brooklyn.drbd.brooklyn-drbd:drbd.png'\n" +
-            "  items:\n" +
-            "  - \"https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom\"\n" +
-            "  - id: drbd-node\n";
+    private static final String DRBD_YAML = Strings.lines(
+            "brooklyn.catalog:",
+            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION",
+            "  items:",
+            "  - \"https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom\"",
+            "  - id: drbd-node");
 
-    public static final String DRBD_TESTS_YAML = "brooklyn.catalog:\n" +
-            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION\n" +
-            "  items:\n" +
-            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom\n" +
-            "  - id: drbd-test\n" +
-            "    name: DRBD Test\n" +
-            "    itemType: template\n" +
-            "    iconUrl: https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\n" +
-            "    license: Apache-2.0\n" +
-            "    item:\n" +
-            "      booklyn.config:\n" +
-            "        defaultDisplayName: DRBD Test\n" +
-            "      services:\n" +
-            "      - type: drbd-webapp\n";
+    private static final String DRBD_TESTS_YAML = Strings.lines(
+            "brooklyn.catalog:",
+            "  version: \"1.0.0-SNAPSHOT\" # BROOKLYN_DRBD_VERSION",
+            "  items:",
+            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.tests.bom\n");
 
-    public static final String DRBR_YAML_WITH_COMMENTS = DRBD_YAML + "\n" +
-            "# this is a comment";
-    private static final String DRBR_YAML_WITHOUT_QUOTES = "brooklyn.catalog:\n" +
-            "  version: 1.0.0-SNAPSHOT # BROOKLYN_DRBD_VERSION\n" +
-            "  publish:\n" +
-            "    description: |\n" +
-            "      DRBD is a distributed replicated storage system for the Linux platform. It is implemented as a kernel driver, \n" +
-            "      several userspace management applications, and some shell scripts. DRBD is traditionally used in high availability (HA) computer clusters to provide a\n" +
-            "      RAID 1 like configuration over a network.\n" +
-            "    license_code: Apache-2.0\n" +
-            "    defaults:\n" +
-            "      drbdIconUrl: https://s3.eu-central-1.amazonaws.com/misc-csft/drbd.jpg\n" +
-            "      classpathIconUrl: &drbdIconUrl 'classpath://io.brooklyn.drbd.brooklyn-drbd:drbd.png'\n" +
-            "  items:\n" +
-            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom\n" +
-            "  - id: drbd-node\n";
+    private static final String DRBR_YAML_WITH_COMMENTS = Strings.lines(
+            DRBD_YAML,
+            "# this is a comment");
+
+    private static final String DRBR_YAML_WITHOUT_QUOTES = Strings.lines(
+            "brooklyn.catalog:",
+            "  version: 1.0.0-SNAPSHOT # BROOKLYN_DRBD_VERSION",
+            "  items:",
+            "  - https://github.com/brooklyncentral/common-catalog-utils/releases/download/v0.1.0/common.bom",
+            "  - id: drbd-node");
 
     @Test
     public void testIdenticalPlansAreEquivalent() {
-        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType planA = makeTypeWithYaml(DRBD_YAML);
 
-        BasicRegisteredType b = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType planB = makeTypeWithYaml(DRBD_YAML);
 
-        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
-                a, b);
-        assertTrue(plansEquivalent);
+        assertPlansEquivalent(planA, planB, "Identical plans");
     }
 
     @Test
     public void testDifferentPlansAreNotEquivalent() {
-        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
-        BasicRegisteredType b = makeTypeWithYaml(DRBD_TESTS_YAML);
+        BasicRegisteredType planA = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType planB = makeTypeWithYaml(DRBD_TESTS_YAML);
 
-        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
-                a, b);
-        assertFalse(plansEquivalent);
+        assertPlansDifferent(planA, planB, "Completely different plans");
     }
 
     @Test
     public void testComparisonIgnoresComments() {
-        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType planA = makeTypeWithYaml(DRBD_YAML);
 
-        BasicRegisteredType b = makeTypeWithYaml(DRBR_YAML_WITH_COMMENTS);
+        BasicRegisteredType planB = makeTypeWithYaml(DRBR_YAML_WITH_COMMENTS);
 
-        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
-                a, b);
-        assertTrue(plansEquivalent);
+        assertPlansEquivalent(planA, planB, "Only difference comments");
     }
 
     @Test
     public void testComparisonIgnoresQuotedStrings() {
-        BasicRegisteredType a = makeTypeWithYaml(DRBD_YAML);
+        BasicRegisteredType planA = makeTypeWithYaml(DRBD_YAML);
 
-        BasicRegisteredType b = makeTypeWithYaml(DRBR_YAML_WITHOUT_QUOTES);
+        BasicRegisteredType planB = makeTypeWithYaml(DRBR_YAML_WITHOUT_QUOTES);
 
-        boolean plansEquivalent = RegisteredTypes.arePlansEquivalent(
-                a, b);
-        assertTrue(plansEquivalent);
+        assertPlansEquivalent(planA, planB, "Compares same yaml with and without quotes");
+    }
+
+    private void assertPlansDifferent(BasicRegisteredType planA, BasicRegisteredType planB, String messageOnError) {
+        assertFalse(RegisteredTypes.arePlansEquivalent(planA, planB), createErrorMessage("Plans equivalent: ", planA, planB, messageOnError));
+    }
+
+    private void assertPlansEquivalent(BasicRegisteredType planA, BasicRegisteredType planB, String messageOnError) {
+        assertTrue(RegisteredTypes.arePlansEquivalent(planA, planB), createErrorMessage("Plans differ: ",planA, planB, messageOnError));
+    }
+
+    private String createErrorMessage(String issue, BasicRegisteredType planA, BasicRegisteredType planB, String messageOnError) {
+        return Strings.lines(issue + messageOnError, planA.toString(), planB.toString());
     }
 
     BasicRegisteredType makeTypeWithYaml(final String yaml) {


### PR DESCRIPTION
This PR follows on from #968 
It adds 2 commits.  The first adds tests for the functionality fixed in #968 
The second changes the logic in #968 in a way that I think is equivalent but I haven't managed to add the requisite test coverage to prove this.