### PR TITLE
add distinction between "application" and "template" in catalog itemType

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
@@ -45,6 +45,7 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
     
     public static enum CatalogItemType {
         TEMPLATE, 
+        APPLICATION,
         ENTITY, 
         POLICY,
         ENRICHER,
@@ -63,7 +64,7 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
             if (Policy.class.isAssignableFrom(type)) return POLICY;
             if (Enricher.class.isAssignableFrom(type)) return ENRICHER;
             if (Location.class.isAssignableFrom(type)) return LOCATION;
-            if (Application.class.isAssignableFrom(type)) return TEMPLATE;
+            if (Application.class.isAssignableFrom(type)) return APPLICATION;
             if (Entity.class.isAssignableFrom(type)) return ENTITY;
             return null;
         }

--- a/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
@@ -99,9 +99,10 @@ public enum BrooklynObjectType {
         switch (t) {
         case ENRICHER: return BrooklynObjectType.ENRICHER;
         case ENTITY: return BrooklynObjectType.ENTITY;
+        case APPLICATION: return BrooklynObjectType.ENTITY;
+        case TEMPLATE: return BrooklynObjectType.ENTITY;
         case LOCATION: return BrooklynObjectType.LOCATION;
         case POLICY: return BrooklynObjectType.POLICY;
-        case TEMPLATE: return BrooklynObjectType.ENTITY;
         default: return BrooklynObjectType.UNKNOWN;
         }
     }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
@@ -141,8 +141,10 @@ public class CatalogPredicates {
 
     public static final Predicate<CatalogItem<Application,EntitySpec<? extends Application>>> IS_TEMPLATE = 
             CatalogPredicates.<Application,EntitySpec<? extends Application>>isCatalogItemType(CatalogItemType.TEMPLATE);
+    public static final Predicate<CatalogItem<Entity,EntitySpec<?>>> IS_APPLICATION = 
+        CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.APPLICATION);
     public static final Predicate<CatalogItem<Entity,EntitySpec<?>>> IS_ENTITY = 
-            CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.ENTITY);
+        CatalogPredicates.<Entity,EntitySpec<?>>isCatalogItemType(CatalogItemType.ENTITY);
     public static final Predicate<CatalogItem<Policy,PolicySpec<?>>> IS_POLICY = 
             CatalogPredicates.<Policy,PolicySpec<?>>isCatalogItemType(CatalogItemType.POLICY);
     public static final Predicate<CatalogItem<Enricher,EnricherSpec<?>>> IS_ENRICHER =

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -954,6 +954,9 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
             if (itemType==CatalogItemType.TEMPLATE) {
                 tags.add(BrooklynTags.CATALOG_TEMPLATE);
+                itemType = CatalogItemType.APPLICATION;
+            }
+            if (itemType==CatalogItemType.APPLICATION) {
                 itemType = CatalogItemType.ENTITY;
                 superTypes.add(Application.class);
             }
@@ -1371,7 +1374,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);
                 // record the error if we have reason to expect this guess to succeed
