### PR TITLE
Add support for finally block in TestCase entity

### DIFF
--- a/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
+++ b/test-framework/src/main/java/org/apache/brooklyn/test/framework/TestCase.java
@@ -39,6 +39,13 @@ public interface TestCase extends TargetableTestComponent {
             .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
             .build();
 
+    @SuppressWarnings("serial")
+    ConfigKey<EntitySpec<?>> ON_FINALLY_SPEC = ConfigKeys.builder(new TypeToken<EntitySpec<?>>() {})
+            .name("on.finally.spec")
+            .description("Spec of entity to instantiate (and start, if startable) after a test-case either passes or fails")
+            .runtimeInheritance(BasicConfigInheritance.NOT_REINHERITED)
+            .build();
+
     ConfigKey<Boolean> CONTINUE_ON_FAILURE = ConfigKeys.builder(Boolean.class)
             .name("continueOnFailure")
             .description("Whether to continue executing subsequent children if an earlier child fails")


### PR DESCRIPTION
This adds a new config key called `on.finally.spec` where one can configure it to execute a new entity, regardless of the state of the test. This is very useful to execute cleanups for tests 