### PR TITLE
improved templates support, and jackson bump

### DIFF
--- a/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogTemplateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/catalog/internal/CatalogTemplateTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.catalog.internal;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.brooklyn.api.catalog.BrooklynCatalog;
+import org.apache.brooklyn.api.catalog.CatalogItem;
+import org.apache.brooklyn.core.catalog.CatalogPredicates;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+
+public class CatalogTemplateTest {
+    private LocalManagementContext managementContext;
+    private BrooklynCatalog catalog;
+    
+    @BeforeMethod(alwaysRun = true)
+    public void setUp() throws Exception {
+        managementContext = LocalManagementContextForTests.newInstance();
+        catalog = managementContext.getCatalog();
+    }
+    
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() throws Exception {
+        if (managementContext != null) Entities.destroyAll(managementContext);
+    }
+
+    @Test
+    public void testMultiLineStringTemplate() {
+        catalog.addItems(
+            "brooklyn.catalog:\n" + 
+            "  version: 1\n" + 
+            "  items:\n" + 
+            "    - id: test\n" + 
+            "      itemType: template\n" + 
+            "      item: |\n" + 
+            "        # comment\n" + 
+            "        type: "+BasicEntity.class.getCanonicalName()+"\n");
+        CatalogItem<Object, Object> item = assertSingleCatalogItem("test", "1");
+        Asserts.assertTrue(item.getPlanYaml().startsWith("# comment"), "Wrong format: "+item.getPlanYaml());
+    }
+    
+    @Test
+    public void testOneLineStringMapTemplate() {
+        catalog.addItems(
+            "brooklyn.catalog:\n" + 
+            "  version: 1\n" + 
+            "  items:\n" + 
+            "    - id: test\n" + 
+            "      itemType: template\n" + 
+            "      item: |\n" + 
+            "        type: "+BasicEntity.class.getCanonicalName()+"\n");
+        CatalogItem<Object, Object> item = assertSingleCatalogItem("test", "1");
+        Asserts.assertTrue(item.getPlanYaml().startsWith("type: org"), "Wrong format: "+item.getPlanYaml());
+    }
+    
+    @Test
+    public void testOneLineStringTypeTemplate() {
+        catalog.addItems(
+            "brooklyn.catalog:\n" + 
+            "  version: 1\n" + 
+            "  items:\n" + 
+            "    - id: test\n" + 
+            "      itemType: template\n" + 
+            "      item: |\n" + 
+            "        "+BasicEntity.class.getCanonicalName()+"\n");
+        CatalogItem<Object, Object> item = assertSingleCatalogItem("test", "1");
+        Asserts.assertTrue(item.getPlanYaml().startsWith("type: |\n  org"), "Wrong format: "+item.getPlanYaml());
+    }
+    
+    @Test
+    public void testMapTemplate() {
+        catalog.addItems(
+            "brooklyn.catalog:\n" + 
+            "  version: 1\n" + 
+            "  items:\n" + 
+            "    - id: test\n" + 
+            "      itemType: template\n" + 
+            "      item:\n" + 
+            "        type: "+BasicEntity.class.getCanonicalName()+"\n");
+        CatalogItem<Object, Object> item = assertSingleCatalogItem("test", "1");
+        Asserts.assertTrue(item.getPlanYaml().startsWith("type: org"), "Wrong format: "+item.getPlanYaml());
+    }
+    
+    private CatalogItem<Object, Object> assertSingleCatalogItem(String symbolicName, String version) {
+        Iterable<CatalogItem<Object, Object>> items = catalog.getCatalogItems(CatalogPredicates.symbolicName(Predicates.equalTo(symbolicName)));
+        CatalogItem<Object, Object> item = Iterables.getOnlyElement(items);
+        assertEquals(item.getSymbolicName(), symbolicName);
+        assertEquals(item.getVersion(), version);
+        return item;
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.10.0.pr2</fasterxml.jackson.version> <!-- 2.9.9 matches cxf-jackson (from cxf-jaxrs), but 2.10 has better yaml support -->
+        <fasterxml.jackson.version>2.10.1</fasterxml.jackson.version> <!-- 2.9.9 matches cxf-jackson (from cxf-jaxrs), but 2.10 has better yaml support -->
         <cxf.version>3.2.8</cxf.version>
         <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
         <httpcomponents.httpcore.version>4.4.9</httpcomponents.httpcore.version> <!-- To match cxf-http-async -->

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.9.8</fasterxml.jackson.version> <!-- To match cxf-jackson (from cxf-jaxrs) -->
+        <fasterxml.jackson.version>2.10.0.pr2</fasterxml.jackson.version> <!-- 2.9.9 matches cxf-jackson (from cxf-jaxrs), but 2.10 has better yaml support -->
         <cxf.version>3.2.8</cxf.version>
         <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
         <httpcomponents.httpcore.version>4.4.9</httpcomponents.httpcore.version> <!-- To match cxf-http-async -->
@@ -131,7 +131,7 @@
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.4.15</groovy.version> <!-- Version 2.4.7 supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes; not sure what more recent will be -->
         <jsr305.version>2.0.1</jsr305.version>
-        <snakeyaml.version>1.23</snakeyaml.version> <!-- To match cxf-jackson -->
+        <snakeyaml.version>1.25</snakeyaml.version>
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.5.6</swagger.version>
         <gson.version>2.5</gson.version>

--- a/utils/rest-swagger/pom.xml
+++ b/utils/rest-swagger/pom.xml
@@ -105,6 +105,24 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- jackson above v 2.10.0 wants 6.0 of woodstox, but cxf used elsewhere is only at 5.x -->
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- jackson above v 2.10.0 wants 4.2 but woodstox 5 on 3.1.4 -->
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>stax2-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- not needed here, but pulls in the right version of woodstox and stax2 for compatibility elsewhere, needed for jackson above -->
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+            <version>${cxf.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
templates can be given a string, for cases where it isn't valid YAML.
(note even without that, if templates include comments even not as a string, they are preserved).

also bump jackson, exclude some deps in case versions conflict.