### PR TITLE
Version bumps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -205,10 +205,10 @@ Apache License: |
    
 Dependency licenses:
 
-   # This software includes dependencies released under other licenses.
-   # These other licenses are compatible with the Apache License above.
+   # This software includes dependencies released under their licenses.
+   # These licenses are compatible with the Apache License above.
    # Details of these dependencies can be found in the accompanying NOTICE file.
-   # These other licenses are included below with their full text.
+   # These licenses are included below with their full text.
 
   Apache License, version 2.0: |
     # from https://www.apache.org/licenses/LICENSE-2.0

--- a/NOTICE
+++ b/NOTICE
@@ -69,13 +69,13 @@ Runtime dependencies:
     Developed by: QOS.ch (http://www.qos.ch)
     License name: Eclipse Public License, version 1.0
   
-  com.fasterxml.jackson:2.7.5: 
+  com.fasterxml.jackson:2.9.6: 
     Project:      Jackson FasterXML
-    Version:      2.7.5
+    Version:      2.9.6
     Available at: 
       - http://github.com/FasterXML/jackson
-      - http://wiki.fasterxml.com/JacksonHome
       - https://github.com/FasterXML/jackson-core
+      - https://github.com/FasterXML/jackson-modules-base
     Developed by: FasterXML (http://fasterxml.com/)
     License name: Apache License, version 2.0
   
@@ -144,7 +144,7 @@ Runtime dependencies:
     Available at: http://www.jcraft.com/jzlib/
     Developed by: jcraft (http://www.jcraft.com/)
     License name: BSD 3-Clause (New BSD) License
-    Notice:       Copyright (c) Copyright (c) 2000-2011 ymnk, JCraft,Inc. All rights reserved.
+    Notice:       Copyright (c) 2000-2011 ymnk, JCraft,Inc. All rights reserved.
   
   com.jcraft:0.0.9: 
     Project:      JCraft jsch ssh library
@@ -152,7 +152,7 @@ Runtime dependencies:
     Available at: http://www.jcraft.com/jsch-agent-proxy/
     Developed by: JCraft,Inc. (http://www.jcraft.com/)
     License name: BSD 3-Clause (New BSD) License
-    Notice:       Copyright (c) Copyright (c) 2011-2012 Atsuhiko Yamanaka, JCraft,Inc.
+    Notice:       Copyright (c) 2011-2012 Atsuhiko Yamanaka, JCraft,Inc.
   
   com.maxmind.db.maxmind-db:1.2.1: 
     Project:      MaxMind DB Reader
@@ -396,11 +396,11 @@ Runtime dependencies:
     License name: MIT License
     Notice:       Copyright (c) The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
   
-  org.codehaus.groovy.groovy-all:2.3.7: 
-    Project:      Groovy
-    Version:      2.3.7
-    Available at: http://groovy.codehaus.org/
-    Developed by: The Codehaus (http://codehaus.org)
+  org.codehaus.groovy.groovy-all:2.4.15: 
+    Project:      Apache Groovy
+    Version:      2.4.15
+    Available at: http://groovy-lang.org
+    Developed by: Apache Software Foundation (http://groovy-lang.org)
     License name: Apache License, version 2.0
   
   org.codehaus.woodstox.stax2-api:3.1.4: 
@@ -495,9 +495,9 @@ Runtime dependencies:
     Developed by: XMLUnit (http://www.xmlunit.org/)
     License name: Apache License, version 2.0
   
-  org.yaml.snakeyaml:1.17: 
+  org.yaml.snakeyaml:1.21: 
     Project:      SnakeYAML
-    Version:      1.17
+    Version:      1.21
     Available at: http://www.snakeyaml.org
     License name: Apache License, version 2.0
   

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/PossiblyStrictPreferringFieldsVisibilityChecker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/PossiblyStrictPreferringFieldsVisibilityChecker.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Value;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
@@ -52,7 +53,8 @@ public class PossiblyStrictPreferringFieldsVisibilityChecker implements Visibili
     @Override public PossiblyStrictPreferringFieldsVisibilityChecker withSetterVisibility(Visibility v) { throw new UnsupportedOperationException(); }
     @Override public PossiblyStrictPreferringFieldsVisibilityChecker withCreatorVisibility(Visibility v) { throw new UnsupportedOperationException(); }
     @Override public PossiblyStrictPreferringFieldsVisibilityChecker withFieldVisibility(Visibility v) { throw new UnsupportedOperationException(); }
-    
+    @Override public PossiblyStrictPreferringFieldsVisibilityChecker withOverrides(Value vis) { throw new UnsupportedOperationException(); }
+
     protected VisibilityChecker<?> viz() {
         return BidiSerialization.isStrictSerialization() ? vizStrict : vizDefault;
     }

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
@@ -35,13 +35,11 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
-import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.javalang.coerce.ClassCoercionException;
 import org.apache.brooklyn.util.text.StringPredicates;
-import org.codehaus.groovy.runtime.GStringImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -302,11 +300,11 @@ public class TypeCoercionsTest {
         Assert.assertEquals(s, ImmutableMap.of("a", "1", "b", "2"));
     }
 
-    @Test(expectedExceptions=ClassCoercionException.class)
+    @Test
     public void testJsonStringWithoutBracesOrSpaceDisallowedAsMapCoercion() {
-        // yaml requires spaces after the colon
-        TypeCoercions.coerce("a:1,b:2", Map.class);
-        Asserts.shouldHaveFailedPreviously();
+        Map<?,?> s = TypeCoercions.coerce("a:1,b:2", Map.class);
+        Assert.assertEquals(s, ImmutableMap.of("a", "1", "b", "2"));
+        // NB: snakeyaml 1.17 required spaces after the colon, but 1.21 accepts the above
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/TypeCoercionsTest.java
@@ -53,6 +53,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 
+import groovy.lang.GString;
+
 public class TypeCoercionsTest {
 
     private static final Logger log = LoggerFactory.getLogger(TypeCoercionsTest.class);
@@ -60,7 +62,7 @@ public class TypeCoercionsTest {
     @Test
     public void testCoerceCharSequenceToString() {
         assertEquals(TypeCoercions.coerce(new StringBuilder("abc"), String.class), "abc");
-        assertEquals(TypeCoercions.coerce(new GStringImpl(new Object[0], new String[0]), String.class), "");
+        assertEquals(TypeCoercions.coerce(GString.EMPTY, String.class), "");
     }
     
     @Test

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -252,6 +252,7 @@
 
     <feature name="brooklyn-locations-jclouds" version="${project.version}" description="Brooklyn Jclouds Location Targets">
         <bundle>mvn:org.apache.jclouds/jclouds-loadbalancer/${jclouds.version}</bundle>
+        <feature>brooklyn-core</feature>
         <feature>jclouds-services</feature>
         <feature>jclouds-driver-sshj</feature>
         <feature>jclouds-driver-slf4j</feature>
@@ -274,8 +275,40 @@
     <feature name="brooklyn-container-service" version="${project.version}" description="Brooklyn Container Service and Location Targets">
         <bundle start-level="85">mvn:org.apache.brooklyn/brooklyn-locations-container/${project.version}</bundle>
 
+        <feature>brooklyn-core</feature>
+<!-- previously we used these, but they pull in wrong versions - jackson 2.7.5 and snakeyaml 1.17 
         <feature>kubernetes-client</feature>
         <feature>openshift-client</feature>
+-->
+<!-- these are pulled in elsewhere
+        <bundle dependency='true'>mvn:javax.validation/validation-api/1.1.0.Final</bundle>
+        <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+-->
+<!-- these are wrong version, right version pulled in elsewhere
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.7.5</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.7.5</bundle>
+        <bundle dependency='true'>mvn:org.yaml/snakeyaml/1.17</bundle>
+-->
+<!-- these are needed -->
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.generex/1.0.1_1</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.automaton/1.11-8_1</bundle>
+<!-- these are pulled at very different versions elsewhere but let's use these versions too -->
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.9.0_1</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.4.1_1</bundle>
+<!-- main required bundles -->
+        <bundle>mvn:io.fabric8/kubernetes-model/1.0.64</bundle>
+        <bundle>mvn:io.fabric8/zjsonpatch/0.2.3</bundle>
+        <bundle>mvn:io.fabric8/kubernetes-client/1.4.27/jar/bundle</bundle>
+        <bundle>mvn:io.fabric8/openshift-client/1.4.27/jar/bundle</bundle>
+<!-- previously we used these, but they pull in wrong versions - jackson 2.7.5 and snakeyaml 1.17 
+        <feature>kubernetes-client</feature>
+        <feature>openshift-client</feature>
+-->
     </feature>
 
     <feature name="brooklyn-test-framework" version="${project.version}" description="Brooklyn Test Framework" >

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -250,6 +250,13 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-jmxrmi-agent/${project.version}</bundle>
     </feature>
 
+    <!-- redeclare, overridden to use our version of snakeyaml  -->
+    <feature name='jclouds-api-byon' description='jclouds - API - Byon' version='${jclouds.version}'>
+        <feature version='${jclouds.version}'>jclouds-compute</feature>
+        <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
+        <bundle>mvn:org.apache.jclouds.api/byon/${jclouds.version}</bundle>
+    </feature>
+
     <feature name="brooklyn-locations-jclouds" version="${project.version}" description="Brooklyn Jclouds Location Targets">
         <bundle>mvn:org.apache.jclouds/jclouds-loadbalancer/${jclouds.version}</bundle>
         <feature>brooklyn-core</feature>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -283,15 +283,16 @@
         <bundle start-level="85">mvn:org.apache.brooklyn/brooklyn-locations-container/${project.version}</bundle>
 
         <feature>brooklyn-core</feature>
-<!-- previously we used these, but they pull in wrong versions - jackson 2.7.5 and snakeyaml 1.17 
+        
+<!-- the intention is to pull in these features to support deploy-to k8s 
         <feature>kubernetes-client</feature>
         <feature>openshift-client</feature>
--->
-<!-- these are pulled in elsewhere
+     however they pull in incompatible versions - jackson 2.7.5 and snakeyaml 1.17 -
+     so we declare instead the extra deps it declares, but skip those already pulled in.
+     these two we skip because we pull them in elsewhere (same versions, but don't redeclare fixed version)
         <bundle dependency='true'>mvn:javax.validation/validation-api/1.1.0.Final</bundle>
         <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
--->
-<!-- these are wrong version, right version pulled in elsewhere
+    these it declares at a different version, right version pulled in elsewhere
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/2.7.5</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/2.7.5</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/2.7.5</bundle>
@@ -300,22 +301,19 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.7.5</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.7.5</bundle>
         <bundle dependency='true'>mvn:org.yaml/snakeyaml/1.17</bundle>
--->
-<!-- these are needed -->
+    these are needed:  -->
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.generex/1.0.1_1</bundle>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.automaton/1.11-8_1</bundle>
-<!-- these are pulled at very different versions elsewhere but let's use these versions too -->
+<!-- 
+    these are used elsewhere at different versions, but pull these versions also (OSGi will wire correctly): -->
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/1.9.0_1</bundle>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/3.4.1_1</bundle>
-<!-- main required bundles -->
+<!--
+    these are the main required bundles for the features above: -->
         <bundle>mvn:io.fabric8/kubernetes-model/1.0.64</bundle>
         <bundle>mvn:io.fabric8/zjsonpatch/0.2.3</bundle>
         <bundle>mvn:io.fabric8/kubernetes-client/1.4.27/jar/bundle</bundle>
         <bundle>mvn:io.fabric8/openshift-client/1.4.27/jar/bundle</bundle>
-<!-- previously we used these, but they pull in wrong versions - jackson 2.7.5 and snakeyaml 1.17 
-        <feature>kubernetes-client</feature>
-        <feature>openshift-client</feature>
--->
     </feature>
 
     <feature name="brooklyn-test-framework" version="${project.version}" description="Brooklyn Test Framework" >

--- a/locations/container/pom.xml
+++ b/locations/container/pom.xml
@@ -42,9 +42,14 @@
             <version>${kubernetes-client.version}</version>
             <classifier>bundle</classifier>
             <exclusions>
+                <!-- we use newer versions -->
                 <exclusion>
                     <groupId>com.squareup.okio</groupId>
                     <artifactId>okio</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -134,6 +134,13 @@
             <groupId>${jclouds.groupId}</groupId>
             <artifactId>jclouds-allcompute</artifactId>
             <version>${jclouds.version}</version>
+            <exclusions>
+              <exclusion>
+                <!-- pulls in 1.17 where we want 1.21 -->
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${jclouds.groupId}.labs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.4.15</groovy.version> <!-- Version 2.4.7 supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes; not sure what more recent will be -->
         <jsr305.version>2.0.1</jsr305.version>
-        <snakeyaml.version>1.17</snakeyaml.version>
+        <snakeyaml.version>1.21</snakeyaml.version>
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.5.6</swagger.version>
         <jansi.version>1.2.1</jansi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,14 +116,14 @@
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.7.5</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.9.6</fasterxml.jackson.version>
         <cxf.version>3.1.10</cxf.version>
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
         <!-- @deprecated since 0.11 -->
         <httpclient.version>4.5.2</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <groovy.version>2.3.7</groovy.version> <!-- Version supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes -->
+        <groovy.version>2.4.15</groovy.version> <!-- Version 2.4.7 supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes; not sure what more recent will be -->
         <jsr305.version>2.0.1</jsr305.version>
         <snakeyaml.version>1.17</snakeyaml.version>
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
@@ -186,8 +186,8 @@
         <jsonSmart.version>2.3</jsonSmart.version>
         <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
         <ow2.asm.version>5.0.4</ow2.asm.version>
-        <commons-beanutils.version>1.9.1</commons-beanutils.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-beanutils.version>1.9.3</commons-beanutils.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <javax.mail.version>1.4.4</javax.mail.version>
         <cxf.javax.annotation-api.version>1.2</cxf.javax.annotation-api.version>
         <testng.version>6.10</testng.version>

--- a/server-cli/LICENSE
+++ b/server-cli/LICENSE
@@ -205,10 +205,10 @@ Apache License: |
    
 Dependency licenses:
 
-   # This software includes dependencies released under other licenses.
-   # These other licenses are compatible with the Apache License above.
+   # This software includes dependencies released under their licenses.
+   # These licenses are compatible with the Apache License above.
    # Details of these dependencies can be found in the accompanying NOTICE file.
-   # These other licenses are included below with their full text.
+   # These licenses are included below with their full text.
 
   Apache License, version 2.0: |
     # from https://www.apache.org/licenses/LICENSE-2.0

--- a/server-cli/NOTICE
+++ b/server-cli/NOTICE
@@ -69,16 +69,24 @@ Runtime dependencies:
     Developed by: QOS.ch (http://www.qos.ch)
     License name: Eclipse Public License, version 1.0
   
-  com.fasterxml.jackson:2.7.5: 
+  com.fasterxml.jackson:2.9.6: 
     Project:      Jackson FasterXML
-    Version:      2.7.5
+    Version:      2.9.6
     Available at: 
       - http://github.com/FasterXML/jackson
       - http://wiki.fasterxml.com/JacksonExtensionXmlDataBinding
-      - http://wiki.fasterxml.com/JacksonHome
       - http://wiki.fasterxml.com/JacksonModuleJoda
-      - https://github.com/FasterXML/jackson
+      - https://github.com/FasterXML/jackson-core
+      - https://github.com/FasterXML/jackson-dataformats-text
+      - https://github.com/FasterXML/jackson-modules-base
     Developed by: FasterXML (http://fasterxml.com/)
+    License name: Apache License, version 2.0
+  
+  com.fasterxml.woodstox.woodstox-core:5.0.3: 
+    Project:      Woodstox
+    Version:      5.0.3
+    Available at: https://github.com/FasterXML/woodstox
+    Developed by: FasterXML (http://fasterxml.com)
     License name: Apache License, version 2.0
   
   com.google.code.findbugs.annotations:2.0.3: 
@@ -150,7 +158,7 @@ Runtime dependencies:
     Available at: http://www.jcraft.com/jzlib/
     Developed by: jcraft (http://www.jcraft.com/)
     License name: BSD 3-Clause (New BSD) License
-    Notice:       Copyright (c) Copyright (c) 2000-2011 ymnk, JCraft,Inc. All rights reserved.
+    Notice:       Copyright (c) 2000-2011 ymnk, JCraft,Inc. All rights reserved.
   
   com.jcraft:0.0.9: 
     Project:      JCraft jsch ssh library
@@ -158,7 +166,7 @@ Runtime dependencies:
     Available at: http://www.jcraft.com/jsch-agent-proxy/
     Developed by: JCraft,Inc. (http://www.jcraft.com/)
     License name: BSD 3-Clause (New BSD) License
-    Notice:       Copyright (c) Copyright (c) 2011-2012 Atsuhiko Yamanaka, JCraft,Inc.
+    Notice:       Copyright (c) 2011-2012 Atsuhiko Yamanaka, JCraft,Inc.
   
   com.maxmind.db.maxmind-db:1.2.1: 
     Project:      MaxMind DB Reader
@@ -204,11 +212,11 @@ Runtime dependencies:
     Developed by: XStream (http://xstream.codehaus.org)
     License name: BSD 3-Clause (New BSD) License
   
-  commons-beanutils:1.9.1: 
+  commons-beanutils:1.9.3: 
     Project:      Apache Commons BeanUtils
-    Version:      1.9.1
-    Available at: http://commons.apache.org/proper/commons-beanutils/
-    Developed by: The Apache Software Foundation (http://www.apache.org/)
+    Version:      1.9.3
+    Available at: https://commons.apache.org/proper/commons-beanutils/
+    Developed by: The Apache Software Foundation (https://www.apache.org/)
     License name: Apache License, version 2.0
   
   commons-codec:1.9: 
@@ -218,9 +226,9 @@ Runtime dependencies:
     Developed by: The Apache Software Foundation (http://www.apache.org/)
     License name: Apache License, version 2.0
   
-  commons-collections:3.2.1: 
-    Project:      Commons Collections
-    Version:      3.2.1
+  commons-collections:3.2.2: 
+    Project:      Apache Commons Collections
+    Version:      3.2.2
     Available at: http://commons.apache.org/collections/
     Developed by: The Apache Software Foundation (http://www.apache.org/)
     License name: Apache License, version 2.0
@@ -309,9 +317,9 @@ Runtime dependencies:
     Developed by: Oracle Corporation (http://www.oracle.com/)
     License name: Common Development and Distribution License, version 1.1
   
-  joda-time:2.4: 
+  joda-time:2.7: 
     Project:      Joda-Time
-    Version:      2.4
+    Version:      2.7
     Available at: http://www.joda.org/joda-time/
     Developed by: Joda.org (http://www.joda.org)
     License name: Apache License, version 2.0
@@ -431,11 +439,11 @@ Runtime dependencies:
     License name: MIT License
     Notice:       Copyright (c) The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
   
-  org.codehaus.groovy.groovy-all:2.3.7: 
-    Project:      Groovy
-    Version:      2.3.7
-    Available at: http://groovy.codehaus.org/
-    Developed by: The Codehaus (http://codehaus.org)
+  org.codehaus.groovy.groovy-all:2.4.15: 
+    Project:      Apache Groovy
+    Version:      2.4.15
+    Available at: http://groovy-lang.org
+    Developed by: Apache Software Foundation (http://groovy-lang.org)
     License name: Apache License, version 2.0
   
   org.codehaus.woodstox.stax2-api:3.1.4: 
@@ -535,9 +543,9 @@ Runtime dependencies:
     Developed by: XMLUnit (http://www.xmlunit.org/)
     License name: Apache License, version 2.0
   
-  org.yaml.snakeyaml:1.17: 
+  org.yaml.snakeyaml:1.21: 
     Project:      SnakeYAML
-    Version:      1.17
+    Version:      1.21
     Available at: http://www.snakeyaml.org
     License name: Apache License, version 2.0
   

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
@@ -39,7 +39,6 @@ import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.text.StringPredicates;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.codehaus.groovy.runtime.GStringImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -51,6 +50,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
+
+import groovy.lang.GString;
 
 public class TypeCoercionsTest {
 
@@ -68,7 +69,7 @@ public class TypeCoercionsTest {
     @Test
     public void testCoerceCharSequenceToString() {
         assertEquals(coerce(new StringBuilder("abc"), String.class), "abc");
-        assertEquals(coerce(new GStringImpl(new Object[0], new String[0]), String.class), "");
+        assertEquals(coerce(GString.EMPTY, String.class), "");
     }
     
     @Test

--- a/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercionsTest.java
@@ -369,11 +369,11 @@ public class TypeCoercionsTest {
         Assert.assertEquals(s, ImmutableMap.of("a", "1", "b", "2"));
     }
 
-    @Test(expectedExceptions=ClassCoercionException.class)
+    @Test
     public void testJsonStringWithoutBracesOrSpaceDisallowedAsMapCoercion() {
-        // yaml requires spaces after the colon
-        coerce("a:1,b:2", Map.class);
-        Asserts.shouldHaveFailedPreviously();
+        Map<?,?> s = coerce("a:1,b:2", Map.class);
+        Assert.assertEquals(s, ImmutableMap.of("a", "1", "b", "2"));
+        // NB: snakeyaml 1.17 required spaces after the colon, but 1.21 accepts the above
     }
     
     @Test
@@ -456,6 +456,7 @@ public class TypeCoercionsTest {
     // Expect to get a log.warn about that now. Could assert that using LogWatcher.
     @Test
     public void testListOfFromThrowingException() {
+        @SuppressWarnings("serial")
         TypeToken<List<WithFromThrowingException>> typeToken = new TypeToken<List<WithFromThrowingException>>() {};
         List<String> rawVal = ImmutableList.of("myval");
         
@@ -463,13 +464,14 @@ public class TypeCoercionsTest {
         assertEquals(val, rawVal);
 
         List<WithFromThrowingException> val2 = coercer.tryCoerce(rawVal, typeToken).get();
-        assertEquals(val, rawVal);
+        assertEquals(val2, rawVal);
     }
 
     // See comment on testListOfFromThrowingException for why we're asserting this undesirable
     // behaviour.
     @Test
     public void testMapOfFromThrowingException() {
+        @SuppressWarnings("serial")
         TypeToken<Map<String, WithFromThrowingException>> typeToken = new TypeToken<Map<String, WithFromThrowingException>>() {};
         ImmutableMap<String, String> rawVal = ImmutableMap.of("mykey", "myval");
         


### PR DESCRIPTION
Update:

* fasterxml.jackson.version 2.7.5 -> 2.9.6
* groovy.version 2.3.7 -> 2.4.15
* commons-beanutils.version 1.9.1 -> 1.9.3
* commons-collections.version 3.2.1 -> 3.2.2

In response to CVEs in the old versions.  (It is not confirmed that those CVEs impact us, but the upgrade is advisable even so.)

The Jackson update also requires an update::

* snakeyaml.version 1.17 -> 1.21

Which is done.  Some of these required minor test changes and some pom-fu and feature-fu to prevent the old versions from being pulled in, hence the changeset being larger than usual for a version bump.