### PR TITLE
[Security] Bump logback.version from 1.0.7 to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
         <!-- Dependency Versions -->
         <jclouds.version>2.1.0</jclouds.version> <!-- JCLOUDS_VERSION -->
-        <logback.version>1.0.7</logback.version>
+        <logback.version>1.2.3</logback.version>
         <slf4j.version>1.7.25</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->
         <guava.version>18.0</guava.version>

--- a/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
+++ b/test-support/src/main/java/org/apache/brooklyn/test/LogWatcher.java
@@ -158,7 +158,7 @@ public class LogWatcher implements Closeable {
 
         PatternLayoutEncoder ple = new PatternLayoutEncoder() {
             @Override
-            public void doEncode(ILoggingEvent event) throws IOException {
+            public byte[] encode(ILoggingEvent event) {
                 final String txt = layout.doLayout(event);
 
                 // Jump through hoops to turn the input event (without any layout)
@@ -182,7 +182,7 @@ public class LogWatcher implements Closeable {
                 }
                 LOG.trace("level="+event.getLevel()+"; event="+event+"; msg="+event.getFormattedMessage());
 
-                super.doEncode(event);
+                return super.encode(event);
             }
         };
 


### PR DESCRIPTION
Bumps `logback.version` from 1.0.7 to 1.2.3.

Updates `logback-classic` from 1.0.7 to 1.2.3. **This update includes security fixes.**
<details>
<summary>Vulnerabilities fixed</summary>

*Sourced from [The Sonatype OSS Index](https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374).*

> **[CVE-2017-5929]  Deserialization of Untrusted Data**
> QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components.
> 
> Affected versions: <= 1.1.10

</details>
<br />

Updates `logback-core` from 1.0.7 to 1.2.3. **This update includes security fixes.**
<details>
<summary>Vulnerabilities fixed</summary>

*Sourced from [The Sonatype OSS Index](https://ossindex.sonatype.org/vuln/391196a7-f007-430b-b47f-cd9a3fec6374).*

> **[CVE-2017-5929]  Deserialization of Untrusted Data**
> QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components.
> 
> Affected versions: <= 1.1.10

</details>