### PR TITLE
Tidies - adjunct destroy, and better error messages

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -21,7 +21,6 @@ package org.apache.brooklyn.camp.brooklyn.spi.creation;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
@@ -92,7 +92,7 @@ public abstract class BrooklynYamlTypeInstantiator {
 
         @Override
         public Maybe<String> getTypeName() {
-            Maybe<Object> result = data.getStringKeyMaybe(getPreferredKeyName());
+            Maybe<Object> result = data.getStringKeyMaybe(getTypedKeyName());
             if (result.isAbsent() && typeKeyPrefix!=null) {
                 // try alternatives if a prefix was specified
                 result = data.getStringKeyMaybe(typeKeyPrefix+"Type");
@@ -100,15 +100,15 @@ public abstract class BrooklynYamlTypeInstantiator {
             }
             
             if (result.isAbsent() || result.get()==null) 
-                return Maybe.absent("Missing key '"+getPreferredKeyName()+"'");
+                return Maybe.absent("Missing key 'type'"+(typeKeyPrefix!=null ? " (or '"+getTypedKeyName()+"')" : ""));
             
             if (result.get() instanceof String) return Maybe.of((String)result.get());
             
-            throw new IllegalArgumentException("Invalid value "+result.get().getClass()+" for "+getPreferredKeyName()+"; "
+            throw new IllegalArgumentException("Invalid value "+result.get().getClass()+" for "+getTypedKeyName()+"; "
                 + "expected String, got "+result.get());
         }
         
-        protected String getPreferredKeyName() {
+        protected String getTypedKeyName() {
             if (typeKeyPrefix!=null) return typeKeyPrefix+"_type";
             return "type";
         }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampTypePlanTransformer.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampTypePlanTransformer.java
@@ -20,16 +20,18 @@ package org.apache.brooklyn.camp.brooklyn.spi.creation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry.RegisteredTypeKind;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredType.TypeImplementationPlan;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
-import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry.RegisteredTypeKind;
 import org.apache.brooklyn.core.typereg.AbstractFormatSpecificTypeImplementationPlan;
 import org.apache.brooklyn.core.typereg.AbstractTypePlanTransformer;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.collect.ImmutableList;
@@ -64,13 +66,27 @@ public class CampTypePlanTransformer extends AbstractTypePlanTransformer {
         }
         
         Maybe<Map<?,?>> plan = RegisteredTypes.getAsYamlMap(planData);
-        if (plan.isAbsent()) return 0;
-        if (plan.get().containsKey("services")) return weight*0.8;
-        if (plan.get().containsKey("type")) return weight*0.4;
-        // TODO these should become legacy
-        if (plan.get().containsKey("brooklyn.locations")) return weight*0.7;
-        if (plan.get().containsKey("brooklyn.policies")) return weight*0.7;
-        if (plan.get().containsKey("brooklyn.enrichers")) return weight*0.7;
+        if (plan.isPresent()) {
+            return weight * scoreObject(plan.get(), (map,s) -> map.containsKey(s));
+        }
+        if (planData==null) {
+            return 0;
+        }
+        double unparseableScore = scoreObject(planData.toString(), (p,s) -> p.contains(s));
+        if (unparseableScore>0) {
+            return 0.5 + 0.25 * unparseableScore;
+        }
+        return 0;
+    }
+    
+    protected <T> double scoreObject(T plan, BiFunction<T, String, Boolean> contains) {
+        if (contains.apply(plan, "services")) return 0.8;
+        if (contains.apply(plan, "type")) return 0.4;
+        if (contains.apply(plan, "brooklyn.locations")) return 0.7;
+        if (contains.apply(plan, "brooklyn.policies")) return 0.7;
+        if (contains.apply(plan, "brooklyn.enrichers")) return 0.7;
+        // score low so we can say it's the wrong place
+        if (contains.apply(plan, "catalog.bom")) return 0.2;
         return 0;
     }
 
@@ -84,8 +100,31 @@ public class CampTypePlanTransformer extends AbstractTypePlanTransformer {
 
     @Override
     protected AbstractBrooklynObjectSpec<?, ?> createSpec(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {
-        // TODO cache
-        return new CampResolver(mgmt, type, context).createSpec();
+        try {
+            return new CampResolver(mgmt, type, context).createSpec();
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+            String message = null;
+            // check a few common errors, annotate if so
+            if (type==null || type.getPlan()==null || type.getPlan().getPlanData()==null) {
+                // shouldn't happen
+                message = "Type/plan/data is null when resolving CAMP blueprint";
+            } else {
+                Object planData = type.getPlan().getPlanData();
+                if (RegisteredTypes.getAsYamlMap(planData).isAbsent()) {
+                    message = "Type or plan is invalid YAML when resolving CAMP blueprint";
+                } else if (planData.toString().contains("brooklyn.catalog")) {
+                    message = "CAMP blueprint for type definition looks like a catalog file";
+                } else {
+                    // leave null, don't annotate
+                }
+            }
+            if (message!=null) {
+                throw Exceptions.propagateAnnotated(message, e);
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Override

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslInterpreter.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslInterpreter.java
@@ -79,6 +79,8 @@ public class BrooklynDslInterpreter extends PlanInterpreterAdapter {
                 node.setNewValue( evaluate(parsedNode, true) );
             }
         } catch (Exception e) {
+            // we could try parsing it as yaml and if it comes back as a map or a list, reapply the interpreter;
+            // useful in some contexts where strings are required by the source (eg CFN, TOSCA)
             log.warn("Error evaluating node (rethrowing) '"+expression+"': "+e);
             Exceptions.propagateIfFatal(e);
             throw new IllegalArgumentException("Error evaluating node '"+expression+"'", e);

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
@@ -19,8 +19,25 @@
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
 import java.util.Arrays;
+import java.util.Map;
 
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.camp.brooklyn.BrooklynCampPlatform;
+import org.apache.brooklyn.camp.brooklyn.spi.creation.BrooklynComponentTemplateResolver;
+import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.yaml.Yamls;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
 
 public class DslUtils {
 
@@ -41,5 +58,65 @@ public class DslUtils {
             }
         }
         return allResolved;
+    }
+    
+    private static Object transformSpecialFlags(ManagementContext mgmt, AbstractBrooklynObjectSpec<?,?> spec, Object v) {
+        return new BrooklynComponentTemplateResolver.SpecialFlagsTransformer(
+            CatalogUtils.newClassLoadingContext(mgmt, spec.getCatalogItemId(), ImmutableList.of()),
+            MutableSet.of()).apply(v);
+    }
+
+    /** resolve an object which might be (or contain in a map or list) a $brooklyn DSL string expression */
+    private static Optional<Object> resolveBrooklynDslValueInternal(Object originalValue, @Nullable TypeToken<?> desiredType, @Nullable ManagementContext mgmt, @Nullable AbstractBrooklynObjectSpec<?,?> specForCatalogItemIdContext, boolean requireType) {
+        if (originalValue == null) {
+            return Optional.absent();
+        }
+        Object value = originalValue;
+        if (mgmt!=null) {
+            if (value instanceof String && ((String)value).matches("\\$brooklyn:[A-Za-z_]+:\\s(?s).*")) {
+                // input is a map as a string, parse it as yaml first
+                value = Iterables.getOnlyElement( Yamls.parseAll((String)value) );
+            }
+            
+            // The 'dsl' key is arbitrary, but the interpreter requires a map
+            ImmutableMap<String, Object> inputToPdpParse = ImmutableMap.of("dsl", value);
+            Map<String, Object> resolvedConfigMap = BrooklynCampPlatform.findPlatform(mgmt)
+                    .pdp()
+                    .applyInterpreters(inputToPdpParse);
+            value = resolvedConfigMap.get("dsl");
+            // TODO if it fails log a warning -- eg entitySpec with root.war that doesn't exist
+
+            if (specForCatalogItemIdContext!=null) {
+                value = transformSpecialFlags(mgmt, specForCatalogItemIdContext, value);
+            }
+        }
+        
+        if (requireType && value instanceof DeferredSupplier) {
+            // Don't cast - let Brooklyn evaluate it later (the value is a resolved DSL expression).
+            return Optional.of(value);
+        }
+        
+        if (desiredType!=null) {
+            // coerce to _raw_ type as per other config-setting coercion; config _retrieval_ does type correctness
+            return Optional.of(TypeCoercions.coerce(value, desiredType.getRawType()));
+
+        } else {
+            return Optional.of(value);
+        }
+    }
+
+    /** Resolve an object which might be (or contain in a map or list) a $brooklyn DSL string expression,
+     * attempting to coerce if a type is supplied (unless it is a {@link DeferredSupplier}) */
+    public static Optional<Object> resolveBrooklynDslValue(Object originalValue, @Nullable TypeToken<?> desiredType, @Nullable ManagementContext mgmt, @Nullable AbstractBrooklynObjectSpec<?,?> specForCatalogItemIdContext) {
+        return resolveBrooklynDslValueInternal(originalValue, desiredType, mgmt, specForCatalogItemIdContext, false);
+        
+    }
+    
+    /** As {@link #resolveBrooklynDslValue(Object, TypeToken, ManagementContext, AbstractBrooklynObjectSpec)}
+     * but returning absent if the object is DeferredSupplier, ensuring type correctness.
+     * This is particularly useful for maps and other objects which might contain deferred suppliers but won't be one. */
+    @SuppressWarnings("unchecked")
+    public static <T> Optional<T> resolveNonDeferredBrooklynDslValue(Object originalValue, @Nullable TypeToken<T> desiredType, @Nullable ManagementContext mgmt, @Nullable AbstractBrooklynObjectSpec<?,?> specForCatalogItemIdContext) {
+        return (Optional<T>) resolveBrooklynDslValueInternal(originalValue, desiredType, mgmt, specForCatalogItemIdContext, true);
     }
 }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -287,6 +287,8 @@ public class BrooklynDslCommon {
 
     // Build complex things
 
+    // TODO allow entitySpec to take string, parsed as YAML, and if just a string that's taken as the type
+    
     @DslAccessible
     public static EntitySpecConfiguration entitySpec(Map<String, Object> arguments) {
         return new EntitySpecConfiguration(arguments);

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/parse/DslParser.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/parse/DslParser.java
@@ -85,7 +85,7 @@ public class DslParser {
         } while (true);
         String fn = expression.substring(fnStart, index);
         if (fn.length()==0)
-            throw new IllegalStateException("Expected a function name at position "+start);
+            throw new IllegalStateException("Expected a function name or double-quoted string at position "+start);
         skipWhitespace();
         
         if (index < expression.length() && expression.charAt(index)=='(') {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
@@ -45,7 +45,6 @@ import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.entity.stock.BasicStartable;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.testng.annotations.Test;
 
@@ -551,7 +550,7 @@ public class DslYamlTest extends AbstractYamlTest {
                     "  brooklyn.config:",
                     "    dest: $brooklyn:self().invalidMethod()");
             Asserts.shouldHaveFailedPreviously("Non-existing non-deferred method should fail deployment");
-        } catch (CompoundRuntimeException e) {
+        } catch (Exception e) {
             Asserts.expectedFailureContains(e, "No such function 'invalidMethod'");
         }
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/TagsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/TagsYamlTest.java
@@ -15,20 +15,19 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
+import static org.testng.Assert.assertTrue;
+
+import javax.annotation.Nullable;
+
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.util.exceptions.CompoundRuntimeException;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.testng.annotations.Test;
 
-import javax.annotation.Nullable;
-
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 
 public class TagsYamlTest extends AbstractYamlTest {
     @Test
@@ -64,9 +63,11 @@ public class TagsYamlTest extends AbstractYamlTest {
                     "  brooklyn.tags:",
                     "    tag1: true",
                     "    tag2: 2");
-            fail("Should throw IllegalArgumentException exception; instead got: "+app);
-        } catch (CompoundRuntimeException e) {
-            Asserts.assertStringContainsAtLeastOne(Exceptions.getFirstInteresting(e).getMessage(),"brooklyn.tags must be a list, is: ");
+            Asserts.shouldHaveFailedPreviously("Should throw IllegalArgumentException exception; instead got: "+app);
+        } catch (Exception e) {
+            Asserts.expectedFailureContainsIgnoreCase(e, "brooklyn.tags must be a list");
+            Asserts.assertStringContainsAtLeastOne(Exceptions.getFirstInteresting(e).getMessage(),
+                "brooklyn.tags must be a list, is: ");
         }
     }
 
@@ -112,9 +113,13 @@ public class TagsYamlTest extends AbstractYamlTest {
                     "      type: "+TagsTestObject.class.getName(),
                     "      constructor.args:",
                     "      - $brooklyn:attributeWhenReady(\"host.name\")");
-            fail("Should throw IllegalArgumentException exception; instead got "+app);
-        } catch (CompoundRuntimeException e) {
-            Asserts.assertStringContainsAtLeastOne(Exceptions.getFirstInteresting(e).getMessage(),"brooklyn.tags should not contain DeferredSupplier. A DeferredSupplier is made when using $brooklyn:attributeWhenReady");
+            Asserts.shouldHaveFailedPreviously("Should throw IllegalArgumentException exception; instead got "+app);
+        } catch (Exception e) {
+            Asserts.expectedFailureContainsIgnoreCase(e, 
+                "brooklyn.tags should not contain DeferredSupplier",
+                "A DeferredSupplier is made when using $brooklyn:attributeWhenReady");
+            Asserts.assertStringContainsAtLeastOne(Exceptions.getFirstInteresting(e).getMessage(),
+                "brooklyn.tags should not contain DeferredSupplier");
         }
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/StaticSensor.java
@@ -70,6 +70,7 @@ public class StaticSensor<T> extends AddSensor<T> {
         class ResolveValue implements Callable<Maybe<T>> {
             @Override
             public Maybe<T> call() throws Exception {
+                // TODO resolve deep?
                 return Tasks.resolving(value).as(sensor.getTypeToken()).timeout(timeout).getMaybe();
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -50,7 +50,6 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.concurrent.Locks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.exceptions.UserFacingException;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.osgi.VersionedName;
 import org.apache.brooklyn.util.osgi.VersionedName.VersionedNameStringComparator;

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynTypePlanTransformer.java
@@ -64,8 +64,11 @@ public interface BrooklynTypePlanTransformer extends ManagementContextInjectable
      * 1 means this is clearly the intended transformer and no others need be tried 
      * (for instance because the format is explicitly specified),
      * and values between 0 and 1 indicate how likely a transformer believes it should be used.
+     * <p>
      * Values greater than 0.5 are generally reserved for the presence of marker tags or files
      * which strongly indicate that the format is compatible.
+     * Such a value should be returned even if the plan is not actually parseable, but if it looks like a user error
+     * which prevents parsing (eg mal-formed YAML) and the transformer could likely be the intended target.
      * <p>
      * */
     double scoreForType(@Nonnull RegisteredType type, @Nonnull RegisteredTypeLoadingContext context);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
@@ -125,10 +125,13 @@ public class TypePlanTransformers {
                     (Strings.isNonBlank(e.getMessage()) ? " ("+e.getMessage()+")" : ""));
             } catch (Throwable e) {
                 Exceptions.propagateIfFatal(e);
-                log.debug("Transformer for "+t.getFormatCode()+" gave an error creating this plan (retrying with others): "+e, e);
+                if (log.isTraceEnabled()) {
+                    log.trace("Transformer for "+t.getFormatCode()+" gave an error creating this plan (may retry): "+e, e);
+                }
                 failuresFromTransformers.add(new PropagatedRuntimeException(
-                    (type.getSymbolicName()!=null ? "Error in definition of "+type.getId() : 
-                        "Transformer for "+t.getFormatCode()+" gave an error creating this plan") + ": "+
+                    (type.getSymbolicName()!=null ? 
+                        t.getFormatCode()+" plan creation error in "+type.getId() :
+                        t.getFormatCode()+" plan creation error") + ": "+
                     Exceptions.collapseText(e), e));
             }
         }
@@ -150,7 +153,8 @@ public class TypePlanTransformers {
                 Exceptions.create("All plan transformers failed", failuresFromTransformers);
         } else {
             if (transformers.isEmpty()) {
-                result = new UnsupportedTypePlanException("Invalid plan; format could not be recognized, none of the available transformers "+all(mgmt)+" support "+type);
+                result = new UnsupportedTypePlanException("Invalid plan; format could not be recognized, none of the available transformers "+all(mgmt)+" support "+
+                    (type.getId()!=null ? type.getId() : "plan:\n"+type.getPlan().getPlanData()));
             } else {
                 result = new UnsupportedTypePlanException("Invalid plan; potentially applicable transformers "+transformers+" do not support it, and other available transformers "+
 //                    // the removeAll call below won't work until "all" caches it

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/DashboardAggregator.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/DashboardAggregator.java
@@ -51,7 +51,7 @@ public class DashboardAggregator extends AbstractEnricher {
 
     private ScheduledTask task;
 
-    public static BasicAttributeSensorAndConfigKey<Duration> DASHBOARD_COST_PER_MONTH = new BasicAttributeSensorAndConfigKey(Duration.class,
+    public static BasicAttributeSensorAndConfigKey<Duration> DASHBOARD_AGGREGATION_PERIOD = new BasicAttributeSensorAndConfigKey(Duration.class,
             "dashboard.period",
             "The amount of time to wait between aggregation jobs",
             Duration.seconds(1));
@@ -61,7 +61,7 @@ public class DashboardAggregator extends AbstractEnricher {
     public void setEntity(EntityLocal entity) {
         super.setEntity(entity);
 
-        Duration duration = config().get(DASHBOARD_COST_PER_MONTH);
+        Duration duration = config().get(DASHBOARD_AGGREGATION_PERIOD);
 
         Callable<Task<?>> taskFactory = () -> Tasks.builder()
                 .dynamic(false)

--- a/core/src/main/java/org/apache/brooklyn/util/core/ClassLoaderUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/ClassLoaderUtils.java
@@ -347,7 +347,15 @@ public class ClassLoaderUtils {
         } else {
             Maybe<T> result = dispatcher.tryLoadFrom(classLoader, name);
             if (result.isAbsent()) {
-                log.warn("Request for bundle '"+symbolicName+"' "+(Strings.isNonBlank(version) ? "("+version+") " : "")+"was ignored as no framework available; and failed to find '"+name+"' in plain old classpath");
+                if (name==null || name.startsWith("//") || symbolicName==null || "classpath".equals(symbolicName) || "http".equals(symbolicName) || "https".equals(symbolicName) || "file".equals(symbolicName)) {
+                    // this is called speculatively by BasicBrooklynCatalog.PlanInterpreterGuessingType so can log a lot of warnings where URLs are passed
+                    if (log.isTraceEnabled()) {
+                        log.trace("Request for bundle '"+symbolicName+"' "+(Strings.isNonBlank(version) ? "("+version+") " : "")+"was ignored as no framework available; and failed to find '"+name+"' in plain old classpath");
+                    }
+                } else {
+                    // TODO not sure warning is appropriate, but won't hide that in all cases yet
+                    log.warn("Request for bundle '"+symbolicName+"' "+(Strings.isNonBlank(version) ? "("+version+") " : "")+"was ignored as no framework available; and failed to find '"+name+"' in plain old classpath");
+                }
             }
             return result;
         }

--- a/policy/src/main/java/org/apache/brooklyn/policy/action/AbstractScheduledEffectorPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/action/AbstractScheduledEffectorPolicy.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -137,6 +138,7 @@ public abstract class AbstractScheduledEffectorPolicy extends AbstractPolicy imp
         if (executor != null) {
             executor.shutdownNow();
         }
+        // TODO instead of a custom executor it would be nicer to use scheduled tasks
         executor = Executors.newSingleThreadScheduledExecutor();
         running = new AtomicBoolean(false);
     }
@@ -288,5 +290,10 @@ public abstract class AbstractScheduledEffectorPolicy extends AbstractPolicy imp
                 start();
             }
         }
+    }
+    
+    @VisibleForTesting
+    public ScheduledExecutorService getExecutor() {
+        return executor;
     }
 }

--- a/policy/src/main/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicy.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicy.java
@@ -58,6 +58,7 @@ import com.google.common.base.Preconditions;
 @Beta
 public class PeriodicEffectorPolicy extends AbstractScheduledEffectorPolicy {
 
+    @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(PeriodicEffectorPolicy.class);
 
     public static final ConfigKey<Duration> PERIOD = ConfigKeys.builder(Duration.class)

--- a/policy/src/test/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicyTest.java
@@ -19,15 +19,11 @@
 
 package org.apache.brooklyn.policy.action;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 import org.slf4j.Logger;
@@ -40,6 +36,7 @@ import com.google.common.collect.Iterables;
 
 public class PeriodicEffectorPolicyTest extends AbstractEffectorPolicyTest {
 
+    @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(PeriodicEffectorPolicyTest.class);
     
     @Test

--- a/policy/src/test/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicyTest.java
+++ b/policy/src/test/java/org/apache/brooklyn/policy/action/PeriodicEffectorPolicyTest.java
@@ -19,13 +19,19 @@
 
 package org.apache.brooklyn.policy.action;
 
+import java.util.Arrays;
+import java.util.Map;
+
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicates;
@@ -34,6 +40,8 @@ import com.google.common.collect.Iterables;
 
 public class PeriodicEffectorPolicyTest extends AbstractEffectorPolicyTest {
 
+    private static final Logger log = LoggerFactory.getLogger(PeriodicEffectorPolicyTest.class);
+    
     @Test
     public void testPeriodicEffectorFires() {
         TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
@@ -52,6 +60,9 @@ public class PeriodicEffectorPolicyTest extends AbstractEffectorPolicyTest {
         entity.sensors().set(START, Boolean.TRUE);
         assertConfigEqualsEventually(policy, PeriodicEffectorPolicy.RUNNING, true);
         assertCallHistoryEventually(entity, "myEffector", 2);
+        
+        app.stop();
+        Asserts.assertTrue( ((PeriodicEffectorPolicy)policy).getExecutor().isShutdown(), "Executor should have been shut down");
     }
 
     // Integration because of long wait

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/AdjunctApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/AdjunctApi.java
@@ -68,6 +68,7 @@ public interface AdjunctApi {
             @QueryParam("adjunctType") final String adjunctType);
 
     // TODO support YAML ?
+    // TODO support timeout
     @POST
     @ApiOperation(value = "Create and add an adjunct (e.g. a policy, enricher, or feed) to this entity", notes = "Returns a summary of the added adjunct")
     @ApiResponses(value = {

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/AdjunctDetail.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/AdjunctDetail.java
@@ -57,6 +57,14 @@ public class AdjunctDetail extends AdjunctSummary {
         return tags;
     }
     
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+    
+    public Set<ConfigSummary> getParameters() {
+        return parameters;
+    }
+
     public AdjunctDetail parameter(ConfigSummary p) {
         parameters.add(p); return this;
     }
@@ -68,5 +76,5 @@ public class AdjunctDetail extends AdjunctSummary {
     public AdjunctDetail config(Map<String,Object> vals) {
         config.putAll(vals); return this;
     }
-
+    
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -513,7 +513,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
             legacyFormatException = e;
-            log.debug("Input is not legacy ApplicationSpec JSON (will try others): "+e, e);
+            log.debug("Input is not legacy ApplicationSpec JSON (will try others)");
         }
 
         //TODO infer encoding from request

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,23 +30,19 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.objs.HighlightTuple;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.test.policy.TestPolicy;
 import org.apache.brooklyn.rest.domain.AdjunctDetail;
 import org.apache.brooklyn.rest.domain.AdjunctSummary;
 import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.ConfigSummary;
 import org.apache.brooklyn.rest.domain.EntitySpec;
-import org.apache.brooklyn.rest.domain.TaskSummary;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.rest.testing.mocks.RestMockSimpleEntity;
 import org.apache.brooklyn.rest.testing.mocks.RestMockSimplePolicy;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.http.HttpAsserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -56,7 +51,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 @Test(singleThreaded = true,

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,24 +31,32 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.objs.HighlightTuple;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.test.policy.TestPolicy;
 import org.apache.brooklyn.rest.domain.AdjunctDetail;
 import org.apache.brooklyn.rest.domain.AdjunctSummary;
 import org.apache.brooklyn.rest.domain.ApplicationSpec;
 import org.apache.brooklyn.rest.domain.ConfigSummary;
 import org.apache.brooklyn.rest.domain.EntitySpec;
+import org.apache.brooklyn.rest.domain.TaskSummary;
 import org.apache.brooklyn.rest.testing.BrooklynRestResourceTest;
 import org.apache.brooklyn.rest.testing.mocks.RestMockSimpleEntity;
 import org.apache.brooklyn.rest.testing.mocks.RestMockSimplePolicy;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.http.HttpAsserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 @Test(singleThreaded = true,
@@ -195,4 +204,30 @@ public class AdjunctResourceTest extends BrooklynRestResourceTest {
         assertEquals(highlightTupleNoTask.getTime(), 123L);
         assertEquals(highlightTupleNoTask.getTaskId(), null);
     }
+    
+    @Test
+    public void testAddPolicy() throws Exception {
+        // to test in GUI: 
+        // services: [ { type: org.apache.brooklyn.entity.stock.BasicEntity }]
+        AdjunctDetail result = client().path(ENDPOINT)
+            .query("timeout", "10s")
+            .query("type", TestPolicy.class.getName())
+            // TODO encode this correctly as json?
+            // TODO on backend, parse DSL
+            .query("config", MutableMap.of(
+                TestPolicy.CONF_FROM_FUNCTION.getName(), "$brooklyn.literal('x')"))
+            .post(
+                null,
+                // TODO support YAML in the impl
+//                javax.ws.rs.client.Entity.entity(
+//                    "type: "+TestPolicy.class.getName()+"\n"+
+//                    "brooklyn.config:\n"+
+//                    "  "+TestPolicy.CONF_FROM_FUNCTION.getName()+": "+
+//                        "$brooklyn.literal('x')", 
+//                    "application/yaml"),
+                AdjunctDetail.class);
+
+        Assert.assertEquals(result.getConfig().get(TestPolicy.CONF_FROM_FUNCTION.getName()), "x");
+    }
+    
 }


### PR DESCRIPTION
Fixes a few minor things I've encountered:

* When invalid plans were sent, the error messages were awful.  Now they are more concise and sometimes more relevant.
* We never called `destroy` on adjuncts
* a couple other negligible things