### PR TITLE
Add version for docker build plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
         <requirejs-maven-plugin.version>2.0.0</requirejs-maven-plugin.version>
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <ant.version>1.8.4</ant.version>
+        <dockerfile-maven-plugin.version>1.4.3</dockerfile-maven-plugin.version>
 
         <jaxb.version>2.2.11</jaxb.version>
         <javax.activation.version>1.1.1</javax.activation.version>


### PR DESCRIPTION
Allows https://github.com/apache/brooklyn-dist/pull/136 review comments to be addressed - i.e. moving docker plugin version to shared pom in brooklyn-server