### PR TITLE
Winrm improvements

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractWindowsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractWindowsYamlTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
@@ -109,6 +110,10 @@ public abstract class AbstractWindowsYamlTest extends AbstractYamlTest {
         return (stream != null) ? stream.streamContents.get() : null;
     }
 
+    protected Optional<Task<?>> findTaskOrSubTask(Entity entity, Predicate<? super Task<?>> matcher) {
+        return findTaskOrSubTask(BrooklynTaskTags.getTasksInEntityContext(mgmt().getExecutionManager(), entity), matcher);
+    }
+    
     protected Optional<Task<?>> findTaskOrSubTask(Iterable<? extends Task<?>> tasks, Predicate<? super Task<?>> matcher) {
         List<String> taskNames = Lists.newArrayList();
         Optional<Task<?>> result = findTaskOrSubTaskImpl(tasks, matcher, taskNames);

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/CanResolveOnBoxDir.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/CanResolveOnBoxDir.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.ssh;
+
+import org.apache.brooklyn.api.entity.Entity;
+
+public interface CanResolveOnBoxDir {
+
+    String resolveOnBoxDirFor(Entity entity, String unresolvedPath);
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessDriver.java
@@ -51,6 +51,7 @@ import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffect
 import org.apache.brooklyn.entity.software.base.lifecycle.MachineLifecycleEffectorTasks.CloseableLatch;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.json.ShellEnvironmentSerializer;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.core.text.TemplateProcessor;
@@ -664,6 +665,16 @@ public abstract class AbstractSoftwareProcessDriver implements SoftwareProcessDr
 
     public String getVersion() {
         return getEntity().config().get(SoftwareProcess.SUGGESTED_VERSION);
+    }
+
+    /**
+     * The environment variables to be set when executing the commands (for install, run, check running, etc).
+     * @see SoftwareProcess#SHELL_ENVIRONMENT
+     */
+    public Map<String, String> getShellEnvironment() {
+        Map<String, Object> env = entity.getConfig(SoftwareProcess.SHELL_ENVIRONMENT);
+        ShellEnvironmentSerializer envSerializer = new ShellEnvironmentSerializer(((EntityInternal)entity).getManagementContext());
+        return envSerializer.serialize(env);
     }
 
     public abstract String getRunDir();

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
@@ -379,16 +379,6 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     }
 
     /**
-     * The environment variables to be set when executing the commands (for install, run, check running, etc).
-     * @see SoftwareProcess#SHELL_ENVIRONMENT
-     */
-    public Map<String, String> getShellEnvironment() {
-        Map<String, Object> env = entity.getConfig(SoftwareProcess.SHELL_ENVIRONMENT);
-        ShellEnvironmentSerializer envSerializer = new ShellEnvironmentSerializer(((EntityInternal)entity).getManagementContext());
-        return envSerializer.serialize(env);
-    }
-
-    /**
      * @param sshFlags Extra flags to be used when making an SSH connection to the entity's machine.
      *                 If the map contains the key {@link #IGNORE_ENTITY_SSH_FLAGS} then only the
      *                 given flags are used. Otherwise, the given flags are combined with (and take

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessSshDriver.java
@@ -493,6 +493,8 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
     public static final String RESTARTING = "restarting";
 
     public static final String PID_FILENAME = "pid.txt";
+    static final String INSTALL_DIR_ENV_VAR = "INSTALL_DIR";
+    static final String RUN_DIR_ENV_VAR = "RUN_DIR";
 
     /* Flags */
 
@@ -578,9 +580,9 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
                 final String mutexId = "installation lock at host";
                 s.useMutex(getLocation().mutexes(), mutexId, "installing "+elvis(entity,this));
                 s.header.append(
-                        "export INSTALL_DIR=\""+getInstallDir()+"\"",
-                        "mkdir -p $INSTALL_DIR",
-                        "cd $INSTALL_DIR",
+                        "export "+INSTALL_DIR_ENV_VAR+"=\""+getInstallDir()+"\"",
+                        "mkdir -p $"+INSTALL_DIR_ENV_VAR,
+                        "cd $"+INSTALL_DIR_ENV_VAR,
                         "test -f BROOKLYN && exit 0"
                         );
 
@@ -592,10 +594,10 @@ public abstract class AbstractSoftwareProcessSshDriver extends AbstractSoftwareP
             }
             if (ImmutableSet.of(CUSTOMIZING, LAUNCHING, CHECK_RUNNING, STOPPING, KILLING, RESTARTING).contains(phase)) {
                 s.header.append(
-                        "export INSTALL_DIR=\""+getInstallDir()+"\"",
-                        "export RUN_DIR=\""+getRunDir()+"\"",
-                        "mkdir -p $RUN_DIR",
-                        "cd $RUN_DIR"
+                        "export "+INSTALL_DIR_ENV_VAR+"=\""+getInstallDir()+"\"",
+                        "export "+RUN_DIR_ENV_VAR+"=\""+getRunDir()+"\"",
+                        "mkdir -p $"+RUN_DIR_ENV_VAR,
+                        "cd $"+RUN_DIR_ENV_VAR
                         );
             }
         }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -29,8 +29,10 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
 import javax.xml.ws.WebServiceException;
 
