### PR TITLE
Ignore RAT check for `.brooklyn` persisted state created by tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1136,6 +1136,8 @@
                   <exclude>docs/**</exclude>
                   <!-- maven cache -->
                   <exclude>**/.m2/**</exclude>
+                  <!-- brooklyn persisted state, created by tests -->
+                  <exclude>**/.brooklyn/**</exclude>
 
                 </excludes>
               </configuration>


### PR DESCRIPTION
This is when builds are run within docker, the home directory is not properly expanded and the brooklyn persisted state (created by unit tests) ends up in the workspace. Subsequently, the RAT plugin checks the file within the workspace and fails because of these.

Ignoring them should fix the build issue on docker