### PR TITLE
[Security] Bump commons-compress from 1.4 to 1.18

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -187,7 +187,6 @@
 
         <feature>brooklyn-utils-common</feature>
         <bundle dependency="true">mvn:org.apache.commons/commons-compress/${commons-compress.version}</bundle>
-        <bundle dependency="true">wrap:mvn:org.tukaani/xz/${commons-compress.version}</bundle>
         <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <freemarker.version>2.3.25-incubating</freemarker.version>
         <commons-io.version>2.4</commons-io.version>
         <jsonPath.version>2.4.0</jsonPath.version>
-        <commons-compress.version>1.4</commons-compress.version>
+        <commons-compress.version>1.18</commons-compress.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
         <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>


### PR DESCRIPTION
Bumps commons-compress from 1.4 to 1.18. **This update includes security fixes.**
<details>
<summary>Vulnerabilities fixed</summary>

*Sourced from [The Sonatype OSS Index](https://ossindex.sonatype.org/vuln/c30fadee-a5fc-47e5-9b28-3bd160719296).*

> **[CVE-2012-2098]  Cryptographic Issues**
> Algorithmic complexity vulnerability in the sorting algorithms in bzip2 compressing stream (BZip2CompressorOutputStream) in Apache Commons Compress before 1.4.1 allows remote attackers to cause a denial of service (CPU consumption) via a file with many repeating inputs.
> 
> Affected versions: <= 1.4.0

</details>