### PR TITLE
[WIP] Subtype setting config val: use as key’s default val

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -265,6 +265,8 @@ public class BrooklynComponentTemplateResolver {
         new BrooklynEntityDecorationResolver.TagsResolver(yamlLoader).decorate(spec, attrs, encounteredRegisteredTypeIds);
 
         configureEntityConfig(spec, encounteredRegisteredTypeIds);
+        
+        new BrooklynEntityDecorationResolver.SpecParameterResolver(yamlLoader).decorateDefaultVals(spec, attrs, encounteredRegisteredTypeIds);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
**For review/feedback only - failing unit tests.**

Otherwise if another blueprint uses this subtype, it does not see the
config val for that key. Worst case, it says the blueprint is invalid
because the config key has no value.

---
My new unit tests pass, but it breaks existing unit tests (e.g. in `ConfigParametersYamlTest.java`). The logic is applied to a catalog item and also to a blueprint being deployed. Our assertions in existing tests check that the config keys of the app being deployed have particular default vals, but these are now being overridden by the blueprint.

What do folk think (cc @ahgittin) - should we use this approach, and fix the tests, or do something else?