### PR TITLE
add check for missing endpoint

### DIFF
--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AbstractComputeServiceRegistry.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AbstractComputeServiceRegistry.java
@@ -57,7 +57,7 @@ public abstract class AbstractComputeServiceRegistry implements ComputeServiceRe
     private final Map<Map<?, ?>, ComputeService> cachedComputeServices = new ConcurrentHashMap<>();
 
     @Override
-    public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) throws IllegalArgumentException {
+    public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) {
         JCloudsPropertiesBuilder propertiesBuilder = new JCloudsPropertiesBuilder(conf)
                 .setCommonJcloudsProperties();
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AbstractComputeServiceRegistry.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/AbstractComputeServiceRegistry.java
@@ -57,7 +57,7 @@ public abstract class AbstractComputeServiceRegistry implements ComputeServiceRe
     private final Map<Map<?, ?>, ComputeService> cachedComputeServices = new ConcurrentHashMap<>();
 
     @Override
-    public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) {
+    public ComputeService findComputeService(ConfigBag conf, boolean allowReuse) throws IllegalArgumentException {
         JCloudsPropertiesBuilder propertiesBuilder = new JCloudsPropertiesBuilder(conf)
                 .setCommonJcloudsProperties();
 
@@ -81,6 +81,11 @@ public abstract class AbstractComputeServiceRegistry implements ComputeServiceRe
                 .addAll(linkingContext(conf));
 
         Iterable<? extends Module> modules = modulesBuilder.build();
+
+        //Check for missing endpoint when provider is azure
+        if (properties.getProperty(Constants.PROPERTY_ENDPOINT) == null && ("azurecompute-arm".equals(provider))) {
+            throw new IllegalArgumentException("Endpoint property cannot be null when provider is azure-arm");
+        }
 
         Supplier<ComputeService> computeServiceSupplier = new ComputeServiceSupplier(conf, modules, properties);
         if (allowReuse) {

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -612,6 +612,9 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         for (int i = 1; i <= attempts; i++) {
             try {
                 return obtainOnce(setup);
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Attempt #{}/{} to obtain machine threw error: {}", new Object[]{i, attempts, e});
+                exceptions.add(e);
             } catch (RuntimeException e) {
                 LOG.warn("Attempt #{}/{} to obtain machine threw error: {}", new Object[]{i, attempts, e});
                 exceptions.add(e);

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/JcloudsLocation.java
@@ -612,9 +612,6 @@ public class JcloudsLocation extends AbstractCloudMachineProvisioningLocation im
         for (int i = 1; i <= attempts; i++) {
             try {
                 return obtainOnce(setup);
-            } catch (IllegalArgumentException e) {
-                LOG.warn("Attempt #{}/{} to obtain machine threw error: {}", new Object[]{i, attempts, e});
-                exceptions.add(e);
             } catch (RuntimeException e) {
                 LOG.warn("Attempt #{}/{} to obtain machine threw error: {}", new Object[]{i, attempts, e});
                 exceptions.add(e);


### PR DESCRIPTION
Azure-ARM locations with no defined `endpoint` led to extreme server performance issues at app deployment time. Eventually causes OOME, Jackson serialisation timeouts, can even hang Chrome sub-process.
Added a check for missing endpoint parameter when deploying to Azure-ARM locations to avoid this issue on the server.