### PR TITLE
Prevent racing persistence

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.api.entity.Entity;
+
 /**
  * EntityAdjuncts are supplementary logic that can be attached to Entities, 
  * such as providing sensor enrichment or event-driven policy behavior
@@ -53,4 +55,7 @@ public interface EntityAdjunct extends BrooklynObject {
     @Nullable String getUniqueTag();
 
     Map<String, HighlightTuple> getHighlights();
+    
+    Entity getEntity();
+    
 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -488,6 +488,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
      */
     protected void setHighlight(String name, HighlightTuple tuple) {
         highlights.put(name, tuple);
+        requestPersist();
     }
 
     /** As {@link #setHighlight(String, HighlightTuple)}, convenience for recording an item which is intended to be ongoing. */
@@ -574,6 +575,7 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
     public void setHighlights(Map<String, HighlightTuple> highlights) {
         if(highlights != null) {
             this.highlights.putAll(highlights);
+            requestPersist();
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
@@ -99,9 +99,7 @@ public abstract class AbstractPolicy extends AbstractEntityAdjunct implements Po
     @Override
     protected void onChanged() {
         // currently changes simply trigger re-persistence; there is no intermediate listener as we do for EntityChangeListener
-        if (getManagementContext() != null) {
-            getManagementContext().getRebindManager().getChangeListener().onChanged(this);
-        }
+        requestPersist();
     }
     
     @Override

--- a/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesRebindTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/DynamicClusterWithAvailabilityZonesRebindTest.java
@@ -77,6 +77,9 @@ public class DynamicClusterWithAvailabilityZonesRebindTest extends RebindTestFix
         
         Entities.unmanage(cluster);
         Locations.unmanage(loc);
+        // TODO sometimes this feed is still around when it comes to rebind; trying a fix for it
+        // FunctionFeed{uniqueTag=FunctionFeed[fn[ClusterOneAndAllMembersUpCallable->cluster.one_and_all.members.up]], running=false, entity=DynamicClusterImpl{id=g1gix9e93k}, id=c85yn37m43} for DynamicClusterImpl{id=g1gix9e93k}
+        // causing dangling reference
 
         // Start a second cluster
         SimulatedLocation locUnrelated = mgmt().getLocationManager().createLocation(LocationSpec.create(SimulatedLocationWithZoneExtension.class)

--- a/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/autoscaling/AutoScalerPolicyRebindTest.java
@@ -157,8 +157,7 @@ public class AutoScalerPolicyRebindTest extends RebindTestFixtureWithApp {
         Map<String, HighlightTuple> highlights = new HashMap<>();
         highlights.put("testNameTask",  new HighlightTuple("testDescription", 123L, "testTaskId"));
 
-
-        Policy originalPolicy = origCluster.policies().iterator().next();
+        AutoScalerPolicy originalPolicy = (AutoScalerPolicy) Iterables.getOnlyElement(origCluster.policies());
         ((AbstractEntityAdjunct)originalPolicy).setHighlights(highlights);
 
         TestApplication newApp = rebind();


### PR DESCRIPTION
This _might_ fix the cause of the failure observed after #988 , and so then reinstates it, effectively unreverting #990 .

Worth having this be tested a few times in the PR to see whether it does the trick.

I suspect the FunctionFeed which is being left around is being added in a window where the entity is shutting down.  Just a guess though, not high confidence.