### PR TITLE
[Security] Bump bouncycastle.version from 1.51 to 1.61

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,13 @@
         <dependency>
             <groupId>com.hierynomus</groupId>
             <artifactId>sshj</artifactId>
+            <exclusions>
+                <!-- provided by bcprov-ext instead -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -154,6 +154,7 @@
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream.servicemix.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>
+        <bundle dependency="true">mvn:net.i2p.crypto/eddsa/${eddsa.version}</bundle><!-- from com.hierynomous/sshj -->
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/1.1.3_2</bundle> <!-- jzlib version is 1.1.3, but bundle is 1.1.3_2 -->
         <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <swagger.version>1.5.6</swagger.version>
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
-        <bouncycastle.version>1.51</bouncycastle.version>
+        <bouncycastle.version>1.61</bouncycastle.version>
         <sshj.version>0.20.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <sshj.version>0.27.0</sshj.version>
+        <eddsa.version>0.2.0</eddsa.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
-        <sshj.version>0.27.0</sshj.version>
         <eddsa.version>0.2.0</eddsa.version>
+        <sshj.version>0.22.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
-        <sshj.version>0.20.0</sshj.version>
+        <sshj.version>0.27.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>


### PR DESCRIPTION
Bumps `bouncycastle.version` from 1.51 to 1.61.

Updates `bcprov-ext-jdk15on` from 1.51 to 1.61. **This update includes security fixes.**
<details>
<summary>Vulnerabilities fixed</summary>

*Sourced from [The Sonatype OSS Index](https://ossindex.sonatype.org/vuln/3a59870b-28b3-4b6b-86b0-9629ebe9de40).*

> **[CVE-2015-6644] Information disclosure**
> > An information disclosure vulnerability in Bouncy Castle could enable a local malicious application to gain access to user?s private information
> > 
> > -- [source.android.com](https://source.android.com/security/bulletin/2016-01-01#information_disclosure_vulnerability_in_bouncy_castle)
> 
> Affected versions: < 1.55.0

</details>
<details>
<summary>Changelog</summary>

*Sourced from [bcprov-ext-jdk15on's changelog](https://github.com/bcgit/bc-java/blob/master/docs/releasenotes.html).*

> <html>
> <head>
> <title>Bouncy Castle Crypto Package - Release Notes</title>
> </head>
> 
> <body bgcolor="#ffffff" text="#000000#">
> 
> <center>
> <h1>Bouncy Castle Crypto Package - Release Notes</h1>
> <font size=1>
> <pre>
> </pre>
> </font>
> </center>
> <h2>1.0 Introduction</h2>
> <p>
> The Bouncy Castle Crypto package is a Java implementation of 
> cryptographic algorithms.  The package is organised so that it 
> contains a light-weight API suitable for use in any environment
> (including the J2ME) with the additional infrastructure
> to conform the algorithms to the JCE framework.
> </p>
> <h2>2.0 Release History</h2>
> 
> 
> <h3>2.1.1 Version</h3>
> Release: 1.61<br/>
> Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2018,
> <h3>2.1.2 Defects Fixed</h3>
> <ul>
> <li>Use of EC named curves could be lost if keys were constructed via a key factory and algorithm parameters. This has been fixed.</li>
> <li>RFC3211WrapEngine would not properly handle messages longer than 127 bytes. This has been fixed.</li>
> <li>The JCE implementations for RFC3211 would not returned null AlgorithmParameters. This has been fixed.</li>
> </ul>
> <h3>2.1.3 Additional Features and Functionality</h3>
> <ul>
> <li>TLS: Finalised support for RFC 8442 cipher suites.</li>
> </ul>
> 
> <h3>2.2.1 Version</h3>
> Release: 1.60<br/>
> Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2018, June 30
> <h3>2.2.2 Defects Fixed</h3>
> <ul>
> <li>Base64/UrlBase64 would throw an exception on a zero length string. This has been fixed.</li>
> <li>Base64/UrlBase64 would throw an exception if there was whitespace in the last 4 characters. This has been fixed.</li>
> <li>The SM2 Signature JCE class now properly resets of Signature.sign() is called.</li>
> <li>XMSS applies further validation to deserialisation of the BDS tree so that failure occurs as soon as tampering is detected (see CVE below).</li>
> <li>An off by one error in the JsseDefaultHostnameAuthorizer isValidNameMatch method has been fixed.</li>
> <li>BCJSSE: Return empty byte array instead of null, for the null session ID.</li>
></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- See full diff in [compare view](https://github.com/bcgit/bc-java/commits)
</details>
<br />

Updates `bcpkix-jdk15on` from 1.51 to 1.60
<details>
<summary>Changelog</summary>

*Sourced from [bcpkix-jdk15on's changelog](https://github.com/bcgit/bc-java/blob/master/docs/releasenotes.html).*

> <html>
> <head>
> <title>Bouncy Castle Crypto Package - Release Notes</title>
> </head>
> 
> <body bgcolor="#ffffff" text="#000000#">
> 
> <center>
> <h1>Bouncy Castle Crypto Package - Release Notes</h1>
> <font size=1>
> <pre>
> </pre>
> </font>
> </center>
> <h2>1.0 Introduction</h2>
> <p>
> The Bouncy Castle Crypto package is a Java implementation of 
> cryptographic algorithms.  The package is organised so that it 
> contains a light-weight API suitable for use in any environment
> (including the J2ME) with the additional infrastructure
> to conform the algorithms to the JCE framework.
> </p>
> <h2>2.0 Release History</h2>
> 
> 
> <h3>2.1.1 Version</h3>
> Release: 1.61<br/>
> Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2018,
> <h3>2.1.2 Defects Fixed</h3>
> <ul>
> <li>Use of EC named curves could be lost if keys were constructed via a key factory and algorithm parameters. This has been fixed.</li>
> <li>RFC3211WrapEngine would not properly handle messages longer than 127 bytes. This has been fixed.</li>
> <li>The JCE implementations for RFC3211 would not returned null AlgorithmParameters. This has been fixed.</li>
> </ul>
> <h3>2.1.3 Additional Features and Functionality</h3>
> <ul>
> <li>TLS: Finalised support for RFC 8442 cipher suites.</li>
> </ul>
> 
> <h3>2.2.1 Version</h3>
> Release: 1.60<br/>
> Date:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 2018, June 30
> <h3>2.2.2 Defects Fixed</h3>
> <ul>
> <li>Base64/UrlBase64 would throw an exception on a zero length string. This has been fixed.</li>
> <li>Base64/UrlBase64 would throw an exception if there was whitespace in the last 4 characters. This has been fixed.</li>
> <li>The SM2 Signature JCE class now properly resets of Signature.sign() is called.</li>
> <li>XMSS applies further validation to deserialisation of the BDS tree so that failure occurs as soon as tampering is detected (see CVE below).</li>
> <li>An off by one error in the JsseDefaultHostnameAuthorizer isValidNameMatch method has been fixed.</li>
> <li>BCJSSE: Return empty byte array instead of null, for the null session ID.</li>
></table> ... (truncated)
</details>
<details>
<summary>Commits</summary>

- See full diff in [compare view](https://github.com/bcgit/bc-java/commits)
</details>