### PR TITLE
minor changes to make working w AWS profiles easier

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AwsEc2SessionAwareLocationConfig.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AwsEc2SessionAwareLocationConfig.java
@@ -24,5 +24,5 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 public interface AwsEc2SessionAwareLocationConfig extends JcloudsLocationConfig{
 
     ConfigKey<String> IAM_ROLE_NAME = ConfigKeys.newStringConfigKey("iamRoleName",
-            "Use IAM role to get session credentials when connecting to AWS EC2", "brooklyn");
+            "IAM role / profile name to get session credentials when connecting to AWS EC2", "brooklyn");
 }

--- a/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
+++ b/logging/logback-includes/src/main/resources/brooklyn/logback-logger-excludes.xml
@@ -60,6 +60,11 @@
     <logger name="org.mongodb.driver" level="WARN" additivity="false">
         <appender-ref ref="FILE" />
     </logger>
+    <!-- Also very noisy even at WARN, if you have [profile xxx] in your ~/.aws/config file;
+         as with o.a.http above, this requires our custom bridge from LoggingSetup to be configured, or comparable -->
+    <logger name="com.amazonaws.auth.profile.internal.BasicProfileConfigLoader" level="ERROR" additivity="false">
+        <appender-ref ref="FILE" />
+    </logger>
 
     <!-- CXF logging is extremely verbose, including 
          debug logging for every REST in and out,
@@ -69,4 +74,6 @@
     <logger name="org.apache.cxf" level="ERROR"/>
     
     <logger name="io.cloudsoft.winrm4j.winrm.WinRmTool" level="DEBUG"/>
+    
+
 </included>


### PR DESCRIPTION
* tune logging so `[profile xxx]` in `~/.aws/config` doesn't cause lots of WARNs
* better description of the role/profile config key