### PR TITLE
Use servicemix bundle of xstream at runtime

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -155,7 +155,7 @@
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.ops4j.pax.web/pax-web-spi/${pax-web.version}</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-ws-metadata_2.0_spec/${geronimo-ws-metadata_2.0_spec.version}</bundle>
-        <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream.servicemix.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/1.1.3_2</bundle> <!-- jzlib version is 1.1.3, but bundle is 1.1.3_2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,13 @@
             For example jclouds and jackson-datatype-guava both depend on guava [16,20).
         -->
         <guava-swagger.version>18.0</guava-swagger.version>
+
+        <!-- xstream -->
         <xstream.version>1.4.11.1</xstream.version>
+        <!-- xstream has dependencies that are not OSGi bundles, the servicemix repackage version embeds them -->
+        <!-- note the servicemix suffix when upgrading xstream -->
+        <xstream.servicemix.version>${xstream.version}_1</xstream.servicemix.version>
+
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->


### PR DESCRIPTION
The updated xstream includes dependencies on libraries that are not
OSGi bundles. This servicemix repackaging, includes these libraries
within the bundle.

Follows on from #1038 