### PR TITLE
Adds SERVER_STATUS entitlement for read-only role

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/Entitlements.java
@@ -351,6 +351,7 @@ public class Entitlements {
             FineGrainedEntitlements.allowing(SEE_ENTITY),
             FineGrainedEntitlements.allowing(SEE_ACTIVITY_STREAMS),
             FineGrainedEntitlements.allowing(SEE_CATALOG_ITEM),
+            FineGrainedEntitlements.allowing(SERVER_STATUS),
             FineGrainedEntitlements.seeNonSecretSensors(),
             FineGrainedEntitlements.seeNonSecretConfig()
         );


### PR DESCRIPTION
The UI calls to `extended` end point and that need being entitled for SERVER_STATUS entitlement.  The read-only role hadn't this and that makes show a error message on the interface.