### PR TITLE
Upgrade CXF from 3.2.8 to 3.3.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -204,11 +204,6 @@
                 <version>${ant.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.sourceforge.plantuml</groupId>
-                <artifactId>plantuml</artifactId>
-                <version>${plantuml.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <version>${jetty.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,15 +123,15 @@
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>
         <!-- double-check downstream projects before changing jackson version -->
         <fasterxml.jackson.version>2.10.1</fasterxml.jackson.version> <!-- 2.9.9 matches cxf-jackson (from cxf-jaxrs), but 2.10 has better yaml support -->
-        <cxf.version>3.2.8</cxf.version>
-        <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
-        <httpcomponents.httpcore.version>4.4.9</httpcomponents.httpcore.version> <!-- To match cxf-http-async -->
+        <cxf.version>3.3.2</cxf.version>
+        <httpcomponents.httpclient.version>4.5.8</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
+        <httpcomponents.httpcore.version>4.4.11</httpcomponents.httpcore.version> <!-- To match cxf-http-async -->
         <!-- @deprecated since 0.11 -->
-        <httpclient.version>4.5.6</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
+        <httpclient.version>4.5.8</httpclient.version> <!-- kept for compatibility in 0.11.0-SNAPSHOT, remove after -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <groovy.version>2.4.15</groovy.version> <!-- Version 2.4.7 supported by https://github.com/groovy/groovy-eclipse/wiki/Groovy-Eclipse-2.9.1-Release-Notes; not sure what more recent will be -->
         <jsr305.version>2.0.1</jsr305.version>
-        <snakeyaml.version>1.25</snakeyaml.version>
+        <snakeyaml.version>1.25</snakeyaml.version> <!-- 1.24 matches cxf-jackson 3.3.2, but 1.25 has better yaml support -->
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.5.6</swagger.version>
         <gson.version>2.5</gson.version>
@@ -163,7 +163,7 @@
         <jax-rs-api.version>2.1.1</jax-rs-api.version>
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
-        <winrm4j.version>0.7.0</winrm4j.version>
+        <winrm4j.version>0.8.0</winrm4j.version>
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <kubernetes-client.version>1.4.27</kubernetes-client.version>
 
@@ -180,16 +180,15 @@
         <objenesis.version>2.5</objenesis.version>
         <clojure.version>1.4.0</clojure.version>
         <clj-time.version>0.4.1</clj-time.version>
-        <commons-codec.version>1.10</commons-codec.version>
+        <commons-codec.version>1.11</commons-codec.version>
         <log4j.version>1.2.17</log4j.version>
         <commons-logging.version>1.2</commons-logging.version>
         <jsonSmart.version>2.3</jsonSmart.version>
         <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
-        <ow2.asm.version>5.2</ow2.asm.version> <!-- version should align with cxf-rt-frontend-jaxws; see also json-path and karaf version requirements -->
+        <ow2.asm.version>5.2</ow2.asm.version> <!-- minidev.accessors-smart requires 5.x; aries-proxy:4.2.7 brings in 7.1 -->
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
-        <javax.mail.version>1.4.4</javax.mail.version>
-        <cxf.javax.annotation-api.version>1.3</cxf.javax.annotation-api.version> <!-- cxf-specs feature v3.2.7 declares v1.3 (as does org.apache.cxf:cxf-rt-frontend-jaxrs), but karaf 4.2.2 has 1.2 -->
-        <plantuml.version>6121</plantuml.version>
+        <javax.mail.version>1.4.7</javax.mail.version> <!-- version should align with 'jetty' feature -->
+        <cxf.javax.annotation-api.version>1.3.1</cxf.javax.annotation-api.version> <!-- cxf-specs feature v3.3.2 declares v1.3.1; jetty 9.4.20.v20190813 declares v1.3 -->
 
         <!-- Test dependencies -->
         <testng.version>6.10</testng.version>


### PR DESCRIPTION
... and bump related versions.

This is so our CXF version matches the one listed for Karaf 4.2.7 (see https://karaf.apache.org/news.html).

It required a new release of winrm4j (0.8.0 has just been released - it is in the sonatype main repo, https://oss.sonatype.org/index.html#nexus-search;quick~winrm4j, but hadn't been synced to search.maven.org yet last time I looked; that normally takes a couple of hours I think).

I tested this by building all of brooklyn, and then (in the karaf `brooklyn-dist/karaf/apache-brooklyn/target/assembly/`) I provisioned a new AWS windows VM with winzip installed:

```
name: windows@aws
location:
  jclouds:aws-ec2:
    region: us-west-2
    identity: <snip>
    credential: <snip>
    imageNameRegex: Windows_Server-2012-R2_RTM-English-64Bit-Base-.*
    imageOwner: 801119661308
    hardwareId: t3.medium
    useJcloudsSshInit: false
    templateOptions: {mapNewVolumeToDeviceName: ["/dev/sda1", 100, true]}
    machineCreateAttempts: 1

services:
- type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
  brooklyn.config:
    templates.preinstall:
      file:///Users/aledsage/temp/install7zip.ps1: "C:\\install7zip.ps1"
    install.command: powershell -command "C:\\install7zip.ps1"
    customize.command: echo true
    launch.command: echo true
    stop.command: echo true
    checkRunning.command: echo true
    installer.download.url: http://www.7-zip.org/a/7z938-x64.msi
```
