### PR TITLE
[WIP] Bump bouncycastle: 1.51 to 1.61

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,13 @@
         <dependency>
             <groupId>com.hierynomus</groupId>
             <artifactId>sshj</artifactId>
+            <exclusions>
+                <!-- provided by bcprov-ext instead -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>

--- a/core/src/test/java/org/apache/brooklyn/util/core/crypto/SecureKeysAndSignerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/crypto/SecureKeysAndSignerTest.java
@@ -78,7 +78,7 @@ public class SecureKeysAndSignerTest {
     @Test
     public void testInjectCertificateAuthority() throws Exception {
         KeyPair caKey = SecureKeys.newKeyPair();
-        X509Certificate caCert = new FluentKeySigner("the-root", caKey).selfsign().getAuthorityCertificate();
+        X509Certificate caCert = new FluentKeySigner("the-root", caKey).ca(0).selfsign().getAuthorityCertificate();
 
         FluentKeySigner signer = new FluentKeySigner(caCert, caKey);
         Assert.assertEquals("the-root", signer.getCommonName());

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -154,6 +154,7 @@
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream.servicemix.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>
+        <bundle dependency="true">mvn:net.i2p.crypto/eddsa/${eddsa.version}</bundle><!-- from com.hierynomous/sshj -->
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/1.1.3_2</bundle> <!-- jzlib version is 1.1.3, but bundle is 1.1.3_2 -->
         <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <swagger.version>1.5.6</swagger.version>
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
-        <bouncycastle.version>1.51</bouncycastle.version>
+        <bouncycastle.version>1.61</bouncycastle.version>
         <sshj.version>0.20.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
         <sshj.version>0.27.0</sshj.version>
+        <eddsa.version>0.2.0</eddsa.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
-        <sshj.version>0.27.0</sshj.version>
         <eddsa.version>0.2.0</eddsa.version>
+        <sshj.version>0.22.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <gson.version>2.5</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.61</bouncycastle.version>
-        <sshj.version>0.20.0</sshj.version>
+        <sshj.version>0.27.0</sshj.version>
         <reflections.version>0.9.10</reflections.version>
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>

--- a/utils/jmx/jmxmp-ssl-agent/src/test/java/org/apache/brooklyn/util/jmx/jmxmp/JmxmpAgentSslTest.java
+++ b/utils/jmx/jmxmp-ssl-agent/src/test/java/org/apache/brooklyn/util/jmx/jmxmp/JmxmpAgentSslTest.java
@@ -76,7 +76,7 @@ public class JmxmpAgentSslTest {
     
     @BeforeMethod
     public void setup() throws Exception {
-        caRootSigner = new FluentKeySigner("ca-root").selfsign();
+        caRootSigner = new FluentKeySigner("ca-root").ca(0).selfsign();
         caRootKey = caRootSigner.getKey();
         caRootCert = caRootSigner.getAuthorityCertificate();
 


### PR DESCRIPTION
This pull request builds on and extends https://github.com/apache/brooklyn-server/pull/1039.

The original branch for that PR was deleted. The git fu to get a branch with these commits was:
```
git fetch upstream pull/1039/head:bump-bouncycastle
git checkout bump-bouncycastle
git pull --rebase
````

---
The build still has the following unit test failures:

```
Tests run: 2366, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 105.431 sec <<< FAILURE! - in TestSuite
testInjectCertificateAuthority(org.apache.brooklyn.util.core.crypto.SecureKeysAndSignerTest)  Time elapsed: 0.181 sec  <<< FAILURE!
java.lang.AssertionError: expected [true] but found [false]
	at org.apache.brooklyn.util.core.crypto.SecureKeysAndSignerTest.testInjectCertificateAuthority(SecureKeysAndSignerTest.java:89)
```

As per @kemitix's comment (https://github.com/apache/brooklyn-server/pull/1039#issuecomment-462750504), bumping to sshj 0.27 fixed it - but then he rolled it back to 0.22 because:
```
This avoids an issue where sshj, >= v0.23.0, is broken in OSGi
environments, as it uses a class in a private package in a child
dependency, eddsa. In v0.23.0, sshj upgrdes to use 0.2.0 of eddsa
where this package is made private.
```

This still needs further investigation and fixed.