+import com.google.common.base.Function;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -83,10 +85,18 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     }
 
     protected WinRmExecuteHelper newScript(String command, String psCommand, String phase, String ntDomain) {
+        Map<String, String> environment = (Map)getEntity().getConfig(WinRmTool.SHELL_ENVIRONMENT);
+    
+        if (environment == null) {
+            // Important only to call getShellEnvironment() if env was not supplied; otherwise it
+            // could cause us to resolve config (e.g. block for attributeWhenReady) too early.
+            environment = getShellEnvironment();
+        }
         return newScript(phase)
                 .setNtDomain(ntDomain)
                 .setCommand(command)
                 .setPsCommand(psCommand)
+                .setEnv(environment)
                 .failOnNonZeroResultCode()
                 .gatherOutput();
     }

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/AbstractSoftwareProcessWinRmDriver.java
@@ -29,10 +29,8 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
 import javax.xml.ws.WebServiceException;
 
-import com.google.common.base.Function;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
@@ -43,6 +41,7 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.lifecycle.NativeWindowsScriptRunner;
 import org.apache.brooklyn.entity.software.base.lifecycle.WinRmExecuteHelper;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.core.mutex.WithMutexes;
@@ -75,37 +74,37 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         entity.sensors().set(WINDOWS_PASSWORD, location.config().get(WinRmMachineLocation.PASSWORD));
     }
 
