### PR TITLE
karaf/features: include snakeyaml 1.17 bundle explicitly

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -268,6 +268,7 @@
              it did not prevent it from needing the 1.17 at runtime. Luckily having the two
              snakeyaml versions doesn't seem to be a problem. -->
         <feature>jclouds-all-compute</feature>
+        <bundle dependency='true'>mvn:org.yaml/snakeyaml/1.17</bundle>
 
         <!-- Same as allblobstore -->
         <feature>jclouds-all-blobstore</feature>


### PR DESCRIPTION
The feature entry for jclouds-all-compute still requires the snakeyaml 1.17 to be explicitly
added. Now both versions of snakeyaml are available.