### PR TITLE
New ChildrenBatchEffector

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/util/ChildrenBatchEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/util/ChildrenBatchEffector.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.util;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.EffectorTasks.EffectorBodyTaskFactory;
+import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.BasicExecutionContext;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Effector to  invoking an effector across children or members,
+ */
+public class ChildrenBatchEffector implements EntityInitializer {
+    public static final Effector<Object> EFFECTOR = Effectors.effector(Object.class, "childrenBatchEffector").
+            description("Invokes an effector e.g. across children or members").buildAbstract();
+    public static final ConfigKey<Integer> BATCH_SIZE = ConfigKeys.builder(Integer.class)
+            .name("batchSize")
+            .description("Supply a limit to the number of elements replaced at a time; 0 (default) means no limit")
+            .defaultValue(0)
+            .build();
+    public static final ConfigKey<String> EFFECTOR_TO_INVOKE = ConfigKeys.builder(String.class)
+            .name("effectorToInvoke")
+            .description("Name of the effector to invoke; if not supplied will use 'repave'")
+            .defaultValue("repave")
+            .build();
+    public static final ConfigKey<Boolean> FAIL_ON_MISSING_EFFECTOR_TO_INVOKE = ConfigKeys.builder(Boolean.class)
+            .name("failOnMissingEffector")
+            .description("Whether to fail (true) or ignore (false, default) if an entity does not have a matching target effector")
+            .defaultValue(false)
+            .build();
+    public static final ConfigKey<Boolean> FAIL_ON_EFFECTOR_FAILURE = ConfigKeys.builder(Boolean.class)
+            .name("failOnEffectorFailure")
+            .description("Whether to fail (true) or not (false, default) if an effector invocation failed")
+            .defaultValue(false)
+            .build();
+    public static final MapConfigKey<Object> EFFECTOR_ARGS = new MapConfigKey.Builder<Object>(Object.class, "effectorArgs")
+            .build();
+    private static final Logger log = LoggerFactory.getLogger(ChildrenBatchEffector.class);
+    // TODO config to apply to children or members or both
+    private final ConfigBag paramsCreationTime;
+
+    public ChildrenBatchEffector(ConfigBag params) {
+        this.paramsCreationTime = params;
+    }
+
+    public ChildrenBatchEffector(Map<String, String> params) {
+        this(ConfigBag.newInstance(params));
+    }
+
+
+    // wire up the entity to call the task factory to create the task on invocation
+
+    private static Effector<Object> makeEffector(ConfigBag paramsCreationTime) {
+        return Effectors.effector(EFFECTOR)
+                .parameter(BATCH_SIZE)
+                .parameter(EFFECTOR_TO_INVOKE)
+                .parameter(EFFECTOR_ARGS)
+                .impl(new EffectorBodyTaskFactory<>(new ChildrenBatchEffectorBody(paramsCreationTime))).build();
+    }
+
+    @Override
+    public void apply(@SuppressWarnings("deprecation") org.apache.brooklyn.api.entity.EntityLocal entity) {
+        ((EntityInternal) entity).getMutableEntityType().addEffector(makeEffector(paramsCreationTime));
+    }
+
+    protected static class ChildrenBatchEffectorBody extends EffectorBody<Object> {
+
+        private final ConfigBag paramsCreationTime;
+
+        public ChildrenBatchEffectorBody(ConfigBag paramsCreationTime) {
+            this.paramsCreationTime = paramsCreationTime;
+        }
+
+        @Override
+        public Object call(ConfigBag explicitEffectorInvocationParams) {
+            ConfigBag params = ConfigBag.newInstanceCopying(paramsCreationTime);
+            explicitEffectorInvocationParams.getAllConfig().forEach((k, v) ->
+            {
+                if (v != null) params.putStringKey(k, v);
+            });
+
+            final int batchSize = params.get(BATCH_SIZE);
+
+            // pass through parameters that were explicitly defined, and those supplied as extra args
+            // but defaults specified in the effector initializer block (in yaml) do _not_ get passed through
+            ConfigBag argsToPass = ConfigBag.newInstanceCopying(explicitEffectorInvocationParams).putAll(params.get(EFFECTOR_ARGS));
+
+            final boolean failOnMissingEffector = params.get(FAIL_ON_MISSING_EFFECTOR_TO_INVOKE);
+            final boolean failOnEffectorFailure = params.get(FAIL_ON_EFFECTOR_FAILURE);
+
+            List<Task<?>> activeTasks = MutableList.of();
+            List<Entity> items = MutableList.copyOf(entity().getChildren());
+            int initialSize = items.size();
+            int count = 0;
+
+            while (!items.isEmpty()) {
+                Entity child = items.remove(0);
+                String effectorName = params.get(EFFECTOR_TO_INVOKE);
+
+                Effector<?> effector = ((EntityInternal) child).getMutableEntityType().getEffector(effectorName);
+                if (effector == null) {
+                    if (failOnMissingEffector) {
+                        throw new IllegalStateException("No effector '" + effectorName + "' found on " + child);
+                    } else {
+                        // Skipping
+                        log.debug("Skipping {} when invoking effector on {} because it does not have an effector '{}'", child, entity(), effectorName);
+                    }
+                } else {
+                    Task<Object> t = Tasks.builder()
+                            .displayName("Invoking " + effectorName + " on " + child.getDisplayName() + " (" + child.getId() + ")")
+                            .swallowChildrenFailures(!failOnEffectorFailure)
+                            .add(Effectors.invocation(effector, argsToPass.getAllConfig(), child)).build();
+                    activeTasks.add(t);
+                    BasicExecutionContext.getCurrentExecutionContext().submit(t);
+                    count++;
+                    queue(t);
+                }
+
+                if (batchSize > 0 && !items.isEmpty()) {
+                    while (activeTasks.size() >= batchSize) {
+                        Iterator<Task<?>> ati = activeTasks.iterator();
+                        while (ati.hasNext()) {
+                            final Task<?> task = ati.next();
+                            if (task.isDone()) ati.remove();
+                        }
+                        if (activeTasks.size() >= batchSize) {
+                            try {
+                                Tasks.withBlockingDetails("Waiting for something in current batch of " + batchSize + " to complete "
+                                                + "before submitting the remaining " + items.size() + " invocation" + Strings.s(items.size()),
+                                        () -> {
+                                            Time.sleep(Duration.millis(100));
+                                            return null;
+                                        });
+                            } catch (Exception e) {
+                                throw Exceptions.propagate(e);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return "Invoked " + count + " of " + initialSize + " effectors";
+        }
+
+    }
+}

--- a/core/src/test/java/org/apache/brooklyn/core/effector/util/ChildrenBatchEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/util/ChildrenBatchEffectorTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.apache.brooklyn.core.effector.util.ChildrenBatchEffectorTest.DoNothingEffector.MUST_FAIL_AT;
+import static org.apache.brooklyn.test.Asserts.*;
+
+public class ChildrenBatchEffectorTest extends BrooklynAppUnitTestSupport {
+
+    public final static Effector<String> EFFECTOR_PARENT = Effectors.effector(String.class, "childrenBatchEffector").buildAbstract();
+    public final static Effector<String> EFFECTOR_CHILDREN = Effectors.effector(String.class, "children-effector").impl(new DoNothingEffector()).build();
+    ChildrenBatchEffector cut;
+
+    @BeforeMethod
+    public void init() throws IOException {
+        cut = null;
+        DoNothingEffector.executionAttempts = 0;
+        DoNothingEffector.correctExecutions = 0;
+    }
+
+    @Test
+    public void testCorrectExecution() {
+
+        cut = new ChildrenBatchEffector(ConfigBag.newInstance()
+                .configure(ChildrenBatchEffector.BATCH_SIZE, 1)
+                .configure(ChildrenBatchEffector.EFFECTOR_TO_INVOKE, EFFECTOR_CHILDREN.getName())
+        );
+        assertNotNull(cut);
+
+        TestEntity testEntity = app.createAndManageChild(buildEntitySpec(cut));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
+
+        assertEquals(testEntity.getChildren().size(), 3);
+
+        Object output = testEntity.invoke(EFFECTOR_PARENT, ImmutableMap.of()).getUnchecked(Duration.minutes(1));
+        assertTrue(output.toString().startsWith("Invoked 2"));
+        assertEquals(DoNothingEffector.executionAttempts, 2);
+        assertEquals(DoNothingEffector.correctExecutions, 2);
+    }
+
+    @Test
+    public void testContinueInvocationsWhenOneEffectorFail() {
+
+        cut = new ChildrenBatchEffector(ConfigBag.newInstance()
+                .configure(ChildrenBatchEffector.BATCH_SIZE, 1)
+                .configure(ChildrenBatchEffector.EFFECTOR_TO_INVOKE, EFFECTOR_CHILDREN.getName())
+                .configure(ChildrenBatchEffector.FAIL_ON_EFFECTOR_FAILURE, false) // default value too
+                .configure(ChildrenBatchEffector.EFFECTOR_ARGS, ImmutableMap.of(MUST_FAIL_AT.getName(), 2))
+        );
+        assertNotNull(cut);
+        TestEntity testEntity = app.createAndManageChild(buildEntitySpec(cut));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
+        assertEquals(testEntity.getChildren().size(), 4);
+
+        Object output = testEntity.invoke(EFFECTOR_PARENT, ImmutableMap.of()).getUnchecked(Duration.minutes(1));
+
+        assertTrue(output.toString().startsWith("Invoked 3"));
+        assertEquals(DoNothingEffector.executionAttempts, 3);
+        assertEquals(DoNothingEffector.correctExecutions, 2);
+    }
+
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testExceptionWhenEffectorFailIfRequired() {
+
+        cut = new ChildrenBatchEffector(ConfigBag.newInstance()
+                .configure(ChildrenBatchEffector.BATCH_SIZE, 1)
+                .configure(ChildrenBatchEffector.EFFECTOR_TO_INVOKE, EFFECTOR_CHILDREN.getName())
+                .configure(ChildrenBatchEffector.FAIL_ON_EFFECTOR_FAILURE, true)
+                .configure(ChildrenBatchEffector.EFFECTOR_ARGS, ImmutableMap.of(MUST_FAIL_AT.getName(), 2))
+        );
+        assertNotNull(cut);
+        TestEntity testEntity = app.createAndManageChild(buildEntitySpec(cut));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
+        assertEquals(testEntity.getChildren().size(), 3);
+
+        Object output = testEntity.invoke(EFFECTOR_PARENT, ImmutableMap.of()).getUnchecked(Duration.minutes(1));
+    }
+
+    @Test
+    public void testContinuesChildEffectorIsMissing() {
+
+        cut = new ChildrenBatchEffector(ConfigBag.newInstance()
+                .configure(ChildrenBatchEffector.BATCH_SIZE, 1)
+                .configure(ChildrenBatchEffector.FAIL_ON_MISSING_EFFECTOR_TO_INVOKE, false) // default value
+                .configure(ChildrenBatchEffector.EFFECTOR_TO_INVOKE, "unexisting")
+        );
+        assertNotNull(cut);
+        TestEntity testEntity = app.createAndManageChild(buildEntitySpec(cut));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
+        assertEquals(testEntity.getChildren().size(), 3);
+
+        Object output = testEntity.invoke(EFFECTOR_PARENT, ImmutableMap.of()).getUnchecked(Duration.minutes(1));
+
+        assertEquals(DoNothingEffector.executionAttempts, 0);
+        assertEquals(DoNothingEffector.correctExecutions, 0);
+    }
+
+    @Test(expectedExceptions = PropagatedRuntimeException.class)
+    public void testExceptionChildEffectorIsMissing() {
+
+        cut = new ChildrenBatchEffector(ConfigBag.newInstance()
+                .configure(ChildrenBatchEffector.BATCH_SIZE, 1)
+                .configure(ChildrenBatchEffector.FAIL_ON_MISSING_EFFECTOR_TO_INVOKE, true)
+                .configure(ChildrenBatchEffector.EFFECTOR_TO_INVOKE, "unexisting")
+        );
+        assertNotNull(cut);
+        TestEntity testEntity = app.createAndManageChild(buildEntitySpec(cut));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(new AddEffector(EFFECTOR_CHILDREN)));
+        testEntity.createAndManageChild(EntitySpec.create(TestEntity.class));
+        assertEquals(testEntity.getChildren().size(), 3);
+
+        Object output = testEntity.invoke(EFFECTOR_PARENT, ImmutableMap.of()).getUnchecked(Duration.minutes(1));
+    }
+
+
+    private EntitySpec<TestEntity> buildEntitySpec(EntityInitializer childrenBatchEffector) {
+        return EntitySpec.create(TestEntity.class).addInitializer(childrenBatchEffector);
+    }
+
+    static class DoNothingEffector extends EffectorBody<String> {
+
+        public static final ConfigKey<Integer> MUST_FAIL_AT = ConfigKeys.builder(Integer.class)
+                .name("mustFailAt")
+                .defaultValue(-1)
+                .build();
+        static int executionAttempts = 0;
+        static int correctExecutions = 0;
+
+        @Override
+        public String call(ConfigBag config) {
+            executionAttempts++;
+            if (executionAttempts == config.get(MUST_FAIL_AT)) {
+                throw new IllegalStateException();
+            }
+            correctExecutions++;
+            return "OK";
+        }
+    }
+}


### PR DESCRIPTION
Adding a new effector to call a inner effector in all the children entities where the effector is inserted in batches of a parametrized size.
It accept also a couple of parameters for define if it should continue or fail when the child effector doesn't exist and for failing and skipt next if one of the inner effector taks fails. An of course a parameter for define the name of the child effector o be called
This example blueprint shows the idea
```
services:
  - type: org.apache.brooklyn.entity.stock.BasicApplication
    name: Test ChildrenBatchEffector

    brooklyn.initializers:
      - type: org.apache.brooklyn.core.effector.util.ChildrenBatchEffector
        brooklyn.config:
          name: ChildrenBatchEffectorInParent
          effectorToInvoke: testEffector
          failOnMissingEffector: true

    brooklyn.children:
      - type: org.apache.brooklyn.entity.stock.BasicEntity
        name: child one
        brooklyn.initializers:
          - type: org.apache.brooklyn.core.effector.http.HttpCommandEffector
            brooklyn.config:
              name: testEffector
              uri: "http://localhost.io:8081/v1/applications"
              httpUsername: admin
              httpPassword: password
              httpVerb: get

      - type: org.apache.brooklyn.entity.stock.BasicEntity
        name: child two
        brooklyn.initializers:
          - type: org.apache.brooklyn.core.effector.http.HttpCommandEffector
            brooklyn.config:
              name: testEffector
              uri: "http://localhost.io:8081/v1/applications"
              httpUsername: admin
              httpPassword: password
              httpVerb: get
```

If you call the effector from the UI it will show you this dialog with the fields filled with the information from the blueprint
![image](https://user-images.githubusercontent.com/17095501/89804846-a5819b80-db2c-11ea-9ea8-be176d89bf06.png)