-    /** @see #newScript(Map, String) */
-    protected WinRmExecuteHelper newScript(String phase) {
-        return newScript(Maps.<String, Object>newLinkedHashMap(), phase);
+    protected WinRmExecuteHelper newScript(String command, String psCommand, String phase, String taskNamePrefix) {
+        return newScript(command, psCommand, phase, taskNamePrefix, null);
     }
 
-    protected WinRmExecuteHelper newScript(String command, String psCommand, String phase) {
-        return newScript(command, psCommand, phase, null);
-    }
-
-    protected WinRmExecuteHelper newScript(String command, String psCommand, String phase, String ntDomain) {
-        Map<String, String> environment = (Map)getEntity().getConfig(WinRmTool.SHELL_ENVIRONMENT);
-    
-        if (environment == null) {
-            // Important only to call getShellEnvironment() if env was not supplied; otherwise it
-            // could cause us to resolve config (e.g. block for attributeWhenReady) too early.
-            environment = getShellEnvironment();
-        }
-        return newScript(phase)
-                .setNtDomain(ntDomain)
+    protected WinRmExecuteHelper newScript(String command, String psCommand, String phase, String taskNamePrefix, String ntDomain) {
+        WinRmExecuteHelper result = newEmptyScript(taskNamePrefix);
+        result.setNtDomain(ntDomain)
                 .setCommand(command)
                 .setPsCommand(psCommand)
-                .setEnv(environment)
                 .failOnNonZeroResultCode()
                 .gatherOutput();
+        
+        Map<String, String> env = MutableMap.of();
+        env.put("INSTALL_DIR", getInstallDir());
+        if (AbstractSoftwareProcessSshDriver.INSTALLING.equals(phase)) {
+            // don't set shell env during this phase; otherwise it could cause us 
+            // to resolve config (e.g. block for attributeWhenReady) too early; instead just give install dir
+        } else {
+            env.put("RUN_DIR", getRunDir());
+            env.putAll(getShellEnvironment());
+        }
+        result.setEnv(env);
+        
+        return result;
     }
 
-    protected WinRmExecuteHelper newScript(Map<String, ?> flags, String phase) {
+    protected WinRmExecuteHelper newEmptyScript(String taskNamePrefix) {
         if (!Entities.isManaged(getEntity()))
-            throw new IllegalStateException(getEntity() + " is no longer managed; cannot create script to run here (" + phase + ")");
+            throw new IllegalStateException(getEntity() + " is no longer managed; cannot create script to run here (" + taskNamePrefix + ")");
 
-        WinRmExecuteHelper s = new WinRmExecuteHelper(this, phase + " " + elvis(entity, this));
+        WinRmExecuteHelper s = new WinRmExecuteHelper(this, taskNamePrefix + " " + elvis(entity, this));
         return s;
     }
 
@@ -115,6 +114,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             newScript(
                     getEntity().getConfig(BrooklynConfigKeys.PRE_INSTALL_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.PRE_INSTALL_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.INSTALLING,
                     "pre-install-command")
                 .useMutex(getLocation().mutexes(), "installation lock at host", "installing "+elvis(entity,this))
                 .execute();
@@ -135,6 +135,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             newScript(
                     getEntity().getConfig(BrooklynConfigKeys.POST_INSTALL_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.POST_INSTALL_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.INSTALLING,
                     "post-install-command")
             .useMutex(getLocation().mutexes(), "installation lock at host", "installing "+elvis(entity,this))
             .execute();
@@ -147,6 +148,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             executeCommandInTask(
                     getEntity().getConfig(BrooklynConfigKeys.PRE_CUSTOMIZE_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.PRE_CUSTOMIZE_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.CUSTOMIZING,
                     "pre-customize-command");
         }
     }
@@ -157,6 +159,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             executeCommandInTask(
                     getEntity().getConfig(BrooklynConfigKeys.POST_CUSTOMIZE_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.POST_CUSTOMIZE_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.CUSTOMIZING,
                     "post-customize-command");
         }
     }
@@ -167,6 +170,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             executeCommandInTask(
                     getEntity().getConfig(BrooklynConfigKeys.PRE_LAUNCH_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.PRE_LAUNCH_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.LAUNCHING,
                     "pre-launch-command");
         }
     }
@@ -177,6 +181,7 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
             executeCommandInTask(
                     getEntity().getConfig(BrooklynConfigKeys.POST_LAUNCH_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.POST_LAUNCH_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.LAUNCHING,
                     "post-launch-command");
         }
     }
@@ -235,12 +240,12 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         return getLocation();
     }
 
