### PR TITLE
undo the redeclation of jclouds-byon-api that avoids snakeyaml 1.17

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -250,13 +250,6 @@
         <bundle>mvn:org.apache.brooklyn/brooklyn-jmxrmi-agent/${project.version}</bundle>
     </feature>
 
-    <!-- redeclare, overridden to use our version of snakeyaml  -->
-    <feature name='jclouds-api-byon' description='jclouds - API - Byon' version='${jclouds.version}'>
-        <feature version='${jclouds.version}'>jclouds-compute</feature>
-        <bundle dependency='true'>mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.api/byon/${jclouds.version}</bundle>
-    </feature>
-
     <feature name="brooklyn-locations-jclouds" version="${project.version}" description="Brooklyn Jclouds Location Targets">
         <bundle>mvn:org.apache.jclouds/jclouds-loadbalancer/${jclouds.version}</bundle>
         <feature>brooklyn-core</feature>
@@ -265,6 +258,15 @@
         <feature>jclouds-driver-slf4j</feature>
 
         <!-- Same as allcompute -->
+        <!-- As at jclouds 2.1.0 this pulls in snakeyaml 1.17 via jclouds-api-byon;
+             I cannot see any way to prevent this, short of not using the jclouds feature
+             definitions. Things we have tried include redeclaring that feature here
+             with our preferred bundle and it works most places but at least one runtime
+             (an RPM build of a downstream project installed to Docker) won't start as
+             it seems to read the other feature definition.  We also tried the etc/overrides.properties
+             but that did not prevent it from pulling in 1.17 at build, or if we built correctly,
+             it did not prevent it from needing the 1.17 at runtime. Luckily having the two
+             snakeyaml versions doesn't seem to be a problem. -->
         <feature>jclouds-all-compute</feature>
 
         <!-- Same as allblobstore -->


### PR DESCRIPTION
it can cause startup failures; for now live with both snakeyaml versions installed.