### PR TITLE
add a profile to allow downstream projects not to deploy brooklyn projects

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1766,5 +1766,19 @@
               </pluginManagement>
             </build>
         </profile>
+        <profile>
+            <id>skipBrooklynDeploy</id>
+            <!-- allow downstream projects that compile brooklyn to specify not to attempt to deploy it to apache's maven repo -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
useful if they do `mvn clean deploy` and rebuild brooklyn projects, as they shouldn't be attempting to deploy brooklyn projects.
(they might rebuild eg the ui if they are whitelabelling.  the alternative is that they _do_ deploy them, but
specify alternative repos via the command line or a .mvn/maven.config)