-    protected int executeCommandInTask(String command, String psCommand, String phase) {
-        return executeCommandInTask(command, psCommand, phase, null);
+    protected int executeCommandInTask(String command, String psCommand, String phase, String taskNamePrefix) {
+        return executeCommandInTask(command, psCommand, phase, taskNamePrefix, null);
     }
 
-    protected int executeCommandInTask(String command, String psCommand, String phase, String ntDomain) {
-        WinRmExecuteHelper helper = newScript(command, psCommand, phase, ntDomain);
+    protected int executeCommandInTask(String command, String psCommand, String phase, String taskNamePrefix, String ntDomain) {
+        WinRmExecuteHelper helper = newScript(command, psCommand, phase, taskNamePrefix, ntDomain);
         return helper.execute();
     }
 
@@ -324,15 +329,15 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
     }
 
     @Override
-    public Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powerShellCommand, String phase, Boolean allowNoOp) {
+    public Integer executeNativeOrPsCommand(Map flags, String regularCommand, String powerShellCommand, String summary, Boolean allowNoOp) {
         if (Strings.isBlank(regularCommand) && Strings.isBlank(powerShellCommand)) {
             if (allowNoOp) {
                 return new WinRmToolResponse("", "", 0).getStatusCode();
             } else {
-                throw new IllegalStateException(String.format("Exactly one of cmd or psCmd must be set for %s of %s", phase, entity));
+                throw new IllegalStateException(String.format("Exactly one of cmd or psCmd must be set for %s of %s", summary, entity));
             }
         } else if (!Strings.isBlank(regularCommand) && !Strings.isBlank(powerShellCommand)) {
-            throw new IllegalStateException(String.format("%s and %s cannot both be set for %s of %s", regularCommand, powerShellCommand, phase, entity));
+            throw new IllegalStateException(String.format("%s and %s cannot both be set for %s of %s", regularCommand, powerShellCommand, summary, entity));
         }
 
         ByteArrayOutputStream stdIn = new ByteArrayOutputStream();
@@ -359,6 +364,9 @@ public abstract class AbstractSoftwareProcessWinRmDriver extends AbstractSoftwar
         ImmutableMap.Builder winrmProps = ImmutableMap.builder();
         if (flags.get(WinRmTool.COMPUTER_NAME) != null) {
             winrmProps.put(WinRmTool.COMPUTER_NAME, flags.get(WinRmTool.COMPUTER_NAME));
+        }
+        if (flags.get(WinRmTool.ENVIRONMENT)!=null) {
+            winrmProps.put(WinRmTool.ENVIRONMENT, flags.get(WinRmTool.ENVIRONMENT));
         }
 
         if (Strings.isBlank(regularCommand)) {

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/VanillaWindowsProcessWinRmDriver.java
@@ -50,7 +50,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
         // TODO: At some point in the future, this should probably be refactored to get the name of the machine in WinRmMachineLocation and set it as the hostname sensor
         String hostname = null;
         if (entity.getConfig(VanillaWindowsProcess.INSTALL_REBOOT_REQUIRED)) {
-            WinRmExecuteHelper checkHostnameTask = newScript("Checking hostname")
+            WinRmExecuteHelper checkHostnameTask = newEmptyScript("Checking hostname")
                     .setCommand("hostname")
                     .failOnNonZeroResultCode()
                     .gatherOutput();
@@ -62,7 +62,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
         if(Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND)) || Strings.isNonBlank(getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND))) {
             String cmd = getEntity().getConfig(VanillaWindowsProcess.INSTALL_COMMAND);
             String psCmd = getEntity().getConfig(VanillaWindowsProcess.INSTALL_POWERSHELL_COMMAND);
-            newScript(cmd, psCmd, "install-command", hostname)
+            newScript(cmd, psCmd, AbstractSoftwareProcessSshDriver.INSTALLING, "installing-command", hostname)
                     .useMutex(getLocation().mutexes(), "installation lock at host", "installing "+elvis(entity,this))
                     .execute();
         }
@@ -77,6 +77,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
             executeCommandInTask(
                     getEntity().getConfig(VanillaWindowsProcess.CUSTOMIZE_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.CUSTOMIZE_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.CUSTOMIZING,
                     "customize-command");
         }
         if (entity.getConfig(VanillaWindowsProcess.CUSTOMIZE_REBOOT_REQUIRED)) {
@@ -91,6 +92,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
             executeCommandInTask(
                     getEntity().getConfig(VanillaWindowsProcess.LAUNCH_COMMAND),
                     getEntity().getConfig(VanillaWindowsProcess.LAUNCH_POWERSHELL_COMMAND),
+                    AbstractSoftwareProcessSshDriver.LAUNCHING,
                     "launch-command");
         }
     }
