### PR TITLE
fix session sharing and simplify logout

### DIFF
--- a/karaf/jetty-config/src/main/resources/jetty.xml
+++ b/karaf/jetty-config/src/main/resources/jetty.xml
@@ -20,47 +20,4 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">karaf</Set>
-                <Set name="loginModuleName">karaf</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
-                    </Array>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">default</Set>
-                <Set name="loginModuleName">karaf</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
-                    </Array>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">webconsole</Set>
-                <Set name="loginModuleName">webconsole</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule$RolePrincipal</Item>
-                    </Array>
-                </Set>
-                <Set name="identityService">
-                    <New class="org.eclipse.jetty.security.DefaultIdentityService"/>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-
 </Configure>

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/BrooklynImageChooser.java
@@ -341,7 +341,12 @@ public class BrooklynImageChooser implements Cloneable {
                 return ComparisonChain.start()
                     .compare(left, right, primaryOrdering)
                     // fall back to default strategy otherwise, except preferring *non*-null values
-                    // TODO use AlphaNum string comparator
+                    // TODO suggest to use NaturalOrderComparator (so 10>9) then order by:
+                    // 1) `name.replaceAll("([^0-9]+)", " ")` 
+                    // 2) shortest non-empty name
+                    // 3) version (NaturalOrderComparator, prefer last)
+                    // 4) name (NaturalOrderComparator, prefer last)
+                    // 5) other fields (NaturalOrderComparator, prefer last)
                     .compare(left.getName(), right.getName(), Ordering.<String> natural().nullsFirst())
                     .compare(left.getVersion(), right.getVersion(), Ordering.<String> natural().nullsFirst())
                     .compare(left.getDescription(), right.getDescription(), Ordering.<String> natural().nullsFirst())

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -553,6 +553,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-jetty</artifactId>
                 <version>${cxf.version}</version>
             </dependency>

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -18,14 +18,11 @@
  */
 package org.apache.brooklyn.rest.api;
 
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-
-import com.google.common.annotations.Beta;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -40,18 +37,6 @@ public interface LogoutApi {
     Response logout(
             @ApiParam(value = "Instead of 200 (the default) to indicate successful logout, "
                 + "return a 401 with this value in a message key in the body (a 401 will cause browsers to clear some locally cached credentials)", 
-                required = false) 
-            @QueryParam("unauthorize") String unauthorize,
-            
-            @ApiParam(value = "Require that this user be logged in", required = false) 
-            @QueryParam("user") String user
-        );
-
-    @Beta
-    @GET
-    @ApiOperation(value = "Logout and clean session (using GET)")
-    Response logoutGet(
-            @ApiParam(value = "As per the POST logout method, but offered as a GET)", 
                 required = false) 
             @QueryParam("unauthorize") String unauthorize,
             

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -21,13 +21,12 @@ package org.apache.brooklyn.rest.api;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 
 @Path("/logout")
 @Api("Logout")
@@ -35,25 +34,27 @@ public interface LogoutApi {
 
     @POST
     @ApiOperation(value = "Logout and clean session")
-    Response logout();
+    Response logout(
+            @ApiParam(value = "Instead of 200 (the default) to indicate successful logout, "
+                + "return a 401 with this value as the message body (a 401 will cause browsers to clear some locally cached credentials)", 
+                required = false) 
+            @QueryParam("unauthorize") String unauthorize,
+            
+            @ApiParam(value = "Require that this user be logged in", required = false) 
+            @QueryParam("user") String user
+        );
 
-    @POST
-    @Path("/redirect")
-    @ApiOperation(value = "Request a redirect to the user-specific logout")
-    @ApiResponses(value = {
-            @ApiResponse(code = 307, message = "Redirect to /logout/{user}, keeping the request method")
-    })
-    Response redirect();
-
-    // TODO what is this for?  misleading as it does not unauthorize the _session_ or log out in any way;
+    // misleading as it does not unauthorize the _session_ or log out in any way;
     // deprecating as at 2019-01
-    /** @deprecated since 1.0 */
+    /** @deprecated since 1.0 in favour of /logout query parameter */
     @Deprecated
     @POST
     @Path("/unauthorize")
-    @ApiOperation(value = "Return UNAUTHORIZED 401 response, but without disabling the session [deprecated]")
+    @ApiOperation(value = "Return UNAUTHORIZED 401 response, but without disabling the session [deprecated in favour of /logout query parameter]")
     Response unAuthorize();
 
+    /** @deprecated since 1.0 in favour of /logout query parameter */
+    @Deprecated
     @POST
     @Path("/{user}")
     @ApiOperation(value = "Logout and clean session if matching user logged in")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/LogoutApi.java
@@ -18,11 +18,14 @@
  */
 package org.apache.brooklyn.rest.api;
 
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+
+import com.google.common.annotations.Beta;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -36,7 +39,19 @@ public interface LogoutApi {
     @ApiOperation(value = "Logout and clean session")
     Response logout(
             @ApiParam(value = "Instead of 200 (the default) to indicate successful logout, "
-                + "return a 401 with this value as the message body (a 401 will cause browsers to clear some locally cached credentials)", 
+                + "return a 401 with this value in a message key in the body (a 401 will cause browsers to clear some locally cached credentials)", 
+                required = false) 
+            @QueryParam("unauthorize") String unauthorize,
+            
+            @ApiParam(value = "Require that this user be logged in", required = false) 
+            @QueryParam("user") String user
+        );
+
+    @Beta
+    @GET
+    @ApiOperation(value = "Logout and clean session (using GET)")
+    Response logoutGet(
+            @ApiParam(value = "As per the POST logout method, but offered as a GET)", 
                 required = false) 
             @QueryParam("unauthorize") String unauthorize,
             

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -117,11 +117,6 @@
             <artifactId>cxf-rt-rs-security-cors</artifactId>
             <version>${cxf.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>${cxf.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
@@ -220,10 +215,9 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.karaf.jaas.config,
-                            org.eclipse.jetty.jaas,
                             *
                         </Import-Package>
+                        <Export-Package>org.apache.brooklyn.*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.rest.filter;
 
 import java.lang.reflect.Field;
+import java.util.Set;
 
 import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
@@ -35,10 +36,15 @@ import org.apache.brooklyn.rest.security.provider.SecurityProvider;
 import org.apache.brooklyn.rest.security.provider.SecurityProvider.SecurityProviderDeniedAuthentication;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.StringEscapes;
+import org.apache.brooklyn.util.time.Time;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.cxf.jaxrs.impl.tl.ThreadLocalHttpServletRequest;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandler.Context;
+import org.eclipse.jetty.server.session.DefaultSessionCache;
+import org.eclipse.jetty.server.session.Session;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +99,76 @@ public class BrooklynSecurityProviderFilterHelper {
     /** The first session handler encountered becomes the shared handler that replaces all others encountered. */
     private static SessionHandler sharedSessionHandler;
     
+    public static boolean onInvalidate(String sessionId) {
+        if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) return false;
+        Set<SessionHandler> handlers = sharedSessionHandler.getSessionIdManager().getSessionHandlers();
+        log.info("SessionIdManager "+sharedSessionHandler.getSessionIdManager()+" has "+handlers.size()+" handlers, on invalidate "+sessionId);
+        for (SessionHandler sh: handlers) {
+            try {
+                log.info("  "+sh+" "+
+                    (sh.getSessionCache() instanceof DefaultSessionCache ? ((DefaultSessionCache)sh.getSessionCache()).exists(sessionId) 
+                        ? ((DefaultSessionCache)sh.getSessionCache()).doGet(sessionId) : "<ID-not-present>" : ""));
+                Field f = SessionHandler.class.getDeclaredField("_context");
+                f.setAccessible(true);
+                ContextHandler.Context ctx = (Context) f.get(sh);
+                // TODO why do we see multiple handlers with the session?  are they the same?
+                log.info("    path "+ctx.getContextPath()+"  name "+ctx.getServletContextName());
+            } catch (Exception e) {
+                log.warn("Error checking session", e);
+            }
+        }
+        final Session s1 = sharedSessionHandler.getSession(sessionId);
+        if (s1==null) return false;
+        log.info("INVALIDATING "+s1+" - "+s1.isResident()+" "+s1.isValid());
+        
+        new Thread("check session "+sessionId) {
+            public void run() {
+                log.info("RESIDENT "+s1.isResident());
+                Object s = ((DefaultSessionCache)sharedSessionHandler.getSessionCache()).doGet(sessionId);
+                log.info("LOOKUP GAVE "+s+(s!=null ? " RESIDENT "+((Session)s).isResident() + " VALID "+((Session)s).isValid() : ""));
+                Time.sleep(500);
+                s = ((DefaultSessionCache)sharedSessionHandler.getSessionCache()).doGet(sessionId);
+                log.info("LOOKUP 2 GAVE "+s+(s!=null ? " RESIDENT "+((Session)s).isResident() + " VALID "+((Session)s).isValid() : ""));
+                Time.sleep(500);
+                s = ((DefaultSessionCache)sharedSessionHandler.getSessionCache()).doGet(sessionId);
+                log.info("LOOKUP 3A GAVE "+s+(s!=null ? " RESIDENT "+((Session)s).isResident() + " VALID "+((Session)s).isValid() : ""));
+                s = sharedSessionHandler.getSession(sessionId);
+                log.info("LOOKUP 3B GAVE "+s+(s!=null ? " RESIDENT "+((Session)s).isResident() + " VALID "+((Session)s).isValid() : ""));
+            }
+        }.start();
+        
+//        sharedSessionHandler.invalidate(sessionId);
+        
+//        if (session==null) return false;
+//        
+//        try (LogClose lock = new LogClose(session.lock())) {
+//            log.debug("Logout for {}, new thread got locker", session);
+//            session.invalidate();
+//            log.debug("Logout for {}, completed call to invalidate", session);
+//        }
+//
+        return true;
+    }
+    
+    public static class LogClose implements AutoCloseable {
+        AutoCloseable delegate;
+        LogClose(AutoCloseable delegate) {
+            this.delegate = delegate;
+            log.debug("Logout, received " + delegate);
+        }
+        @Override
+        public void close() {
+            try {
+                log.debug("Logout, closing " + delegate);
+                delegate.close();
+                log.debug("Logout, closed " + delegate);
+            } catch (Exception e) {
+                log.debug("Logout, error closing " + delegate, e);
+                throw Exceptions.propagate(e);
+            }
+        }
+    }
+    
     /* check all contexts for sessions; surprisingly hard to configure session management for karaf/pax web container.
      * they _really_ want each servlet to have their own sessions. how you're meant to do oauth for multiple servlets i don't know! */
     public HttpSession getSession(HttpServletRequest webRequest, ManagementContext mgmt, boolean create) throws SecurityProviderDeniedAuthentication {
@@ -106,6 +182,7 @@ public class BrooklynSecurityProviderFilterHelper {
         if (webRequest instanceof Request) {
             if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                 synchronized (BrooklynSecurityProviderFilterHelper.class) {
+                    // TODO should we change the store to use a primary?
                     if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                         SessionHandler candidateSessionHandler = ((Request)webRequest).getSessionHandler();
                         if (candidateSessionHandler!=null && candidateSessionHandler.getSessionPath()==null) {
@@ -148,6 +225,9 @@ public class BrooklynSecurityProviderFilterHelper {
                     if (s==null) {
                         log.debug("Brooklyn user-requested session not found, request "+webRequest+", requested session "+webRequest.getRequestedSessionId()+"; will create if needed");
                     } else if (sharedSessionHandler.isValid(s)) {
+                        // later in the handling the session will be put in the original handler for the bundle;
+                        // not ideal as the Session is tied to the shared handler, and that breaks invalidation,
+                        // but custom invalidation in LogoutResource repairs that
                         ((Request)webRequest).setSession(s);
                     } else {
                         log.info("Brooklyn user-requested session not valid, request "+webRequest+", requested session "+webRequest.getRequestedSessionId()+"; will create if needed");
@@ -160,13 +240,21 @@ public class BrooklynSecurityProviderFilterHelper {
 
         HttpSession s = webRequest.getSession(false);
         if (s!=null) {
-            log.trace("Session found for {} {}: {}", webRequest.getRequestURI(), webRequest.getRequestedSessionId(), s);
+            log.trace("Session found for {} {}: {} ({})", webRequest.getRequestURI(), webRequest.getRequestedSessionId(), s, s.getAttribute(AUTHENTICATED_USER_SESSION_ATTRIBUTE));
+            log.info("Session found for {} {}: {} ({})", webRequest.getRequestURI(), webRequest.getRequestedSessionId(), s, s.getAttribute(AUTHENTICATED_USER_SESSION_ATTRIBUTE));
             return s;
         }
         
         if (create) {
             HttpSession session = webRequest.getSession(true);
+            // note, other processes may create the session, that's fine as it will use the right handler;
+            // typically that's done when a browser is trying to access when not logged in, e.g. to a new server
+            // where the auth doesn't need a session to tell the client he is unauthorized.
+            // this means however that the log messages here might not be complete, someone else might create the session.
+            // (not sure who _is_ creating the session when not logged in, and it would be more efficient not to have a session
+            // for clients who aren't logged in, but it doesn't break things at least!)
             log.trace("Session being created for {} (wanted {}): {}", webRequest.getRequestURI(), webRequest.getRequestedSessionId(), session);
+            log.info("Session being created for {} (wanted {}): {}", webRequest.getRequestURI(), webRequest.getRequestedSessionId(), session);
             return session;
         }
         

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -104,9 +104,9 @@ public class BrooklynSecurityProviderFilterHelper {
             webRequest = (HttpServletRequest) ((ServletRequestWrapper)webRequest).getRequest();
         }
         if (webRequest instanceof Request) {
-            if (sharedSessionHandler==null) {
+            if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                 synchronized (BrooklynSecurityProviderFilterHelper.class) {
-                    if (sharedSessionHandler==null) {
+                    if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                         SessionHandler candidateSessionHandler = ((Request)webRequest).getSessionHandler();
                         if (candidateSessionHandler!=null && candidateSessionHandler.getSessionPath()==null) {
                             try {
@@ -131,7 +131,7 @@ public class BrooklynSecurityProviderFilterHelper {
                             return null;
                         }
                         sharedSessionHandler = candidateSessionHandler;
-                        log.debug("Brooklyn shared session handler installed as "+sharedSessionHandler+" from "+webRequest+" "+webRequest.getRequestURI());
+                        log.debug("Brooklyn shared session handler installed as "+sharedSessionHandler+" ("+sharedSessionHandler.getState()+") from "+webRequest+" "+webRequest.getRequestURI());
                     }
                 }
             }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -91,7 +91,7 @@ public class BrooklynSecurityProviderFilterHelper {
     public static final String BASIC_REALM_HEADER_VALUE = "BASIC realm="+StringEscapes.JavaStringEscapes.wrapJavaString(BASIC_REALM_NAME);
     
     /** The first session handler encountered becomes the shared handler that replaces all others encountered. */
-    private static SessionHandler sharedSessionHandler;
+    private volatile static SessionHandler sharedSessionHandler;
     
     /* check all contexts for sessions; surprisingly hard to configure session management for karaf/pax web container.
      * they _really_ want each servlet to have their own sessions. how you're meant to do oauth for multiple servlets i don't know! */

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -37,6 +36,8 @@ import javax.ws.rs.ext.Provider;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.rest.api.ServerApi;
 import org.apache.brooklyn.rest.domain.ApiError;
+import org.apache.brooklyn.rest.resources.LogoutResource;
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.commons.collections.EnumerationUtils;
@@ -149,8 +150,9 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
         List<String> suppliedTokens = Lists.newArrayList(suppliedTokensDefault);
         suppliedTokens.addAll(suppliedTokensAngular);
 
-        Object requiredToken = request.getSession().getAttribute(CSRF_TOKEN_VALUE_ATTR);
-        CsrfTokenRequiredForRequests whenRequired = (CsrfTokenRequiredForRequests) request.getSession().getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
+        MultiSessionAttributeAdapter session = MultiSessionAttributeAdapter.of(request);
+        Object requiredToken = session.getAttribute(CSRF_TOKEN_VALUE_ATTR);
+        CsrfTokenRequiredForRequests whenRequired = (CsrfTokenRequiredForRequests) session.getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
 
         boolean isRequired;
         
@@ -165,7 +167,7 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
                 whenRequired = DEFAULT_REQUIRED_FOR_REQUESTS;
             }
             // remember it to suppress warnings subsequently
-            request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, whenRequired);
+            session.setAttribute(CSRF_TOKEN_REQUIRED_ATTR, whenRequired);
         }
         
         switch (whenRequired) {
@@ -213,7 +215,8 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        HttpSession session = request.getSession(false);
+        log.debug("CSRF FILTER finishing - "+MultiSessionAttributeAdapter.info(request));
+        MultiSessionAttributeAdapter session = MultiSessionAttributeAdapter.of(request, false);
         String token = (String) (session==null ? null : session.getAttribute(CSRF_TOKEN_VALUE_ATTR));
         String requiredWhenS = request.getHeader(CSRF_TOKEN_REQUIRED_HEADER);
         
@@ -222,14 +225,18 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
                 // no session and no requirement specified, bail out 
                 return;
             }
-            // explicit requirement request forces a session  
-            session = request.getSession();
+            // explicit requirement request forces a session
+            if (Boolean.TRUE.equals(request.getAttribute(LogoutResource.DID_LOGOUT))) {
+                // user has logged out, don't make a session
+                return;
+            }
+            session = MultiSessionAttributeAdapter.of(request, true);
         }
         
         CsrfTokenRequiredForRequests requiredWhen;
         if (Strings.isNonBlank(requiredWhenS)) {
             requiredWhen = getRequiredForRequests(requiredWhenS, DEFAULT_REQUIRED_FOR_REQUESTS);
-            request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
+            session.setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
             if (Strings.isNonBlank(token)) {
                 // already set csrf token, and the client got it
                 // (with the session token if they are in a session;
@@ -243,10 +250,10 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
                 // or if client didn't get it it isn't in a session)
                 return;
             }
-            requiredWhen = (CsrfTokenRequiredForRequests) request.getSession().getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
+            requiredWhen = (CsrfTokenRequiredForRequests) session.getAttribute(CSRF_TOKEN_REQUIRED_ATTR);
             if (requiredWhen==null) {
                 requiredWhen = DEFAULT_REQUIRED_FOR_REQUESTS;
-                request.getSession().setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
+                session.setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
             }
         }
 
@@ -257,7 +264,7 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
 
         // create the token
         token = Identifiers.makeRandomId(16);
-        request.getSession().setAttribute(CSRF_TOKEN_VALUE_ATTR, token);
+        session.setAttribute(CSRF_TOKEN_VALUE_ATTR, token);
         
         addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE, token, "Clients should send this value in header "+CSRF_TOKEN_VALUE_HEADER+" for validation");
         addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE_ANGULAR_NAME, token, "Compatibility cookie for "+CSRF_TOKEN_VALUE_COOKIE+" following AngularJS conventions");

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
@@ -197,11 +197,11 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
         }
 
         if (suppliedTokens.isEmpty()) {
-            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.FORBIDDEN)
                     .message(HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_COOKIE)+" header is required, containing token previously returned from server in cookie")
                     .build());
         } else {
-            fail(requestContext, ApiError.builder().errorCode(Response.Status.UNAUTHORIZED)
+            fail(requestContext, ApiError.builder().errorCode(Response.Status.FORBIDDEN)
                 .message(HEADER_OF_COOKIE(CSRF_TOKEN_VALUE_COOKIE)+" header did not match expected CSRF token")
                 .build());
         }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -23,7 +23,6 @@ import java.security.Principal;
 
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -35,6 +34,7 @@ import javax.ws.rs.ext.Provider;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
 import org.apache.brooklyn.util.text.Strings;
 
 @Provider
@@ -56,7 +56,7 @@ public class EntitlementContextFilter implements ContainerRequestFilter, Contain
 
             // now look in session attribute - because principals hard to set from javax filter
             if (request!=null) {
-                HttpSession s = request.getSession(false);
+                MultiSessionAttributeAdapter s = MultiSessionAttributeAdapter.of(request, false);
                 if (s!=null) {
                     userName = Strings.toString(s.getAttribute(
                             BrooklynSecurityProviderFilterHelper.AUTHENTICATED_USER_SESSION_ATTRIBUTE));

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LogoutResource.java
@@ -95,8 +95,9 @@ public class LogoutResource extends AbstractBrooklynRestResource implements Logo
         if (unauthorize!=null) {
             // returning 401 UNAUTHORIZED has the nice property that it causes browser (mostly)
             // to re-prompt for cached credentials to set in the "Authorization: " header to re-login;
-            // TODO however it's not 100%; 
-            // some repeated requests (eg /server/up/extended) in brooklyn webapp seem to keep that header  
+            // however it's not 100%; e.g. in Chrome if there is an active ajax/$http request that had prompted for
+            // credentials it will keep the Authorization header and log you back in (eg /server/up/extended);
+            // it is a known issue that we cannot absolutely clear creds in most browsers, but returning 401 helps
             return Response.status(Status.UNAUTHORIZED)
                 .entity(body.add("message", unauthorize))
                 .build();
@@ -113,6 +114,7 @@ public class LogoutResource extends AbstractBrooklynRestResource implements Logo
         // if we need to intercept session creation then can use this
         // create TrackingSessionHandler which delegates (no-op if delegate==null esp in setSessionTrackingMode)
         // and log with stack trace in newHttpSession
+        //   can remove this after we've been running happily with new session management model for a while
 //        HttpServletRequest jreq = req;
 //        if (jreq instanceof ThreadLocalHttpServletRequest) jreq = ((ThreadLocalHttpServletRequest)jreq).get();
 //        if (jreq instanceof ServletRequestWrapper) jreq = (HttpServletRequest) ((ServletRequestWrapper)jreq).getRequest();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ScriptResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ScriptResource.java
@@ -18,24 +18,23 @@
  */
 package org.apache.brooklyn.rest.resources;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.rest.api.ScriptApi;
 import org.apache.brooklyn.rest.domain.ScriptExecutionSummary;
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
 import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.apache.brooklyn.util.stream.ThreadLocalPrintStream;
 import org.apache.brooklyn.util.stream.ThreadLocalPrintStream.OutputCapturingContext;
-
-import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 
 public class ScriptResource extends AbstractBrooklynRestResource implements ScriptApi {
 
@@ -59,7 +58,7 @@ public class ScriptResource extends AbstractBrooklynRestResource implements Scri
         Binding binding = new Binding();
         binding.setVariable("mgmt", mgmt());
         
-        HttpSession session = request!=null ? request.getSession() : null;
+        MultiSessionAttributeAdapter session = request==null ? null : MultiSessionAttributeAdapter.of(request);
         if (session!=null) {
             Map data = (Map) session.getAttribute(USER_DATA_MAP_SESSION_ATTRIBUTE);
             if (data==null) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -63,6 +63,7 @@ import org.apache.brooklyn.rest.domain.HighAvailabilitySummary;
 import org.apache.brooklyn.rest.domain.VersionSummary;
 import org.apache.brooklyn.rest.transform.BrooklynFeatureTransformer;
 import org.apache.brooklyn.rest.transform.HighAvailabilityTransformer;
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
 import org.apache.brooklyn.rest.util.WebResourceUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
@@ -378,7 +379,9 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
     
     @Override
     public Map<String,Object> getUpExtended() {
-        request.getSession();
+        // force creation of a session to demonstrate health, help the UI be more efficient
+        MultiSessionAttributeAdapter.of(request);
+        
         return MutableMap.<String,Object>of(
             "up", isUp(),
             "shuttingDown", isShuttingDown(),
@@ -457,7 +460,9 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
 
     @Override
     public String getUser() {
-        request.getSession();
+        // force creation of session to help ui, ensure continuity of user info
+        MultiSessionAttributeAdapter.of(request);
+        
         EntitlementContext entitlementContext = Entitlements.getEntitlementContext();
         if (entitlementContext!=null && entitlementContext.user()!=null){
             return (String) WebResourceUtils.getValueForDisplay(mapper(), entitlementContext.user(), true, true);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/AbstractSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/AbstractSecurityProvider.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.rest.security.provider;
 
 import javax.servlet.http.HttpSession;
 
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
 import org.apache.brooklyn.util.text.Strings;
 
 /**
@@ -31,14 +32,14 @@ public abstract class AbstractSecurityProvider implements SecurityProvider {
     @Override
     public boolean isAuthenticated(HttpSession session) {
         if (session == null) return false;
-        Object value = session.getAttribute(getAuthenticationKey());
+        Object value = MultiSessionAttributeAdapter.of(session).getAttribute(getAuthenticationKey());
         return Strings.isNonBlank(Strings.toString(value));
     }
 
     @Override
     public boolean logout(HttpSession session) {
         if (session == null) return false;
-        session.removeAttribute(getAuthenticationKey());
+        MultiSessionAttributeAdapter.of(session).configureWhetherToSetInAll(true).removeAttribute(getAuthenticationKey());
         return true;
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/AnyoneSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/AnyoneSecurityProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.rest.security.provider;
 
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 /** provider who allows all access with no need to supply a user
@@ -36,7 +39,7 @@ public class AnyoneSecurityProvider implements SecurityProvider {
     }
     
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) {
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
         // doesn't matter as isAuth always returns true, this should never be called
         return true;
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/BlackholeSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/BlackholeSecurityProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.rest.security.provider;
 
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 /** provider who disallows everyone, though it does require a user/pass */
@@ -29,7 +32,7 @@ public class BlackholeSecurityProvider implements SecurityProvider {
     }
 
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) {
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
         return false;
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -180,8 +180,9 @@ public class DelegatingSecurityProvider implements SecurityProvider {
             }
             if (constructor!=null) {
                 delegateO = constructor.newInstance();
+            } else {
+                throw new NoSuchMethodException("Security provider "+clazz+" does not have required no-arg or 1-arg (mgmt) constructor");
             }
-            throw new NoSuchMethodException("Security provider "+clazz+" does not have required no-arg or 1-arg (mgmt) constructor");
         }
         
         if (!(delegateO instanceof SecurityProvider)) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -23,7 +23,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -205,8 +207,8 @@ public class DelegatingSecurityProvider implements SecurityProvider {
     }
 
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) throws SecurityProviderDeniedAuthentication {
-        boolean authenticated = getDelegate().authenticate(session, user, password);
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
+        boolean authenticated = getDelegate().authenticate(request, sessionSupplierOnSuccess, user, pass);
         if (log.isTraceEnabled() && authenticated) {
             log.trace("User {} authenticated with provider {}", user, getDelegate());
         } else if (!authenticated && log.isDebugEnabled()) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
@@ -21,16 +21,18 @@ package org.apache.brooklyn.rest.security.provider;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.function.Supplier;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.rest.security.PasswordHasher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Security provider which validates users against passwords according to property keys,
@@ -71,8 +73,8 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
     }
     
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) {
-        if (session==null || user==null) return false;
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
+        if (user==null) return false;
         if (!allowAnyUserWithValidPass) {
             if (!allowedUsers.contains(user)) {
                 LOG.debug("REST rejecting unknown user "+user);
@@ -80,8 +82,8 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
             }
         }
 
-        if (checkExplicitUserPassword(mgmt, user, password)) {
-            return allow(session, user);
+        if (checkExplicitUserPassword(mgmt, user, pass)) {
+            return allow(sessionSupplierOnSuccess.get(), user);
         }
         return false;
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
@@ -73,7 +73,6 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
     @Override
     public boolean authenticate(HttpSession session, String user, String password) {
         if (session==null || user==null) return false;
-        
         if (!allowAnyUserWithValidPass) {
             if (!allowedUsers.contains(user)) {
                 LOG.debug("REST rejecting unknown user "+user);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/SecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/SecurityProvider.java
@@ -18,8 +18,10 @@
  */
 package org.apache.brooklyn.rest.security.provider;
 
-import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
 import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 
@@ -32,21 +34,47 @@ import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
  */
 public interface SecurityProvider {
 
+    /** If user supplied a value session, this passes that in so the {@link SecurityProvider}
+     * can check whether the user has previously authenticated, e.g. via an {@link HttpSession#setAttribute(String, Object)}
+     * done by {@link #authenticate(HttpServletRequest, Supplier, String, String)}.
+     * <p>
+     * Note that this will be the {@link MultiSessionAttributeAdapter#getPreferredSession()}.
+     * <p>
+     * If the user didn't request a session or they requested a session which is not known here,
+     * the argument will be null.
+     */
     public boolean isAuthenticated(@Nullable HttpSession session);
+    
     /** whether this provider requires a user/pass; if this returns false, the framework can
      * send null/null as the user/pass to {@link #authenticate(HttpSession, String, String)},
      * and should do that if user/pass info is not immediately available
      * (ie for things like oauth, the framework should not require basic auth if this method returns false)
      */
     public boolean requiresUserPass();
+    
     /** Perform the authentication. If {@link #requiresUserPass()} returns false, user/pass may be null;
      * otherwise the framework will guarantee the basic auth is in effect and these values are set.
      * The provider should not send a response but should throw {@link SecurityProviderDeniedAuthentication}
      * if a custom response is required. It can include a response in that exception,
-     * e.g. to provide more information or supply a redirect. */
-    public boolean authenticate(@Nonnull HttpSession session, String user, String pass) throws SecurityProviderDeniedAuthentication;
-    /** Will get invoked on explicit REST API callback. Callers should pass the preferred session 
-     * if using {@link MultiSessionAttributeAdapter}. Code can assume this is the preferred shared session. */
+     * e.g. to provide more information or supply a redirect. 
+     * <p>
+     * It should not create a session via {@link HttpServletRequest#getSession()}, especially if
+     * auth is not successful (easy for DOS attack to chew up memory), and even on auth it should use
+     * the {@link Supplier} given here to get a session (that will create a session) to install.
+     * (Note that this will return the {@link MultiSessionAttributeAdapter#getPreferredSession()},
+     * not the request's local session.)
+     * <p>
+     * On successful auth this method may {@link HttpSession#setAttribute(String, Object)} so that
+     * {@link #isAuthenticated(HttpSession)} can return quickly on subsequent requests.
+     * If so, see {@link #logout(HttpSession)} about clearing those values. */
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication;
+    
+    /** Will get invoked on explicit REST API callback. 
+     * The preferred session according to {@link MultiSessionAttributeAdapter} will be passed,
+     * just as for other methods here.
+     * <p>
+     * Implementations here may remove any provider-specific attributes which cache authentication
+     * (although the session will be invalidated so that may be overkill). */
     public boolean logout(HttpSession session);
     
     public static class SecurityProviderDeniedAuthentication extends Exception {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/SecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/SecurityProvider.java
@@ -23,6 +23,8 @@ import javax.annotation.Nullable;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
+
 /**
  * The SecurityProvider is responsible for doing authentication.
  *
@@ -43,6 +45,8 @@ public interface SecurityProvider {
      * if a custom response is required. It can include a response in that exception,
      * e.g. to provide more information or supply a redirect. */
     public boolean authenticate(@Nonnull HttpSession session, String user, String pass) throws SecurityProviderDeniedAuthentication;
+    /** Will get invoked on explicit REST API callback. Callers should pass the preferred session 
+     * if using {@link MultiSessionAttributeAdapter}. Code can assume this is the preferred shared session. */
     public boolean logout(HttpSession session);
     
     public static class SecurityProviderDeniedAuthentication extends Exception {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
@@ -1,0 +1,485 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.util;
+
+import java.lang.reflect.Field;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.session.Session;
+import org.eclipse.jetty.server.session.SessionHandler;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Convenience to assist working with multiple sessions, ensuring requests in different bundles can
+ * get a consistent shared view of data.
+ * <p>
+ * Any processing that wants to {@link #getAttribute(String)}, {@link #setAttribute(String, Object)} or {@link #removeAttribute(String)}
+ * in a way that all Brooklyn bundles will see (e.g. authentication, etc) should use the methods in this class,
+ * as opposed to calling {@link HttpServletRequest#getSession()} then {@link HttpSession#getAttribute(String)}.
+ * <p>
+ * This class will follow heuristics to find a preferred shared session.  The heuristics are as follows:
+ * <ul>
+ * <li>We look at the {@link Server} for a {@link #KEY_PREFERRED_SESSION_HANDLER_INSTANCE}, and
+ *     if it has a session with {@link #KEY_IS_PREFERRED}, we use it
+ * <li>We look in all session handlers for a session marked as {@link #KEY_IS_PREFERRED}
+ * <li>If there is a {@link #KEY_PREFERRED_SESSION_HANDLER_INSTANCE} at the server,
+ *     we create a session there (if needed, and if we can, ie we have the request)
+ *     and mark it (or one already existing there) as {@link #KEY_IS_PREFERRED}
+ * <li>If there is no {@link #KEY_PREFERRED_SESSION_HANDLER_INSTANCE} at the server,
+ *     we go through all bundles looking for the CXF one and we store that against the {@link Server}
+ *     (this should only happen once, will log warnings if not found)
+ * <li>Finally we mark the originating session as the {@link #KEY_IS_PREFERRED} so that it
+ *     is used in preference to others, including ones at the {@link #KEY_PREFERRED_SESSION_HANDLER_INSTANCE},
+ *     if we were invoked in a way where we couldn't find such a handler (ie no such bundle) and we couldn't create one there
+ * </ul>
+ * This class may have the occasional quirk if run in parallel but we can live with that,
+ * and the danger I think is confined to inconsistent sessions.
+ * It logs in that case and other fringe cases.
+ * <p>
+ * In future we may wish to make this more configurable, so bundles can specify a priority
+ * or a configuration property could specify the preferred bundles and/or context paths.
+ * But for now hard-coding CXF is fine.
+ * <p>
+ * Obviously code that bypasses this and uses the {@link HttpServletRequest#getSession()}
+ * will only read/write things in their session, and it won't be visible to requests from other bundles.
+ * <p>
+ * Previously we tried sharing sessions across bundles; you'll see in git history the code for that;
+ * however it was messy, and ended up being dodgy when we invalidate, and likely very dodgy if the
+ * system auto-invalidates (e.g. time- or memory-based expiry), as code there is quite fragile assuming
+ * sessions are one-to-one tied to their handlers.
+ */
+public class MultiSessionAttributeAdapter {
+
+    // TODO restructure
+    
+    private static final Logger log = LoggerFactory.getLogger(MultiSessionAttributeAdapter.class);
+    
+    private static final String KEY_PREFERRED_SESSION_HANDLER_INSTANCE = "org.apache.brooklyn.server.PreferredSessionHandlerInstance";
+//    private static final String KEY_PREFERRED_SESSION_HANDLER_PATH = "org.apache.brooklyn.server.PreferredSessionHandlerPath";
+    private static final String KEY_IS_PREFERRED = "org.apache.brooklyn.server.IsPreferred";
+
+    private static final Object PREFERRED_SYMBOLIC_NAME = 
+        "org.apache.cxf.cxf-rt-transports-http";
+        //// our bundle here doesn't have a session handler; sessions to the REST API get the handler from CXF
+        //"org.apache.brooklyn.rest.rest-resources";
+    
+    private final HttpSession preferredSession;
+    private final HttpSession localSession;
+
+    private boolean silentlyAcceptLocalOnlyValues = false;
+    private boolean setLocalValuesAlso = false;
+    private boolean setAllKnownSessions = false;
+    
+    private static final Factory FACTORY = new Factory();
+
+    protected MultiSessionAttributeAdapter(HttpSession preferredSession, HttpSession localSession) {
+        this.preferredSession = preferredSession;
+        this.localSession = localSession;
+    }
+    
+    public static MultiSessionAttributeAdapter of(HttpServletRequest r) {
+        return of(r, true);
+    }
+    /** May return null iff create is false */
+    public static MultiSessionAttributeAdapter of(HttpServletRequest r, boolean create) {
+        HttpSession session = r.getSession(create);
+        if (session==null) return null;
+        return new MultiSessionAttributeAdapter(FACTORY.findPreferredSession(r), session);
+    }
+    
+    /** Where the request isn't available, and the preferred session is expected to exist.
+     * Note we cannot create a new session at the preferred handler without a request. */
+    public static MultiSessionAttributeAdapter of(HttpSession session) {
+        return new MultiSessionAttributeAdapter(FACTORY.findPreferredSession(session, null), session);
+    }
+
+    
+    protected static class Factory {
+        
+        private HttpSession findPreferredSession(HttpServletRequest r) {
+            if (r.getSession(false)==null) {
+                log.warn("Creating session", new Exception("source of created session"));
+                r.getSession();
+            }
+            return findPreferredSession(r.getSession(), r);
+        }
+        
+        private HttpSession findPreferredSession(HttpSession localSession, HttpServletRequest optionalRequest) {
+            if (localSession instanceof Session) {
+                SessionHandler preferredHandler = getPreferredJettyHandler((Session)localSession, true, true);
+                HttpSession preferredSession = preferredHandler==null ? null : preferredHandler.getHttpSession(localSession.getId());
+                if (log.isTraceEnabled()) {
+                    log.trace("Preferred session for "+info(optionalRequest, localSession)+": "+
+                        (preferredSession!=null ? info(preferredSession) : "none, willl make new session in "+info(preferredHandler)));
+                }
+                // TODO delete
+                log.info("Looking up preferred session for "+info(optionalRequest, localSession)+"; found "+
+                    (preferredSession!=null ? info(preferredSession) : "none, willl make new session in "+info(preferredHandler)));
+                if (preferredSession!=null) {
+                    return preferredSession;
+                }
+                if (preferredHandler!=null) {
+                    if (optionalRequest!=null) { 
+                        HttpSession result = preferredHandler.newHttpSession(optionalRequest);
+                        if (log.isTraceEnabled()) {
+                            log.trace("Creating new session "+info(result)+" to be preferred for " + info(optionalRequest, localSession));
+                        }
+                        // TODO trace
+                        log.info("Creating new session "+info(result)+" to be preferred for " + info(optionalRequest, localSession));
+                        return result;
+                    }
+                    // the server has a preferred handler, but no session yet; fall back to marking on the session 
+                    log.warn("No request so cannot create preferred session at preferred handler "+info(preferredHandler)+" for "+info(optionalRequest, localSession)+"; will exceptionally mark the calling session as the preferred one");
+                    markSessionAsPreferred(localSession, " (request came in for "+info(optionalRequest, localSession)+")");
+                    return localSession;
+                } else {
+                    // shouldn't come here; at minimum it should have returned the local session's handler
+                    log.warn("Unexpected failure to find a handler for "+info(optionalRequest, localSession));
+                }
+            } else {
+                log.warn("Unsupported session impl in "+info(optionalRequest, localSession));
+            }
+            return localSession;
+        }
+        
+        private SessionHandler getPreferredJettyHandler(Session localSession, boolean allowHandlerThatDoesntHaveSession, boolean markAndReturnThisIfNoneFound) {
+            SessionHandler localHandler = ((Session)localSession).getSessionHandler();
+            Server server = localHandler.getServer();
+            // NB: this can also be useful: ((DefaultSessionIdManager)localHandler.getSessionIdManager())
+    
+            if (server!=null) {
+                Session sessionAtServerGlobalPreferredHandler = null;
+                
+                // does the server have a globally preferred handler
+                SessionHandler preferredServerGlobalSessionHandler = getServerGlobalPreferredHandler(server);
+                if (preferredServerGlobalSessionHandler!=null) {
+                    sessionAtServerGlobalPreferredHandler = preferredServerGlobalSessionHandler.getSession(localSession.getId());
+                    if (sessionAtServerGlobalPreferredHandler!=null && Boolean.TRUE.equals( sessionAtServerGlobalPreferredHandler.getAttribute(KEY_IS_PREFERRED)) ) {
+                        return preferredServerGlobalSessionHandler;
+                    }
+                }
+                
+                Handler[] handlers = server.getChildHandlersByClass(SessionHandler.class);
+                
+                // if there is a session marked, use it, unless the server has a preferred session handler and it has an equivalent session
+                // this way if a session is marked (from use in a context where we don't have a web request) it will be used
+                SessionHandler preferredHandlerForMarkedSession = findPeerSessionMarkedPreferred(localSession.getId(), handlers);
+                if (preferredHandlerForMarkedSession!=null) return preferredHandlerForMarkedSession;
+                
+                // nothing marked as preferred; if server global handler has a session, mark it as preferred
+                // this way it will get found quickly on subsequent requests
+                if (sessionAtServerGlobalPreferredHandler!=null) {
+                    sessionAtServerGlobalPreferredHandler.setAttribute(KEY_IS_PREFERRED, true);
+                    return preferredServerGlobalSessionHandler; 
+                }
+                
+                if (allowHandlerThatDoesntHaveSession && preferredServerGlobalSessionHandler!=null) {
+                    return preferredServerGlobalSessionHandler;
+                }
+                if (preferredServerGlobalSessionHandler==null) {
+                    preferredServerGlobalSessionHandler = findPreferredBundleHandler(localSession, server, handlers);
+                    if (preferredServerGlobalSessionHandler!=null) {
+                        // recurse
+                        return getPreferredJettyHandler(localSession, allowHandlerThatDoesntHaveSession, markAndReturnThisIfNoneFound);
+                    }
+                }
+    
+                if (markAndReturnThisIfNoneFound) {
+                    // nothing detected as preferred ... let's mark this session as the preferred one
+                    markSessionAsPreferred(localSession, " (this is the handler that the request came in on)");
+                    return localHandler;               
+                }
+                
+            } else {
+                log.warn("Could not find server for "+info(localSession));
+            }
+            return null;
+        }
+    
+        protected void markSessionAsPreferred(HttpSession localSession, String msg) {
+            if (log.isTraceEnabled()) {
+                log.trace("Recording on "+info(localSession)+" that it is the preferred session"+msg);
+            }
+            localSession.setAttribute(KEY_IS_PREFERRED, true);
+        }
+    
+        protected SessionHandler findPreferredBundleHandler(Session localSession, Server server, Handler[] handlers) {
+            if (PREFERRED_SYMBOLIC_NAME==null) return null;
+            
+            SessionHandler preferredHandler = null;
+            
+            if (handlers != null) {
+                for (Handler handler: handlers) {
+                    SessionHandler sh = (SessionHandler) handler;
+                    ContextHandler.Context ctx = getContext(sh);
+                    if (ctx!=null) {
+                        BundleContext bundle = (BundleContext) ctx.getAttribute("osgi-bundlecontext");
+                        if (bundle!=null) {
+                            if (PREFERRED_SYMBOLIC_NAME.equals(bundle.getBundle().getSymbolicName())) {
+                                if (preferredHandler==null) {
+                                    preferredHandler = sh;
+                                    server.setAttribute(KEY_PREFERRED_SESSION_HANDLER_INSTANCE, sh);
+                                    log.debug("Recording "+info(sh)+" as server-wide preferred session handler");
+                                } else {
+                                    log.warn("Multiple preferred session handlers detected; keeping "+info(preferredHandler)+", ignoring "+info(sh));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (preferredHandler==null) {
+                log.warn("Did not find handler in bundle "+PREFERRED_SYMBOLIC_NAME+"; not using server-wide handler; check whether bundle is installed!");
+            }
+            return preferredHandler;
+        }
+    
+        protected SessionHandler findPeerSessionMarkedPreferred(String localSessionId, Handler[] handlers) {
+            SessionHandler preferredHandler = null;
+            // are any sessions themselves marked as primary
+            if (handlers != null) {
+                for (Handler h: handlers) {
+                    SessionHandler sh = (SessionHandler)h;
+                    Session sessionHere = sh.getSession(localSessionId);
+                    if (sessionHere!=null) {
+                        if (Boolean.TRUE.equals(sessionHere.getAttribute(KEY_IS_PREFERRED))) {
+                            if (preferredHandler!=null) {
+                                // could occasionally happen on race, but should be extremely unlikely
+                                log.warn("Multiple sessions marked as preferred for "+localSessionId+"; using "+info(preferredHandler)+" not "+info(sh));
+                                sessionHere.setAttribute(KEY_IS_PREFERRED, null);
+                            } else {
+                                preferredHandler = sh;
+                            }
+                        }
+                    }
+                }
+            }
+            return preferredHandler;
+        }
+    
+        protected SessionHandler getServerGlobalPreferredHandler(Server server) {
+            SessionHandler preferredHandler = (SessionHandler) server.getAttribute(KEY_PREFERRED_SESSION_HANDLER_INSTANCE);
+            if (preferredHandler!=null) {
+                if (preferredHandler.isRunning()) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("Found "+info(preferredHandler)+" as server-wide preferred handler");
+                    }
+                    return preferredHandler;
+                }
+                log.warn("Preferred session handler "+info(preferredHandler)+" detected on server is not running; resetting");
+            }
+            return null;
+        }
+    }
+
+    private static String getContextPath(Handler h) {
+        if (h instanceof SessionHandler) {
+            ContextHandler.Context ctx = getContext((SessionHandler)h);
+            if (ctx!=null) {
+                return ctx.getContextPath();
+            }
+        }
+        return null;
+    }
+
+    private static String getBundle(Handler h) {
+        if (h instanceof SessionHandler) {
+            ContextHandler.Context ctx = getContext((SessionHandler)h);
+            if (ctx!=null) {
+                BundleContext bundle = (BundleContext) ctx.getAttribute("osgi-bundlecontext");
+                if (bundle!=null) return bundle.getBundle().getSymbolicName();
+            }
+        }
+        return null;
+    }
+
+    private static String getContextPath(HttpSession h) {
+        if (h instanceof Session) {
+            return getContextPath( ((Session)h).getSessionHandler() );
+        }
+        return null;
+    }
+
+    private static String getBundle(HttpSession h) {
+        if (h instanceof Session) {
+            ContextHandler.Context ctx = getContext(((Session)h).getSessionHandler());
+            if (ctx!=null) {
+                BundleContext bundle = (BundleContext) ctx.getAttribute("osgi-bundlecontext");
+                if (bundle!=null) return bundle.getBundle().getSymbolicName();
+            }
+        }
+        return null;
+    }
+
+    protected static ContextHandler.Context getContext(SessionHandler sh) {
+        try {
+            Field f = SessionHandler.class.getDeclaredField("_context");
+            f.setAccessible(true);
+            return (ContextHandler.Context) f.get(sh);
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            // else ignore, security doesn't allow finding context
+            return null;
+        }
+    }
+    
+    private static String info(HttpServletRequest req, HttpSession sess) {
+        if (req!=null) return info(req);
+        return info(sess);
+    }
+
+    public static String info(HttpServletRequest r) {
+        if (r==null) return "null";
+        return ""+r+"["+r.getRequestURI()+"@"+info(r.getSession(false))+"]";
+    }
+
+    public static String info(SessionHandler h) {
+        if (h==null) return "null";
+        return ""+h+"["+(Strings.isBlank(getContextPath(h)) ? getBundle(h) : getContextPath(h))+"]";
+    }
+
+    public static String info(HttpSession s) {
+        if (s==null) return "null";
+        String hh = getContextPath(s);
+        if (Strings.isBlank(hh)) hh = getBundle(s);
+        if (Strings.isBlank(hh)) {
+            hh = s instanceof Session ? info( ((Session)s).getSessionHandler() ) : "<non-jetty>";
+        }
+        return ""+s+"["+s.getId()+" @ "+hh+"]";
+    }
+
+
+    public MultiSessionAttributeAdapter configureWhetherToSilentlyAcceptLocalOnlyValues(boolean silentlyAcceptLocalOnlyValues) {
+        this.silentlyAcceptLocalOnlyValues = silentlyAcceptLocalOnlyValues;
+        return this;
+    }
+    public MultiSessionAttributeAdapter configureWhetherToSetLocalValuesAlso(boolean setLocalValuesAlso) {
+        this.setLocalValuesAlso = setLocalValuesAlso;
+        return this;
+    }
+    public MultiSessionAttributeAdapter configureWhetherToSetInAll(boolean setAllKnownSessions) {
+        this.setAllKnownSessions = setAllKnownSessions;
+        return this;
+    }
+    
+    
+    public Object getAttribute(String name) {
+        Object v = preferredSession.getAttribute(name);
+        if (v==null) {
+            v = localSession.getAttribute(name);
+            if (v!=null && !silentlyAcceptLocalOnlyValues) {
+                log.warn(this+" found value for '"+name+"' in local session but not in preferred session; ensure value is written using this class if it is going to be read with this class");
+                preferredSession.setAttribute(name, v);
+            }
+        }
+        return v;
+    }
+
+    public void setAttribute(String name, Object value) {
+        if (setAllKnownSessions) {
+            Handler[] hh = getSessionHandlers();
+            if (hh!=null) {
+                for (Handler h: hh) {
+                    Session ss = ((SessionHandler)h).getSession(localSession.getId());
+                    if (ss!=null) {
+                        ss.setAttribute(name, value);
+                    }
+                    return;
+                }
+            } else {
+                if (!setLocalValuesAlso) {
+                    // can't do all, but at least to local
+                    configureWhetherToSetLocalValuesAlso(true);
+                }
+            }
+        }
+        preferredSession.setAttribute(name, value);
+        if (setLocalValuesAlso) {
+            localSession.setAttribute(name, value);
+        }
+    }
+    
+    public void removeAttribute(String name) {
+        if (setAllKnownSessions) {
+            Handler[] hh = getSessionHandlers();
+            if (hh!=null) {
+                for (Handler h: hh) {
+                    Session ss = ((SessionHandler)h).getSession(localSession.getId());
+                    if (ss!=null) {
+                        ss.removeAttribute(name);
+                    }
+                    return;
+                }
+            } else {
+                if (!setLocalValuesAlso) {
+                    // can't do all, but at least to local
+                    configureWhetherToSetLocalValuesAlso(true);
+                }
+            }
+        }
+        preferredSession.removeAttribute(name);
+        if (setLocalValuesAlso) {
+            localSession.removeAttribute(name);
+        }
+    }
+
+    protected Handler[] getSessionHandlers() {
+        Server srv = getServer();
+        Handler[] handlers = null;
+        if (srv!=null) {
+            handlers = srv.getChildHandlersByClass(SessionHandler.class);
+        }
+        return handlers;
+    }
+
+    protected Server getServer() {
+        Server server = null;
+        if (localSession instanceof Session) {
+            server = ((Session)localSession).getSessionHandler().getServer();
+            if (server!=null) return server;
+        }
+        if (preferredSession instanceof Session) {
+            server = ((Session)preferredSession).getSessionHandler().getServer();
+            if (server!=null) return server;
+        }
+        return null;
+    }
+
+    public HttpSession getPreferredSession() {
+        return preferredSession;
+    }
+
+    public HttpSession getOriginalSession() {
+        return localSession;
+    }
+
+    public String getId() {
+        return getPreferredSession().getId();
+    }
+
+}

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
@@ -75,12 +75,9 @@ import org.slf4j.LoggerFactory;
  */
 public class MultiSessionAttributeAdapter {
 
-    // TODO restructure
-    
     private static final Logger log = LoggerFactory.getLogger(MultiSessionAttributeAdapter.class);
     
     private static final String KEY_PREFERRED_SESSION_HANDLER_INSTANCE = "org.apache.brooklyn.server.PreferredSessionHandlerInstance";
-//    private static final String KEY_PREFERRED_SESSION_HANDLER_PATH = "org.apache.brooklyn.server.PreferredSessionHandlerPath";
     private static final String KEY_IS_PREFERRED = "org.apache.brooklyn.server.IsPreferred";
 
     private static final Object PREFERRED_SYMBOLIC_NAME = 
@@ -137,9 +134,6 @@ public class MultiSessionAttributeAdapter {
                     log.trace("Preferred session for "+info(optionalRequest, localSession)+": "+
                         (preferredSession!=null ? info(preferredSession) : "none, willl make new session in "+info(preferredHandler)));
                 }
-                // TODO delete
-                log.info("Looking up preferred session for "+info(optionalRequest, localSession)+"; found "+
-                    (preferredSession!=null ? info(preferredSession) : "none, willl make new session in "+info(preferredHandler)));
                 if (preferredSession!=null) {
                     return preferredSession;
                 }
@@ -149,8 +143,6 @@ public class MultiSessionAttributeAdapter {
                         if (log.isTraceEnabled()) {
                             log.trace("Creating new session "+info(result)+" to be preferred for " + info(optionalRequest, localSession));
                         }
-                        // TODO trace
-                        log.info("Creating new session "+info(result)+" to be preferred for " + info(optionalRequest, localSession));
                         return result;
                     }
                     // the server has a preferred handler, but no session yet; fall back to marking on the session 

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -19,12 +19,9 @@ limitations under the License.
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.2.0"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns:cxf="http://cxf.apache.org/blueprint/core"
-           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-
              http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
-             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
-             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0">
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd">
 
     <cxf:bus>
         <cxf:features>
@@ -134,4 +131,5 @@ limitations under the License.
     <bean class="org.apache.brooklyn.rest.util.ScannerInjectHelper">
         <property name="server" ref="brooklynRestApiV1"/>
     </bean>
+    
 </blueprint>

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/CsrfTokenFilterLauncherTest.java
@@ -80,7 +80,7 @@ public class CsrfTokenFilterLauncherTest extends BrooklynRestApiLauncherTestFixt
             ImmutableMap.<String,String>of(
                 HttpHeaders.CONTENT_TYPE, "application/text" ),
             "return 0;".getBytes());
-        assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED);
+        assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN);
 
         // can get without token
         response = HttpTool.httpGet(
@@ -98,7 +98,7 @@ public class CsrfTokenFilterLauncherTest extends BrooklynRestApiLauncherTestFixt
         response = HttpTool.httpGet(
             client, URI.create(getBaseUriRest() + "server/ha/state"),
             ImmutableMap.<String,String>of());
-        assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED);
+        assertEquals(response.getResponseCode(), HttpStatus.SC_FORBIDDEN);
         
         // however note if we use a new client, with no session, then we can post with no token
         // (ie we don't guard against CSRF if your brooklyn is unsecured)

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/AuthenticateAnyoneSecurityProvider.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/entitlement/AuthenticateAnyoneSecurityProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.rest.entitlement;
 
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.apache.brooklyn.rest.security.provider.AnyoneSecurityProvider;
@@ -33,7 +36,7 @@ public class AuthenticateAnyoneSecurityProvider implements SecurityProvider {
     }
 
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) {
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
         return user != null;
     }
 

--- a/rest/rest-server/src/test/java/org/apache/brooklyn/rest/security/provider/TestSecurityProvider.java
+++ b/rest/rest-server/src/test/java/org/apache/brooklyn/rest/security/provider/TestSecurityProvider.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.rest.security.provider;
 
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -35,8 +38,8 @@ public class TestSecurityProvider implements SecurityProvider {
     }
 
     @Override
-    public boolean authenticate(HttpSession session, String user, String password) {
-        return USER.equals(user) && PASSWORD.equals(password);
+    public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
+        return USER.equals(user) && PASSWORD.equals(pass);
     }
 
     @Override


### PR DESCRIPTION
### have a shared session available for the various bundles 

mainly to know if each other have authorized.  see https://github.com/apache/brooklyn-server/pull/1032/commits/1a15c36ad9a5caa76bab2e140c89cc4770fa0abb for the main new code, in `MultiSessionAttributeAdapter`.
note this has some historic aborted stuff, in case we need to revisit.  that can be ignored, best to evaluate this _not_ commit-by-commit!

also...

### this makes /logout just log out and simplifies it

previously it redirected to the user-specific logout; but some clients didn't respect that, and assumed the logout had happened.
not convinced there is a good reason for /logout/{user} ... and if there is, you can now use /logout/redirect to get to it.

### calls SecurityProvider.logout and correctly invalildates everything on logout

previously that was neglected

### CSRF fail returns `403 FORBIDDEN` not `401 UNAUTHORIZED`

it's more accurate, and allows clients to distinguish problems from auth fails
