### PR TITLE
leave a note to tell user this is not secure

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/crypto/SslTrustUtils.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/crypto/SslTrustUtils.java
@@ -39,7 +39,7 @@ public class SslTrustUtils {
         return connection;
     }
     
-    /** trusts all SSL certificates */
+    /** trusts all SSL certificates, it is not secure*/
     public static final TrustManager TRUST_ALL = new X509TrustManager() {
         @Override
         public X509Certificate[] getAcceptedIssuers() {


### PR DESCRIPTION
It would be better to warn users TRUST_ALL is not secure.