### PR TITLE
Fix dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,16 +116,16 @@
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.9.6</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.9.7</fasterxml.jackson.version> <!-- To match cxf-jackson (from cxf-jaxrs) -->
         <cxf.version>3.2.7</cxf.version>
-        <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
-        <httpcomponents.httpcore.version>4.4.4</httpcomponents.httpcore.version>
+        <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
+        <httpcomponents.httpcore.version>4.4.9</httpcomponents.httpcore.version> <!-- To match cxf-http-async -->
         <!-- @deprecated since 0.11 -->
-        <httpclient.version>4.5.2</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
+        <httpclient.version>4.5.6</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.4.15</groovy.version> <!-- Version 2.4.7 supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes; not sure what more recent will be -->
         <jsr305.version>2.0.1</jsr305.version>
-        <snakeyaml.version>1.22</snakeyaml.version>
+        <snakeyaml.version>1.23</snakeyaml.version> <!-- To match cxf-jackson -->
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.5.6</swagger.version>
         <gson.version>2.5</gson.version>
@@ -170,7 +170,7 @@
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>
         <clj-time.version>0.4.1</clj-time.version>
-        <commons-codec.version>1.9</commons-codec.version>
+        <commons-codec.version>1.10</commons-codec.version>
         <log4j.version>1.2.17</log4j.version>
         <commons-logging.version>1.2</commons-logging.version>
         <jsonSmart.version>2.3</jsonSmart.version>
@@ -220,7 +220,7 @@
 
         <jaxb.version>2.2.11</jaxb.version>
         <javax.activation.version>1.1.1</javax.activation.version>
-        <pax-web.version>7.2.3</pax-web.version><!-- match version from karaf 4.2.1 -->
+        <pax-web.version>7.2.5</pax-web.version><!-- match version from karaf 4.2.2 (from pax-web-core, from pax-http-jetty, from pax-http) -->
         <geronimo-ws-metadata_2.0_spec.version>1.1.3</geronimo-ws-metadata_2.0_spec.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <karaf.version>4.2.2</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <felix.framework.version>5.6.10</felix.framework.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <clojure.version>1.4.0</clojure.version>

--- a/software/winrm/pom.xml
+++ b/software/winrm/pom.xml
@@ -43,34 +43,6 @@
             <groupId>io.cloudsoft.windows</groupId>
             <artifactId>winrm4j</artifactId>
             <version>${winrm4j.version}</version>
-            <exclusions>
-                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.cxf</groupId>
-                    <artifactId>cxf-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.cxf</groupId>
-                    <artifactId>cxf-rt-transports-http</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--
-            Excluded from winrm4j the wrong jcl-over-slf4j version; include the right one below.
-            Note use of explicit exclude, rather than wildcard, because maven-enforcer-plugin 1.4.1
-            does not support wildcards: https://issues.apache.org/jira/browse/MENFORCER-195
-         -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
Bump versions to match those in karaf 4.2.2, and cxf 3.2.7

And remove exclusions` for winrm4j, which are not needed and make things harder for downstream projects.

The version bumps should not change what actually happens at runtime: these higher numbered bundles will be the ones that export their packages, because they are added by cxf etc. The consequences of depending on the wrong (older) version are: 1) we compile against a different version from that used at runtime; 2) it bloats the distro size and memory usage (because both versions are present); and 3) it cab contribute towards re-wiring problems at startup (where bundles are stopped and started because different versions are being added).