### PR TITLE
BROOKLYN-600: cleanup entities on deploy-failure

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagerInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagerInternal.java
@@ -39,4 +39,12 @@ public interface EntityManagerInternal extends EntityManager, BrooklynObjectMana
      */
     @Beta
     <T extends Entity> T createEntity(EntitySpec<T> spec, Optional<String> entityId);
+    
+    /**
+     * Similar to {@link #unmanage(Entity)}, but used to discard partially constructed entities.
+     * 
+     * @throws IllegalStateException if the entity, or any of its descendents are already managed.
+     */
+    @Beta
+    void discardPremanaged(Entity e);
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentEntityManager.java
@@ -190,6 +190,11 @@ public class NonDeploymentEntityManager implements EntityManagerInternal {
         throw new IllegalStateException("Non-deployment context "+this+" is not valid for this operation: cannot unmanage "+e);
     }
     
+    @Override
+    public void discardPremanaged(Entity e) {
+        throw new IllegalStateException("Non-deployment context "+this+" is not valid for this operation: cannot discardPremanaged "+e);
+    }
+    
     private boolean isInitialManagementContextReal() {
         return (initialManagementContext != null && !(initialManagementContext instanceof NonDeploymentManagementContext));
     }
@@ -202,5 +207,4 @@ public class NonDeploymentEntityManager implements EntityManagerInternal {
             throw new IllegalStateException("Non-deployment context "+this+" (with no initial management context supplied) is not valid for this operation.");
         }
     }
-    
 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/DeployFailureTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/DeployFailureTest.java
@@ -18,28 +18,85 @@
  */
 package org.apache.brooklyn.core.mgmt;
 
+import static org.testng.Assert.assertFalse;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.ConstraintViolationException;
 import org.apache.brooklyn.core.mgmt.internal.LocalEntityManager;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Predicates;
+
 public class DeployFailureTest extends BrooklynAppUnitTestSupport {
 
+    private static final Set<Entity> constructedEntities = Collections.synchronizedSet(new LinkedHashSet<>());
+    
     private LocalEntityManager entityManager;
     
     @BeforeMethod(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
+        constructedEntities.clear();
         super.setUp();
         entityManager = (LocalEntityManager) mgmt.getEntityManager();
     }
     
+    @AfterMethod(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            super.tearDown();
+        } finally {
+            constructedEntities.clear();
+        }
+    }
+    
+    @Test
+    public void testConfigConstraintViolation() throws Exception {
+        try {
+            mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class)
+                    .child(EntitySpec.create(TestEntityWithConfigConstraint.class)));
+            Asserts.shouldHaveFailedPreviously();
+        } catch (ConstraintViolationException e) {
+            // Check gives nice exception
+            Asserts.expectedFailureContains(e, "myNonNullKey", "Predicates.notNull()");
+        }
+
+        // Should have disposed of entities that failed to be created
+        assertEntitiesNotKnown(constructedEntities);
+    }
+
+    @Test
+    public void testFailedInit() throws Exception {
+        try {
+            mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class)
+                    .child(EntitySpec.create(TestEntity.class)
+                            .impl(TestEntityFailingInitImpl.class)));
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception e) {
+            // Check gives nice exception
+            Asserts.expectedFailureContains(e, "Simulating failure in entity init");
+        }
+
+        // Should have disposed of entities that failed to be created
+        assertEntitiesNotKnown(constructedEntities);
+    }
+
     @Test
     public void testFailedGetParent() throws Exception {
         entityManager.getAllEntitiesInApplication(app);
@@ -50,15 +107,51 @@ public class DeployFailureTest extends BrooklynAppUnitTestSupport {
                             .impl(TestEntityFailingGetParentImpl.class)));
             Asserts.shouldHaveFailedPreviously();
         } catch (ClassCastException e) {
+            // TODO Should give nicer exception
             Asserts.expectedFailureContains(e, "cannot be cast", "WrongParentEntity");
         }
 
         // This should continue to work, after the failed entity-deploy above
         // See https://issues.apache.org/jira/browse/BROOKLYN-599
         entityManager.getAllEntitiesInApplication(app);
+
+        // Should have disposed of entities that failed to be created
+        assertEntitiesNotKnown(constructedEntities);
     }
 
-    public static class TestEntityFailingGetParentImpl extends TestEntityImpl {
+    private void assertEntitiesNotKnown(Iterable<Entity> entities) {
+        for (Entity entity : constructedEntities) {
+            if (entity.getId() != null) {
+                assertFalse(entityManager.isKnownEntityId(entity.getId()), "entity="+entity);
+            }
+        }
+    }
+
+    public static class TestEntityRecordingConstructionImpl extends TestEntityImpl {
+        public TestEntityRecordingConstructionImpl() {
+            constructedEntities.add(this);
+        }
+    }
+    
+    @ImplementedBy(TestEntityWithConfigConstraintImpl.class)
+    public static interface TestEntityWithConfigConstraint extends TestEntity {
+        ConfigKey<String> NON_NULL_KEY = ConfigKeys.builder(String.class)
+                .name("myNonNullKey")
+                .constraint(Predicates.notNull())
+                .build();
+    }
+    
+    public static class TestEntityWithConfigConstraintImpl extends TestEntityRecordingConstructionImpl implements TestEntityWithConfigConstraint {
+    }
+    
+    public static class TestEntityFailingInitImpl extends TestEntityRecordingConstructionImpl {
+        @Override
+        public void init() {
+            throw new RuntimeException("Simulating failure in entity init()");
+        }
+    }
+    
+    public static class TestEntityFailingGetParentImpl extends TestEntityRecordingConstructionImpl {
         private static interface WrongParentEntity extends Entity {}
         
         @Override


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/BROOKLYN-600

Note the `LocalEntityManager. discardPremanaged(Entity)` is a bit more complex/long that it might need to be because I want to make sure it does no harm - fail if the entity or any child is already managed (because then should call `unmanage()` instead.