### PR TITLE
Add cxf-karaf-commands dependency

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -208,6 +208,7 @@
         <feature>cxf-jaxrs</feature>
         <bundle dependency="true">mvn:org.apache.cxf/cxf-rt-rs-security-cors/${cxf.version}</bundle>
         <bundle dependency="true">mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/${cxf.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.cxf.karaf/cxf-karaf-commands/{cxf.version}</bundle>
 
         <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml.jackson.version}</bundle>
 


### PR DESCRIPTION
This is a dependency of cxf that was introduced by the version change to 3.2.7.
This adds cxf commands to the karaf shell such as listing endpoints.