### PR TITLE
bump karaf version to get consistent jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
         <winrm4j.version>0.5.0</winrm4j.version>
-        <karaf.version>4.1.2</karaf.version>
+        <karaf.version>4.1.6</karaf.version>
         <karaf.plugin.version>4.1.1</karaf.plugin.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <kubernetes-client.version>1.4.27</kubernetes-client.version>


### PR DESCRIPTION
#991 broke the feature verification build in `dist`.  seems we need to bump karaf as well as it pullls in a version of jetty, and we want them consistent.