### PR TITLE
BROOKLYN-627: fix okhttp/kubernetes startup issue

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -314,7 +314,7 @@
         <bundle dependency='true'>wrap:mvn:com.squareup.okio/okio/1.15.0$Bundle-SymbolicName=squareup-okio&amp;Bundle-Version=1.15.0&amp;Export-Package=okio;version=1.15.0</bundle>
         <!-- (3) -->
         <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/okhttp/3.12.6$Bundle-SymbolicName=squareup-okhttp3&amp;Bundle-Version=3.12.6&amp;Import-Package=okio;version=1.15,*;resolution:=optional</bundle>
-        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/logging-interceptor/3.12.6</bundle>
+        <bundle dependency='true'>wrap:mvn:com.squareup.okhttp3/logging-interceptor/3.12.6$Bundle-SymbolicName=squareup-okhttp3-logging-interceptor&amp;Bundle-Version=3.12.6&amp;Import-Package=*;resolution:=mandatory</bundle>
         <!-- (4) -->
         <!-- these are the main required bundles for these features above -->
         <bundle>mvn:io.fabric8/zjsonpatch/0.3.0</bundle>


### PR DESCRIPTION
See description in https://issues.apache.org/jira/browse/BROOKLYN-627, which this is intended to fix.

I wrote a little script to loop round, starting Brooklyn and tearing it down again (deleting the data dir each time) to see if I could reproduce the error reported in BROOKLYN-627. I could not do so locally, and it continued to work after this fix!

I think it's worth including this fix, speculatively, as it could plausibly fix the non-deterministic issue.