### PR TITLE
LogWatcher - don't change log level if not needed

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ExternalConfigYamlTest.java
@@ -321,10 +321,8 @@ public class ExternalConfigYamlTest extends AbstractYamlTest {
         String loggerName = BrooklynDslDeferredSupplier.class.getName();
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.DEBUG;
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessage("myval");
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
 
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             String yaml = Joiner.on("\n").join(
                 "services:",
                 "- serviceType: org.apache.brooklyn.core.test.entity.TestApplication",
@@ -338,9 +336,6 @@ public class ExternalConfigYamlTest extends AbstractYamlTest {
         
             List<ILoggingEvent> events = watcher.getEvents();
             assertTrue(events.isEmpty(), "events="+events);
-            
-        } finally {
-            watcher.close();
         }
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/FunctionSensorYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/FunctionSensorYamlTest.java
@@ -157,10 +157,7 @@ public class FunctionSensorYamlTest extends AbstractYamlRebindTest {
                 Poller.class.getName());
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.TRACE;
         Predicate<ILoggingEvent> filter = Predicates.alwaysTrue();
-        LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter)) {
             Entity app = createAndStartApplication(
                     "services:",
                     "- type: " + TestEntity.class.getName(),
@@ -214,8 +211,6 @@ public class FunctionSensorYamlTest extends AbstractYamlRebindTest {
                 fail("exceptionEvents="+watcher.printEventsToString(exceptionEvents));
             }
 
-        } finally {
-            watcher.close();
         }
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlAwsTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/JcloudsTemplateOptionsYamlAwsTest.java
@@ -103,13 +103,10 @@ public class JcloudsTemplateOptionsYamlAwsTest extends AbstractJcloudsStubYamlTe
 
         final String ignoreOption = "Ignoring request to set template option";
 
-        final LogWatcher watcher = new LogWatcher(
-            ImmutableList.of(LoggerFactory.getLogger(TemplateOptionsOption.class).getName()),
-            ch.qos.logback.classic.Level.WARN,
-            Predicates.and(containsMessage(ignoreOption), containsMessage("subnetId")));
-
-        watcher.start();
-        try {
+        try (final LogWatcher watcher = new LogWatcher(
+                ImmutableList.of(LoggerFactory.getLogger(TemplateOptionsOption.class).getName()),
+                ch.qos.logback.classic.Level.WARN,
+                Predicates.and(containsMessage(ignoreOption), containsMessage("subnetId")))) {
             EntitySpec<?> spec = managementContext.getTypeRegistry().createSpecFromPlan(
                 CampTypePlanTransformer.FORMAT, yaml,
                 RegisteredTypeLoadingContexts.spec(Application.class), EntitySpec.class);
@@ -121,8 +118,6 @@ public class JcloudsTemplateOptionsYamlAwsTest extends AbstractJcloudsStubYamlTe
 
             AWSEC2TemplateOptions options = (AWSEC2TemplateOptions) findTemplateOptionsInCustomizerArgs();
             assertEquals(options.getSubnetId(), subnetValue);
-        } finally {
-            watcher.close();
         }
 
     }

--- a/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyDeprecationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyDeprecationTest.java
@@ -213,14 +213,10 @@ public class ConfigKeyDeprecationTest extends BrooklynAppUnitTestSupport {
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessages(
                 "Using deprecated config value on MyBaseEntity",
                 "should use 'superKey1', but used 'oldSuperKey1'");
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
 
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             testUsingDeprecatedName();
             watcher.assertHasEvent();
-        } finally {
-            watcher.close();
         }
     }
 
@@ -232,14 +228,10 @@ public class ConfigKeyDeprecationTest extends BrooklynAppUnitTestSupport {
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessages(
                 "Ignoring deprecated config value(s) on MyBaseEntity",
                 "because contains value for 'superKey1', other deprecated name(s) present were: [oldSuperKey1]");
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
-
-        watcher.start();
-        try {
+        
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             testPrefersNonDeprecatedName();
             watcher.assertHasEvent();
-        } finally {
-            watcher.close();
         }
     }
 
