### PR TITLE
restore the field `subType` for sub-element config keys

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/ListConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ListConfigKey.java
@@ -85,7 +85,7 @@ public class ListConfigKey<V> extends AbstractCollectionConfigKey<List<V>,List<O
         }
         public Builder(String newName, ListConfigKey<V> key) {
             super(newName, key);
-            subType = key.subType;
+            subType = key.getSubTypeToken();
         }
         @Override
         public Builder<V> self() {

--- a/core/src/main/java/org/apache/brooklyn/core/config/MapConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/MapConfigKey.java
@@ -85,7 +85,7 @@ public class MapConfigKey<V> extends AbstractStructuredConfigKey<Map<String,V>,M
         }
         public Builder(String newName, MapConfigKey<V> key) {
             super(newName, key);
-            subType = key.subType;
+            subType = key.getSubTypeToken();
         }
         @Override
         public Builder<V> self() {

--- a/core/src/main/java/org/apache/brooklyn/core/config/SetConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/SetConfigKey.java
@@ -74,7 +74,7 @@ public class SetConfigKey<V> extends AbstractCollectionConfigKey<Set<V>, Set<Obj
         }
         public Builder(String newName, SetConfigKey<V> key) {
             super(newName, key);
-            subType = key.subType;
+            subType = key.getSubTypeToken();
         }
         @Override
         public Builder<V> self() {

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractCollectionConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractCollectionConfigKey.java
@@ -50,7 +50,7 @@ public abstract class AbstractCollectionConfigKey<T, RawT extends Collection<Obj
 
     public ConfigKey<V> subKey() {
         String subName = Identifiers.makeRandomId(8);
-        return new SubElementConfigKey<V>(this, subType, getName()+"."+subName, "element of "+getName()+", uid "+subName, null);
+        return new SubElementConfigKey<V>(this, getSubTypeToken(), getName()+"."+subName, "element of "+getName()+", uid "+subName, null);
     }
 
     protected abstract RawT merge(boolean unmodifiable, Iterable<?> ...items);


### PR DESCRIPTION
now supports generics _or_ plain, so persistence is simpler when plain,
(as done for BasicConfigKey)