-                if (item.containsKey("services") && (candidateCiType==CatalogItemType.ENTITY || candidateCiType==CatalogItemType.TEMPLATE)) {
+                if (item.containsKey("services") && (candidateCiType==CatalogItemType.ENTITY || candidateCiType==CatalogItemType.APPLICATION || candidateCiType==CatalogItemType.TEMPLATE)) {
                     // explicit services supplied, so plan should have been parseable for an entity or a a service
                     errors.add(e);
                 } else if (catalogItemType!=null && key!=null) {
@@ -2079,6 +2082,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 dto.setSymbolicName(dto.getJavaType());
                 switch (dto.getCatalogItemType()) {
                     case TEMPLATE:
+                    case APPLICATION:
                     case ENTITY:
                         dto.setPlanYaml("services: [{ type: "+dto.getJavaType()+" }]");
                         break;

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogApplicationItemDto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogApplicationItemDto.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.catalog.internal;
+
+import org.apache.brooklyn.api.entity.Application;
+import org.apache.brooklyn.api.entity.EntitySpec;
+
+public class CatalogApplicationItemDto extends CatalogItemDtoAbstract<Application,EntitySpec<? extends Application>> {
+
+    @Override
+    public CatalogItemType getCatalogItemType() {
+        return CatalogItemType.APPLICATION;
+    }
+
+    @Override
+    public Class<Application> getCatalogItemJavaType() {
+        return Application.class;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public Class<EntitySpec<? extends Application>> getSpecType() {
+        return (Class)EntitySpec.class;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
@@ -33,6 +33,7 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
         Preconditions.checkNotNull(itemType, "itemType required");
         switch (itemType) {
         case ENTITY: return newEntity(symbolicName, version);
+        case APPLICATION: return newApplication(symbolicName, version);
         case TEMPLATE: return newTemplate(symbolicName, version);
         case POLICY: return newPolicy(symbolicName, version);
         case ENRICHER: return newEnricher(symbolicName, version);
@@ -43,6 +44,12 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
 
     public static CatalogItemBuilder<CatalogEntityItemDto> newEntity(String symbolicName, String version) {
         return new CatalogItemBuilder<CatalogEntityItemDto>(new CatalogEntityItemDto())
+                .symbolicName(symbolicName)
+                .version(version);
+    }
+
+    public static CatalogItemBuilder<CatalogApplicationItemDto> newApplication(String symbolicName, String version) {
+        return new CatalogItemBuilder<CatalogApplicationItemDto>(new CatalogApplicationItemDto())
                 .symbolicName(symbolicName)
                 .version(version);
     }

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
@@ -52,7 +52,7 @@ public final class AggregationJob implements Runnable {
 
     public static BasicAttributeSensorAndConfigKey<List<Map<String, String>>> DASHBOARD_POLICY_HIGHLIGHTS = new BasicAttributeSensorAndConfigKey(List.class,
             "dashboard.policyHighlights",
-            "Highlights from policies. List of Masps, where each map should contain text and category");
+            "Highlights from policies. List of Maps, where each map should contain text and category");
 
     private final Entity entity;
 

--- a/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
+++ b/core/src/test/java/org/apache/brooklyn/core/plan/XmlPlanToSpecTransformer.java
@@ -84,7 +84,7 @@ public class XmlPlanToSpecTransformer implements PlanToSpecTransformer {
         if (item.getCatalogItemType()==CatalogItemType.ENTITY) {
             return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 1);
         }
-        if (item.getCatalogItemType()==CatalogItemType.TEMPLATE) {
+        if (item.getCatalogItemType()==CatalogItemType.TEMPLATE || item.getCatalogItemType()==CatalogItemType.APPLICATION) {
             return (SpecT)toEntitySpec(parseXml(item.getPlanYaml()), 0);
         }
         throw new UnsupportedTypePlanException("Type "+item.getCatalogItemType()+" not supported");

--- a/policy/src/main/java/org/apache/brooklyn/policy/failover/PropagatePrimaryEnricher.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/failover/PropagatePrimaryEnricher.java
@@ -90,6 +90,7 @@ public class PropagatePrimaryEnricher extends AbstractEnricher implements Sensor
             Collection<? extends Sensor<?>> sensorsToRemove = config().get(PROPAGATING);
             if (sensorsToRemove!=null) {
                 for (Sensor<?> s: sensorsToRemove) {
+                    // TODO - allow strings above also
                     if (s instanceof AttributeSensor) {
                         ((EntityInternal)entity).sensors().remove((AttributeSensor<?>)s);
                     }
@@ -119,7 +120,7 @@ public class PropagatePrimaryEnricher extends AbstractEnricher implements Sensor
         
         Collection<? extends Sensor<?>> sensorsToPropagate = getConfig(PROPAGATING);
         if (sensorsToPropagate==null || sensorsToPropagate.isEmpty()) {
-            log.warn("");
+            log.warn("Nothing found to propagate from primary "+primary+" at "+entity);
             return;
         }
         spec.configure(Propagator.PROPAGATING, sensorsToPropagate);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/CatalogTransformer.java
@@ -294,6 +294,7 @@ public class CatalogTransformer {
         try {
             switch (item.getCatalogItemType()) {
             case TEMPLATE:
+            case APPLICATION:
             case ENTITY:
                 return catalogEntitySummary(b, item, ub);
             case POLICY:
@@ -369,6 +370,7 @@ public class CatalogTransformer {
         String itemId = item.getId();
         switch (item.getCatalogItemType()) {
         case TEMPLATE:
+        case APPLICATION:
             return serviceUriBuilder(ub, CatalogApi.class, "getApplication").build(itemId, item.getVersion());
         case ENTITY:
             return serviceUriBuilder(ub, CatalogApi.class, "getEntity").build(itemId, item.getVersion());

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
@@ -239,7 +239,7 @@ public class ItemLister {
                         Map<String,Object> itemDescriptor = ItemDescriptors.toItemDescriptor(catalog, item, headingsOnly);
 
                         itemCount++;
-                        if (item.getCatalogItemType() == CatalogItem.CatalogItemType.ENTITY || item.getCatalogItemType() == CatalogItem.CatalogItemType.TEMPLATE) {
+                        if (item.getCatalogItemType() == CatalogItem.CatalogItemType.ENTITY || item.getCatalogItemType() == CatalogItem.CatalogItemType.TEMPLATE || item.getCatalogItemType() == CatalogItem.CatalogItemType.APPLICATION) {
                             entities.add(itemDescriptor);
                         } else if (item.getCatalogItemType() == CatalogItem.CatalogItemType.POLICY) {
                             policies.add(itemDescriptor);


### PR DESCRIPTION
previously `template` was the only way to class something as an application, and it did both:
* generate a spec for an `Application`
* add the `catalog_template` tag so it looks llke a template

this adds support for an `itemType: application` which only does the first of these