### PR TITLE
Retry flaky unit tests

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/lifecycle/ServiceStateLogicTest.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.test.entity.TestEntityImpl.TestEntityWithoutEnrichers;
 import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.collections.QuorumCheck.QuorumChecks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.time.Duration;
@@ -58,7 +59,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
-@Test
+@Test(retryAnalyzer = FlakyRetryAnalyser.class)
 public class ServiceStateLogicTest extends BrooklynAppUnitTestSupport {
     
     private static final Logger log = LoggerFactory.getLogger(ServiceStateLogicTest.class);

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/LocationEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/LocationEntityTest.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -116,7 +117,7 @@ public class LocationEntityTest extends BrooklynAppUnitTestSupport {
         EntityAsserts.assertEntityHealthy(entity);
     }
 
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testLocationEntityConfigurationWithWrongTypeAndNoDefault() throws Exception {
         Map<String, EntitySpec<?>> map = ImmutableMap.<String, EntitySpec<?>>builder()
                         .put("OtherLocation", EntitySpec.create(TestEntity.class).configure(TestEntity.CONF_NAME, "Other"))

--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.launcher.common.BrooklynPropertiesFactoryHelperTest;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
 import org.apache.brooklyn.util.http.HttpToolResponse;
@@ -269,7 +270,7 @@ public class BrooklynLauncherTest {
         }
     }
 
-    @Test  // takes a bit of time because starts webapp, but also tests rest api so useful
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)  // takes a bit of time because starts webapp, but also tests rest api so useful
     public void testErrorsCaughtByApiAndRestApiWorks() throws Exception {
         launcher = newLauncherForTests(true)
                 .catalogInitialization(new CatalogInitialization(null) {

--- a/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicySoakTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/loadbalancing/LoadBalancingPolicySoakTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +57,7 @@ public class LoadBalancingPolicySoakTest extends AbstractLoadBalancingPolicyTest
         runLoadBalancingSoakTest(config);
     }
     
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testLoadBalancingManyItemsQuickTest() {
         RunConfig config = new RunConfig();
         config.numCycles = 1;

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorResourceTest.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.rest.api.EffectorApi;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.Test;
 
@@ -79,7 +80,7 @@ public class EffectorResourceTest extends BrooklynRestResourceTest {
         Asserts.succeedsEventually(() -> assertTrue(entity.getCallHistory().contains("myEffector")));
     }
     
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testInvokeEffectorNoArgsBlocking() throws Exception {
         String path = "/applications/"+app.getId()+"/entities/"+entity.getId()+"/effectors/"+"myEffector";
 

--- a/utils/test-support/src/main/java/org/apache/brooklyn/test/support/FlakyRetryAnalyser.java
+++ b/utils/test-support/src/main/java/org/apache/brooklyn/test/support/FlakyRetryAnalyser.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.test.support;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class FlakyRetryAnalyser implements IRetryAnalyzer {
+    private int retryCount = 0;
+    private static final int maxRetryCount = 3;
+
+    @Override
+    public boolean retry(ITestResult result) {
+        if (retryCount < maxRetryCount) {
+            retryCount++;
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/utils/test-support/src/main/java/org/apache/brooklyn/test/support/FlakyRetryAnalyser.java
+++ b/utils/test-support/src/main/java/org/apache/brooklyn/test/support/FlakyRetryAnalyser.java
@@ -22,13 +22,14 @@ import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 
 public class FlakyRetryAnalyser implements IRetryAnalyzer {
-    private int retryCount = 0;
-    private static final int maxRetryCount = 3;
+    private static final int MAX = 3;
+
+    private int count = 0;
 
     @Override
     public boolean retry(ITestResult result) {
-        if (retryCount < maxRetryCount) {
-            retryCount++;
+        if (count < MAX) {
+            count++;
             return true;
         }
         return false;


### PR DESCRIPTION
We know that some of our unit tests are flaky. Testng has support for retrying tests by implementing `IRetryAnalyzer` interface, then reference that for selected tests.

This does exactly that, and add the retry strategy to the usual suspects.

As a side note, these flaky tests are because of races conditions, or test environments not being properly setup/cleanup. **We should definitely fix the root cause!** But for now, retrying maximum 3 times would eliminate false positive.