### PR TITLE
take build number from submodules' git sha1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -775,7 +775,8 @@
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>1.3</version>
                     <configuration>
-                        <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                        <!-- where git submodules are built take the SHA-1 from the submodule as the build number -->
+                        <getRevisionOnlyOnce>false</getRevisionOnlyOnce>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
instead of the root module, so that the SHA-1 written to manifests accurately reflects the state of the code that built it