### PR TITLE
Upgrade jclouds to 2.1.2 (from 2.1.0)

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -288,7 +288,6 @@
     </feature>
 
     <feature name="brooklyn-locations-jclouds-labs" version="${project.version}" description="Brooklyn JClouds Labs Location Targets">
-        <bundle>mvn:org.apache.jclouds.labs/azurecompute/${jclouds.version}</bundle>
     </feature>
 
     <feature name="brooklyn-container-service" version="${project.version}" description="Brooklyn Container Service and Location Targets">

--- a/locations/jclouds/pom.xml
+++ b/locations/jclouds/pom.xml
@@ -136,16 +136,11 @@
             <version>${jclouds.version}</version>
             <exclusions>
               <exclusion>
-                <!-- pulls in 1.17 where we want 1.21 -->
+                <!-- pulls in 1.17 where we want a newer version -->
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
               </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>${jclouds.groupId}.labs</groupId>
-            <artifactId>azurecompute</artifactId>
-            <version>${jclouds.version}</version>
         </dependency>
 
         <!-- these two seem needed here to prevent Eclipse IDE from getting wrong version of logback-core -->

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/networking/creator/DefaultAzureArmNetworkCreator.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.jclouds.azurecompute.arm.AzureComputeApi;
+import org.jclouds.azurecompute.arm.domain.AddressSpace;
 import org.jclouds.azurecompute.arm.domain.ResourceGroup;
 import org.jclouds.azurecompute.arm.domain.Subnet;
 import org.jclouds.azurecompute.arm.domain.VirtualNetwork;
@@ -123,7 +124,7 @@ public class DefaultAzureArmNetworkCreator {
             Subnet subnet = Subnet.create(subnetName, null, null, subnetProperties);
 
             VirtualNetwork.VirtualNetworkProperties virtualNetworkProperties = VirtualNetwork.VirtualNetworkProperties
-                    .builder().addressSpace(VirtualNetwork.AddressSpace.create(Arrays.asList(DEFAULT_VNET_ADDRESS_PREFIX)))
+                    .builder().addressSpace(AddressSpace.create(Arrays.asList(DEFAULT_VNET_ADDRESS_PREFIX)))
                     .subnets(Arrays.asList(subnet)).build();
             virtualNetworkApi.createOrUpdate(vnetName, location, Maps.newHashMap(), virtualNetworkProperties);
         } else {

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsStubTemplateBuilder.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsStubTemplateBuilder.java
@@ -170,8 +170,6 @@ public class JcloudsStubTemplateBuilder {
         case "google-compute-engine" :
             return new GoogleComputeEngineTemplateOptions();
             //return mock(GoogleComputeEngineTemplateOptions.class);
-        case "azurecompute" :
-            return new org.jclouds.azurecompute.compute.options.AzureComputeTemplateOptions();
         case "azurecompute-arm" :
             return new org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions();
         case "softlayer" :

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsWinrmingLiveTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsWinrmingLiveTest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.jclouds.Constants;
-import org.jclouds.azurecompute.arm.compute.options.AzureTemplateOptions;
-import org.jclouds.azurecompute.compute.options.AzureComputeTemplateOptions;
 import org.jclouds.compute.domain.OsFamily;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
         <!-- Dependency Versions -->
-        <jclouds.version>2.1.0</jclouds.version> <!-- JCLOUDS_VERSION -->
+        <jclouds.version>2.1.2</jclouds.version> <!-- JCLOUDS_VERSION -->
         <logback.version>1.0.7</logback.version>
         <slf4j.version>1.7.25</slf4j.version>  <!-- used for java.util.logging jul-to-slf4j interception -->
         <!-- Must match jclouds' version. From jclouds 1.9.3+ can be any version in the range [16-20) -->


### PR DESCRIPTION
jclouds 2.1.2 is the latest with a jclouds-karaf build (there isn't one yet for 2.1.3 or 2.2.0).

The biggest improvement (for me) in jclouds 2.1.2 [1] is support for "EC2 r5, t3, and x1 instance types".

I've smoke-tested this in the karaf distro by deploying a Windows entity to aws-ec2.

Note that `org.apache.jclouds.labs/azurecompute/${jclouds.version}` was removed in jclouds 2.1.2. That's fine - we only really want to support azure ARM rather than the ancient azure-classic.

[1] https://jclouds.apache.org/releasenotes/2.1.2/