### PR TITLE
comment out CXF logging feature

### DIFF
--- a/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
+++ b/rest/rest-resources/src/main/resources/OSGI-INF/blueprint/service.xml
@@ -25,7 +25,9 @@ limitations under the License.
 
     <cxf:bus>
         <cxf:features>
+           <!-- breaks with: java.lang.NoClassDefFoundError: javax/xml/ws/WebServiceFeature
             <cxf:logging/>
+           -->
         </cxf:features>
     </cxf:bus>
 


### PR DESCRIPTION
it prevents launch on java 9 due to feature loading trying to access `javax.xml.ws.WebServiceFeature` and getting `NoClassDefFoundError`.  not sure why, have tried with all the dependent bundles (the ones removed in java 9/11) added and an `Import-Package` line in this bundle, but whatever aries/cxf context is trying to load isn't allowed to.

```
2019-02-14T15:07:37,112 - ERROR  18 o.a.a.b.c.BlueprintContainerImpl [activation/1.2.0] Unable to start container for blueprint bundle org.apache.brooklyn.rest-resources/1.0.0.SNAPSHOT
java.lang.NoClassDefFoundError: javax/xml/ws/WebServiceFeature
	at org.apache.cxf.internal.CXFAPINamespaceHandler.parse(CXFAPINamespaceHandler.java:90) ~[?:?]
	at org.apache.aries.blueprint.parser.Parser.parseCustomElement(Parser.java:1369) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.Parser.parseValueGroup(Parser.java:1290) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.Parser.parseCollection(Parser.java:830) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.Parser.parseElement(Parser.java:453) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.ParserContextImpl.parseElement(ParserContextImpl.java:74) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.cxf.configuration.blueprint.AbstractBPBeanDefinitionParser.parseListData(AbstractBPBeanDefinitionParser.java:88) ~[?:?]
	at org.apache.cxf.bus.blueprint.BusDefinitionParser.mapElement(BusDefinitionParser.java:63) ~[?:?]
	at org.apache.cxf.configuration.blueprint.AbstractBPBeanDefinitionParser.parseChildElements(AbstractBPBeanDefinitionParser.java:309) ~[?:?]
	at org.apache.cxf.bus.blueprint.BusDefinitionParser.parse(BusDefinitionParser.java:42) ~[?:?]
	at org.apache.cxf.internal.CXFAPINamespaceHandler.parse(CXFAPINamespaceHandler.java:87) ~[?:?]
	at org.apache.aries.blueprint.parser.Parser.parseCustomElement(Parser.java:1369) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.Parser.loadComponents(Parser.java:427) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.parser.Parser.populate(Parser.java:331) ~[18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.doRun(BlueprintContainerImpl.java:351) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.run(BlueprintContainerImpl.java:278) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:299) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:268) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintExtender.createContainer(BlueprintExtender.java:264) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.blueprint.container.BlueprintExtender.modifiedBundle(BlueprintExtender.java:254) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.customizerModified(BundleHookBundleTracker.java:500) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.customizerModified(BundleHookBundleTracker.java:433) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$AbstractTracked.track(BundleHookBundleTracker.java:725) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$Tracked.bundleChanged(BundleHookBundleTracker.java:463) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.aries.util.tracker.hook.BundleHookBundleTracker$BundleEventHook.event(BundleHookBundleTracker.java:422) [18:org.apache.aries.blueprint.core:1.10.1]
	at org.apache.felix.framework.util.SecureAction.invokeBundleEventHook(SecureAction.java:1179) [?:?]
	at org.apache.felix.framework.EventDispatcher.createWhitelistFromHooks(EventDispatcher.java:730) [?:?]
	at org.apache.felix.framework.EventDispatcher.fireBundleEvent(EventDispatcher.java:485) [?:?]
	at org.apache.felix.framework.Felix.fireBundleEvent(Felix.java:4579) [?:?]
	at org.apache.felix.framework.Felix.startBundle(Felix.java:2174) [?:?]
	at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:998) [?:?]
	at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:984) [?:?]
	at org.apache.karaf.bundle.command.Install.execute(Install.java:115) [22:org.apache.karaf.bundle.core:4.2.2]
	at org.apache.karaf.shell.impl.action.command.ActionCommand.execute(ActionCommand.java:84) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:68) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.karaf.shell.impl.console.osgi.secured.SecuredCommand.execute(SecuredCommand.java:86) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Closure.executeCmd(Closure.java:599) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Closure.executeStatement(Closure.java:526) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Closure.execute(Closure.java:415) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Pipe.doCall(Pipe.java:416) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Pipe.call(Pipe.java:229) [41:org.apache.karaf.shell.core:4.2.2]
	at org.apache.felix.gogo.runtime.Pipe.call(Pipe.java:59) [41:org.apache.karaf.shell.core:4.2.2]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) [?:?]
	at java.lang.Thread.run(Thread.java:844) [?:?]
```
