### PR TITLE
Add support for use of DSL when specifying the pattern for $brooklyn:formatString()

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -368,10 +368,10 @@ public class BrooklynDslCommon {
      * are not yet fully resolved.
      */
     @DslAccessible
-    public static Object formatString(final String pattern, final Object...args) {
-        if (resolved(args)) {
+    public static Object formatString(final Object pattern, final Object...args) {
+        if (resolved(Lists.asList(pattern, args))) {
             // if all args are resolved, apply the format string now
-            return String.format(pattern, args);
+            return String.format(String.valueOf(pattern), args);
         } else {
             return new DslFormatString(pattern, args);
         }
@@ -433,16 +433,16 @@ public class BrooklynDslCommon {
     /**
      * Deferred execution of String formatting.
      *
-     * @see DependentConfiguration#formatString(String, Object...)
+     * @see DependentConfiguration#formatString(Object, Object...)
      */
     protected static class DslFormatString extends BrooklynDslDeferredSupplier<String> {
 
         private static final long serialVersionUID = -4849297712650560863L;
 
-        private final String pattern;
+        private final Object pattern;
         private final Object[] args;
 
-        public DslFormatString(String pattern, Object ...args) {
+        public DslFormatString(Object pattern, Object ...args) {
             this.pattern = pattern;
             this.args = args;
         }
@@ -526,7 +526,7 @@ public class BrooklynDslCommon {
     @SuppressWarnings({ "serial", "unused" })
     @Deprecated
     private static class FormatString extends DslFormatString {
-        public FormatString(String pattern, Object[] args) {
+        public FormatString(Object pattern, Object[] args) {
             super(pattern, args);
         }
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseComponentsTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseComponentsTest.java
@@ -57,6 +57,7 @@ public class DslParseComponentsTest extends AbstractYamlTest {
                     "  brooklyn.config:",
                     "    dest: 1",
                     "    dest2: 1",
+                    "    pattern: '%s-%s'",
                     "  brooklyn.children:",
                     "  - type: "+BasicEntity.class.getName(),
                     "    id: two",
@@ -130,6 +131,17 @@ public class DslParseComponentsTest extends AbstractYamlTest {
         
         String y3 = Tasks.resolveValue(y1, String.class, ((EntityInternal) find("one")).getExecutionContext());
         Assert.assertEquals(y3.toString(), "1-1");
+    }
+
+    @Test
+    public void testFormatStringWithDslPatternEvaluation() throws Exception {
+        app();
+
+        Object y1 = parseDslExpression("$brooklyn:formatString($brooklyn:config(\"pattern\"), $brooklyn:config(\"dest\"), $brooklyn:config(\"dest2\"))");
+        Assert.assertEquals(y1.toString(), "$brooklyn:formatString(config(\"pattern\"), config(\"dest\"), config(\"dest2\"))");
+
+        String y2 = Tasks.resolveValue(y1, String.class, ((EntityInternal) find("one")).getExecutionContext());
+        Assert.assertEquals(y2.toString(), "1-1");
     }
 
     @Test


### PR DESCRIPTION
Previously, the `$brooklyn:formatString()` didn't accept nested DSL for its pattern, i.e. the first parameter of the function. This fixes it.