### PR TITLE
Fix for SUREFIRE-1588

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1385,6 +1385,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.version}</version>
                         <configuration>
+                            <useSystemClassLoader>false</useSystemClassLoader>
                             <properties>
                                 <property>
                                     <name>listener</name>


### PR DESCRIPTION
Latest version of Java 1.8.0_191 enforces that Manifest classpath entries be relative.

https://issues.apache.org/jira/browse/SUREFIRE-1588