@@ -250,14 +242,10 @@ public class ConfigKeyDeprecationTest extends BrooklynAppUnitTestSupport {
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessages(
                 "Using deprecated config value on MyBaseEntity",
                 "should use 'superKey1', but used 'oldSuperKey1b' and ignored values present for other deprecated name(s) [oldSuperKey1b]");
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
 
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             testPrefersFirstDeprecatedNameIfMultiple();
             watcher.assertHasEvent();
-        } finally {
-            watcher.close();
         }
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/effector/EffectorExceptionLoggedTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/EffectorExceptionLoggedTest.java
@@ -143,10 +143,8 @@ public class EffectorExceptionLoggedTest extends BrooklynAppUnitTestSupport {
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.DEBUG;
         Predicate<ILoggingEvent> filter = Predicates.and(EventPredicates.containsMessage("Error invoking myEffector"), 
                 EventPredicates.containsExceptionStackLine(ThrowingEntitlementManager.class, "isEntitled"));
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
 
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             Entities.submit(entity, Tasks.<Void>builder().displayName("Effector-invoker")
                     .description("Invoke in task")
                     .tag(BrooklynTaskTags.NON_TRANSIENT_TASK_TAG)
@@ -160,8 +158,6 @@ public class EffectorExceptionLoggedTest extends BrooklynAppUnitTestSupport {
                     .blockUntilEnded();
 
             watcher.assertHasEventEventually();
-        } finally {
-            watcher.close();
         }
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLoggingTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/ApplicationLoggingTest.java
@@ -152,10 +152,8 @@ public class ApplicationLoggingTest extends BrooklynAppUnitTestSupport {
         ids.push(app.getId());
         final TestEntityWithLogging entity = app.createAndManageChild(EntitySpec.create(TestEntityWithLogging.class));
         final TestEntityWithLogging child = entity.addChild(EntitySpec.create(EntitySpec.create(TestEntityWithLogging.class)));
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, containsMessage(app.getId()));
 
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, containsMessage(app.getId()))) {
             app.start(ImmutableList.of(app.newSimulatedLocation()));
             assertHealthEventually(app, Lifecycle.RUNNING, true);
             final TaskAdaptable<Void> stopTask = Effectors.invocation(app, Startable.STOP, ImmutableMap.of());
@@ -181,8 +179,6 @@ public class ApplicationLoggingTest extends BrooklynAppUnitTestSupport {
             watcher.assertHasEvent(matchingRegexes(".*" +
                 ImmutableList.of(app.getId(), entity.getId(), child.getId()).toString()
                 + ".*from entity.*" + child.getId() + ".*"));
-        } finally {
-            watcher.close();
         }
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
@@ -618,15 +618,10 @@ public class XmlMementoSerializerTest {
         String loggerName = UnwantedStateLoggingMapper.class.getName();
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.WARN;
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessage("Task object serialization is not supported or recommended"); 
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
-        
         String serializedForm;
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             serializedForm = serializer.toString(completedTask);
             watcher.assertHasEvent();
-        } finally {
-            watcher.close();
         }
 
         assertEquals(serializedForm.trim(), "<"+BasicTask.class.getName()+">myval</"+BasicTask.class.getName()+">");

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricEntitySpecTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindHistoricEntitySpecTest.java
@@ -103,9 +103,7 @@ public class RebindHistoricEntitySpecTest extends AbstractRebindHistoricTest {
         addMemento(BrooklynObjectType.ENTITY, "entity-with-entityspec-containing-policies", "aeifj99fjd");
         
         Predicate<ILoggingEvent> filter = EventPredicates.containsMessage("NOT SUPPORTED"); 
-        LogWatcher watcher = new LogWatcher(EntitySpec.class.getName(), ch.qos.logback.classic.Level.WARN, filter);
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(EntitySpec.class.getName(), ch.qos.logback.classic.Level.WARN, filter)) {
             rebind(RebindOptions.create().exceptionHandler(exceptionHandler));
             watcher.assertHasEventEventually();
             
@@ -113,8 +111,6 @@ public class RebindHistoricEntitySpecTest extends AbstractRebindHistoricTest {
             Optional<ILoggingEvent> enrichersWarning = Iterables.tryFind(watcher.getEvents(), EventPredicates.containsMessage("enrichers will be ignored"));
             assertTrue(policiesWarning.isPresent());
             assertTrue(enrichersWarning.isPresent());
-        } finally {
-            watcher.close();
         }
     }
 

--- a/core/src/test/java/org/apache/brooklyn/enricher/stock/MathAggregatorFunctionsTest.java
+++ b/core/src/test/java/org/apache/brooklyn/enricher/stock/MathAggregatorFunctionsTest.java
@@ -108,13 +108,11 @@ public class MathAggregatorFunctionsTest {
     public void testTryCastInputValuesWhenNotNumbers() throws Exception {
         Function<Collection<? extends Number>, Integer> func = MathAggregatorFunctions.computingSum(null, null, Integer.class);
         
-        final LogWatcher watcher = new LogWatcher(
+        try (final LogWatcher watcher = new LogWatcher(
                 ImmutableList.of(LoggerFactory.getLogger(MathAggregatorFunctions.class).getName()),
                 ch.qos.logback.classic.Level.WARN,
-                containsMessage("Input to numeric aggregator is not a number"));
+                containsMessage("Input to numeric aggregator is not a number"))) {
 
-        watcher.start();
-        try {
             // Sums only things that can be numbers, ingnoring others; logs non-numbers only once
             List<Number> inputWithNonNumber = (List<Number>) (List) MutableList.<Object>of(1, null, "not a number", "4", true);
             for (int i = 0; i < 2; i++) {
@@ -132,9 +130,6 @@ public class MathAggregatorFunctionsTest {
                 assertEquals(func.apply(inputWithNonNumber), (Integer)5);
             }
             assertEquals(watcher.getEvents().size(), 1, "events="+watcher.getEvents());
-            
-        } finally {
-            watcher.close();
         }
     }
     

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationIntegrationTest.java
@@ -321,18 +321,14 @@ public class SshMachineLocationIntegrationTest extends SshMachineLocationTest {
                 SshjTool.class.getName());
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.DEBUG;
         Predicate<ILoggingEvent> filter = Predicates.alwaysTrue();
-        LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter);
+        try (LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter)) {
 
-        watcher.start();
-        try {
             host.execCommands("mySummary", ImmutableList.of("echo mystdout1", "echo mystdout2", "echo mystderr1 1>&2", "echo mystderr2 1>&2"));
             
             watcher.assertHasEvent(EventPredicates.containsMessage(":22:stdout] mystdout1"));
             watcher.assertHasEvent(EventPredicates.containsMessage(":22:stdout] mystdout2"));
             watcher.assertHasEvent(EventPredicates.containsMessage(":22:stderr] mystderr1"));
             watcher.assertHasEvent(EventPredicates.containsMessage(":22:stderr] mystderr2"));
-        } finally {
-            watcher.close();
         }
     }
     

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -321,17 +321,12 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
         Predicate<ILoggingEvent> filter = Predicates.or(
                 EventPredicates.containsMessage("DB_PASSWORD"), 
                 EventPredicates.containsMessage("mypassword"));
-        LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter)) {
             host.execCommands("mySummary", ImmutableList.of("true"), ImmutableMap.of("DB_PASSWORD", "mypassword"));
             watcher.assertHasEventEventually();
             
             Optional<ILoggingEvent> eventWithPasswd = Iterables.tryFind(watcher.getEvents(), EventPredicates.containsMessage("mypassword"));
             assertFalse(eventWithPasswd.isPresent(), "event="+eventWithPasswd);
-        } finally {
-            watcher.close();
         }
     }
     
