### PR TITLE
bump commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <freemarker.version>2.3.25-incubating</freemarker.version>
         <commons-io.version>2.4</commons-io.version>
         <jsonPath.version>2.4.0</jsonPath.version>
-        <commons-compress.version>1.4</commons-compress.version>
+        <commons-compress.version>1.4.1</commons-compress.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
         <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>


### PR DESCRIPTION
from 1.4 to 1.4.1 to avoid being flagged as a CVE

(both very old versions, not tested with 1.18, but 1.4.1 has the fix in question)