### PR TITLE
JcloudsLocation: don’t expose cloud identity in toString()

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -312,12 +312,21 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
 
     @Override
     public String toString() {
-        Object identity = getIdentity();
+        String className = getClass().getSimpleName();
         String configDescription = config().getLocalBag().getDescription();
-        if (configDescription!=null && configDescription.startsWith(getClass().getSimpleName()))
+        String displayName = getDisplayName();
+
+        if (configDescription != null && configDescription.startsWith(className))
             return configDescription;
-        return getClass().getSimpleName()+"["+getDisplayName()+":"+(identity != null ? identity : null)+
-                (configDescription!=null ? "/"+configDescription : "") + "@" + getId() + "]";
+
+        if (displayName != null)
+            return className + "['" + displayName + "']";
+
+        return className + "[" +
+                getIdentity() +
+                (configDescription == null ? "" : "/" + configDescription) +
+                "@" + getId() +
+                "]";
     }
 
     @Override


### PR DESCRIPTION
Although it's not strictly secret, IMO it'd be preferable not to expose the `identity` field in `JcloudsLocation.toString()`, which does pop up in a few random places in the web UI. Display name and ID ought to be sufficient.