@@ -344,18 +339,13 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
                 SshjTool.class.getName());
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.DEBUG;
         Predicate<ILoggingEvent> filter = Predicates.alwaysTrue();
-        LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter)) {
             host.execCommands("mySummary", ImmutableList.of("mycommand"));
             
             watcher.assertHasEvent(EventPredicates.containsMessage("[1.2.3.4:22:stdout] mystdout1"));
             watcher.assertHasEvent(EventPredicates.containsMessage("[1.2.3.4:22:stdout] mystdout2"));
             watcher.assertHasEvent(EventPredicates.containsMessage("[1.2.3.4:22:stderr] mystderr1"));
             watcher.assertHasEvent(EventPredicates.containsMessage("[1.2.3.4:22:stderr] mystderr2"));
-        } finally {
-            watcher.close();
         }
     }
     
@@ -368,10 +358,7 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
                 SshjTool.class.getName());
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.DEBUG;
         Predicate<ILoggingEvent> filter = Predicates.alwaysTrue();
-        LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerNames, logLevel, filter)) {
             host.execCommands(
                     ImmutableMap.of(SshMachineLocation.NO_STDOUT_LOGGING.getName(), true, SshMachineLocation.NO_STDERR_LOGGING.getName(), true), 
                     "mySummary", 
@@ -379,8 +366,6 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
             
             assertFalse(Iterables.tryFind(watcher.getEvents(), EventPredicates.containsMessage(":stdout]")).isPresent());
             assertFalse(Iterables.tryFind(watcher.getEvents(), EventPredicates.containsMessage(":stderr]")).isPresent());
-        } finally {
-            watcher.close();
         }
     }
 }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/machine/MachineEntityRebindTest.java
