### PR TITLE
Add Flaky retry analyser to more tests

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
@@ -47,6 +47,7 @@ import org.apache.brooklyn.policy.failover.ElectPrimaryConfig.PrimaryDefaultSens
 import org.apache.brooklyn.policy.failover.ElectPrimaryConfig.SelectionMode;
 import org.apache.brooklyn.policy.failover.ElectPrimaryEffector;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.test.support.LoggingVerboseReporter;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -278,7 +279,7 @@ public class ElectPrimaryTest extends AbstractYamlRebindTest {
 
     // TODO tests for timeout configurability
     
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testSelectionModeStrictReelectWithPreference() throws Exception {
         runSelectionModeTest(SelectionMode.STRICT, false);
     }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindFeedWithHaTest.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.core.http.BetterMockWebServer;
 import org.apache.brooklyn.util.core.task.BasicExecutionManager;
 import org.apache.brooklyn.util.repeat.Repeater;
@@ -83,7 +84,7 @@ public class RebindFeedWithHaTest extends RebindTestFixtureWithApp {
         return super.createApp();
     }
 
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testHttpFeedCleansUpAfterHaDisabledAndRunsAtFailover() throws Exception {
         TestEntity origEntity = origApp.createAndManageChild(EntitySpec.create(TestEntity.class).impl(RebindFeedTest.MyEntityWithHttpFeedImpl.class)
                 .configure(RebindFeedTest.MyEntityWithHttpFeedImpl.BASE_URL, baseUrl));

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessStopsDuringStartTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/SoftwareProcessStopsDuringStartTest.java
@@ -51,6 +51,7 @@ import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.LogWatcher;
 import org.apache.brooklyn.test.LogWatcher.EventPredicates;
+import org.apache.brooklyn.test.support.FlakyRetryAnalyser;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.internal.ssh.RecordingSshTool;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -140,7 +141,7 @@ public class SoftwareProcessStopsDuringStartTest extends BrooklynAppUnitTestSupp
         assertEquals(loc.getCalls(), ImmutableList.of("obtain", "release", "obtain", "release"));
     }
 
-    @Test
+    @Test(retryAnalyzer = FlakyRetryAnalyser.class)
     public void testStopDuringProvisionWaitsForCompletion() throws Exception {
         Future<?> startFuture = executor.submit(new Runnable() {
             @Override


### PR DESCRIPTION
This follows #1049 and add the `FlakyRetryAnalyser` to more tests, based on the latest failure from Jenkins (see: https://lists.apache.org/list.html?dev@brooklyn.apache.org)