### PR TITLE
Share sessions among all bundles so we can share auth

### DIFF
--- a/karaf/jetty-config/src/main/resources/jetty.xml
+++ b/karaf/jetty-config/src/main/resources/jetty.xml
@@ -20,47 +20,4 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">karaf</Set>
-                <Set name="loginModuleName">karaf</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
-                    </Array>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">default</Set>
-                <Set name="loginModuleName">karaf</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.karaf.jaas.boot.principal.RolePrincipal</Item>
-                    </Array>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-    <Call name="addBean">
-        <Arg>
-            <New class="org.eclipse.jetty.jaas.JAASLoginService">
-                <Set name="name">webconsole</Set>
-                <Set name="loginModuleName">webconsole</Set>
-                <Set name="roleClassNames">
-                    <Array type="java.lang.String">
-                        <Item>org.apache.brooklyn.rest.security.jaas.BrooklynLoginModule$RolePrincipal</Item>
-                    </Array>
-                </Set>
-                <Set name="identityService">
-                    <New class="org.eclipse.jetty.security.DefaultIdentityService"/>
-                </Set>
-            </New>
-        </Arg>
-    </Call>
-
 </Configure>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -553,6 +553,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http-jetty</artifactId>
                 <version>${cxf.version}</version>
             </dependency>

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -117,11 +117,6 @@
             <artifactId>cxf-rt-rs-security-cors</artifactId>
             <version>${cxf.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-            <version>${cxf.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.brooklyn</groupId>
@@ -220,10 +215,9 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.karaf.jaas.config,
-                            org.eclipse.jetty.jaas,
                             *
                         </Import-Package>
+                        <Export-Package>org.apache.brooklyn.*</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -104,9 +104,9 @@ public class BrooklynSecurityProviderFilterHelper {
             webRequest = (HttpServletRequest) ((ServletRequestWrapper)webRequest).getRequest();
         }
         if (webRequest instanceof Request) {
-            if (sharedSessionHandler==null) {
+            if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                 synchronized (BrooklynSecurityProviderFilterHelper.class) {
-                    if (sharedSessionHandler==null) {
+                    if (sharedSessionHandler==null || !sharedSessionHandler.isRunning()) {
                         SessionHandler candidateSessionHandler = ((Request)webRequest).getSessionHandler();
                         if (candidateSessionHandler!=null && candidateSessionHandler.getSessionPath()==null) {
                             try {
@@ -131,7 +131,7 @@ public class BrooklynSecurityProviderFilterHelper {
                             return null;
                         }
                         sharedSessionHandler = candidateSessionHandler;
-                        log.debug("Brooklyn shared session handler installed as "+sharedSessionHandler+" from "+webRequest+" "+webRequest.getRequestURI());
+                        log.debug("Brooklyn shared session handler installed as "+sharedSessionHandler+" ("+sharedSessionHandler.getState()+") from "+webRequest+" "+webRequest.getRequestURI());
                     }
                 }
             }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -91,7 +91,7 @@ public class BrooklynSecurityProviderFilterHelper {
     public static final String BASIC_REALM_HEADER_VALUE = "BASIC realm="+StringEscapes.JavaStringEscapes.wrapJavaString(BASIC_REALM_NAME);
     
     /** The first session handler encountered becomes the shared handler that replaces all others encountered. */
-    private static SessionHandler sharedSessionHandler;
+    private volatile static SessionHandler sharedSessionHandler;
     
     /* check all contexts for sessions; surprisingly hard to configure session management for karaf/pax web container.
      * they _really_ want each servlet to have their own sessions. how you're meant to do oauth for multiple servlets i don't know! */

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -180,8 +180,9 @@ public class DelegatingSecurityProvider implements SecurityProvider {
             }
             if (constructor!=null) {
                 delegateO = constructor.newInstance();
+            } else {
+                throw new NoSuchMethodException("Security provider "+clazz+" does not have required no-arg or 1-arg (mgmt) constructor");
             }
-            throw new NoSuchMethodException("Security provider "+clazz+" does not have required no-arg or 1-arg (mgmt) constructor");
         }
         
         if (!(delegateO instanceof SecurityProvider)) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/ExplicitUsersSecurityProvider.java
@@ -73,7 +73,6 @@ public class ExplicitUsersSecurityProvider extends AbstractSecurityProvider impl
     @Override
     public boolean authenticate(HttpSession session, String user, String password) {
         if (session==null || user==null) return false;
-        
         if (!allowAnyUserWithValidPass) {
             if (!allowedUsers.contains(user)) {
                 LOG.debug("REST rejecting unknown user "+user);

--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -19,12 +19,9 @@ limitations under the License.
            xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.2.0"
            xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs"
            xmlns:cxf="http://cxf.apache.org/blueprint/core"
-           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-
              http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
-             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
-             http://karaf.apache.org/xmlns/jaas/v1.0.0 http://karaf.apache.org/xmlns/jaas/v1.0.0">
+             http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd">
 
     <cxf:bus>
         <cxf:features>
@@ -134,4 +131,5 @@ limitations under the License.
     <bean class="org.apache.brooklyn.rest.util.ScannerInjectHelper">
         <property name="server" ref="brooklynRestApiV1"/>
     </bean>
+    
 </blueprint>


### PR DESCRIPTION
this takes the first encountered session handler and caches it,
also setting the sessonPath on the cookies so cookies are valid for all bundles.

some low-level hacking to work around pain that CXF doesn't let you configure session handling;
if there is a nicer way i'd love to see it, but i think it would require rewriting chunks of CXF