### PR TITLE
Bump karaf to 4.1.6 (from 4.1.2)

### DIFF
--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -54,7 +54,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.karaf.tooling</groupId>
                         <artifactId>karaf-maven-plugin</artifactId>
-                        <versionRange>[4.1.1,)</versionRange>
+                        <versionRange>[4.1.6,)</versionRange>
                         <goals>
                           <goal>verify</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
         <winrm4j.version>0.5.0</winrm4j.version>
-        <karaf.version>4.1.2</karaf.version>
-        <karaf.plugin.version>4.1.1</karaf.plugin.version>
+        <karaf.version>4.1.6</karaf.version>
+        <karaf.plugin.version>4.1.6</karaf.plugin.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <kubernetes-client.version>1.4.27</kubernetes-client.version>
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->


### PR DESCRIPTION
Bumping jetty version to 9.3.24 (from 9.3.14) done in #991 clashes with jetty that ships in karaf 4.1.2, breaking the build. Therefore bumping karaf to 4.1.6.

Replaces https://github.com/apache/brooklyn-server/pull/994 - difference is this PR also bumps the `karaf.plugin.version` to match.

Also see https://github.com/apache/brooklyn-ui/pull/70