### PR TITLE
Fix session cleaner

### DIFF
--- a/karaf/jetty-config/src/main/resources/jetty.xml
+++ b/karaf/jetty-config/src/main/resources/jetty.xml
@@ -20,4 +20,19 @@
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
 
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+    <!--Config Jetty HouseKeeper scavenge interval for invalidate session to one hour to avoid losing authentication-->
+    <!--token -->
+    <Set name="sessionIdManager">
+        <New id="idMgr" class="org.eclipse.jetty.server.session.DefaultSessionIdManager">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="sessionHouseKeeper">
+                <New class="org.eclipse.jetty.server.session.HouseKeeper">
+                    <Set name="intervalSec"><Property name="jetty.sessionScavengeInterval.seconds" default="3600"/></Set>
+                </New>
+            </Set>
+        </New>
+    </Set>
+
 </Configure>
+

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/CsrfTokenFilter.java
@@ -217,7 +217,7 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         log.debug("CSRF FILTER finishing - "+MultiSessionAttributeAdapter.info(request));
         MultiSessionAttributeAdapter session = MultiSessionAttributeAdapter.of(request, false);
-        String previousToken = (String) (session==null ? null : session.getAttribute(CSRF_TOKEN_VALUE_ATTR));
+        String token = (String) (session==null ? null : session.getAttribute(CSRF_TOKEN_VALUE_ATTR));
         String requiredWhenS = request.getHeader(CSRF_TOKEN_REQUIRED_HEADER);
 
         if (session==null) {
@@ -233,25 +233,28 @@ public class CsrfTokenFilter implements ContainerRequestFilter, ContainerRespons
             session = MultiSessionAttributeAdapter.of(request, true);
         }
 
-        // create the token
-        String newToken = Identifiers.makeRandomId(16);
-        session.setAttribute(CSRF_TOKEN_VALUE_ATTR, newToken);
+        if (token==null) {
+            // create the token
+            token = Identifiers.makeRandomId(16);
+            log.trace("Created new token {} for {}", token, session);
+        }
+        session.setAttribute(CSRF_TOKEN_VALUE_ATTR, token);
 
-        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE, newToken, "Clients should send this value in header "+CSRF_TOKEN_VALUE_HEADER+" for validation");
-        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE_ANGULAR_NAME, newToken, "Compatibility cookie for "+CSRF_TOKEN_VALUE_COOKIE+" following AngularJS conventions");
+        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE, token, "Clients should send this value in header "+CSRF_TOKEN_VALUE_HEADER+" for validation");
+        addCookie(responseContext, CSRF_TOKEN_VALUE_COOKIE_ANGULAR_NAME, token, "Compatibility cookie for "+CSRF_TOKEN_VALUE_COOKIE+" following AngularJS conventions");
 
         CsrfTokenRequiredForRequests requiredWhen;
         if (Strings.isNonBlank(requiredWhenS)) {
             requiredWhen = getRequiredForRequests(requiredWhenS, DEFAULT_REQUIRED_FOR_REQUESTS);
             session.setAttribute(CSRF_TOKEN_REQUIRED_ATTR, requiredWhen);
-            if (Strings.isNonBlank(previousToken)) {
+            if (Strings.isNonBlank(token)) {
                 // already set csrf token, and the client got it
                 // (with the session token if they are in a session;
                 // or if client didn't get it it isn't in a session)
                 return;
             }
         } else {
-            if (Strings.isNonBlank(previousToken)) {
+            if (Strings.isNonBlank(token)) {
                 // already set csrf token, and the client got it
                 // (with the session token if they are in a session;
                 // or if client didn't get it it isn't in a session)

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/MultiSessionAttributeAdapter.java
@@ -140,6 +140,9 @@ public class MultiSessionAttributeAdapter {
                 if (preferredHandler!=null) {
                     if (optionalRequest!=null) { 
                         HttpSession result = preferredHandler.newHttpSession(optionalRequest);
+                        // bigger than HouseKeeper.sessionScavengeInterval: 3600
+                        // https://www.eclipse.org/jetty/documentation/9.4.x/session-configuration-housekeeper.html
+                        result.setMaxInactiveInterval(3601);
                         if (log.isTraceEnabled()) {
                             log.trace("Creating new session "+info(result)+" to be preferred for " + info(optionalRequest, localSession));
                         }
@@ -148,6 +151,7 @@ public class MultiSessionAttributeAdapter {
                     // the server has a preferred handler, but no session yet; fall back to marking on the session 
                     log.warn("No request so cannot create preferred session at preferred handler "+info(preferredHandler)+" for "+info(optionalRequest, localSession)+"; will exceptionally mark the calling session as the preferred one");
                     markSessionAsPreferred(localSession, " (request came in for "+info(optionalRequest, localSession)+")");
+                    localSession.setMaxInactiveInterval(3601);
                     return localSession;
                 } else {
                     // shouldn't come here; at minimum it should have returned the local session's handler


### PR DESCRIPTION
Jetty 9.4 HouseKeeper cleans the session each 10 minutes by default, that is a problem if you are more than 10 minutes in a module browse to other even the MultiSessionAttributeAdapter tries to give you the correct previous session where the Oauth token is stored.
This increase the time scavenge interval and re-send the CSRF token each time.
Also changed the NO CONNECTION message in UI: https://github.com/apache/brooklyn-ui/pull/122