### PR TITLE
Remove override for karaf jaxb-api following upgrade to 4.2.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -144,14 +144,6 @@
                 <artifactId>org.osgi.compendium</artifactId>
                 <version>${felix-osgi-compendium.version}</version>
             </dependency>
-            <dependency>
-                <!-- karaf/assemblies/features/base includes both 2.3.0 and 2.3.1 jaxb libraries -->
-                <!-- declaring the version here stops maven loading the conflicting versino from glassfish -->
-                <!-- Review if this is needed after karaf-4.2.2 -->
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb-api.version}</version>
-            </dependency>
             <!-- END karaf version overrides -->
 
             <dependency>


### PR DESCRIPTION
Following #1068 "Bumps karaf version to 4.2.7 (latest)" the Brooklyn build was
failing with the below error. 

Seems we can now remove the override from 81edd728
as part of #1035 "Use dependencyManagement from Karaf as a bom".


```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (default) on project rpm-packaging: Failed to resolve dependencies for one or more projects in the reactor. Reason: Missing:

[ERROR] ----------

[ERROR] 1) javax.xml.bind:jaxb-api:jar:2.3.2

[ERROR]

[ERROR]   Try downloading the file manually from the project website.

[ERROR]

[ERROR]   Then, install it using the command:

[ERROR]       mvn install:install-file -DgroupId=javax.xml.bind -DartifactId=jaxb-api -Dversion=2.3.2 -Dpackaging=jar -Dfile=/path/to/file

[ERROR]

[ERROR]   Alternatively, if you host your own repository you can deploy the file there:

[ERROR]       mvn deploy:deploy-file -DgroupId=javax.xml.bind -DartifactId=jaxb-api -Dversion=2.3.2 -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]

[ERROR]

[ERROR]   Path to dependency:

[ERROR]   	1) org.apache.brooklyn:rpm-packaging:pom:1.0.0-SNAPSHOT

[ERROR]   	2) org.apache.brooklyn:apache-brooklyn:zip:1.0.0-SNAPSHOT

[ERROR]   	3) org.apache.karaf.features:enterprise:xml:features:4.2.7

[ERROR]   	4) org.hibernate:hibernate-osgi:jar:5.4.2.Final

[ERROR]   	5) org.hibernate:hibernate-core:jar:5.4.2.Final

[ERROR]   	6) javax.xml.bind:jaxb-api:jar:2.3.2

[ERROR]
```