### PR TITLE
Use dependencyManagement from Karaf as a bom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -42,6 +42,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/camp/camp-server/pom.xml
+++ b/camp/camp-server/pom.xml
@@ -38,8 +38,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.activation</groupId>

--- a/camp/camp-server/pom.xml
+++ b/camp/camp-server/pom.xml
@@ -42,8 +42,8 @@
             <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.activator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.brooklyn.camp</groupId>

--- a/camp/camp-server/pom.xml
+++ b/camp/camp-server/pom.xml
@@ -98,10 +98,6 @@
             <artifactId>jetty-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -131,6 +131,7 @@
     </feature>
 
     <feature name="brooklyn-core" version="${project.version}" description="Brooklyn Core">
+        <feature>jetty</feature>
         <feature>brooklyn-api</feature>
 
         <bundle>mvn:org.apache.brooklyn/brooklyn-core/${project.version}</bundle>
@@ -148,11 +149,6 @@
         <bundle dependency="true">mvn:org.ow2.asm/asm-tree/${ow2.asm.version}</bundle>
         <bundle dependency="true">mvn:org.ow2.asm/asm-analysis/${ow2.asm.version}</bundle>
         <bundle dependency="true">mvn:org.ow2.asm/asm-util/${ow2.asm.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-client/${jetty.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/${jetty.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.ops4j.pax.web/pax-web-spi/${pax-web.version}</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-ws-metadata_2.0_spec/${geronimo-ws-metadata_2.0_spec.version}</bundle>
         <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>

--- a/karaf/init/pom.xml
+++ b/karaf/init/pom.xml
@@ -57,7 +57,6 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.osgi.compendium</artifactId>
-            <version>${felix-osgi-compendium.version}</version>
         </dependency>
 
         <dependency>

--- a/karaf/start/pom.xml
+++ b/karaf/start/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.osgi.compendium</artifactId>
-            <version>${felix-osgi-compendium.version}</version>
         </dependency>
 
         <dependency>

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -86,26 +86,6 @@
             <artifactId>org.apache.felix.framework</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-schemas</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -144,6 +144,14 @@
                 <artifactId>org.osgi.compendium</artifactId>
                 <version>${felix-osgi-compendium.version}</version>
             </dependency>
+            <dependency>
+                <!-- karaf/assemblies/features/base includes both 2.3.0 and 2.3.1 jaxb libraries -->
+                <!-- declaring the version here stops maven loading the conflicting versino from glassfish -->
+                <!-- Review if this is needed after karaf-4.2.2 -->
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,21 +85,6 @@
             <!-- END karaf version overrides -->
 
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-core</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.activation</groupId>
                 <artifactId>activation</artifactId>
                 <version>${javax.activation.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -570,11 +570,6 @@
                 <version>${kubernetes-client.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.web</groupId>
-                <artifactId>pax-web-spi</artifactId>
-                <version>${pax-web.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,6 +114,11 @@
                 <artifactId>javax.servlet-api</artifactId> <!-- match servlet.spec.artifactId in karaf/pom.xml -->
                 <version>${javax-servlet.version}</version> <!-- match servlet.spec.version in karaf/pom.xml -->
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -329,11 +334,6 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${javax-inject.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,8 +79,33 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.fusesource.jansi</groupId>
+                <artifactId>jansi</artifactId>
+                <version>${jansi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <!-- END karaf version overrides -->
 
@@ -103,16 +128,6 @@
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
                 <version>${xstream.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.fusesource.jansi</groupId>
-                <artifactId>jansi</artifactId>
-                <version>${jansi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
@@ -155,16 +170,6 @@
                 <groupId>net.sourceforge.plantuml</groupId>
                 <artifactId>plantuml</artifactId>
                 <version>${plantuml.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
@@ -424,11 +429,6 @@
                 <groupId>org.glassfish.external</groupId>
                 <artifactId>opendmk_jmxremote_optional_jar</artifactId>
                 <version>${opendmk_jmxremote_optional_jar.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,6 +119,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -375,11 +380,6 @@
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${commons-configuration.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -372,11 +372,6 @@
                 <version>${commons-beanutils.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${commons-configuration.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -124,6 +124,11 @@
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -441,11 +446,6 @@
                 <groupId>org.apache.whirr</groupId>
                 <artifactId>whirr-elasticsearch</artifactId>
                 <version>${whirr.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>${commons-compress.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.hierynomus</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -139,6 +139,11 @@
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.osgi.compendium</artifactId>
+                <version>${felix-osgi-compendium.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -193,28 +193,13 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jaas</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-io</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
                 <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.toolchain</groupId>
-                <artifactId>jetty-schemas</artifactId>
-                <version>${jetty-schemas.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -134,6 +134,11 @@
                 <artifactId>asm</artifactId>
                 <version>${ow2.asm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jline</groupId> <!-- when removing this, replace uses with org.jline -->
+                <artifactId>jline</artifactId>
+                <version>${jline.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -513,11 +518,6 @@
                 <groupId>com.maxmind.geoip2</groupId>
                 <artifactId>geoip2</artifactId>
                 <version>${maxmind.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jline</groupId>
-                <artifactId>jline</artifactId>
-                <version>${jline.version}</version>
             </dependency>
 
             <!-- JAX-RS dependencies-->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -107,6 +107,13 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
+            <dependency>
+                <!-- despite being defined in karaf's pom, we can't inherit it as they use parameters to -->
+                <!-- select the groupId, artifactId and version -->
+                <groupId>javax.servlet</groupId> <!-- match servlet.spec.groupId in karaf/pom.xml -->
+                <artifactId>javax.servlet-api</artifactId> <!-- match servlet.spec.artifactId in karaf/pom.xml -->
+                <version>${javax-servlet.version}</version> <!-- match servlet.spec.version in karaf/pom.xml -->
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -292,11 +299,6 @@
                         <artifactId>jackson-jaxrs-json-provider</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax-servlet.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.beust</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -129,6 +129,11 @@
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${ow2.asm.version}</version>
+            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>
@@ -503,11 +508,6 @@
                 <groupId>net.minidev</groupId>
                 <artifactId>accessors-smart</artifactId>
                 <version>${minidev.accessors-smart.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${ow2.asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.maxmind.geoip2</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,11 +85,6 @@
             <!-- END karaf version overrides -->
 
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${javax.activation.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
                 <version>${geronimo-ws-metadata_2.0_spec.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,6 +55,36 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf</artifactId>
+                <version>${karaf.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- BEGIN karaf version overrides -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>${jna.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.objenesis</groupId>
+                <artifactId>objenesis</artifactId>
+                <version>${objenesis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <!-- END karaf version overrides -->
+
+            <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
                 <version>${jaxb.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -403,11 +403,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.framework</artifactId>
-                <version>${felix.framework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.external</groupId>
                 <artifactId>opendmk_jmxremote_optional_jar</artifactId>
                 <version>${opendmk_jmxremote_optional_jar.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <felix.framework.version>5.6.10</felix.framework.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <jna.version>4.1.0</jna.version>
@@ -179,7 +180,6 @@
         <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
         <ow2.asm.version>5.2</ow2.asm.version> <!-- version should align with cxf-rt-frontend-jaxws; see also json-path and karaf version requirements -->
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
-        <commons-collections.version>3.2.2</commons-collections.version>
         <javax.mail.version>1.4.4</javax.mail.version>
         <cxf.javax.annotation-api.version>1.3</cxf.javax.annotation-api.version> <!-- cxf-specs feature v3.2.7 declares v1.3 (as does org.apache.cxf:cxf-rt-frontend-jaxrs), but karaf 4.2.2 has 1.2 -->
         <plantuml.version>6121</plantuml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,6 @@
         <ant.version>1.8.4</ant.version>
         <dockerfile-maven-plugin.version>1.4.3</dockerfile-maven-plugin.version>
 
-        <javax.activation.version>1.1.1</javax.activation.version>
         <pax-web.version>7.2.5</pax-web.version><!-- match version from karaf 4.2.2 (from pax-web-core, from pax-http-jetty, from pax-http) -->
         <geronimo-ws-metadata_2.0_spec.version>1.1.3</geronimo-ws-metadata_2.0_spec.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <pax-web.version>7.2.5</pax-web.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <jna.version>4.1.0</jna.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,8 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
+        <jna.version>4.1.0</jna.version>
+        <objenesis.version>2.5</objenesis.version>
         <clojure.version>1.4.0</clojure.version>
         <clj-time.version>0.4.1</clj-time.version>
         <commons-codec.version>1.10</commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,6 @@
         <ant.version>1.8.4</ant.version>
         <dockerfile-maven-plugin.version>1.4.3</dockerfile-maven-plugin.version>
 
-        <jaxb.version>2.2.11</jaxb.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <pax-web.version>7.2.5</pax-web.version><!-- match version from karaf 4.2.2 (from pax-web-core, from pax-http-jetty, from pax-http) -->
         <geronimo-ws-metadata_2.0_spec.version>1.1.3</geronimo-ws-metadata_2.0_spec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <commons-collections.version>3.2.2</commons-collections.version>
+        <pax-web.version>7.2.5</pax-web.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
         <jna.version>4.1.0</jna.version>
@@ -219,7 +220,6 @@
         <ant.version>1.8.4</ant.version>
         <dockerfile-maven-plugin.version>1.4.3</dockerfile-maven-plugin.version>
 
-        <pax-web.version>7.2.5</pax-web.version><!-- match version from karaf 4.2.2 (from pax-web-core, from pax-http-jetty, from pax-http) -->
         <geronimo-ws-metadata_2.0_spec.version>1.1.3</geronimo-ws-metadata_2.0_spec.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
         <!-- Dependencies shipped with vanilla karaf; update these when we update the karaf version -->
         <karaf.version>4.2.2</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
-        <felix.framework.version>5.6.10</felix.framework.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <commons-collections.version>3.2.2</commons-collections.version>
 

--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jaas</artifactId>
+            <artifactId>jetty-http</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/rest/rest-server/pom.xml
+++ b/rest/rest-server/pom.xml
@@ -106,15 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jaas</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/utils/common/pom.xml
+++ b/utils/common/pom.xml
@@ -114,8 +114,6 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>${org.osgi.core.version}</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
Apache Brooklyn uses a lot of the same dependencies are provided by Apache Karaf. However, we redeclare these dependencies and rely on notes and comments to upgrade them when Karaf is upgraded.

Karaf provides a `<dependencyManagement>` element that we can import into our parent `pom.xml`.

This PR does this and removes any duplicates. Where we use a conflicting/alternative version they have been grouped together and commented that they are overriding versions in Karaf. All of them are holding back to older versions of the dependency.

Some properties that are not used with a `<dependency>` are used within a `features.xml` file to declare a `<bundle dependency....>`. These have been grouped next to the `<karaf.version>` property to aid in remembering to update them when Karaf is upgraded.

The intention is to make future upgrades of Karaf easier by reducing the potential for conflicting versions. It also makes it clearer which dependencies are no longer matching those used by Karaf. Removing the relevant entry, and property (if not used in a `feature`) in our `pom.xml` would upgrade to the Karaf version.

`javax.xml.bind` and `javax.activation` libraries have been replaced with the Apache Servicemix versions that Karaf uses, to avoid the risk of classes being included from different sources.

Features that used `jetty` dependencies have been updated to use the Karaf-provided feature `jetty`. This removes the need to maintain a `<jetty.version>` property.