### PR TITLE
Unwrap entity specs when used from the DSL

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -568,7 +568,7 @@ public class BrooklynComponentTemplateResolver {
                         throw Exceptions.propagateAnnotated(errorMessage, exceptionToInclude);
                     }
                 }
-                cached = EntityManagementUtils.unwrapEntity(entitySpec);
+                cached = EntityManagementUtils.unwrapEntity(entitySpec, false);
                 return cached;
             }
         }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -568,7 +568,7 @@ public class BrooklynComponentTemplateResolver {
                         throw Exceptions.propagateAnnotated(errorMessage, exceptionToInclude);
                     }
                 }
-                cached = EntityManagementUtils.unwrapEntity(entitySpec, false);
+                cached = EntityManagementUtils.unwrapEntity(entitySpec, true);
                 return cached;
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -294,6 +294,10 @@ public class EntityManagementUtils {
         return (childSpec.getType()!=null && Application.class.isAssignableFrom(childSpec.getType()));
     }
     
+    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec) {
+        return canUnwrapEntity(spec, true);
+    }
+    
     /** Returns true if the spec is for a wrapper app with no important settings, wrapping a single child entity. 
      * for use when adding from a plan specifying multiple entities but there is nothing significant at the application level,
      * and the context would like to flatten it to remove the wrapper yielding just a single entity.
@@ -303,8 +307,8 @@ public class EntityManagementUtils {
      * Note callers will normally use one of {@link #unwrapEntity(EntitySpec)} or {@link #unwrapApplication(EntitySpec)}.
      * 
      * @see #WRAPPER_APP_MARKER for an overview */
-    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec) {
-        return isWrapperApp(spec) && hasSingleChild(spec) &&
+    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec, boolean requireWrapperAppTag) {
+        return (!requireWrapperAppTag || isWrapperApp(spec)) && hasSingleChild(spec) &&
             // these "brooklyn.*" items on the app rather than the child absolutely prevent unwrapping
             // as their semantics could well be different whether they are on the parent or the child
             spec.getEnricherSpecs().isEmpty() &&

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -219,13 +219,13 @@ public class EntityManagementUtils {
     }
     
     public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication) {
-        return unwrapEntity(wrapperApplication, true);
+        return unwrapEntity(wrapperApplication, false);
     }
     
     /** Unwraps a single {@link Entity} if appropriate. See {@link #WRAPPER_APP_MARKER}.
      * Also see {@link #canUnwrapEntity(EntitySpec)} to test whether it will unwrap. */
-    public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication, boolean wrapperAppMarkerRequired) {
-        if (!canUnwrapEntity(wrapperApplication, wrapperAppMarkerRequired)) {
+    public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication, boolean allowUnwrappingApplicationsWithoutWrapperAppMarker) {
+        if (!canUnwrapEntity(wrapperApplication, allowUnwrappingApplicationsWithoutWrapperAppMarker)) {
             return wrapperApplication;
         }
         EntitySpec<?> wrappedEntity = Iterables.getOnlyElement(wrapperApplication.getChildren());
@@ -299,7 +299,7 @@ public class EntityManagementUtils {
     }
     
     public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec) {
-        return canUnwrapEntity(spec, true);
+        return canUnwrapEntity(spec, false);
     }
     
     /** Returns true if the spec is for a wrapper app with no important settings, wrapping a single child entity. 
@@ -311,8 +311,10 @@ public class EntityManagementUtils {
      * Note callers will normally use one of {@link #unwrapEntity(EntitySpec)} or {@link #unwrapApplication(EntitySpec)}.
      * 
      * @see #WRAPPER_APP_MARKER for an overview */
-    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec, boolean wrapperAppMarkerRequired) {
-        return (!wrapperAppMarkerRequired || isWrapperApp(spec)) && hasSingleChild(spec) &&
+    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec, boolean allowUnwrappingApplicationsWithoutWrapperAppMarker) {
+        return ((allowUnwrappingApplicationsWithoutWrapperAppMarker && Application.class.isAssignableFrom(spec.getType())) 
+                || isWrapperApp(spec)) && 
+            hasSingleChild(spec) &&
             // these "brooklyn.*" items on the app rather than the child absolutely prevent unwrapping
             // as their semantics could well be different whether they are on the parent or the child
             spec.getEnricherSpecs().isEmpty() &&

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -218,10 +218,14 @@ public class EntityManagementUtils {
         return CreationResult.of(children, task);
     }
     
+    public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication) {
+        return unwrapEntity(wrapperApplication, true);
+    }
+    
     /** Unwraps a single {@link Entity} if appropriate. See {@link #WRAPPER_APP_MARKER}.
      * Also see {@link #canUnwrapEntity(EntitySpec)} to test whether it will unwrap. */
-    public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication) {
-        if (!canUnwrapEntity(wrapperApplication)) {
+    public static EntitySpec<? extends Entity> unwrapEntity(EntitySpec<? extends Entity> wrapperApplication, boolean wrapperAppMarkerRequired) {
+        if (!canUnwrapEntity(wrapperApplication, wrapperAppMarkerRequired)) {
             return wrapperApplication;
         }
         EntitySpec<?> wrappedEntity = Iterables.getOnlyElement(wrapperApplication.getChildren());
@@ -307,8 +311,8 @@ public class EntityManagementUtils {
      * Note callers will normally use one of {@link #unwrapEntity(EntitySpec)} or {@link #unwrapApplication(EntitySpec)}.
      * 
      * @see #WRAPPER_APP_MARKER for an overview */
-    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec, boolean requireWrapperAppTag) {
-        return (!requireWrapperAppTag || isWrapperApp(spec)) && hasSingleChild(spec) &&
+    public static boolean canUnwrapEntity(EntitySpec<? extends Entity> spec, boolean wrapperAppMarkerRequired) {
+        return (!wrapperAppMarkerRequired || isWrapperApp(spec)) && hasSingleChild(spec) &&
             // these "brooklyn.*" items on the app rather than the child absolutely prevent unwrapping
             // as their semantics could well be different whether they are on the parent or the child
             spec.getEnricherSpecs().isEmpty() &&


### PR DESCRIPTION
At present if you refer to an entity which is trivially wrapped to make an application, in a `$brooklyn:entitySpec` DSL, the application is added without being unwrapped.  This is inconsistent with behaviour elsewhere, eg in the UI for "add child" and when a trivially-app-wrapped entity is referred to in `brooklyn.children`.

(FYI a "trivially-app-wrapped" entity is what you get if you say `services: [ { type: my-entity } ]` or in other places where an entity is supplied but the code needs an application and so constructs a trivial BasicApplication instance with the entity as a child.)

This PR corrects the above behaviour, so that eg such a trivially-wrapped-app can be used in a dynamic cluster and the entity is used as the spec, not the application.

Note that it is straightforward to suppress this unwrapping, just add a no-op initializer or enricher to the `Application`, and that will always prevent unwrapping.