### PR TITLE
add time data to returned data

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -181,7 +181,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
         if (includeTags) {
             result.setExtraField("tags", resolving(MutableList.copyOf(entity.tags().getTags())).preferJson(true).resolve() );
         }
-        
+        result.setExtraField("creationTimeUtc", entity.getCreationTime());
         addSensorsByGlobs(result, entity, extraSensorGlobs);
         addConfigByGlobs(result, entity, extraConfigGlobs);
         


### PR DESCRIPTION
Adds creationTime key to returned data to allow ui to sort applications by creation time.
PR# 150 in brooklyn-ui implements the sorting.