@@ -101,7 +103,9 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
         try {
             exitCode = executeCommandInTask(
                     getEntity().getConfig(VanillaWindowsProcess.CHECK_RUNNING_COMMAND),
-                    getEntity().getConfig(VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND), "is-running-command");
+                    getEntity().getConfig(VanillaWindowsProcess.CHECK_RUNNING_POWERSHELL_COMMAND), 
+                    AbstractSoftwareProcessSshDriver.CHECK_RUNNING,
+                    "is-running-command");
         } catch (Exception e) {
             Throwable interestingCause = findExceptionCausedByWindowsRestart(e);
             if (interestingCause != null) {
@@ -122,6 +126,7 @@ public class VanillaWindowsProcessWinRmDriver extends AbstractSoftwareProcessWin
         executeCommandInTask(
                 getEntity().getConfig(VanillaWindowsProcess.STOP_COMMAND),
                 getEntity().getConfig(VanillaWindowsProcess.STOP_POWERSHELL_COMMAND),
+                AbstractSoftwareProcessSshDriver.STOPPING,
                 "stop-command");
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
@@ -59,6 +59,7 @@ public class WinRmExecuteHelper {
     private String domain;
     private String command;
     private String psCommand;
+    private Map<String, String> env;
 
     @SuppressWarnings("rawtypes")
     protected final Map flags = new LinkedHashMap();
@@ -94,6 +95,11 @@ public class WinRmExecuteHelper {
 
     public WinRmExecuteHelper setPsCommand(String psCommand) {
         this.psCommand = psCommand;
+        return this;
+    }
+
+    public WinRmExecuteHelper setEnv(Map<String, String> env) {
+        this.env = env;
         return this;
     }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/lifecycle/WinRmExecuteHelper.java
@@ -196,6 +196,7 @@ public class WinRmExecuteHelper {
                 flags.put("err", stderr);
             }
             flags.put(WinRmTool.COMPUTER_NAME, domain);
+            if (env!=null) flags.put(WinRmTool.ENVIRONMENT, env);
             result = runner.executeNativeOrPsCommand(flags, command, psCommand, summary, false);
             if (!resultCodeCheck.apply(result)) {
                 throw logWithDetailsAndThrow(format("Execution failed, invalid result %s for %s", result, summary), null);

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.MachineDetails;
 import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.location.OsDetails;
@@ -40,19 +41,24 @@ import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.ConfigUtils;
 import org.apache.brooklyn.core.config.Sanitizer;
+import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.AbstractMachineLocation;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.core.location.access.PortForwardManagerLocationResolver;
 import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
+import org.apache.brooklyn.location.ssh.CanResolveOnBoxDir;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.internal.ssh.SshTool;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
 import org.apache.brooklyn.util.core.internal.winrm.winrm4j.Winrm4jTool;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.commons.codec.binary.Base64;
@@ -71,7 +77,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
 import com.google.common.reflect.TypeToken;
 
-public class WinRmMachineLocation extends AbstractMachineLocation implements MachineLocation {
+public class WinRmMachineLocation extends AbstractMachineLocation implements MachineLocation, CanResolveOnBoxDir {
 
     private static final Logger LOG = LoggerFactory.getLogger(WinRmMachineLocation.class);
 
@@ -490,6 +496,15 @@ public class WinRmMachineLocation extends AbstractMachineLocation implements Mac
 //                        "HQAaABlAG4AdABpAGMAYQB0AGkAbwBuACAAUABhAGMAawBlAHQAUAByAGkAdgBhAGMAeQANAAoAJABSAGUAcwB1AGwAd" +
 //                        "AAgAD0AIAAkAFIARABQAC4AUwBlAHQAQQBsAGwAbwB3AFQAUwBDAG8AbgBuAGUAYwB0AGkAbwBuAHMAKAAxACwAMQApAA=="
 //        ));
+    }
+
+    @Override
+    public String resolveOnBoxDirFor(Entity entity, String unresolvedPath) {
+        // TODO this is simplistic, writes at c:\ for HOME
+        if (unresolvedPath.startsWith("./") || unresolvedPath.startsWith("~/")) {
+            unresolvedPath = "C:\\"+unresolvedPath.substring(2);
+        }
+        return unresolvedPath.replaceAll("/", "\\");
     }
 
 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.annotations.Beta;
@@ -89,6 +90,9 @@ public interface WinRmTool {
     ConfigKey<String> ADDITIONAL_CONNECTION_METADATA = newStringConfigKey("additional.connection.metadata",
             "Can be used to pass additional custom data to the WinrmTool, which is especially useful " +
                     "if writing a bespoke tool implementation");
+
+    @SetFromFlag("env")
+    MapConfigKey<Object> SHELL_ENVIRONMENT = BrooklynConfigKeys.SHELL_ENVIRONMENT;
 
     /**
      * @deprecated since 0.9.0; use {@link #executeCommand(List)} to avoid ambiguity between native command and power shell.

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -49,6 +49,8 @@ public interface WinRmTool {
     ConfigKey<Integer> PROP_PORT = ConfigKeys.newIntegerConfigKey("port", "WinRM port to use when connecting to the remote machine");
     ConfigKey<Boolean> USE_HTTPS_WINRM = ConfigKeys.newBooleanConfigKey("winrm.useHttps", "The parameter tells the machine sensors whether the winrm port is over https. If the parameter is true then 5986 will be used as a winrm port.", false);
     ConfigKey<Integer> RETRIES_OF_NETWORK_FAILURES = ConfigKeys.newIntegerConfigKey("retriesOfNetworkFailures", "The parameter sets the number of retries for connection failures. If you use high value, consider taking care for the machine's network.", 4);
+    
+    @SetFromFlag("env")
     ConfigKey<Map<String,String>> ENVIRONMENT = MapConfigKey.builder(new TypeToken<Map<String,String>>() {})
             .name("winrm.environment")
             .description("WinRM Environment variables").build();
@@ -90,9 +92,6 @@ public interface WinRmTool {
     ConfigKey<String> ADDITIONAL_CONNECTION_METADATA = newStringConfigKey("additional.connection.metadata",
             "Can be used to pass additional custom data to the WinrmTool, which is especially useful " +
                     "if writing a bespoke tool implementation");
-
-    @SetFromFlag("env")
-    MapConfigKey<Object> SHELL_ENVIRONMENT = BrooklynConfigKeys.SHELL_ENVIRONMENT;
 
     /**
      * @deprecated since 0.9.0; use {@link #executeCommand(List)} to avoid ambiguity between native command and power shell.

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -144,7 +144,12 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
             byte[] inputData = new byte[chunkSize];
             int bytesRead;
             int expectedFileSize = 0;
+            int i=0;
             while ((bytesRead = source.read(inputData)) > 0) {
+                i++;
+                
+                LOG.debug("Copying chunk "+i+" to "+destination+" on "+host);
+                
                 byte[] chunk;
                 if (bytesRead == chunkSize) {
                     chunk = inputData;
@@ -156,7 +161,8 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
                         " -value ([System.Convert]::FromBase64String(\"" + new String(Base64.encodeBase64(chunk)) + "\"))}"));
                 expectedFileSize += bytesRead;
             }
-
+            LOG.debug("Finished copying to "+destination+" on "+host);
+            
             return new org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse("", "", 0);
         } catch (java.io.IOException e) {
             throw propagate(e, "Failed copying to server at "+destination);


### PR DESCRIPTION
pass `shell.env` fields to winrm machines, and use `INSTALL_DIR` and `RUN_DIR` similar to as done for linux