### PR TITLE
Don’t prompt for confirmation with apt-get

### DIFF
--- a/camp/camp-brooklyn/src/test/yaml/python-webserver.bom
+++ b/camp/camp-brooklyn/src/test/yaml/python-webserver.bom
@@ -33,7 +33,7 @@ brooklyn.catalog:
         install.command: |
           # install python if not present
           which python || \
-            { sudo apt-get update && sudo apt-get install python ; } || \
+            { sudo apt-get update && sudo apt-get install -y python ; } || \
             { sudo yum update && sudo yum install python ; } || \
             { echo WARNING: cannot install python && exit 1 ; }
 


### PR DESCRIPTION
`apt-get install` will try to prompt the user for confirmation when installing a package unless the `-y` parameter is provided. This causes the install to abort is there is no attached terminal.