### PR TITLE
Revert "This closes #988"

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -488,7 +488,6 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
      */
     protected void setHighlight(String name, HighlightTuple tuple) {
         highlights.put(name, tuple);
-        requestPersist();
     }
 
     /** As {@link #setHighlight(String, HighlightTuple)}, convenience for recording an item which is intended to be ongoing. */
@@ -575,7 +574,6 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     public void setHighlights(Map<String, HighlightTuple> highlights) {
         if(highlights != null) {
             this.highlights.putAll(highlights);
-            requestPersist();
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
@@ -99,7 +99,9 @@ public abstract class AbstractPolicy extends AbstractEntityAdjunct implements Po
     @Override
     protected void onChanged() {
         // currently changes simply trigger re-persistence; there is no intermediate listener as we do for EntityChangeListener
-        requestPersist();
+        if (getManagementContext() != null) {
+            getManagementContext().getRebindManager().getChangeListener().onChanged(this);
+        }
     }
     
     @Override

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
@@ -157,7 +157,8 @@ public class AutoScalerPolicyRebindTest extends RebindTestFixtureWithApp {
         Map<String, HighlightTuple> highlights = new HashMap<>();
         highlights.put("testNameTask",  new HighlightTuple("testDescription", 123L, "testTaskId"));
 
-        AutoScalerPolicy originalPolicy = (AutoScalerPolicy) Iterables.getOnlyElement(origCluster.policies());
+
+        Policy originalPolicy = origCluster.policies().iterator().next();
         ((AbstractEntityAdjunct)originalPolicy).setHighlights(highlights);
 
         TestApplication newApp = rebind();


### PR DESCRIPTION
This reverts commit f6ad11846de2d9ba2e9004648179270e3ca3c25f, reversing
changes made to c782aae54f424e317c0999f5cde3fab19bc45cfb.

This PR broke `DynamicClusterWithAvailabilityZonesRebindTest.testRebindWithCustomZoneFailureDetector`, because it caused the feed to be persisted (which should not have been).

I created this revert by running:
```
git revert f6ad11846d -m 1
```