### PR TITLE
Add ow2 bundles not included in Karaf

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -144,6 +144,10 @@
         <bundle dependency="true">mvn:net.minidev/json-smart/${jsonSmart.version}</bundle>
         <bundle dependency="true">mvn:net.minidev/accessors-smart/${minidev.accessors-smart.version}</bundle>
         <bundle dependency="true">mvn:org.ow2.asm/asm/${ow2.asm.version}</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-commons/${ow2.asm.version}</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-tree/${ow2.asm.version}</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-analysis/${ow2.asm.version}</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-util/${ow2.asm.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-client/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty.version}</bundle>


### PR DESCRIPTION
Fixes the following Karaf startup exception:

```
ERROR  82 o.a.a.b.c.BlueprintContainerImpl [tures-3-thread-1] Unable to start blueprint container for bundle org.apache.brooklyn.karaf-init/1.0.0.SNAPSHOT
org.osgi.service.blueprint.container.ComponentDefinitionException: java.lang.NoClassDefFoundError: org/objectweb/asm/commons/AdviceAdapter
        at org.apache.aries.blueprint.container.ReferenceRecipe.internalCreate(ReferenceRecipe.java:141) ~[?:?]
        at org.apache.aries.blueprint.di.AbstractRecipe$1.call(AbstractRecipe.java:81) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:?]
        at org.apache.aries.blueprint.di.AbstractRecipe.create(AbstractRecipe.java:90) ~[?:?]
        at org.apache.aries.blueprint.container.BeanRecipe.setProperty(BeanRecipe.java:810) ~[?:?]
        at org.apache.aries.blueprint.container.BeanRecipe.setProperties(BeanRecipe.java:784) ~[?:?]
        at org.apache.aries.blueprint.container.BeanRecipe.setProperties(BeanRecipe.java:765) ~[?:?]
        at org.apache.aries.blueprint.container.BeanRecipe.internalCreate2(BeanRecipe.java:699) ~[?:?]
        at org.apache.aries.blueprint.container.BeanRecipe.internalCreate(BeanRecipe.java:666) ~[?:?]
        at org.apache.aries.blueprint.di.AbstractRecipe$1.call(AbstractRecipe.java:81) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:?]
        ...
```

Based on adding the following list of bundles:
- org.ow2.asm/asm-commons
- org.ow2.asm/asm-tree
- org.ow2.asm/asm-analysis
- org.ow2.asm/asm-util