@@ -86,10 +86,7 @@ public class MachineEntityRebindTest extends RebindTestFixtureWithApp {
         String loggerName = InternalFactory.class.getName();
         ch.qos.logback.classic.Level logLevel = ch.qos.logback.classic.Level.WARN;
         Predicate<ILoggingEvent> filter = Predicates.alwaysTrue();
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             origApp.createAndManageChild(EntitySpec.create(MachineEntity.class)
                     .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true));
             origApp.start(ImmutableList.of(origMachine));
@@ -98,9 +95,6 @@ public class MachineEntityRebindTest extends RebindTestFixtureWithApp {
         
             List<ILoggingEvent> events = watcher.getEvents();
             assertTrue(events.isEmpty(), "events="+events);
-            
-        } finally {
-            watcher.close();
         }
     }
 }

--- a/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestSensorTest.java
+++ b/test-framework/src/test/java/org/apache/brooklyn/test/framework/TestSensorTest.java
@@ -364,10 +364,7 @@ public class TestSensorTest extends BrooklynAppUnitTestSupport {
         Predicate<ILoggingEvent> repeatedFailureMsgMatcher = EventPredicates.containsMessage("repeated failure; excluding stacktrace");
         Predicate<ILoggingEvent> stacktraceMatcher = EventPredicates.containsExceptionStackLine(TestFrameworkAssertions.class, "checkActualAgainstAssertions");
         Predicate<ILoggingEvent> filter = Predicates.or(repeatedFailureMsgMatcher, stacktraceMatcher);
-        LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter);
-
-        watcher.start();
-        try {
+        try (LogWatcher watcher = new LogWatcher(loggerName, logLevel, filter)) {
             // Invoke async; will let it complete after we see the log messages we expect
             Task<?> task = Entities.invokeEffector(app, app, Startable.START, ImmutableMap.of("locations", locs));
 
@@ -389,9 +386,6 @@ public class TestSensorTest extends BrooklynAppUnitTestSupport {
             // that we didn't get another stacktrace
             stacktraceEvents = watcher.getEvents(stacktraceMatcher);
             assertEquals(Integer.valueOf(stacktraceEvents.size()), Integer.valueOf(1), "stacktraceEvents="+stacktraceEvents.size());
-            
-        } finally {
-            watcher.close();
         }
     }
 

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -19,14 +19,13 @@
 package org.apache.brooklyn.test;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static org.testng.Assert.assertFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.Proxy;
 import java.io.PrintStream;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -108,11 +107,7 @@ public class LogWatcher implements Closeable {
         }
 
         public static Predicate<ILoggingEvent> containsException() {
-            return new Predicate<ILoggingEvent>() {
-                @Override public boolean apply(ILoggingEvent input) {
-                    return (input != null) && (input.getThrowableProxy() != null);
-                }
-            };
+            return input -> (input != null) && (input.getThrowableProxy() != null);
         }
 
         public static Predicate<ILoggingEvent> containsExceptionMessage(final String expected) {
@@ -120,36 +115,26 @@ public class LogWatcher implements Closeable {
         }
 
         public static Predicate<ILoggingEvent> containsExceptionMessages(final String... expecteds) {
-            return new Predicate<ILoggingEvent>() {
-                @Override public boolean apply(ILoggingEvent input) {
-                    IThrowableProxy throwable = (input != null) ? input.getThrowableProxy() : null;
-                    String msg = (throwable != null) ? throwable.getMessage() : null;
-                    if (msg == null) return false;
-                    for (String expected : expecteds) {
-                        if (!msg.contains(expected)) return false;
-                    }
-                    return true;
+            return input -> {
+                IThrowableProxy throwable = (input != null) ? input.getThrowableProxy() : null;
+                String msg = (throwable != null) ? throwable.getMessage() : null;
+                if (msg == null) return false;
+                for (String expected : expecteds) {
+                    if (!msg.contains(expected)) return false;
                 }
+                return true;
             };
         }
         public static Predicate<ILoggingEvent> containsExceptionClassname(final String expected) {
-            return new Predicate<ILoggingEvent>() {
-                @Override public boolean apply(ILoggingEvent input) {
-                    IThrowableProxy throwable = (input != null) ? input.getThrowableProxy() : null;
-                    String classname = (throwable != null) ? throwable.getClassName() : null;
-                    if (classname == null) return false;
-                    return classname.contains(expected);
-                }
+            return input -> {
+                IThrowableProxy throwable = (input != null) ? input.getThrowableProxy() : null;
+                String classname = (throwable != null) ? throwable.getClassName() : null;
+                if (classname == null) return false;
+                return classname.contains(expected);
             };
         }
         public static Predicate<ILoggingEvent> levelGeaterOrEqual(final Level expectedLevel) {
-            return new Predicate<ILoggingEvent>() {
-                @Override public boolean apply(ILoggingEvent input) {
-                    if (input == null) return false;
-                    Level level = input.getLevel();
-                    return level.isGreaterOrEqual(expectedLevel);
-                }
-            };
+            return input -> input == null ? false : input.getLevel().isGreaterOrEqual(expectedLevel);
         }
     }
     
@@ -164,7 +149,6 @@ public class LogWatcher implements Closeable {
         this(ImmutableList.of(checkNotNull(loggerName, "loggerName")), loggerLevel, filter);
     }
     
-    @SuppressWarnings("unchecked")
     public LogWatcher(Iterable<String> loggerNames, ch.qos.logback.classic.Level loggerLevel, final Predicate<? super ILoggingEvent> filter) {
 
         this.loggerLevel = checkNotNull(loggerLevel, "loggerLevel");
@@ -206,7 +190,7 @@ public class LogWatcher implements Closeable {
         // for root, with a pattern layout encoder, and re-uses its encoder pattern.
         // This is (at time of writing) as defined in logback-appender-stdout.xml.
         final Appender<ILoggingEvent> appender = lc.getLogger("ROOT").getAppender("STDOUT");
-        final ConsoleAppender stdout = ConsoleAppender.class.cast(appender);
+        final ConsoleAppender<?> stdout = ConsoleAppender.class.cast(appender);
         final PatternLayoutEncoder stdoutEncoder = PatternLayoutEncoder.class.cast(stdout.getEncoder());
         ple.setPattern(stdoutEncoder.getPattern());
         ple.setContext(lc);
@@ -217,21 +201,19 @@ public class LogWatcher implements Closeable {
         this.appender.start();
 
         for (String loggerName : loggerNames) {
-            final ch.qos.logback.classic.Logger logger =
-                (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(checkNotNull(loggerName, "loggerName"));
-            logger.addAppender(this.appender);
-            logger.setLevel(this.loggerLevel);
-            logger.setAdditive(false);
-            watchedLoggers.add(logger);
+            watchedLoggers.add( (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(checkNotNull(loggerName, "loggerName")) );
         }
+
+        start();
     }
     
+    /** @deprecated since 1.0.0 called by constructor, will go private as no need for anyone else to call */
     public void start() {
-
-        checkState(!closed.get(), "Cannot start LogWatcher after closed");
         for (ch.qos.logback.classic.Logger watchedLogger : watchedLoggers) {
-            origLevels.put(watchedLogger, watchedLogger.getLevel());
-            watchedLogger.setLevel(loggerLevel);
+            if (loggerLevel.toInteger() < watchedLogger.getEffectiveLevel().toInteger()) {
+                origLevels.putIfAbsent(watchedLogger, watchedLogger.getLevel());
+                watchedLogger.setLevel(loggerLevel);
+            }
             watchedLogger.addAppender(appender);
         }
     }
@@ -239,12 +221,10 @@ public class LogWatcher implements Closeable {
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            if (watchedLoggers != null) {
-                for (ch.qos.logback.classic.Logger watchedLogger : watchedLoggers) {
-                    Level origLevel = origLevels.get(watchedLogger);
-                    if (origLevel != null) watchedLogger.setLevel(origLevel);
-                    watchedLogger.detachAppender(appender);
-                }
+            for (ch.qos.logback.classic.Logger watchedLogger : watchedLoggers) {
+                Level origLevel = origLevels.get(watchedLogger);
+                if (origLevel != null) watchedLogger.setLevel(origLevel);
+                watchedLogger.detachAppender(appender);
             }
             watchedLoggers.clear();
             origLevels.clear();
@@ -268,17 +248,14 @@ public class LogWatcher implements Closeable {
             @Override
             public void run() {
                 assertFalse(events.isEmpty());
+                System.out.println("EVENTS: "+events);
             }});
         return getEvents();
     }
 
     public List<ILoggingEvent> assertHasEventEventually(final Predicate<? super ILoggingEvent> filter) {
         final AtomicReference<List<ILoggingEvent>> result = new AtomicReference<>();
-        Asserts.succeedsEventually(new Runnable() {
-            @Override
-            public void run() {
-                result.set(assertHasEvent(filter));
-            }});
+        Asserts.succeedsEventually(() -> result.set(assertHasEvent(filter)));
         return result.get();
     }
 

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -248,7 +248,6 @@ public class LogWatcher implements Closeable {
             @Override
             public void run() {
                 assertFalse(events.isEmpty());
-                System.out.println("EVENTS: "+events);
             }});
         return getEvents();
     }


### PR DESCRIPTION
prevents the logs from missing useful output if testing for a higher-level message,
useful when investigating tests, esp SoftwareProcessStopsDuringStartTest.testStopDuringProvisionWaitsForCompletion where the log messages we want aren't showing because we reset it to warn.

also use try-close syntax for LogWatcher.