### PR TITLE
Allow arbitrary beans to be added to catalog and used in config, initializers, and elsewhere

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -140,11 +140,25 @@ public interface BrooklynCatalog {
      * Optionally updates a supplied (empty) map containing newly added types as keys
      * and any previously existing type they replace as values, for reference or for use rolling back
      * (this is populated with work done so far if the method throws an error).
+     * <p>
+     * A null bundle can be supplied although that will cause oddness in production installations
+     * that assume bundles for persistence, lookup and other capabilities. (But it's fine for tests.)
      */
     @Beta  // method may move elsewhere, or return type may change
-    public void addTypesFromBundleBom(String yaml, ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result);
-    
-    /** As {@link #validateType(RegisteredType)} but taking a set of types, returning a map whose keys are
+    public void addTypesFromBundleBom(String yaml, @Nullable ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result);
+
+    /** As {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)} followed by {@link #validateType(RegisteredType, RegisteredTypeLoadingContext)}
+     * e.g. for use in tests and ad hoc setup when there is just a YAML file.  In OSGi mode this adds a bundle; otherwise it uses legacy catalog item addition mode.
+     * <p>
+     * Note that if addition or validation fails, this throws, unlike {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)},
+     * and the type registry may have some of the items updated.  It is the caller's responsibility to clean up if required
+     * (note, clean up is only possible if an empty results map is supplied to collect the items, and even then finding the bundle needs work;
+     * or, most commonly, where the management context is just being thrown away, like in tests).
+     */
+    @Beta
+    Collection<RegisteredType> addTypesAndValidateAllowInconsistent(String catalogYaml, @Nullable Map<RegisteredType, RegisteredType> result, boolean forceUpdate);
+
+    /** As {@link #validateType(RegisteredType, RegisteredTypeLoadingContext)} but taking a set of types, returning a map whose keys are
      * those types where validation failed, mapped to the collection of errors validating that type. 
      * An empty map result indicates no validation errors in the types passed in. 
      */
@@ -160,35 +174,13 @@ public interface BrooklynCatalog {
     @Beta  // method may move elsewhere
     Collection<Throwable> validateType(RegisteredType typeToValidate, @Nullable RegisteredTypeLoadingContext optionalConstraint);
 
-    /**
-     * As {@link #addItemsFromBundle(String, ManagedBundle)} with a null bundle.
-     * (Only used for legacy-mode additions.) 
+    /** As {@link #addItems(String, boolean, boolean)}
+     *
+     * @deprecated since 1.1, use {@link #addTypesAndValidateAllowInconsistent(String, Map, boolean)}
+     * (Used in tests.)
      */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml);
-    
-    /**
-     * Adds items (represented in yaml) to the catalog coming from the indicated managed bundle.
-     * Fails if the same version exists in catalog (unless snapshot).
-     * (Only used for legacy-mode additions.) 
-     *
-     * @throws IllegalArgumentException if the yaml was invalid
-     */
-    Iterable<? extends CatalogItem<?,?>> addItems(String yaml, @Nullable ManagedBundle definingBundle);
-    
-    /**
-     * Adds items (represented in yaml) to the catalog.
-     * (Only used for legacy-mode additions.) 
-     * 
-     * @param forceUpdate If true allows catalog update even when an
-     * item exists with the same symbolicName and version
-     *
-     * @throws IllegalArgumentException if the yaml was invalid
-     * 
-     * @deprecated since 1.0.0 use {@link #addItems(String)} or {@link #addItems(String, boolean, boolean)}
-     */
-    @Deprecated
-    Iterable<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate);
-    
+
     /**
      * Adds items (represented in yaml) to the catalog.
      * (Only used for legacy-mode additions.) 
@@ -199,11 +191,24 @@ public interface BrooklynCatalog {
      * item exists with the same symbolicName and version
      *
      * @throws IllegalArgumentException if the yaml was invalid
+     *
+     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)};
+     * (Used for REST API, a few tests, and legacy-compatibility additions.)
      */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, boolean validate, boolean forceUpdate);
-    
-    /** As {@link #addItems(String, ManagedBundle)} but exposing forcing option as per {@link #addItem(String, boolean)}. 
-     * (Only used for legacy-mode additions.) */
+
+    /**
+     * Adds items (represented in yaml) to the catalog coming from the indicated managed bundle.
+     * Fails if the same version exists in catalog (unless snapshot).
+     * (Only used for legacy-mode additions.)
+     *
+     * @param forceUpdate If true allows catalog update even when an
+     * item exists with the same symbolicName and version
+     *
+     * @throws IllegalArgumentException if the yaml was invalid
+     *
+     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)};
+     * (Only used for legacy OSGi bundles.) */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, ManagedBundle bundle, boolean forceUpdate);
     
     /**

--- a/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/CatalogItem.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.api.mgmt.rebind.RebindSupport;
 import org.apache.brooklyn.api.mgmt.rebind.Rebindable;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.CatalogItemMemento;
 import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.BrooklynObjectType;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.Enricher;
@@ -49,8 +50,9 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
         ENTITY, 
         POLICY,
         ENRICHER,
-        LOCATION;
-        
+        LOCATION,
+        BEAN;
+
         public static CatalogItemType ofSpecClass(Class<? extends AbstractBrooklynObjectSpec<?, ?>> type) {
             if (type==null) return null;
             if (PolicySpec.class.isAssignableFrom(type)) return POLICY;
@@ -67,6 +69,10 @@ public interface CatalogItem<T,SpecT> extends BrooklynObject, Rebindable {
             if (Application.class.isAssignableFrom(type)) return APPLICATION;
             if (Entity.class.isAssignableFrom(type)) return ENTITY;
             return null;
+        }
+
+        public BrooklynObjectType getBrooklynObjectType() {
+            return BrooklynObjectType.of(this);
         }
 
         @Override

--- a/api/src/main/java/org/apache/brooklyn/api/entity/EntityInitializer.java
+++ b/api/src/main/java/org/apache/brooklyn/api/entity/EntityInitializer.java
@@ -28,14 +28,16 @@ import org.apache.brooklyn.api.sensor.Feed;
  * Instances of this class supply logic which can be used to initialize entities. 
  * These can be added to an {@link EntitySpec} programmatically, or declared as part
  * of YAML recipes in a <code>brooklyn.initializers</code> section.
- * In the case of the latter, implementing classes should define a no-arg constructor
- * or a {@link Map} constructor so that YAML parameters can be supplied.
+ * In the case of the latter, implementing classes should design as
+ * beans (for fields to be set) or following one of the patterns in EntityInitializers (in core)
+ * which provide a one-arg constructor taking a ConfigBag (for parameters passed in through a <code>brooklyn.config</code> key
+ * under the <code>brooklyn.initializers</code>).
  * <p>
  * Note that initializers are only invoked on first creation; they are not called 
  * during a rebind. Instead, the typical pattern is that initializers will create
  * {@link EntityAdjunct} instances such as {@link Policy} and {@link Feed}
  * which will be attached during rebind.
- **/ 
+ **/
 public interface EntityInitializer {
     
     /** Applies initialization logic to a just-built entity.

--- a/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/BrooklynObjectType.java
@@ -95,7 +95,7 @@ public enum BrooklynObjectType {
     }
     
     public static BrooklynObjectType of(CatalogItemType t) {
-        if (t==null) return null;
+        if (t==null) return BrooklynObjectType.UNKNOWN;
         switch (t) {
         case ENRICHER: return BrooklynObjectType.ENRICHER;
         case ENTITY: return BrooklynObjectType.ENTITY;

--- a/api/src/main/java/org/apache/brooklyn/api/typereg/BrooklynTypeRegistry.java
+++ b/api/src/main/java/org/apache/brooklyn/api/typereg/BrooklynTypeRegistry.java
@@ -73,7 +73,7 @@ public interface BrooklynTypeRegistry {
     <T> T create(RegisteredType type, @Nullable RegisteredTypeLoadingContext optionalContext, @Nullable Class<T> optionalResultSuperType);
     /** Creates a bean or spec (depending on the super-type hint) for the given plan data (e.g. a yaml string) for the given format (optional, will auto-detect if null) */
     @Beta
-    <T> T createFromPlan(Class<T> requiredSuperTypeHint, @Nullable String planFormat, Object planData, @Nullable RegisteredTypeLoadingContext optionalConstraint);
+    <T> T createFromPlan(RegisteredTypeKind kind, @Nullable String planFormat, Object planData, @Nullable RegisteredTypeLoadingContext optionalConstraint, @Nullable Class<T> superTypeHint);
 
     /** Typesafe {@link AbstractBrooklynObjectSpec} variant of {@link #create(RegisteredType, RegisteredTypeLoadingContext, Class)} */
     // NB the seemingly more correct generics <T,SpecT extends AbstractBrooklynObjectSpec<T,SpecT>> 
@@ -81,14 +81,14 @@ public interface BrooklynTypeRegistry {
     // TODO do these belong here, or in a separate master TypePlanTransformer ?  see also BrooklynTypePlanTransformer
     @Beta
     <SpecT extends AbstractBrooklynObjectSpec<?,?>> SpecT createSpec(RegisteredType type, @Nullable RegisteredTypeLoadingContext optionalContext, @Nullable Class<SpecT> optionalSpecSuperType);
-    /** Typesafe {@link AbstractBrooklynObjectSpec} variant of {@link #createFromPlan(Class, String, Object, RegisteredTypeLoadingContext)} */
+    /** Typesafe {@link AbstractBrooklynObjectSpec} variant of {@link #createFromPlan(RegisteredTypeKind, String, Object, RegisteredTypeLoadingContext, Class)} */
     @Beta
     <SpecT extends AbstractBrooklynObjectSpec<?,?>> SpecT createSpecFromPlan(@Nullable String planFormat, Object planData, @Nullable RegisteredTypeLoadingContext optionalContext, @Nullable Class<SpecT> optionalSpecSuperType);
     /** Typesafe non-spec variant of {@link #create(RegisteredType, RegisteredTypeLoadingContext, Class)} */
     @Beta
     <T> T createBean(RegisteredType type, @Nullable RegisteredTypeLoadingContext optionalContext, @Nullable Class<T> optionalResultSuperType);
     @Beta
-    /** Typesafe non-spec variant of {@link #createFromPlan(Class, String, Object, RegisteredTypeLoadingContext)} */
+    /** Typesafe non-spec variant of {@link #createFromPlan(RegisteredTypeKind, String, Object, RegisteredTypeLoadingContext, Class)} */
     <T> T createBeanFromPlan(String planFormat, Object planData, @Nullable RegisteredTypeLoadingContext optionalConstraint, @Nullable Class<T> optionalBeanSuperType);
     
 }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynYamlTypeInstantiator.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.camp.brooklyn.BrooklynCampReservedKeys;
@@ -68,6 +70,9 @@ public abstract class BrooklynYamlTypeInstantiator {
             return new InstantiatorFromName(this, typeName);
         }
 
+        public BrooklynClassLoadingContext getClassLoadingContext() {
+            return loader;
+        }
     }
         
     public static class InstantiatorFromKey extends BrooklynYamlTypeInstantiator {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
@@ -185,7 +185,7 @@ public class DslDeferredFunctionCall extends BrooklynDslDeferredSupplier<Object>
     protected Maybe<?> resolve(Object object, boolean immediate) {
         return Tasks.resolving(object, Object.class)
             .context(entity().getExecutionContext())
-            .deep(true, true)
+            .deep(true, true, true)
             .immediately(immediate)
             .iterator()
             .nextOrLast(DslFunctionSource.class);

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
@@ -185,7 +185,7 @@ public class DslDeferredFunctionCall extends BrooklynDslDeferredSupplier<Object>
     protected Maybe<?> resolve(Object object, boolean immediate) {
         return Tasks.resolving(object, Object.class)
             .context(entity().getExecutionContext())
-            .deep(true, true, true)
+            .deep()
             .immediately(immediate)
             .iterator()
             .nextOrLast(DslFunctionSource.class);

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -610,7 +610,7 @@ public class BrooklynDslCommon {
 
             final Function<Object, Object> resolver = new Function<Object, Object>() {
                 @Override public Object apply(Object value) {
-                    Maybe<Object> result = Tasks.resolving(value, Object.class).context(executionContext).deep(true, true, true).immediately(true).getMaybe();
+                    Maybe<Object> result = Tasks.resolving(value, Object.class).context(executionContext).deep().immediately(true).getMaybe();
                     if (result.isAbsent()) {
                         throw new ImmediateValueNotAvailableException();
                     } else {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -610,7 +610,7 @@ public class BrooklynDslCommon {
 
             final Function<Object, Object> resolver = new Function<Object, Object>() {
                 @Override public Object apply(Object value) {
-                    Maybe<Object> result = Tasks.resolving(value, Object.class).context(executionContext).deep(true, true).immediately(true).getMaybe();
+                    Maybe<Object> result = Tasks.resolving(value, Object.class).context(executionContext).deep(true, true, true).immediately(true).getMaybe();
                     if (result.isAbsent()) {
                         throw new ImmediateValueNotAvailableException();
                     } else {
@@ -645,7 +645,7 @@ public class BrooklynDslCommon {
             final Function<Object, Object> resolver = new Function<Object, Object>() {
                 @Override public Object apply(Object value) {
                     try {
-                        return Tasks.resolveDeepValue(value, Object.class, executionContext);
+                        return Tasks.resolveDeepValueWithoutCoercion(value, executionContext);
                     } catch (ExecutionException | InterruptedException e) {
                         throw Exceptions.propagate(e);
                     }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -661,7 +661,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             if (!resolved) {
                 // attempt to resolve, and recurse
                 final ExecutionContext executionContext = entity().getExecutionContext();
-                Maybe<Object> resolvedSi = Tasks.resolving(si, Object.class).deep(true, true, true).immediately(true).context(executionContext).getMaybe();
+                Maybe<Object> resolvedSi = Tasks.resolving(si, Object.class).deep().immediately(true).context(executionContext).getMaybe();
                 if (resolvedSi.isAbsent()) return Maybe.absent();
                 return getImmediately(resolvedSi.get(), true);
             }
@@ -889,7 +889,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                     .as(Object.class)
                     .context(findExecutionContext(this))
                     .immediately(immediately)
-                    .deep(true, true, true)
+                    .deep()
                     .description("Resolving substitutions " + substitutions + " for template " + template)
                     .get();
         }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -661,7 +661,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             if (!resolved) {
                 // attempt to resolve, and recurse
                 final ExecutionContext executionContext = entity().getExecutionContext();
-                Maybe<Object> resolvedSi = Tasks.resolving(si, Object.class).deep(true, true).immediately(true).context(executionContext).getMaybe();
+                Maybe<Object> resolvedSi = Tasks.resolving(si, Object.class).deep(true, true, true).immediately(true).context(executionContext).getMaybe();
                 if (resolvedSi.isAbsent()) return Maybe.absent();
                 return getImmediately(resolvedSi.get(), true);
             }
@@ -693,7 +693,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                             if (!resolved) {
                                 // attempt to resolve, and recurse
                                 final ExecutionContext executionContext = entity().getExecutionContext();
-                                return resolve(Tasks.resolveDeepValue(si, Object.class, executionContext), true);
+                                return resolve(Tasks.resolveDeepValueWithoutCoercion(si, executionContext), true);
                             }
                             throw new IllegalStateException("Cannot resolve '"+sensorName+"' as a sensor (got type "+(si == null ? "null" : si.getClass().getName()+")"));
                         }})
@@ -889,7 +889,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                     .as(Object.class)
                     .context(findExecutionContext(this))
                     .immediately(immediately)
-                    .deep(true, true)
+                    .deep(true, true, true)
                     .description("Resolving substitutions " + substitutions + " for template " + template)
                     .get();
         }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.Reader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -250,7 +251,9 @@ public abstract class AbstractYamlTest {
     }
 
     protected void addCatalogItems(String catalogYaml) {
-        mgmt().getCatalog().addItems(catalogYaml, true, forceUpdate);
+        mgmt().getCatalog().
+                addTypesAndValidateAllowInconsistent(catalogYaml, null, forceUpdate);
+//                addItems(catalogYaml, true, forceUpdate);
     }
 
     /*

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ApplicationsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ApplicationsYamlTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.camp.brooklyn;
 
+import org.apache.brooklyn.camp.brooklyn.TestSensorAndEffectorInitializerBase.TestConfigurableInitializerConfigBag;
+import org.apache.brooklyn.camp.brooklyn.TestSensorAndEffectorInitializerBase.TestConfigurableInitializerOld;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -25,7 +27,6 @@ import static org.testng.Assert.assertTrue;
 import org.apache.brooklyn.api.entity.Application;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.typereg.RegisteredType;
-import org.apache.brooklyn.camp.brooklyn.TestSensorAndEffectorInitializer.TestConfigurableInitializer;
 import org.apache.brooklyn.camp.brooklyn.catalog.CatalogYamlLocationTest;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
@@ -92,7 +93,7 @@ public class ApplicationsYamlTest extends AbstractYamlTest {
     public void testWrapsWhenInitializer() throws Exception {
         Entity app = createAndStartApplication(
                 "brooklyn.initializers:",
-                "- type: " + TestConfigurableInitializer.class.getName(),
+                "- type: " + TestConfigurableInitializerConfigBag.class.getName(),
                 "services:",
                 "- type: " + BasicApplication.class.getName());
         assertWrapped(app, BasicApplication.class);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -22,6 +22,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.reflect.TypeToken;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import org.apache.brooklyn.core.effector.AddChildrenEffector;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypePlanTransformer;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerializationTest.SampleBean;
+import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
+import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
+import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.util.collections.MutableMap;
 import static org.testng.Assert.assertEquals;
@@ -1454,7 +1460,29 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         fixtureForTestingType("list<string>", "[a, 1]", (cfg,entity) -> {
             assertEquals(cfg.getType(), List.class);
             assertEquals(cfg.getTypeToken(), new TypeToken<List<String>>() {});
-            assertEquals(entity.getConfig(cfg), MutableList.of("a", 1));
+            assertEquals(entity.getConfig(cfg), MutableList.of("a", "1"));
         });
     }
+
+    // TODO
+//    @Test
+//    public void testMapGenericsRegisteredType() throws Exception {
+//        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(
+//                RegisteredTypes.addSuperType(
+//                    RegisteredTypes.bean("my-bean", "1",
+//                        new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+//                                "type: "+ SampleBean.class.getName()
+//                        )),
+//                    SampleBean.class), false);
+//
+//        // cf tests in CustomTypeConfigYamlTest
+//        fixtureForTestingType("map <string, my-bean>", "{ a: {x:1} }", (cfg,entity) -> {
+//            assertEquals(cfg.getType(), Map.class);
+//            assertEquals(cfg.getTypeToken(), new TypeToken<Map<String,SampleBean>>() {});
+//            Map<?,?> l = (Map<?,?>) entity.getConfig(cfg);
+//            SampleBean b = (SampleBean) l.get("a");
+//            Assert.assertEquals(b.x, "1");
+//        });
+//    }
+
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -19,6 +19,11 @@
 package org.apache.brooklyn.camp.brooklyn;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.reflect.TypeToken;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.util.collections.MutableMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -1393,5 +1398,63 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         // none of the p? items are present
         Asserts.assertSize(entity.config().findKeysDeclared(ConfigPredicates.nameMatchesRegex("p.*")), 0);
     }
-    
+
+    void fixtureForTestingType(String typeName, String defaultYaml, BiConsumer<ConfigKey<?>,Entity> test) throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  itemType: entity",
+                "  items:",
+                "  - id: entity-typed-parameter",
+                "    item:",
+                "      type: " + BasicEntity.class.getName(),
+                "      brooklyn.parameters:",
+                "      - name: p1",
+                "        type: "+typeName,
+                "        default: "+defaultYaml);
+
+        String yaml = Joiner.on("\n").join(
+                "services:",
+                "- type: entity-typed-parameter");
+
+        Entity entity = Iterables.getOnlyElement(createStartWaitAndLogApplication(yaml).getChildren());
+        ConfigKey<?> cfg = entity.getEntityType().getConfigKey("p1");
+
+        test.accept(cfg, entity);
+    }
+
+    @Test
+    public void testJUMapType() throws Exception {
+        fixtureForTestingType(Map.class.getName(), "{a: 1}", (cfg,entity) -> {
+            assertEquals(cfg.getType(), Map.class);
+            assertEquals(cfg.getTypeToken(), TypeToken.of(Map.class));
+            assertEquals(entity.getConfig(cfg), MutableMap.of("a", 1));
+        });
+    }
+
+    @Test
+    public void testMapType() throws Exception {
+        fixtureForTestingType("map", "{a: 1}", (cfg,entity) -> {
+            assertEquals(cfg.getType(), Map.class);
+            assertEquals(cfg.getTypeToken(), TypeToken.of(Map.class));
+            assertEquals(entity.getConfig(cfg), MutableMap.of("a", 1));
+        });
+    }
+
+    @Test
+    public void testListType() throws Exception {
+        fixtureForTestingType("list", "[a, 1]", (cfg,entity) -> {
+            assertEquals(cfg.getType(), List.class);
+            assertEquals(cfg.getTypeToken(), TypeToken.of(List.class));
+            assertEquals(entity.getConfig(cfg), MutableList.of("a", 1));
+        });
+    }
+
+    @Test
+    public void testListGenericsType() throws Exception {
+        fixtureForTestingType("list<string>", "[a, 1]", (cfg,entity) -> {
+            assertEquals(cfg.getType(), List.class);
+            assertEquals(cfg.getTypeToken(), new TypeToken<List<String>>() {});
+            assertEquals(entity.getConfig(cfg), MutableList.of("a", 1));
+        });
+    }
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -142,11 +142,19 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
                 "foo", "bar");
     }
 
-    // TODO - implicit typing - base type figured out from key type.  on read?  or on access?
-    // usually done on access
-
+    // TODO - implicit typing - deserialization base type implied by key type.  on creation?  or on access?
+    // probably on access, by config lookup.  though that will need custom logic for initializers and maybe others,
+    // in addition to the obvious place(s) where it is done for entities
+    //
     // test:  type declared on a parameter; get as object it recasts it as official type, and coerces
-    // testRegisteredTypeValueImplicitlyCoercedOn{read?,write?}TypedConfigKey_InheritedFieldsWork
-    // testRegisteredTypeImplicitInValueOfTypedConfigKey_CoercedOnCreation
+    // testRegisteredTypeImplicitInValueReadByTypedConfigKey_CoercedOnCreation
+    // testRegisteredTypeImplicitInValueReadByObjectConfigKey_ReturnsMap
+    // (and change testJavaTypeDeclaredInValueOfAnonymousConfigKey_IgnoresType_FailsCoercionToCustomType,
+    //      if the java type exactly matches the expected type)
+
+    // TODO DSL expressions inside these types might mess things up
+    // they might just work, or maybe just when wrapped in ValueSupplier, or maybe they break horribly ...
+    // can make jackson serialize and deserialize them specially, either pass-through or as strings TBD
+    // see reference to DslSerializationAsToString in BeanWithTypeUtils
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
+import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
+import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer;
+import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.test.Asserts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class CustomTypeConfigYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(CustomTypeConfigYamlTest.class);
+
+    protected Entity setupAndCheckTestEntityInBasicYamlWith(String ...extras) throws Exception {
+        Entity app = createAndStartApplication(loadYaml("test-entity-basic-template.yaml", extras));
+        waitForApplicationTasks(app);
+
+        Dumper.dumpInfo(app);
+        
+        Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
+
+        Assert.assertTrue(app.getChildren().iterator().hasNext(), "Expected app to have child entity");
+        Entity entity = app.getChildren().iterator().next();
+        Assert.assertTrue(entity instanceof TestEntity, "Expected TestEntity, found " + entity.getClass());
+        
+        return entity;
+    }
+
+    public static class TestingCustomType {
+        String x;
+        String y;
+    }
+    
+    protected Entity deployWithTestingCustomTypeObjectConfig(String type, ConfigKey<?> key) throws Exception {
+        return setupAndCheckTestEntityInBasicYamlWith( 
+            "  brooklyn.config:",
+            "    "+key.getName()+":",
+            "      type: "+type,
+            "      x: foo");
+    }
+
+    protected void assertObjectIsOurCustomTypeWithFieldValueFoo(Object customObj) {
+        Assert.assertNotNull(customObj);
+
+        Asserts.assertInstanceOf(customObj, TestingCustomType.class);
+        Asserts.assertEquals(((TestingCustomType)customObj).x, "foo");
+    }
+
+    protected Entity deployWithTestingCustomTypeObjectConfigAndAssert(String type, ConfigKey<?> key) throws Exception {
+        Entity testEntity = deployWithTestingCustomTypeObjectConfig(type, key);
+        Object customObj = testEntity.getConfig(key);
+        assertObjectIsOurCustomTypeWithFieldValueFoo(customObj);
+        return testEntity;
+    }
+
+    @Test
+    public void testCustomTypeInObjectConfigKeyReturnsMap() throws Exception {
+        // baseline behaviour - if the config is of type 'object' there is no conversion; you get raw json map
+
+        Entity testEntity = deployWithTestingCustomTypeObjectConfig(TestingCustomType.class.getName(), TestEntity.CONF_OBJECT);
+        Object customObj = testEntity.getConfig(TestEntity.CONF_OBJECT);
+
+        Assert.assertNotNull(customObj);
+
+        Asserts.assertInstanceOf(customObj, Map.class);
+        Asserts.assertEquals(((Map<?,?>)customObj).get("x"), "foo");
+    }
+
+    public static final ConfigKey<TestingCustomType> CONF_OBJECT_TYPED = ConfigKeys.newConfigKey(TestingCustomType.class, 
+        "test.confTyped", "Configuration key that's our custom type");
+    
+    @Test(groups="WIP")
+    public void testCustomTypeInTypedConfigKeyJavaType() throws Exception {
+        // if the config key is typed, coercion returns the strongly typed value, correctly deserializing the java type
+        // TODO this will require the config to convert or coerce using new routines
+        deployWithTestingCustomTypeObjectConfigAndAssert(TestingCustomType.class.getName(), CONF_OBJECT_TYPED);
+    }
+    
+    @Test(groups="WIP")
+    public void testCustomTypeInTypedConfigKeyRegisteredType() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeConfigYamlTest.TestingCustomType.class.getName())), false);
+        // if the config key is typed, coercion returns the strongly typed value, correctly deserializing the brooklyn registered type
+        // TODO this will require the config to convert or coerce using new routines
+        Entity testEntity = deployWithTestingCustomTypeObjectConfigAndAssert("custom-type", CONF_OBJECT_TYPED);
+    }
+    
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -154,7 +154,7 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
                 "  version: "+TEST_VERSION,
                 "  items:",
                 "  - id: custom-type",
-                "    itemType: bean",   // TODO should be optional, correct the loading in BasicBrooklynCatalog
+//                "    itemType: bean",   // optional
                 "    format: bean-with-type",
                 "    item:",
                 "      type: "+CustomTypeConfigYamlTest.TestingCustomType.class.getName(),

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -101,9 +101,10 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
     
     @Test
     public void testCustomTypeInTypedConfigKeyJavaType() throws Exception {
-        // if the config key is typed, coercion returns the strongly typed value, correctly deserializing the java type
-        deployWithTestingCustomTypeObjectConfigAndAssert(TestingCustomType.class.getName(), CONF_OBJECT_TYPED,
-                "foo", null);
+        // if the config key is typed, coercion returns the strongly typed value, correctly deserializing the java type;
+        // but types used in config must be registered types
+        Asserts.assertFailsWith(() -> deployWithTestingCustomTypeObjectConfigAndAssert(TestingCustomType.class.getName(), CONF_OBJECT_TYPED, "foo", null),
+                e -> Asserts.expectedFailureContains(e, "TestingCustomType", "map", "test.confTyped"));
     }
     
     @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
@@ -18,10 +18,18 @@
  */
 package org.apache.brooklyn.camp.brooklyn;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.google.common.base.Predicates;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.core.entity.Dumper;
+import org.apache.brooklyn.core.entity.EntityInitializers.AddTags;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypePlanTransformer;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerializationTest.SampleBean;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
@@ -37,6 +45,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 
 @Test
 public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
@@ -69,14 +79,35 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         public void apply(EntityLocal entity) {
             lastEntity = entity;
             lastX = x;
+            lastY = y;
         }
     }
 
     public static class TestingCustomInitializerTypeAcceptingConfigBag extends TestingCustomInitializerType {
-        public TestingCustomInitializerTypeAcceptingConfigBag(ConfigBag keys) {
-            if (this.x==null) this.x = (String) keys.getStringKey("x");
-            if (this.y==null) this.y = (String) keys.getStringKey("y");
+        // no-arg constructor needed for bean-with-type instantiation; it can be private
+        private TestingCustomInitializerTypeAcceptingConfigBag() {}
+
+        // old-style constructor if config bag is injected
+        public TestingCustomInitializerTypeAcceptingConfigBag(ConfigBag config) {
+            if (config!=null) setConfig(config.getAllConfig());
+            throw new IllegalStateException("This test should not use the config-bag constructor");
         }
+
+        // this pattern is needed to support nested brooklyn config on initializers (and other beans)
+        @JsonProperty("brooklyn.config")
+        void setConfig(Map<String,Object> config) {
+            if (this.x==null) this.x = (String) config.get("x");
+            if (this.y==null) this.y = (String) config.get("y");
+        }
+
+        // as an alternative to the above, the follow sort-of works
+        // but NOT if brooklyn.config is defined at two levels (ie a bean and then extended);
+        // we need the annotated setter for that.
+        // and even then it doesn't support config inheritance; so only use brooklyn.config for spec objects.
+//        @JsonCreator(mode= Mode.PROPERTIES)
+//        public TestingCustomInitializerTypeAcceptingConfigBag(@JsonProperty("brooklyn.config") Map<String,Object> config) {
+//            if (config!=null) setConfig(config);
+//        }
     }
     
     protected Entity deployWithTestingCustomInitializerType(String type, String ...extras) throws Exception {
@@ -105,24 +136,13 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers; and/or allow java instantiator to read registered types
-    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBag() throws Exception {
-        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
-                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
-
-        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
-                "    brooklyn.config:",
-                "      x: foo");
-        assertInitializerRanAndXY(testEntity, "foo", null);
-    }
-
     @Test
     public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingField() throws Exception {
         Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerType.class.getName(), "    x: foo");
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers
+    @Test
     public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingFieldAndConfigBag() throws Exception {
         Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeAcceptingConfigBag.class.getName(),
                 "    y: bar",
@@ -150,10 +170,21 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers
+    @Test
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBag() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT, "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName())), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+    @Test
     public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBagAndField() throws Exception {
         ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
-                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName())), false);
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT, "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName())), false);
 
         Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
                 "    y: bar",
@@ -162,6 +193,162 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", "bar");
     }
 
-    // TODO try using BeanWithTypePlanTransformer, where value specified in _definition_, here and in CustomTypeConfigYamlTest
+    @Test
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingInheritedFieldAndLocalConfigBag() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName()+"\n" +
+                        "y: bar")), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", "bar");
+    }
+
+    @Test
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingInheritedConfigBagAndLocalField() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName()+"\n" +
+                        "brooklyn.config:\n" +
+                        "  x: foo")), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    y: bar");
+        assertInitializerRanAndXY(testEntity, "foo", "bar");
+    }
+
+
+    public static class TestingCustomInitializerTypeOldStyleAcceptingConfigBagOnly extends TestingCustomInitializerType {
+        // old-style constructor; with just this, it will be forced to use the fallback InstantiatorFromKey.newInstance construction mechanism
+        // fields are not supported. see above for discussion why config bag is not great here.
+        public TestingCustomInitializerTypeOldStyleAcceptingConfigBagOnly(ConfigBag config) {
+            setConfig(config.getAllConfig());
+        }
+
+        void setConfig(Map<String,Object> config) {
+            if (this.x==null) this.x = (String) config.get("x");
+            if (this.y==null) this.y = (String) config.get("y");
+        }
+    }
+
+    @Test
+    public void testOldStyleCustomInitializerTypeSpecifiedAsRegisteredTypeFails() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeOldStyleAcceptingConfigBagOnly.class.getName())), false);
+
+        Asserts.assertFailsWith(() ->deployWithTestingCustomInitializerType("custom-type"),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, TestingCustomInitializerTypeOldStyleAcceptingConfigBagOnly.class.getName(), "no creators", "cannot construct"));
+    }
+
+    @Test
+    public void testOldStyleCustomInitializerTypeSpecifiedAsJavaTypeSupportsBrooklynConfigButNotFields() throws Exception {
+        Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeOldStyleAcceptingConfigBagOnly.class.getName(),
+                "    brooklyn.config:\n" +
+                "      x: foo\n" +
+                "    y: bar");
+
+        // NB: the field 'y' is ignored
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+
+    public static class TestingCustomInitializerTypeFinal implements EntityInitializer {
+        static String lastZ;
+//        @JsonProperty
+        final String z;
+
+        // for use deserializing
+        private TestingCustomInitializerTypeFinal() {
+            z=null;
+        }
+
+        // old-style constructor; with just this, it will be forced to use the fallback InstantiatorFromKey.newInstance construction mechanism
+        // fields are not supported. see above for discussion why config bag is not great here.
+        public TestingCustomInitializerTypeFinal(ConfigBag config) {
+            this.z = (String) config.getStringKey("z");
+        }
+
+        @Override
+        public void apply(EntityLocal entity) {
+            lastZ = z;
+        }
+
+    }
+
+    @Test
+    public void testCustomInitializerFinalPatternTakingFields() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeFinal.class.getName())), false);
+
+        Entity entity = deployWithTestingCustomInitializerType("custom-type",
+                "    z: hi");
+        Assert.assertEquals(TestingCustomInitializerTypeFinal.lastZ, "hi");
+    }
+
+    @Test
+    public void testCustomInitializerFinalPatternTakingConfigBag() throws Exception {
+        Entity entity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeFinal.class.getName(),
+                "    brooklyn.config:",
+                "      z: hi0");
+        Assert.assertEquals(TestingCustomInitializerTypeFinal.lastZ, "hi0");
+    }
+
+    @Test
+    public void testCustomInitializerFinalPatternOverridingFields() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeFinal.class.getName()+"\n" +
+                                "z: hi1")), false);
+
+        Entity entity = deployWithTestingCustomInitializerType("custom-type",
+                "    z: hi2");
+        Assert.assertEquals(TestingCustomInitializerTypeFinal.lastZ, "hi2");
+    }
+
+    @Test
+    public void testCustomInitializerFinalPatternUsingConfigBagWithTypeNotSupported() throws Exception {
+        // we're allowed to add
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+CustomTypeInitializerYamlTest.TestingCustomInitializerTypeFinal.class.getName()+"\n" +
+                        "brooklyn.config:\n" +
+                        "  z: hi1")), false);
+        // but deployment fails as we don't have a json setter; cannot use final var pattern with bean-with-type
+        Asserts.assertFailsWith(() -> deployWithTestingCustomInitializerType("custom-type"),
+            e -> Asserts.expectedFailureContainsIgnoreCase(e, "unrecognized field", "brooklyn.config", "hi1"));
+    }
+
+    // also test the stock initializer
+
+    @Test
+    public void testAddTags() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("add-tags", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+ AddTags.class.getName())), false);
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("sample-bean", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: "+ SampleBean.class.getName())), false);
+        Entity ent = deployWithTestingCustomInitializerType("add-tags",
+                "    tags:",
+                "    - t1",
+                "    - 4",
+                "    - type: sample-bean",
+                "      x: 4");
+        Set<Object> tags = ent.tags().getTags();
+        Assert.assertTrue(tags.contains("t1"));
+        Assert.assertTrue(tags.contains(4));
+        Assert.assertFalse(tags.contains("4"));
+
+        // should this be converted to the type?  here it is iff we add using bean-with-type
+        // (but not if using the legacy ConfigBag constructor), and if the bean declares the List<Object> as a field.
+        // that seems about the right trade-off, convert to types if known, and through one layer of indirection
+        // (eg List<Object>) but not through two (for ConfigKeys the deserializer doesn't know their types)
+        Assert.assertEquals( ((SampleBean)(tags.stream().filter(t -> t instanceof SampleBean).findFirst().get())).x, "4" );
+//        Assert.assertEquals( ((Map)(tags.stream().filter(t -> t instanceof Map).findFirst().get())).get("x"), 4 );
+    }
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
@@ -21,9 +21,6 @@ package org.apache.brooklyn.camp.brooklyn;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
-import org.apache.brooklyn.camp.brooklyn.CustomTypeConfigYamlTest.TestingCustomType;
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
@@ -40,7 +37,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
-import java.util.Map;
 
 @Test
 public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
@@ -109,17 +105,25 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")
+    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers; and/or allow java instantiator to read registered types
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBag() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+    @Test
     public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingField() throws Exception {
-        // TODO this will require the BrooklynYamlTypeInstantiator.Factory to instantiate fields
-        // (currently extra fields are ignored)
         Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerType.class.getName(), "    x: foo");
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")
+    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers
     public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingFieldAndConfigBag() throws Exception {
-        // TODO this will require the BrooklynYamlTypeInstantiator.Factory to instantiate fields
         Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeAcceptingConfigBag.class.getName(),
                 "    y: bar",
                 "    brooklyn.config:",
@@ -127,7 +131,7 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", "bar");
     }
 
-    @Test(groups="WIP")  // TODO registered types not looked at currently
+    @Test
     public void testCustomInitializerTypeSpecifiedAsRegisteredType() throws Exception {
         ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
                 new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
@@ -136,7 +140,7 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, null, null);
     }
 
-    @Test(groups="WIP")  // TODO registered types not looked at currently
+    @Test
     public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingField() throws Exception {
         ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
                 new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
@@ -146,7 +150,7 @@ public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
         assertInitializerRanAndXY(testEntity, "foo", null);
     }
 
-    @Test(groups="WIP")  // TODO registered types not looked at currently (but ensure when they do that we support brooklyn.config to set config keys)
+    @Test(groups="WIP")  // TODO support brooklyn.config to set config keys on initializers
     public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBagAndField() throws Exception {
         ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
                 new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName())), false);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeInitializerYamlTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.camp.brooklyn.CustomTypeConfigYamlTest.TestingCustomType;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
+import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
+import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer;
+import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@Test
+public class CustomTypeInitializerYamlTest extends AbstractYamlTest {
+    private static final Logger log = LoggerFactory.getLogger(CustomTypeInitializerYamlTest.class);
+
+    protected Entity setupAndCheckTestEntityInBasicYamlWith(String ...extras) throws Exception {
+        Entity app = createAndStartApplication(loadYaml("test-entity-basic-template.yaml", extras));
+        waitForApplicationTasks(app);
+
+        Dumper.dumpInfo(app);
+        
+        Assert.assertEquals(app.getDisplayName(), "test-entity-basic-template");
+
+        Assert.assertTrue(app.getChildren().iterator().hasNext(), "Expected app to have child entity");
+        Entity entity = app.getChildren().iterator().next();
+        Assert.assertTrue(entity instanceof TestEntity, "Expected TestEntity, found " + entity.getClass());
+        
+        return entity;
+    }
+
+    public static class TestingCustomInitializerType implements EntityInitializer {
+        static Entity lastEntity;
+        static String lastX;
+        static String lastY;
+
+        String x;
+        String y;
+
+        @Override
+        public void apply(EntityLocal entity) {
+            lastEntity = entity;
+            lastX = x;
+        }
+    }
+
+    public static class TestingCustomInitializerTypeAcceptingConfigBag extends TestingCustomInitializerType {
+        public TestingCustomInitializerTypeAcceptingConfigBag(ConfigBag keys) {
+            if (this.x==null) this.x = (String) keys.getStringKey("x");
+            if (this.y==null) this.y = (String) keys.getStringKey("y");
+        }
+    }
+    
+    protected Entity deployWithTestingCustomInitializerType(String type, String ...extras) throws Exception {
+        return setupAndCheckTestEntityInBasicYamlWith(Strings.lines(MutableList.of(
+            "  brooklyn.initializers:",
+            "  - "+"type: "+type).appendAll(Arrays.asList(extras))));
+    }
+
+    protected void assertInitializerRanAndXY(Entity e, String xValue, String yValue) {
+        Asserts.assertEquals(TestingCustomInitializerType.lastEntity, e);
+        Asserts.assertEquals(TestingCustomInitializerType.lastX, xValue);
+        Asserts.assertEquals(TestingCustomInitializerType.lastY, yValue);
+    }
+
+    @Test
+    public void testCustomInitializerTypeSpecifiedAsJavaType() throws Exception {
+        Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerType.class.getName());
+        assertInitializerRanAndXY(testEntity, null, null);
+    }
+
+    @Test
+    public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingConfigBag() throws Exception {
+        Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeAcceptingConfigBag.class.getName(),
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+    @Test(groups="WIP")
+    public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingField() throws Exception {
+        // TODO this will require the BrooklynYamlTypeInstantiator.Factory to instantiate fields
+        // (currently extra fields are ignored)
+        Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerType.class.getName(), "    x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+    @Test(groups="WIP")
+    public void testCustomInitializerTypeSpecifiedAsJavaTypeWithArgUsingFieldAndConfigBag() throws Exception {
+        // TODO this will require the BrooklynYamlTypeInstantiator.Factory to instantiate fields
+        Entity testEntity = deployWithTestingCustomInitializerType(TestingCustomInitializerTypeAcceptingConfigBag.class.getName(),
+                "    y: bar",
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", "bar");
+    }
+
+    @Test(groups="WIP")  // TODO registered types not looked at currently
+    public void testCustomInitializerTypeSpecifiedAsRegisteredType() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type");
+        assertInitializerRanAndXY(testEntity, null, null);
+    }
+
+    @Test(groups="WIP")  // TODO registered types not looked at currently
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingField() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerType.class.getName())), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", null);
+    }
+
+    @Test(groups="WIP")  // TODO registered types not looked at currently (but ensure when they do that we support brooklyn.config to set config keys)
+    public void testCustomInitializerTypeSpecifiedAsRegisteredTypeWithArgUsingConfigBagAndField() throws Exception {
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, CustomTypeInitializerYamlTest.TestingCustomInitializerTypeAcceptingConfigBag.class.getName())), false);
+
+        Entity testEntity = deployWithTestingCustomInitializerType("custom-type",
+                "    y: bar",
+                "    brooklyn.config:",
+                "      x: foo");
+        assertInitializerRanAndXY(testEntity, "foo", "bar");
+    }
+
+    // TODO try using BeanWithTypePlanTransformer, where value specified in _definition_, here and in CustomTypeConfigYamlTest
+
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ValidationMissingTypeYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ValidationMissingTypeYamlTest.java
@@ -152,7 +152,9 @@ public class ValidationMissingTypeYamlTest extends AbstractYamlTest {
     }
     
     @Test
-    public void testNoEntityTypeInEntitySpecInCatalogEntityIsAllowed() throws Exception {
+    public void testNoEntityTypeInEntitySpecInCatalogEntity() {
+        // using addItems this is allowed; but addTypes validation is stricter
+        Asserts.assertFailsWith(()->
             addCatalogItems(
                     "brooklyn.catalog:",
                     "  id: " + Identifiers.makeRandomId(8),
@@ -164,11 +166,12 @@ public class ValidationMissingTypeYamlTest extends AbstractYamlTest {
                     "      initialSize: 0",
                     "      memberSpec: ",
                     "        $brooklyn:entitySpec:",
-                    "          foo: " + TestEntityImpl.class.getName());
+                    "          foo: " + TestEntityImpl.class.getName()),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "entitySpec"));
     }
 
     @Test
-    public void testNoEntityTypeInEntitySpecInCatalogAppIsAllowed() throws Exception {
+    public void testNoEntityTypeInEntitySpecInTemplateIsAllowed() throws Exception {
             addCatalogItems(
                     "brooklyn.catalog:",
                     "  id: " + Identifiers.makeRandomId(8),

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityTest.java
@@ -411,6 +411,7 @@ public class CatalogYamlEntityTest extends AbstractYamlTest {
             addCatalogEntity(IdAndVersion.of(symbolicName, TEST_VERSION + "-update"), symbolicName);
             Asserts.shouldHaveFailedPreviously("Catalog addition expected to fail due to recursive reference to " + symbolicName);
         } catch (Exception e) {
+            // TODO only the old (SpecToPlanTransformer) reports the recursive problem; the new transformer just doesn't accept it, without error
             Asserts.expectedFailureContains(e, "recursive", symbolicName);
         }
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlVersioningTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlVersioningTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
+import org.apache.brooklyn.api.catalog.CatalogItem;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -75,12 +76,17 @@ public class CatalogYamlVersioningTest extends AbstractYamlTest {
         addCatalogEntity(symbolicName, version);
     }
     
-    @Test
+    @Test(groups="Broken")    // used to pass, depends on logic at BasicBrooklynCatalog.checkItemAllowedAndIfSoReturnAnyDuplicate
+    // which doesn't have an analogue in registered types; we allow conflicting ID:versions so long as their bundles are consistent
     public void testAddSameVersionFailsWhenIconIsDifferent() {
         String symbolicName = "sampleId";
         String version = "0.1.0";
         addCatalogEntity(symbolicName, version);
         try {
+//            mgmt().getCatalog().
+//                addTypesAndValidateAllowInconsistent(catalogYaml, null, forceUpdate);
+//                // if we do the code below, this test used to pass
+//                addItems(catalogYaml, true, forceUpdate);
             addCatalogEntity(symbolicName, version, BasicEntity.class.getName(), "classpath:/another/icon.png");
             Asserts.shouldHaveFailedPreviously("Expected to fail");
         } catch (Exception e) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/GetFileContentsEffector.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/GetFileContentsEffector.java
@@ -21,20 +21,24 @@ package org.apache.brooklyn.camp.brooklyn.catalog;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.AddEffectorInitializerAbstract;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 
 /** simple effector which returns the contents of a file, used to test resolution of */
-public class GetFileContentsEffector extends AddEffector {
+public class GetFileContentsEffector extends AddEffectorInitializerAbstract {
 
     final static ConfigKey<String> FILENAME = ConfigKeys.newStringConfigKey("filename");
     final static Effector<String> GET_FILE_CONTENTS = Effectors.effector(String.class, "getFileContents").parameter(FILENAME).buildAbstract();
     
-    public GetFileContentsEffector() {
-        super(Effectors.effector(GET_FILE_CONTENTS).impl(new Body()).build());
+    public GetFileContentsEffector() {}
+
+    @Override
+    protected EffectorBuilder<String> newEffectorBuilder() {
+        return Effectors.effector(GET_FILE_CONTENTS).impl(new Body());
     }
 
     static class Body extends EffectorBody<String> {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/policy/failover/ElectPrimaryTest.java
@@ -29,9 +29,10 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlRebindTest;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.AddEffectorInitializerAbstract;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
@@ -259,9 +260,17 @@ public class ElectPrimaryTest extends AbstractYamlRebindTest {
     }
     
     List<String> promoteDemoteEffectorMessages = Collections.synchronizedList(MutableList.of());
-    private class MockPromoteDemoteEffector extends AddEffector {
+    private class MockPromoteDemoteEffector extends AddEffectorInitializerAbstract {
+        private final Effector<String> base;
+
         public MockPromoteDemoteEffector(Effector<String> base) {
-            super(Effectors.effector(base).impl(new MockPromoteDemoteEffectorBody(base.getName())).build());
+            super();
+            this.base = base;
+        }
+
+        @Override
+        protected EffectorBuilder<String> newEffectorBuilder() {
+            return Effectors.effector(base).impl(new MockPromoteDemoteEffectorBody(base.getName()));
         }
     }
     private class MockPromoteDemoteEffectorBody extends EffectorBody<String> {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
@@ -151,7 +151,9 @@ public class CatalogPredicates {
             CatalogPredicates.<Enricher,EnricherSpec<?>>isCatalogItemType(CatalogItemType.ENRICHER);
     public static final Predicate<CatalogItem<Location,LocationSpec<?>>> IS_LOCATION = 
             CatalogPredicates.<Location,LocationSpec<?>>isCatalogItemType(CatalogItemType.LOCATION);
-    
+    public static final Predicate<CatalogItem<Location,LocationSpec<?>>> IS_BEAN =
+            CatalogPredicates.<Location,LocationSpec<?>>isCatalogItemType(CatalogItemType.BEAN);
+
     // TODO PERSISTENCE WORKAROUND kept anonymous function in case referenced in persisted state
     @SuppressWarnings("unused")
     private static final Function<CatalogItem<?,?>,String> ID_OF_ITEM_TRANSFORMER_ANONYMOUS = new Function<CatalogItem<?,?>, String>() {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -40,6 +40,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
@@ -60,21 +61,17 @@ import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.core.catalog.CatalogPredicates;
 import org.apache.brooklyn.core.catalog.internal.CatalogClasspathDo.CatalogScanningModes;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
 import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.CampYamlParser;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
-import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
-import org.apache.brooklyn.core.typereg.BasicManagedBundle;
-import org.apache.brooklyn.core.typereg.BasicRegisteredType;
-import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
-import org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer;
-import org.apache.brooklyn.core.typereg.RegisteredTypeNaming;
-import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.core.typereg.*;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution.BrooklynTypeNameResolver;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.osgi.BundleMaker;
 import org.apache.brooklyn.util.core.task.Tasks;
@@ -552,11 +549,11 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return new VersionedName(bundle, version);
     }
 
-    /** See comments on {@link #collectCatalogItemsFromItemMetadataBlock(String, ManagedBundle, Map, List, boolean, Map, int, boolean)};
+    /** See comments on {@link #collectCatalogItemsFromItemMetadataBlock(String, ManagedBundle, Map, List, Map, boolean, Map, int, boolean, Boolean)};
      * this is a shell around that that parses the `brooklyn.catalog` header on the BOM YAML file */
     private void collectCatalogItemsFromCatalogBomRoot(String contextForError, String yaml, ManagedBundle containingBundle, 
             List<CatalogItemDtoAbstract<?, ?>> resultLegacyFormat, Map<RegisteredType, RegisteredType> resultNewFormat, 
-            boolean requireValidation, Map<?, ?> parentMeta, int depth, boolean force) {
+            boolean requireValidation, Map<?, ?> parentMeta, int depth, boolean force, Boolean throwOnError) {
         Map<?,?> itemDef;
         try {
             itemDef = Yamls.getAs(Yamls.parseAll(yaml), Map.class);
@@ -569,7 +566,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         catalogMetadata = MutableMap.copyOf(catalogMetadata);
 
         collectCatalogItemsFromItemMetadataBlock(Yamls.getTextOfYamlAtPath(yaml, "brooklyn.catalog").getMatchedYamlTextOrWarn(), 
-            containingBundle, catalogMetadata, resultLegacyFormat, resultNewFormat, requireValidation, parentMeta, 0, force);
+            containingBundle, catalogMetadata, resultLegacyFormat, resultNewFormat, requireValidation, parentMeta, 0, force, throwOnError);
         
         itemDef.remove("brooklyn.catalog");
         catalogMetadata.remove("item");
@@ -588,7 +585,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 if (rootItemYaml.startsWith(match)) rootItemYaml = Strings.removeFromStart(rootItemYaml, match);
                 else rootItemYaml = Strings.replaceAllNonRegex(rootItemYaml, "\n"+match, "");
             }
-            collectCatalogItemsFromItemMetadataBlock("item:\n"+makeAsIndentedObject(rootItemYaml), containingBundle, rootItem, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, 1, force);
+            collectCatalogItemsFromItemMetadataBlock("item:\n"+makeAsIndentedObject(rootItemYaml), containingBundle, rootItem, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, 1, force, throwOnError);
         }
     }
 
@@ -628,7 +625,11 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
      */
     @SuppressWarnings("unchecked")
     private void collectCatalogItemsFromItemMetadataBlock(String sourceYaml, ManagedBundle containingBundle, Map<?,?> itemMetadata, List<CatalogItemDtoAbstract<?, ?>> resultLegacyFormat, Map<RegisteredType, RegisteredType> resultNewFormat, boolean requireValidation, 
-            Map<?,?> parentMetadata, int depth, boolean force) {
+            Map<?,?> parentMetadata, int depth, boolean force, Boolean throwOnError) {
+        if (throwOnError==null) {
+            // default for legacy format was to throw, for new format to attempt to add and then remove
+            throwOnError = resultLegacyFormat!=null;
+        }
 
         if (sourceYaml==null) sourceYaml = new Yaml().dump(itemMetadata);
 
@@ -690,57 +691,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         libraryBundles = resolveWherePossible(mgmt, libraryBundles);
 
         Boolean scanJavaAnnotations = getFirstAs(itemMetadataWithoutItemDef, Boolean.class, "scanJavaAnnotations", "scan_java_annotations").orNull();
-        if (scanJavaAnnotations==null || !scanJavaAnnotations) {
-            // don't scan
-        } else {
-            log.warn("Deprecated use of scanJavaAnnotations" + (containingBundle != null ? " in bundle " + containingBundle.getVersionedName() : ""));
-            
-            if (isNoBundleOrSimpleWrappingBundle(mgmt, containingBundle)) {
-                Collection<CatalogItemDtoAbstract<?, ?>> scanResult;
-                // BOMs wrapped in JARs, or without JARs, have special treatment
-                if (isLibrariesMoreThanJustContainingBundle(librariesAddedHereBundles, containingBundle)) {
-                    // legacy mode, since 0.12.0, scan libraries referenced in a legacy non-bundle BOM
-                    log.warn("Deprecated use of scanJavaAnnotations to scan other libraries ("+librariesAddedHereBundles+"); libraries should declare they scan themselves");
-                    scanResult = scanAnnotationsLegacyInListOfLibraries(mgmt, librariesAddedHereBundles, catalogMetadata, containingBundle);
-                } else if (!isLibrariesMoreThanJustContainingBundle(libraryBundles, containingBundle)) {
-                    // for default catalog, no libraries declared, we want to scan local classpath
-                    // bundle should be named "brooklyn-default-catalog"
-                    if (containingBundle!=null && !containingBundle.getSymbolicName().contains("brooklyn-default-catalog")) {
-                        // a user uplaoded a BOM trying to tell us to do a local java scan; previously supported but becoming unsupported
-                        log.warn("Deprecated use of scanJavaAnnotations in non-Java BOM outwith the default catalog setup"); 
-                    } else if (depth>0) {
-                        // since 0.12.0, require this to be right next to where libraries are defined, or at root
-                        log.warn("Deprecated use of scanJavaAnnotations declared in item; should be declared at the top level of the BOM");
-                    }
-                    scanResult = scanAnnotationsFromLocalNonBundleClasspath(mgmt, catalogMetadata, containingBundle);
-                } else {
-                    throw new IllegalStateException("Cannot scan for Java catalog items when libraries declared on an ancestor; scanJavaAnnotations should be specified alongside brooklyn.libraries (or ideally those libraries should specify to scan)");
-                }
-                if (scanResult!=null && !scanResult.isEmpty()) {
-                    if (resultLegacyFormat!=null) {
-                        resultLegacyFormat.addAll( scanResult );
-                    } else {
-                        // not returning a result; we need to add here, as type
-                        for (CatalogItem item: scanResult) {
-                            RegisteredType replacedInstance = mgmt.getTypeRegistry().get(item.getSymbolicName(), item.getVersion());
-                            mgmt.getCatalog().addItem(item);
-                            RegisteredType newInstance = mgmt.getTypeRegistry().get(item.getSymbolicName(), item.getVersion());
-                            updateResultNewFormat(resultNewFormat, replacedInstance, newInstance);
-                        }
-                    }
-                }
-            } else {
-                throw new IllegalArgumentException("Scanning for Java annotations is not supported in BOMs in bundles; "
-                    + "entries should be listed explicitly in the catalog.bom");
-                // see comments on scanAnnotationsInBundle
-//                if (depth>0) {
-//                    // since 0.12.0, require this to be right next to where libraries are defined, or at root
-//                    log.warn("Deprecated use of scanJavaAnnotations declared in item; should be declared at the top level of the BOM");
-//                }
-//                // normal JAR install, only scan that bundle (the one containing the catalog.bom)
-//                // note metadata not relevant here
-//                result.addAll(scanAnnotationsInBundle(mgmt, containingBundle));
-            }
+        if (scanJavaAnnotations!=null && scanJavaAnnotations) {
+            addLegacyScannedAnnotations(containingBundle, resultLegacyFormat, resultNewFormat, depth, catalogMetadata, librariesAddedHereBundles, libraryBundles);
         }
         
         Object items = catalogMetadata.remove("items");
@@ -751,11 +703,11 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             int count = 0;
             for (Object ii: checkType(items, "items", List.class)) {
                 if (ii instanceof String) {
-                    collectUrlReferencedCatalogItems((String) ii, containingBundle, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force);
+                    collectUrlReferencedCatalogItems((String) ii, containingBundle, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force, throwOnError);
                 } else {
                     Map<?,?> i = checkType(ii, "entry in items list", Map.class);
                     collectCatalogItemsFromItemMetadataBlock(Yamls.getTextOfYamlAtPath(sourceYaml, "items", count).getMatchedYamlTextOrWarn(),
-                            containingBundle, i, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force);
+                            containingBundle, i, resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force, throwOnError);
                 }
                 count++;
             }
@@ -763,7 +715,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
         if (url != null) {
             collectUrlReferencedCatalogItems(checkType(url, "include in catalog meta", String.class), containingBundle, 
-                resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force);
+                resultLegacyFormat, resultNewFormat, requireValidation, catalogMetadata, depth+1, force, throwOnError);
         }
 
         if (item==null) return;
@@ -780,6 +732,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         String symbolicName = getFirstAs(catalogMetadata, String.class, "symbolicName").orNull();
         String displayName = getFirstAs(catalogMetadata, String.class, "displayName").orNull();
         String name = getFirstAs(catalogMetadata, String.class, "name").orNull();
+        String format = getFirstAs(catalogMetadata, String.class, "format").orNull();
+        if ("auto".equalsIgnoreCase(format)) format = null;
 
         if ((Strings.isNonBlank(id) || Strings.isNonBlank(symbolicName)) && 
                 Strings.isNonBlank(displayName) &&
@@ -787,25 +741,24 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             log.warn("Name property will be ignored due to the existence of displayName and at least one of id, symbolicName");
         }
 
-        PlanInterpreterGuessingType planInterpreter = new PlanInterpreterGuessingType(null, item, sourceYaml, itemType, libraryBundles, resultLegacyFormat).reconstruct();
+        PlanInterpreterInferringType planInterpreter = new PlanInterpreterInferringType(id, item, sourceYaml, itemType, format, libraryBundles, resultLegacyFormat).resolve();
         Exception resolutionError = null;
         if (!planInterpreter.isResolved()) {
             // don't throw yet, we may be able to add it in an unresolved state
             resolutionError = Exceptions.create("Could not resolve definition of item"
                 + (Strings.isNonBlank(id) ? " '"+id+"'" : Strings.isNonBlank(symbolicName) ? " '"+symbolicName+"'" : Strings.isNonBlank(name) ? " '"+name+"'" : "")
-                // better not to show yaml, takes up lots of space, and with multiple plan transformers there might be multiple errors; 
+                // better not to show yaml, takes up lots of space, and with multiple plan transformers there might be multiple errors;
                 // some of the errors themselves may reproduce it
                 // (ideally in future we'll be able to return typed errors with caret position of error)
 //                + ":\n"+sourceYaml
                 , planInterpreter.getErrors());
         }
-        // now allowed to be null here
+        // might be null
         itemType = planInterpreter.getCatalogItemType();
-        
+
         Map<?, ?> itemAsMap = planInterpreter.getItem();
         // the "plan yaml" includes the services: ... or brooklyn.policies: ... outer key,
         // as opposed to the rawer { type: foo } map without that outer key which is valid as item input
-        // TODO this plan yaml is needed for subsequent reconstruction; would be nicer if it weren't! 
 
         // if symname not set, infer from: id, then name, then item id, then item name
         if (Strings.isBlank(symbolicName)) {
@@ -930,10 +883,15 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         final Boolean catalogDeprecated = Boolean.valueOf(setFromItemIfUnset(deprecated, itemAsMap, "deprecated"));
 
         // run again now that we know the ID to catch recursive definitions and possibly other mistakes (itemType inconsistency?)
-        planInterpreter = new PlanInterpreterGuessingType(id, item, sourceYaml, itemType, libraryBundles, resultLegacyFormat).reconstruct();
+        planInterpreter = planInterpreter.setId(id).resolve();
         if (resolutionError==null && !planInterpreter.isResolved()) {
             resolutionError = new IllegalStateException("Plan resolution for "+id+" breaks after id and itemType are set; is there a recursive reference or other type inconsistency?\n"+sourceYaml);
         }
+        if (throwOnError && resolutionError!=null) {
+            // if there was an error, throw it here
+            throw Exceptions.propagate(resolutionError);
+        }
+
         String sourcePlanYaml = planInterpreter.getPlanYaml();
 
         if (resultLegacyFormat==null) {
@@ -969,8 +927,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                     // warn? add as "unresolved" ? just do nothing?
                 }
             }
-            String format = null; // could support specifying format?
-            
+
             if (itemType!=null) {
                 // if supertype is known, set it here;
                 // we don't set kind (spec) because that is inferred from the supertype type
@@ -1009,11 +966,6 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             updateResultNewFormat(resultNewFormat, replacedInstance, type);
             
         } else {
-            if (resolutionError!=null) {
-                // if there was an error, throw it here
-                throw Exceptions.propagate(resolutionError);
-            }
-            
             CatalogItemDtoAbstract<?, ?> dto = createItemBuilder(itemType, symbolicName, version)
                 .libraries(libraryBundles)
                 .displayName(displayName)
@@ -1025,6 +977,49 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
             dto.setManagementContext((ManagementContextInternal) mgmt);
             resultLegacyFormat.add(dto);
+        }
+    }
+
+    private void addLegacyScannedAnnotations(ManagedBundle containingBundle, List<CatalogItemDtoAbstract<?, ?>> resultLegacyFormat, Map<RegisteredType, RegisteredType> resultNewFormat, int depth, Map<Object, Object> catalogMetadata, Collection<CatalogBundle> librariesAddedHereBundles, Collection<CatalogBundle> libraryBundles) {
+        log.warn("Deprecated use of scanJavaAnnotations" + (containingBundle != null ? " in bundle " + containingBundle.getVersionedName() : ""));
+
+        if (isNoBundleOrSimpleWrappingBundle(mgmt, containingBundle)) {
+            Collection<CatalogItemDtoAbstract<?, ?>> scanResult;
+            // BOMs wrapped in JARs, or without JARs, have special treatment
+            if (isLibrariesMoreThanJustContainingBundle(librariesAddedHereBundles, containingBundle)) {
+                // legacy mode, since 0.12.0, scan libraries referenced in a legacy non-bundle BOM
+                log.warn("Deprecated use of scanJavaAnnotations to scan other libraries ("+ librariesAddedHereBundles +"); libraries should declare they scan themselves");
+                scanResult = scanAnnotationsLegacyInListOfLibraries(mgmt, librariesAddedHereBundles, catalogMetadata, containingBundle);
+            } else if (!isLibrariesMoreThanJustContainingBundle(libraryBundles, containingBundle)) {
+                // for default catalog, no libraries declared, we want to scan local classpath
+                // bundle should be named "brooklyn-default-catalog"
+                if (containingBundle !=null && !containingBundle.getSymbolicName().contains("brooklyn-default-catalog")) {
+                    // a user uplaoded a BOM trying to tell us to do a local java scan; previously supported but becoming unsupported
+                    log.warn("Deprecated use of scanJavaAnnotations in non-Java BOM outwith the default catalog setup");
+                } else if (depth >0) {
+                    // since 0.12.0, require this to be right next to where libraries are defined, or at root
+                    log.warn("Deprecated use of scanJavaAnnotations declared in item; should be declared at the top level of the BOM");
+                }
+                scanResult = scanAnnotationsFromLocalNonBundleClasspath(mgmt, catalogMetadata, containingBundle);
+            } else {
+                throw new IllegalStateException("Cannot scan for Java catalog items when libraries declared on an ancestor; scanJavaAnnotations should be specified alongside brooklyn.libraries (or ideally those libraries should specify to scan)");
+            }
+            if (scanResult!=null && !scanResult.isEmpty()) {
+                if (resultLegacyFormat !=null) {
+                    resultLegacyFormat.addAll( scanResult );
+                } else {
+                    // not returning a result; we need to add here, as type
+                    for (CatalogItem item: scanResult) {
+                        RegisteredType replacedInstance = mgmt.getTypeRegistry().get(item.getSymbolicName(), item.getVersion());
+                        mgmt.getCatalog().addItem(item);
+                        RegisteredType newInstance = mgmt.getTypeRegistry().get(item.getSymbolicName(), item.getVersion());
+                        updateResultNewFormat(resultNewFormat, replacedInstance, newInstance);
+                    }
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Scanning for Java annotations is not supported in BOMs in bundles; "
+                + "entries should be listed explicitly in the catalog.bom");
         }
     }
 
@@ -1078,7 +1073,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return wrapped!=null && wrapped.equalsIgnoreCase("true");
     }
 
-    private void collectUrlReferencedCatalogItems(String url, ManagedBundle containingBundle, List<CatalogItemDtoAbstract<?, ?>> resultLegacyFormat, Map<RegisteredType, RegisteredType> resultNewFormat, boolean requireValidation, Map<Object, Object> parentMeta, int depth, boolean force) {
+    private void collectUrlReferencedCatalogItems(String url, ManagedBundle containingBundle, List<CatalogItemDtoAbstract<?, ?>> resultLegacyFormat, Map<RegisteredType, RegisteredType> resultNewFormat, boolean requireValidation, Map<Object, Object> parentMeta, int depth, boolean force, Boolean throwOnError) {
         @SuppressWarnings("unchecked")
         List<?> parentLibrariesRaw = MutableList.copyOf(getFirstAs(parentMeta, Iterable.class, "brooklyn.libraries", "libraries").orNull());
         Collection<CatalogBundle> parentLibraries = CatalogItemDtoAbstract.parseLibraries(parentLibrariesRaw);
@@ -1096,7 +1091,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             throw new IllegalStateException("Remote catalog url " + url + " in "+(containingBundle==null ? "non-bundled load" : containingBundle.getVersionedName())+" can't be fetched.", e);
         }
         try {
-            collectCatalogItemsFromCatalogBomRoot("BOM expected at "+url, yaml, containingBundle, resultLegacyFormat, resultNewFormat, requireValidation, parentMeta, depth, force);
+            collectCatalogItemsFromCatalogBomRoot("BOM expected at "+url, yaml, containingBundle, resultLegacyFormat, resultNewFormat, requireValidation, parentMeta, depth, force, throwOnError);
         } catch (Exception e) {
             Exceptions.propagateAnnotated("Error loading "+url+" as part of "+(containingBundle==null ? "non-bundled load" : containingBundle.getVersionedName()), e);
         }
@@ -1212,11 +1207,13 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return result;
     }
 
-    private class PlanInterpreterGuessingType {
+    private class PlanInterpreterInferringType {
 
-        final String idAsSymbolicNameWithoutVersion;
+        String itemId;
+        @Nonnull
         final Map<?,?> item;
         final String itemYaml;
+        final String format;
         final Collection<CatalogBundle> libraryBundles;
         final List<CatalogItemDtoAbstract<?, ?>> itemsDefinedSoFar;
         
@@ -1225,11 +1222,12 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         boolean resolved = false;
         List<Exception> errors = MutableList.of();
         List<Exception> entityErrors = MutableList.of();
-        
-        public PlanInterpreterGuessingType(@Nullable String idAsSymbolicNameWithoutVersion, Object itemDefinitionParsedToStringOrMap, String itemYaml, @Nullable CatalogItemType optionalCiType,  
-                Collection<CatalogBundle> libraryBundles, List<CatalogItemDtoAbstract<?,?>> itemsDefinedSoFar) {
+        List<Exception> transformerErrors = MutableList.of();
+
+        public PlanInterpreterInferringType(@Nullable String itemId, Object itemDefinitionParsedToStringOrMap, String itemYaml, @Nullable CatalogItemType optionalCiType, @Nullable String format,
+                                            Collection<CatalogBundle> libraryBundles, List<CatalogItemDtoAbstract<?,?>> itemsDefinedSoFar) {
             // ID is useful to prevent recursive references (possibly only supported for entities?)
-            this.idAsSymbolicNameWithoutVersion = idAsSymbolicNameWithoutVersion;
+            this.itemId = itemId;
             
             if (itemDefinitionParsedToStringOrMap instanceof String) {
                 if (((String)itemDefinitionParsedToStringOrMap).trim().indexOf("\n")<0) {
@@ -1259,39 +1257,124 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 throw new IllegalArgumentException("Item definition should be a string or map to use the guesser");
             }
             this.catalogItemType = optionalCiType;
+            this.format = format;
             this.libraryBundles = libraryBundles;
             this.itemsDefinedSoFar = itemsDefinedSoFar;
         }
 
-        public PlanInterpreterGuessingType reconstruct() {
-            if (catalogItemType==CatalogItemType.TEMPLATE) {
-                // template *must* be explicitly defined, and if so, none of the other calls apply
-                attemptType(null, CatalogItemType.TEMPLATE);
-                
-            } else {
-                attemptType(null, CatalogItemType.ENTITY);
-                
-                List<Exception> oldEntityErrors = MutableList.copyOf(entityErrors);
-                // try with services key
-                attemptType("services", CatalogItemType.ENTITY);
-                entityErrors.removeAll(oldEntityErrors);
-                entityErrors.addAll(oldEntityErrors);
-                // errors when wrapped in services block are better currently
-                // as we parse using CAMP and need that
-                // so prefer those for now (may change with YOML)
-                
-                attemptType(POLICIES_KEY, CatalogItemType.POLICY);
-                attemptType(ENRICHERS_KEY, CatalogItemType.ENRICHER);
-                attemptType(LOCATIONS_KEY, CatalogItemType.LOCATION);
-            }
-            
-            if (!resolved && catalogItemType==CatalogItemType.TEMPLATE) {
-                // anything goes, for an explicit template, because we can't easily recurse into the types
+        public PlanInterpreterInferringType resolve() {
+            Maybe<Object> transformedResult = attemptPlanTranformer();
+            boolean onlyNewStyleTransformer = format != null || catalogItemType == CatalogItemType.BEAN;
+            if (transformedResult.isPresent() || onlyNewStyleTransformer) {
                 planYaml = itemYaml;
-                resolved = true;
+                if (catalogItemType!=CatalogItemType.BEAN && catalogItemType!=CatalogItemType.TEMPLATE) {
+                    // for specs types, _also_ do the legacy and let it set resolution,
+                    // as it is better at spotting some types of errors (recursive ones)
+                    resolved = false;
+                    attemptLegacySpecTransformersForVariousSpecTypes();
+                } else {
+                    resolved = transformedResult.isPresent() || catalogItemType == CatalogItemType.TEMPLATE;
+                }
+                return this;
             }
-            
+
+            // for now, these are the lowest-priority errors (reported after the others)
+            transformerErrors.add( ((Maybe.Absent) transformedResult).getException() );
+
+            if (catalogItemType==CatalogItemType.TEMPLATE) {
+                // template *must* be explicitly specified as item type, and if so, the "various" methods below don't apply,
+                // and we always mark it as resolved.  (probably not necessary to do any of the transformers!)
+                attemptLegacySpecTransformersForType(null, CatalogItemType.TEMPLATE);
+                if (!resolved) {
+                    // anything goes, for an explicit template, because we can't easily recurse into the types
+                    planYaml = itemYaml;
+                    resolved = true;
+                }
+                return this;
+            }
+
+            // couldn't resolve it with the plan transformers; retry with legacy "spec" transformers
+            // (not sure if/when we come here...)
+            if (format==null) {
+                attemptLegacySpecTransformersForVariousSpecTypes();
+            }
+
             return this;
+        }
+
+        private void attemptLegacySpecTransformersForVariousSpecTypes() {
+            attemptLegacySpecTransformersForType(null, CatalogItemType.ENTITY);
+
+            List<Exception> oldEntityErrors = MutableList.copyOf(entityErrors);
+            // try with services key
+            attemptLegacySpecTransformersForType("services", CatalogItemType.ENTITY);
+            entityErrors.removeAll(oldEntityErrors);
+            entityErrors.addAll(oldEntityErrors);
+            // errors when wrapped in services block are better currently
+            // as we parse using CAMP and need that
+            // so prefer those for now (may change with YOML)
+
+            attemptLegacySpecTransformersForType(POLICIES_KEY, CatalogItemType.POLICY);
+            attemptLegacySpecTransformersForType(ENRICHERS_KEY, CatalogItemType.ENRICHER);
+            attemptLegacySpecTransformersForType(LOCATIONS_KEY, CatalogItemType.LOCATION);
+        }
+
+        private Maybe<Object> attemptPlanTranformer() {
+            try {
+                Exception e = null;
+                boolean suspicionOfABean = false;
+
+                Set<OsgiBundleWithUrl> searchBundles = MutableSet.copyOf(libraryBundles)
+                        // TODO do we need access to the brooklyn or containing bundle?
+//                    .addAll(currentBundleOrBrooklyn)
+                        ;
+                BrooklynClassLoadingContext loader = new OsgiBrooklynClassLoadingContext(mgmt, null, searchBundles);
+                if (catalogItemType == null) {
+                    // attempt to detect whether it is a bean
+                    Object type = item.get("type");
+                    if (type!=null && type instanceof String) {
+                        Class<?> clz = new BrooklynTypeNameResolver((String)type, loader, true, true)
+                                .findBaseClass((String) type).orNull();
+                        if (clz!=null) {
+                            if (!BrooklynObject.class.isAssignableFrom(clz)) {
+                                suspicionOfABean = true;
+                            }
+                        }
+                    }
+                }
+
+                Object t = null;
+                RegisteredTypeLoadingContext constraint = RegisteredTypeLoadingContexts.loader(loader);
+                if (catalogItemType == CatalogItemType.BEAN || suspicionOfABean) {
+                    try {
+                        t = mgmt.getTypeRegistry().createBeanFromPlan(format, itemYaml, constraint, null);
+                        catalogItemType = CatalogItemType.BEAN;
+                    } catch (Exception eS) {
+                        Exceptions.propagateIfFatal(eS);
+                        // if we were speculatively trying bean then rety as plan
+                        e = eS;
+                    }
+                }
+
+                if (catalogItemType != CatalogItemType.BEAN && t==null) {
+                    t = mgmt.getTypeRegistry().createSpecFromPlan(format, itemYaml, constraint,
+                            BrooklynObjectType.of(catalogItemType).getSpecType());
+                    if (catalogItemType == null) {
+                        catalogItemType = CatalogItemType.ofSpecClass(BrooklynObjectType.of(t.getClass()).getSpecType());
+                    }
+                }
+
+                if (t==null) {
+                    if (e!=null) throw e;
+                    throw new IllegalStateException("Type registry creation returned null");
+                }
+
+                resolved = true;
+                return Maybe.of(t);
+
+            } catch (Exception e) {
+                return Maybe.absent(e);
+            }
         }
 
         public boolean isResolved() { return resolved; }
@@ -1299,8 +1382,11 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         /** Returns potentially useful errors encountered while guessing types. 
          * May only be available where the type is known. */
         public List<Exception> getErrors() {
-            if (errors.isEmpty()) return entityErrors;
-            return errors;
+            // errors are useful in this order, at least historically, and in our tests
+            if (!errors.isEmpty()) return errors;
+            if (!entityErrors.isEmpty()) return entityErrors;
+            if (!transformerErrors.isEmpty()) return transformerErrors;
+            return Collections.emptyList();
         }
         
         public CatalogItemType getCatalogItemType() {
@@ -1311,10 +1397,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             return planYaml;
         }
         
-        private boolean attemptType(String key, CatalogItemType candidateCiType) {
+        private boolean attemptLegacySpecTransformersForType(String key, CatalogItemType candidateCiType) {
             if (resolved) return false;
             if (catalogItemType!=null && catalogItemType!=candidateCiType) return false;
-            
+
             final String candidateYaml;
             if (key==null) candidateYaml = itemYaml;
             else {
@@ -1339,38 +1425,38 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                         }
                     }
                 }
-                {
-                    // legacy routine; should be the same as above code added in 0.12 because:
-                    // if type is symbolic_name, the type will match above, and version will be null so any version allowed to match 
-                    // if type is symbolic_name:version, the id will match, and the version will also have to match 
-                    // SHOULD NEVER NEED THIS - remove during or after 0.13
-                    String typeWithId = type;
-                    String version = null;
-                    if (CatalogUtils.looksLikeVersionedId(type)) {
-                        version = CatalogUtils.getVersionFromVersionedId(type);
-                        type = CatalogUtils.getSymbolicNameFromVersionedId(type);
-                    }
-                    if (type!=null && key!=null) {
-                        for (CatalogItemDtoAbstract<?,?> candidate: itemsDefinedSoFar) {
-                            if (candidateCiType == candidate.getCatalogItemType() &&
-                                    (type.equals(candidate.getSymbolicName()) || type.equals(candidate.getId()))) {
-                                if (version==null || version.equals(candidate.getVersion())) {
-                                    log.error("Lookup of '"+type+"' version '"+version+"' only worked using legacy routines; please advise Brooklyn community so they understand why");
-                                    // matched - exit
-                                    catalogItemType = candidateCiType;
-                                    planYaml = candidateYaml;
-                                    resolved = true;
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-                    
-                    type = typeWithId;
-                    // above line is a change to behaviour; previously we proceeded below with the version dropped in code above;
-                    // but that seems like a bug as the code below will have ignored version.
-                    // likely this means we are now stricter about loading things that reference new versions, but correctly so. 
-                }
+//                {
+//                    // legacy routine; should be the same as above code added in 0.12 because:
+//                    // if type is symbolic_name, the type will match above, and version will be null so any version allowed to match
+//                    // if type is symbolic_name:version, the id will match, and the version will also have to match
+//                    // SHOULD NEVER NEED THIS - remove during or after 0.13
+//                    String typeWithId = type;
+//                    String version = null;
+//                    if (CatalogUtils.looksLikeVersionedId(type)) {
+//                        version = CatalogUtils.getVersionFromVersionedId(type);
+//                        type = CatalogUtils.getSymbolicNameFromVersionedId(type);
+//                    }
+//                    if (type!=null && key!=null) {
+//                        for (CatalogItemDtoAbstract<?,?> candidate: itemsDefinedSoFar) {
+//                            if (candidateCiType == candidate.getCatalogItemType() &&
+//                                    (type.equals(candidate.getSymbolicName()) || type.equals(candidate.getId()))) {
+//                                if (version==null || version.equals(candidate.getVersion())) {
+//                                    log.error("Lookup of '"+type+"' version '"+version+"' only worked using legacy routines; please advise Brooklyn community so they understand why");
+//                                    // matched - exit
+//                                    catalogItemType = candidateCiType;
+//                                    planYaml = candidateYaml;
+//                                    resolved = true;
+//                                    return true;
+//                                }
+//                            }
+//                        }
+//                    }
+//
+//                    type = typeWithId;
+//                    // above line is a change to behaviour; previously we proceeded below with the version dropped in code above;
+//                    // but that seems like a bug as the code below will have ignored version.
+//                    // likely this means we are now stricter about loading things that reference new versions, but correctly so.
+//                }
             }
             
             // then try parsing plan - this will use loader
@@ -1438,10 +1524,15 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         }
 
         private String getIdWithRandomDefault() {
-            return idAsSymbolicNameWithoutVersion != null ? idAsSymbolicNameWithoutVersion : Strings.makeRandomId(10);
+            return itemId != null ? itemId : Strings.makeRandomId(10);
         }
         public Map<?,?> getItem() {
             return item;
+        }
+
+        public PlanInterpreterInferringType setId(String id) {
+            this.itemId = itemId;
+            return this;
         }
     }
     
@@ -1464,35 +1555,9 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return CatalogItemBuilder.newItem(itemType, symbolicName, version);
     }
 
-    // these kept as their logic may prove useful; Apr 2015
-//    private boolean isApplicationSpec(EntitySpec<?> spec) {
-//        return !Boolean.TRUE.equals(spec.getConfig().get(EntityManagementUtils.WRAPPER_APP_MARKER));
-//    }
-//
-//    private boolean isEntityPlan(DeploymentPlan plan) {
-//        return plan!=null && !plan.getServices().isEmpty() || !plan.getArtifacts().isEmpty();
-//    }
-//    
-//    private boolean isPolicyPlan(DeploymentPlan plan) {
-//        return !isEntityPlan(plan) && plan.getCustomAttributes().containsKey(POLICIES_KEY);
-//    }
-//
-//    private boolean isLocationPlan(DeploymentPlan plan) {
-//        return !isEntityPlan(plan) && plan.getCustomAttributes().containsKey(LOCATIONS_KEY);
-//    }
-
-    //------------------------
-    
     @Override
     public List<? extends CatalogItem<?,?>> addItems(String yaml) {
         return addItems(yaml, true, false);
-    }
-    
-    /** @deprecated since 1.0.0 use {@link #addItems(String)} or {@link #addItems(String, boolean, boolean)} */
-    @Deprecated
-    @Override
-    public List<? extends CatalogItem<?,?>> addItems(String yaml, boolean forceUpdate) {
-        return addItems(yaml, true, forceUpdate);
     }
     
     @Override
@@ -1511,8 +1576,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return addItems(yaml, null, forceUpdate);
     }
     
-    /** Like {@link #addItems(String, boolean)} but returning the {@link OsgiBundleInstallationResult} for use from new environments.
-     * If not using OSGi the bundle/code/etc fields are null but the types will always be set. */
+    /** Wraps the given items in an OSGi bundle and adds the bundle.
+     * If OSGi not present, uses {@link #addItems(String, boolean, boolean)}. */
     @SuppressWarnings("deprecation")
     public OsgiBundleInstallationResult addItemsBundleResult(String yaml, boolean forceUpdate) {
         Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)mgmt).getOsgiManager();
@@ -1595,16 +1660,11 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     }
     
     @Override
-    public List<? extends CatalogItem<?, ?>> addItems(String yaml, ManagedBundle bundle) {
-        return addItems(yaml, bundle, false);
-    }
-    
-    @Override
     public List<? extends CatalogItem<?,?>> addItems(String yaml, ManagedBundle bundle, boolean forceUpdate) {
         log.debug("Adding catalog item to "+mgmt+": "+yaml);
         checkNotNull(yaml, "yaml");
         List<CatalogItemDtoAbstract<?, ?>> result = MutableList.of();
-        collectCatalogItemsFromCatalogBomRoot("caller-supplied YAML", yaml, bundle, result, null, true, ImmutableMap.of(), 0, forceUpdate);
+        collectCatalogItemsFromCatalogBomRoot("caller-supplied YAML", yaml, bundle, result, null, true, ImmutableMap.of(), 0, forceUpdate, true);
 
         // do this at the end for atomic updates; if there are intra-yaml references, we handle them specially
         // (but for legacy items we only support them when using `item: { type: co-bundled-type }` syntax,
@@ -1632,12 +1692,36 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
     @Override @Beta
     public void addTypesFromBundleBom(String yaml, ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result) {
-        log.debug("Catalog load, adding catalog item to "+mgmt+": "+yaml);
+        log.debug("Catalog load, adding registered types to "+mgmt+" for bundle "+bundle+": "+yaml);
         checkNotNull(yaml, "yaml");
         if (result==null) result = MutableMap.of();
-        collectCatalogItemsFromCatalogBomRoot("bundle BOM in "+bundle, yaml, bundle, null, result, false, MutableMap.of(), 0, forceUpdate);
+        collectCatalogItemsFromCatalogBomRoot("bundle BOM in "+bundle, yaml, bundle, null, result, false, MutableMap.of(), 0, forceUpdate, false);
     }
-    
+
+    @Override @Beta
+    // mainly needed for tests which expect errors about item addition, which could be masked by errors on version clashes
+    public Collection<RegisteredType> addTypesAndValidateAllowInconsistent(String catalogYaml, @Nullable Map<RegisteredType, RegisteredType> result, boolean forceUpdate) {
+        log.debug("Catalog load, adding registered types to "+mgmt+": "+catalogYaml);
+        checkNotNull(catalogYaml, "catalogYaml");
+
+        Maybe<OsgiManager> osgiManager = ((ManagementContextInternal)mgmt).getOsgiManager();
+        if (osgiManager.isPresent() && AUTO_WRAP_CATALOG_YAML_AS_BUNDLE) {
+            // wrap in a bundle to be managed; need to get bundle and version from yaml
+            return addItemsOsgi(catalogYaml, forceUpdate, osgiManager.get()).getTypesInstalled();
+            // above will have done validation and supertypes recorded
+        }
+
+        // often in tests we don't have osgi and so it acts as follows
+        if (result==null) result = MutableMap.of();
+        collectCatalogItemsFromCatalogBomRoot("unbundled catalog definition", catalogYaml, null, null, result, false, MutableMap.of(), 0, forceUpdate, true);
+
+        Map<RegisteredType, Collection<Throwable>> validation = validateTypes(result.keySet());
+        if (Iterables.concat(validation.values()).iterator().hasNext()) {
+            throw new IllegalStateException("Could not validate one or more items: "+validation);
+        }
+        return validation.keySet();
+    }
+
     @Override @Beta
     public Map<RegisteredType,Collection<Throwable>> validateTypes(Iterable<RegisteredType> typesToValidate) {
         List<RegisteredType> typesRemainingToValidate = MutableList.copyOf(typesToValidate);
@@ -1663,7 +1747,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
     @Override @Beta
     public Collection<Throwable> validateType(RegisteredType typeToValidate, RegisteredTypeLoadingContext constraint) {
-        ReferenceWithError<RegisteredType> result = resolve(typeToValidate, constraint);
+        ReferenceWithError<RegisteredType> result = validateResolve(typeToValidate, constraint);
         if (result.hasError()) {
             if (RegisteredTypes.isTemplate(typeToValidate)) {
                 // ignore for templates
@@ -1684,8 +1768,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
      * The argument may be changed (e.g. its kind set, supertypes set), and normal usage is to add 
      * a type in an "unresolved" state if things may need to reference it, then call resolve here,
      * then replace what was added with the argument given here. */
-    @Beta
-    public ReferenceWithError<RegisteredType> resolve(RegisteredType typeToValidate, RegisteredTypeLoadingContext constraint) {
+    ReferenceWithError<RegisteredType> validateResolve(RegisteredType typeToValidate, RegisteredTypeLoadingContext constraint) {
         Throwable inconsistentSuperTypesError=null, specError=null, beanError=null;
         List<Throwable> guesserErrors = MutableList.of();
         
@@ -1750,15 +1833,14 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         }
         
         if (resultO==null && (constraint==null || constraint.getAlreadyEncounteredTypes().isEmpty())) try {
-            // try the legacy PlanInterpreterGuessingType
-            // (this is the only place where we will guess specs, so it handles 
-            // most of our traditional catalog items in BOMs);
+            // try the messy but useful PlanInterpreterGuessingType
+            // (that is the only place where we will guess specs, so it handles most of our traditional catalog items in BOMs);
             // but do not allow this to run if we are expanding a nested definition as that may fail to find recursive loops
             // (the legacy routines this uses don't support that type of context)
             String yaml = RegisteredTypes.getImplementationDataStringForSpec(typeToValidate);
-            PlanInterpreterGuessingType guesser = new PlanInterpreterGuessingType(typeToValidate.getSymbolicName(), Iterables.getOnlyElement( Yamls.parseAll(yaml) ), 
-                yaml, null, CatalogItemDtoAbstract.parseLibraries( typeToValidate.getLibraries() ), null);
-            guesser.reconstruct();
+            PlanInterpreterInferringType guesser = new PlanInterpreterInferringType(typeToValidate.getSymbolicName(), Iterables.getOnlyElement( Yamls.parseAll(yaml) ),
+                yaml, null, null, CatalogItemDtoAbstract.parseLibraries( typeToValidate.getLibraries() ), null);
+            guesser.resolve();
             guesserErrors.addAll(guesser.getErrors());
             
             if (guesser.isResolved()) {
@@ -1786,13 +1868,13 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 
                 if (!Objects.equal(guesser.getPlanYaml(), yaml)) {
                     RegisteredTypes.changePlanNotingEquivalent(resultT, 
-                        new BasicTypeImplementationPlan(null /* CampTypePlanTransformer.FORMAT */, guesser.getPlanYaml()));
+                        new BasicTypeImplementationPlan(typeToValidate.getPlan().getPlanFormat(), guesser.getPlanYaml()));
                     changedSomething = true;
                 }
                 
                 if (changedSomething) {
                     // try again with new plan or supertype info
-                    return resolve(resultT, constraint);
+                    return validateResolve(resultT, constraint);
                     
                 } else if (Objects.equal(boType, BrooklynObjectType.of(ciType))) {
                     if (specError==null) {
@@ -1816,7 +1898,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (resultO!=null && resultT!=null) {
             if (resultO instanceof BrooklynObject) {
                 // if it was a bean that points at a BO then switch it to a spec and try to re-validate
-                return resolve(RegisteredTypes.copyResolved(RegisteredTypeKind.SPEC, typeToValidate), constraint);
+                return validateResolve(RegisteredTypes.copyResolved(RegisteredTypeKind.SPEC, typeToValidate), constraint);
             }
             Class<?> resultS;
             if (resultT.getKind() == RegisteredTypeKind.SPEC) {
@@ -2114,6 +2196,8 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                     case LOCATION:
                         dto.setPlanYaml(LOCATIONS_KEY + ": [{ type: "+dto.getJavaType()+" }]");
                         break;
+                    default:
+                        throw new IllegalStateException("Not supported to create a catalog item " + dto.getCatalogItemId() + " from: "+dto.getCatalogItemType());
                 }
                 dto.setJavaType(null);
 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -643,7 +643,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         if (parser != null) {
             itemMetadataWithoutItemDef = parser.parse((Map<String, Object>) itemMetadataWithoutItemDef);
             try {
-                itemMetadataWithoutItemDef = (Map<String, Object>) Tasks.resolveDeepValue(itemMetadataWithoutItemDef, Object.class, mgmt.getServerExecutionContext());
+                itemMetadataWithoutItemDef = (Map<String, Object>) Tasks.resolveDeepValueWithoutCoercion(itemMetadataWithoutItemDef, mgmt.getServerExecutionContext());
             } catch (Exception e) {
                 throw Exceptions.propagate(e);
             }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemBuilder.java
@@ -38,6 +38,7 @@ public class CatalogItemBuilder<CIConcreteType extends CatalogItemDtoAbstract<?,
         case POLICY: return newPolicy(symbolicName, version);
         case ENRICHER: return newEnricher(symbolicName, version);
         case LOCATION: return newLocation(symbolicName, version);
+        case BEAN: throw new IllegalStateException("Beans not supported in catalog mode; must use type registry");
         }
         throw new IllegalStateException("Unexpected itemType: "+itemType);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -442,7 +442,8 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     
     protected Object resolveValue(Object v, ExecutionContext exec) throws ExecutionException, InterruptedException {
         if (ValueResolver.supportsDeepResolution(v)) {
-            return Tasks.resolveDeepValue(v, Object.class, exec, "Resolving deep config "+name);
+            return Tasks.resolveDeepValueWithoutCoercion(v, exec, "Resolving deep config "+name);
+            // TODO
         } else {
             return Tasks.resolveValue(v, getTypeToken(), exec, "Resolving config "+name);
         }

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -441,12 +441,7 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     }
     
     protected Object resolveValue(Object v, ExecutionContext exec) throws ExecutionException, InterruptedException {
-        if (ValueResolver.supportsDeepResolution(v)) {
-            return Tasks.resolveDeepValueWithoutCoercion(v, exec, "Resolving deep config "+name);
-            // TODO
-        } else {
-            return Tasks.resolveValue(v, getTypeToken(), exec, "Resolving config "+name);
-        }
+        return Tasks.resolveDeepValueCoerced(v, getTypeToken(), exec, "config "+name);
     }
 
     /** used to record a key which overwrites another; only needed at disambiguation time 

--- a/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/BasicConfigKey.java
@@ -36,6 +36,8 @@ import org.apache.brooklyn.core.config.ConfigKeys.InheritanceContext;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.internal.ConfigKeySelfExtracting;
 import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.Tasks.ForTestingAndLegacyCompatibilityOnly;
+import org.apache.brooklyn.util.core.task.Tasks.ForTestingAndLegacyCompatibilityOnly.LegacyDeepResolutionMode;
 import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.TypeTokens;
@@ -441,7 +443,34 @@ public class BasicConfigKey<T> implements ConfigKeySelfExtracting<T>, Serializab
     }
     
     protected Object resolveValue(Object v, ExecutionContext exec) throws ExecutionException, InterruptedException {
-        return Tasks.resolveDeepValueCoerced(v, getTypeToken(), exec, "config "+name);
+        Exception e1 = null;
+        if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE != LegacyDeepResolutionMode.ONLY_LEGACY) {
+            try {
+                return Tasks.resolveDeepValueCoerced(v, getTypeToken(), exec, "config " + name);
+            } catch (Exception e) {
+                if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE == LegacyDeepResolutionMode.DISALLOW_LEGACY) {
+                    throw Exceptions.propagateAnnotated("Cannot resolve "+v+" for "+this, e);
+                }
+                e1 = e;
+            }
+        }
+
+        try {
+            // legacy mode didn't do coercion if the object was a map/list/etc
+            Object result;
+            if (ValueResolver.supportsDeepResolution(v, null)) {
+                result = Tasks.resolveDeepValueWithoutCoercion(v, exec, "Resolving deep config " + name);
+            } else {
+                result = Tasks.resolveValue(v, getTypeToken(), exec, "Resolving config " + name);
+            }
+            if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE == LegacyDeepResolutionMode.WARN) {
+                log.warn("Conversion of '" + this + "' (" + v + ") to " + type + " failed; leaving as map/list type for legacy compatibility, but this feature may be removed in future");
+            }
+            return result;
+        } catch (Exception e2) {
+            Exceptions.propagateIfFatal(e2);
+            throw Exceptions.propagateAnnotated("Cannot resolve "+v+" for "+this, e1);
+        }
     }
 
     /** used to record a key which overwrites another; only needed at disambiguation time 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddChildrenEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddChildrenEffector.java
@@ -46,7 +46,7 @@ import com.google.common.collect.Iterables;
  * 
  * @since 0.7.0 */
 @Beta
-public class AddChildrenEffector extends AddEffector {
+public class AddChildrenEffector extends AddEffectorInitializerAbstract {
     
     private static final Logger log = LoggerFactory.getLogger(AddChildrenEffector.class);
     
@@ -54,18 +54,13 @@ public class AddChildrenEffector extends AddEffector {
     public static final ConfigKey<String> BLUEPRINT_TYPE = ConfigKeys.newStringConfigKey("blueprint_type");
     public static final ConfigKey<Boolean> AUTO_START = ConfigKeys.newBooleanConfigKey("auto_start");
     
-    public AddChildrenEffector(ConfigBag params) {
-        super(newEffectorBuilder(params).build());
-    }
-    
-    public AddChildrenEffector(Map<String,String> params) {
-        this(ConfigBag.newInstance(params));
-    }
+    private AddChildrenEffector() {}
+    public AddChildrenEffector(ConfigBag params) { super(params); }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static EffectorBuilder<List<String>> newEffectorBuilder(ConfigBag params) {
-        EffectorBuilder<List<String>> eff = (EffectorBuilder) AddEffector.newEffectorBuilder(List.class, params);
-        eff.impl(new Body(eff.buildAbstract(), params));
+    public EffectorBuilder<List<String>> newEffectorBuilder() {
+        EffectorBuilder<List<String>> eff = (EffectorBuilder) newAbstractEffectorBuilder(List.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
         return eff;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
@@ -42,7 +42,7 @@ import com.google.common.base.Preconditions;
  * <p>
  * Alternatively (recommended) extenders may override {@link #effector()} to recompute the effector each time,
  * and provide two constructors, a no-arg, and a 1-arg {@link ConfigBag} calling the super {@link ConfigBag} constructor here.
- * As per {@link org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithConfigBag} their code
+ * As per {@link org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithConfigKeys} their code
  * may refer to {@link #initParam(ConfigKey)} to access parameters.
  * <p>
  * Note that the parameters passed to the call method in the body of the effector implementation

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffector.java
@@ -18,20 +18,10 @@
  */
 package org.apache.brooklyn.core.effector;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.apache.brooklyn.api.effector.Effector;
-import org.apache.brooklyn.api.effector.ParameterType;
-import org.apache.brooklyn.api.entity.EntityInitializer;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.text.Strings;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
@@ -45,72 +35,54 @@ import com.google.common.base.Preconditions;
  * <li> the description from {@link #EFFECTOR_DESCRIPTION}
  * <li> the parameters from {@link #EFFECTOR_PARAMETER_DEFS}
  * <p>
- * Callers should pass the effector to instantiate into the constructor.
+ * Extenders may pass the effector to instantiate into the constructor.
  * Often subclasses will supply a constructor which takes a ConfigBag of parameters,
  * and a custom {@link #newEffectorBuilder(Class, ConfigBag)} which adds the body
  * before passing to this class.
+ * <p>
+ * Alternatively (recommended) extenders may override {@link #effector()} to recompute the effector each time,
+ * and provide two constructors, a no-arg, and a 1-arg {@link ConfigBag} calling the super {@link ConfigBag} constructor here.
+ * As per {@link org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithConfigBag} their code
+ * may refer to {@link #initParam(ConfigKey)} to access parameters.
  * <p>
  * Note that the parameters passed to the call method in the body of the effector implementation
  * are only those supplied by a user at runtime; in order to merge with default
  * values, use {@link #getMergedParams(Effector, ConfigBag)}.
  *  
- * @since 0.7.0 */
+ * @since 0.7.0
+ * @deprecated since 1.1 use {@link AddEffectorInitializerAbstract} because the static {@link Effector} constructor
+ * does not lend itself to bean-with-type creation */
 @Beta
-public class AddEffector implements EntityInitializer {
-    
-    public static final ConfigKey<String> EFFECTOR_NAME = ConfigKeys.newStringConfigKey("name");
-    public static final ConfigKey<String> EFFECTOR_DESCRIPTION = ConfigKeys.newStringConfigKey("description");
-    
-    public static final ConfigKey<Map<String,Object>> EFFECTOR_PARAMETER_DEFS = new MapConfigKey<Object>(Object.class, "parameters");
+@Deprecated
+public class AddEffector extends AddEffectorInitializerAbstractProto {
 
-    protected final Effector<?> effector;
-    
+    protected Effector<?> effector;
+
     public AddEffector(Effector<?> effector) {
-        this.effector = Preconditions.checkNotNull(effector, "effector");
-    }
-    
-    @Override
-    public void apply(EntityLocal entity) {
-        ((EntityInternal)entity).getMutableEntityType().addEffector(effector);
-    }
-    
-    public static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
-        String name = Preconditions.checkNotNull(params.get(EFFECTOR_NAME), "name must be supplied when defining an effector: %s", params);
-        EffectorBuilder<T> eff = Effectors.effector(type, name);
-        eff.description(params.get(EFFECTOR_DESCRIPTION));
-        
-        Map<String, Object> paramDefs = params.get(EFFECTOR_PARAMETER_DEFS);
-        if (paramDefs!=null) {
-            for (Map.Entry<String, Object> paramDef: paramDefs.entrySet()){
-                if (paramDef!=null) {
-                    String paramName = paramDef.getKey();
-                    Object value = paramDef.getValue();
-                    if (value==null) value = Collections.emptyMap();
-                    if (!(value instanceof Map)) {
-                        if (value instanceof CharSequence && Strings.isBlank((CharSequence) value)) 
-                            value = Collections.emptyMap();
-                    }
-                    if (!(value instanceof Map))
-                        throw new IllegalArgumentException("Illegal argument of type "+value.getClass()+" value '"+value+"' supplied as parameter definition "
-                            + "'"+paramName);
-                    eff.parameter(ConfigKeys.DynamicKeys.newNamedInstance(paramName, (Map<?, ?>) value));
-                }
-            }
-        }
-        
-        return eff;
+        super();
+        initEffector(Preconditions.checkNotNull(effector, "effector"));
     }
 
-    /** returns a ConfigBag containing the merger of the supplied parameters with default values on the effector-defined parameters */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static ConfigBag getMergedParams(Effector<?> eff, ConfigBag params) {
-        ConfigBag result = ConfigBag.newInstanceCopying(params);
-        for (ParameterType<?> param: eff.getParameters()) {
-            ConfigKey key = Effectors.asConfigKey(param);
-            if (!result.containsKey(key))
-                result.configure(key, params.get(key));
-        }
-        return result;
+    protected AddEffector(ConfigBag params) {
+        super(params);
+    }
+
+    // JSON deserialization constructor
+    protected AddEffector() {}
+
+    protected void init(ConfigBag params) {
+        throw new IllegalStateException("Not supported as bean-with type; subclasses should overwrite this method");
+    }
+
+    protected void initEffector(Effector<?> effector) {
+        this.effector = effector;
+    }
+    protected Effector<?> effector() {
+        return effector;
+    }
+
+    public static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
+        return AddEffectorInitializerAbstractProto.newEffectorBuilder(type, params);
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstract.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstract.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector;
+
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+
+/**
+ * Entity initializer which adds an effector to an entity.
+ * <p>
+ * This parent instance provides parameter management and a {@link #newAbstractEffectorBuilder(Class)}
+ * which returns an abstract (body-less) effector defining:
+ * <li> the name from {@link #EFFECTOR_NAME};
+ * <li> the description from {@link #EFFECTOR_DESCRIPTION}
+ * <li> the parameters from {@link #EFFECTOR_PARAMETER_DEFS}
+ * <p>
+ * The main thing needed to extend this is to implement {@link #newEffectorBuilder()}, calling {@link #newAbstractEffectorBuilder(Class)} if desired,
+ * and supplying their effector body.
+ * <p>
+ * Extenders should supply a no-arg constructor (can be private) for use during deserializing YAML,
+ * and a {@link ConfigBag} constructor calling to super to allow programmatic creation.
+ * <p>
+ * Extenders may provide additional {@link org.apache.brooklyn.config.ConfigKey} statics and use them like normal.
+ * <p>
+ * Note that the parameters passed to the call method in the body of the effector implementation
+ * are only those supplied by a user at runtime; in order to merge with parameters supplied at effector definition time,
+ * use {@link #getMergedParams(Effector, ConfigBag)}.
+ * <p>
+ * Also note that although fields can be used deserialization from YAML to registered types is not always fully supported.
+ * If strongly typed deserialization is desired and {@link org.apache.brooklyn.util.core.flags.TypeCoercions} not sufficient,
+ * routines in {@link org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils} can be applied.
+ *  
+ * @since 0.7.0 */
+@Beta
+public abstract class AddEffectorInitializerAbstract extends AddEffectorInitializerAbstractProto {
+
+    protected AddEffectorInitializerAbstract() {}
+    protected AddEffectorInitializerAbstract(ConfigBag params) {
+        super(params);
+    }
+
+    protected Effector<?> effector() {
+        return newEffectorBuilder().build();
+    }
+
+    protected abstract <T> EffectorBuilder<T> newEffectorBuilder();
+
+    protected <T> EffectorBuilder<T> newAbstractEffectorBuilder(Class<T> type) {
+        return AddEffectorInitializerAbstractProto.newEffectorBuilder(type, initParams());
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstract.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstract.java
@@ -63,6 +63,7 @@ public abstract class AddEffectorInitializerAbstract extends AddEffectorInitiali
 
     protected abstract <T> EffectorBuilder<T> newEffectorBuilder();
 
+    // TODO support TypeToken here ... and anyone who looks this up dynamically should use BrooklynTypeNameResolver
     protected <T> EffectorBuilder<T> newAbstractEffectorBuilder(Class<T> type) {
         return AddEffectorInitializerAbstractProto.newEffectorBuilder(type, initParams());
     }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.effector.ParameterType;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Beta
+abstract class AddEffectorInitializerAbstractProto extends EntityInitializers.InitializerPatternWithConfigKeys {
+
+    public static final ConfigKey<String> EFFECTOR_NAME = ConfigKeys.newStringConfigKey("name");
+    public static final ConfigKey<String> EFFECTOR_DESCRIPTION = ConfigKeys.newStringConfigKey("description");
+
+    public static final ConfigKey<Map<String,Object>> EFFECTOR_PARAMETER_DEFS = new MapConfigKey<Object>(Object.class, "parameters");
+
+    protected AddEffectorInitializerAbstractProto(ConfigBag params) {
+        super(params);
+    }
+    // JSON deserialization constructor
+    protected AddEffectorInitializerAbstractProto() {}
+
+    protected abstract Effector<?> effector();
+
+    @Override
+    public void apply(EntityLocal entity) {
+        ((EntityInternal)entity).getMutableEntityType().addEffector(effector());
+    }
+
+    /** returns a ConfigBag containing the merger of the supplied parameters with default values on the effector-defined parameters */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static ConfigBag getMergedParams(Effector<?> eff, ConfigBag params) {
+        ConfigBag result = ConfigBag.newInstanceCopying(params);
+        for (ParameterType<?> param: eff.getParameters()) {
+            ConfigKey key = Effectors.asConfigKey(param);
+            if (!result.containsKey(key))
+                result.configure(key, params.get(key));
+        }
+        return result;
+    }
+
+    static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
+        String name = Preconditions.checkNotNull(params.get(EFFECTOR_NAME), "name must be supplied when defining an effector: %s", params);
+        EffectorBuilder<T> eff = Effectors.effector(type, name);
+        eff.description(params.get(EFFECTOR_DESCRIPTION));
+
+        Map<String, Object> paramDefs = params.get(EFFECTOR_PARAMETER_DEFS);
+        if (paramDefs!=null) {
+            for (Map.Entry<String, Object> paramDef: paramDefs.entrySet()){
+                if (paramDef!=null) {
+                    String paramName = paramDef.getKey();
+                    Object value = paramDef.getValue();
+                    if (value==null) value = Collections.emptyMap();
+                    if (!(value instanceof Map)) {
+                        if (value instanceof CharSequence && Strings.isBlank((CharSequence) value))
+                            value = Collections.emptyMap();
+                    }
+                    if (!(value instanceof Map))
+                        throw new IllegalArgumentException("Illegal argument of type "+value.getClass()+" value '"+value+"' supplied as parameter definition "
+                                + "'"+paramName);
+                    eff.parameter(ConfigKeys.DynamicKeys.newNamedInstance(paramName, (Map<?, ?>) value));
+                }
+            }
+        }
+
+        return eff;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
@@ -45,30 +46,26 @@ import com.google.common.base.Preconditions;
  * OSGi bundles added at runtime.
  *
  * @since 0.7.0
+ * @deprecated since 1.1 use {@link AddSensorInitializer}
  */
-@Beta
-public class AddSensor<T> implements EntityInitializer {
+@Beta @Deprecated
+public class AddSensor<T> extends EntityInitializers.InitializerPatternWithFieldsFromConfigKeys implements AddSensorInitializerAbstractProto<T> {
 
-    public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey("name", "The name of the sensor to create");
-    public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newConfigKey(Duration.class, "period", "Period, including units e.g. 1m or 5s or 200ms; default 5 minutes", Duration.FIVE_MINUTES);
-    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newStringConfigKey("targetType", "Target type for the value; default String", "java.lang.String");
+    protected String name;
+    protected Duration period;
+    protected String type;
 
-    protected final String name;
-    protected final Duration period;
-    protected final String type;
+    {
+        addInitConfigMapping(SENSOR_NAME, v -> name = v);
+        addInitConfigMapping(SENSOR_PERIOD, v -> period = v);
+        addInitConfigMapping(SENSOR_TYPE, v -> type = v);
+    }
+
     protected AttributeSensor<T> sensor;
-    protected final ConfigBag params;
 
-    public AddSensor(Map<String, String> params) {
-        this(ConfigBag.newInstance(params));
-    }
-
-    public AddSensor(final ConfigBag params) {
-        this.name = Preconditions.checkNotNull(params.get(SENSOR_NAME), "Name must be supplied when defining a sensor");
-        this.period = params.get(SENSOR_PERIOD);
-        this.type = params.get(SENSOR_TYPE);
-        this.params = params;
-    }
+    public AddSensor() {}
+    public AddSensor(Map<String, String> params) { this(ConfigBag.newInstance(params)); }
+    public AddSensor(final ConfigBag params) { super(params); }
 
     @Override
     public void apply(EntityLocal entity) {
@@ -77,55 +74,9 @@ public class AddSensor<T> implements EntityInitializer {
     }
 
     private AttributeSensor<T> newSensor(Entity entity) {
-        String className = getFullClassName(type);
-        Class<T> clazz = getType(entity, className);
-        return Sensors.newSensor(clazz, name);
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Class<T> getType(Entity entity, String className) {
-        try {
-            // TODO use OSGi loader (low priority however); also ensure that allows primitives
-            Maybe<Class<?>> primitive = Boxing.getPrimitiveType(className);
-            if (primitive.isPresent()) return (Class<T>) primitive.get();
-            
-            return (Class<T>) new ClassLoaderUtils(this, entity).loadClass(className);
-        } catch (ClassNotFoundException e) {
-            if (!className.contains(".")) {
-                // could be assuming "java.lang" package; try again with that
-                try {
-                    return (Class<T>) Class.forName("java.lang."+className);
-                } catch (ClassNotFoundException e2) {
-                    throw new IllegalArgumentException("Invalid target type for sensor "+name+": " + className+" (also tried java.lang."+className+")");
-                }
-            } else {
-                throw new IllegalArgumentException("Invalid target type for sensor "+name+": " + className);
-            }
-        }
-    }
-
-    protected String getFullClassName(String className) {
-        if (className.equalsIgnoreCase("string")) {
-            return "java.lang.String";
-        } else if (className.equalsIgnoreCase("int") || className.equalsIgnoreCase("integer")) {
-            return "java.lang.Integer";
-        } else if (className.equalsIgnoreCase("long")) {
-            return "java.lang.Long";
-        } else if (className.equalsIgnoreCase("float")) {
-            return "java.lang.Float";
-        } else if (className.equalsIgnoreCase("double")) {
-            return "java.lang.Double";
-        } else if (className.equalsIgnoreCase("bool") || className.equalsIgnoreCase("boolean")) {
-            return "java.lang.Boolean";
-        } else if (className.equalsIgnoreCase("byte")) {
-            return "java.lang.Byte";
-        } else if (className.equalsIgnoreCase("char") || className.equalsIgnoreCase("character")) {
-            return "java.lang.Character";
-        } else if (className.equalsIgnoreCase("object")) {
-            return "java.lang.Object";
-        } else {
-            return className;
-        }
+        String className = AddSensorInitializerAbstractProto.getFullClassName(type);
+        Class<T> clazz = AddSensorInitializerAbstractProto.getType(entity, className, name, this);
+        return Sensors.newSensor(clazz, Preconditions.checkNotNull(name));
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.effector;
 
+import com.google.common.reflect.TypeToken;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
@@ -74,8 +75,7 @@ public class AddSensor<T> extends EntityInitializers.InitializerPatternWithField
     }
 
     private AttributeSensor<T> newSensor(Entity entity) {
-        String className = AddSensorInitializerAbstractProto.getFullClassName(type);
-        Class<T> clazz = AddSensorInitializerAbstractProto.getType(entity, className, name, this);
+        TypeToken<T> clazz = AddSensorInitializerAbstractProto.getType(entity, type, name);
         return Sensors.newSensor(clazz, Preconditions.checkNotNull(name));
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.effector.ParameterType;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.MapConfigKey;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.core.ClassLoaderUtils;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.javalang.Boxing;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+
+/**
+ * Entity initializer which adds a sensor to an entity.
+ *
+ * @since 0.7.0 */
+@Beta
+public class AddSensorInitializer<T> extends EntityInitializers.InitializerPatternWithConfigKeys implements Serializable {
+
+    public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey("name", "The name of the sensor to create");
+    public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newConfigKey(Duration.class, "period", "Period, including units e.g. 1m or 5s or 200ms; default 5 minutes", Duration.FIVE_MINUTES);
+    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newStringConfigKey("targetType", "Target type for the value; default String", "java.lang.String");
+
+    // constructor for use in code to conveniently supply params
+    protected AddSensorInitializer(ConfigBag params) {
+        super(params);
+    }
+    // JSON deserialization constructor
+    protected AddSensorInitializer() {}
+
+    @Override
+    public void apply(EntityLocal entity) {
+        addSensor(entity);
+    }
+
+    protected AttributeSensor<T> addSensor(EntityLocal entity) {
+        AttributeSensor<T> sensor = sensor(entity);
+        ((EntityInternal) entity).getMutableEntityType().addSensor(sensor);
+        return sensor;
+    }
+
+    private AttributeSensor<T> sensor(Entity entity) {
+        String className = getFullClassName(initParam(SENSOR_TYPE));
+        Class<T> clazz = getType(entity, className);
+        return Sensors.newSensor(clazz, Preconditions.checkNotNull(initParam(SENSOR_NAME)));
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Class<T> getType(Entity entity, String className) {
+        return AddSensorInitializerAbstractProto.getType(entity, className, initParam(SENSOR_NAME), this);
+    }
+
+    protected String getFullClassName(String className) {
+        return AddSensorInitializerAbstractProto.getFullClassName(className);
+    }
+
+    // kept for backwards deserialization compatibility
+    private String name;
+    private Duration period;
+    private String type;
+    private AttributeSensor<T> sensor;
+    private ConfigBag params;
+    // introduced in 1.1 for legacy compatibility
+    protected Object readResolve() {
+        super.readResolve();
+        initFromConfigBag(ConfigBag.newInstance()
+                .putIfAbsentAndNotNull(SENSOR_NAME, name)
+                .putIfAbsentAndNotNull(SENSOR_PERIOD, period)
+                .putIfAbsentAndNotNull(SENSOR_TYPE, type)
+        );
+        name = null;
+        period = null;
+        type = null;
+        sensor = null;
+        params = null;
+
+        return this;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.core.effector;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
+import com.google.common.reflect.TypeToken;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
@@ -76,18 +77,13 @@ public class AddSensorInitializer<T> extends EntityInitializers.InitializerPatte
     }
 
     private AttributeSensor<T> sensor(Entity entity) {
-        String className = getFullClassName(initParam(SENSOR_TYPE));
-        Class<T> clazz = getType(entity, className);
+        TypeToken<T> clazz = getType(entity, initParam(SENSOR_TYPE));
         return Sensors.newSensor(clazz, Preconditions.checkNotNull(initParam(SENSOR_NAME)));
     }
 
     @SuppressWarnings("unchecked")
-    protected Class<T> getType(Entity entity, String className) {
-        return AddSensorInitializerAbstractProto.getType(entity, className, initParam(SENSOR_NAME), this);
-    }
-
-    protected String getFullClassName(String className) {
-        return AddSensorInitializerAbstractProto.getFullClassName(className);
+    protected TypeToken<T> getType(Entity entity, String className) {
+        return AddSensorInitializerAbstractProto.getType(entity, className, initParam(SENSOR_NAME));
     }
 
     // kept for backwards deserialization compatibility

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
@@ -19,18 +19,12 @@
 package org.apache.brooklyn.core.effector;
 
 import com.google.common.annotations.Beta;
-import com.google.common.base.Preconditions;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
-import org.apache.brooklyn.api.entity.EntityLocal;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.EntityInitializers;
-import org.apache.brooklyn.core.entity.EntityInternal;
-import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
-import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Boxing;
 import org.apache.brooklyn.util.time.Duration;
@@ -69,26 +63,7 @@ interface AddSensorInitializerAbstractProto<T> extends EntityInitializer {
     }
 
     static String getFullClassName(String className) {
-        if (className.equalsIgnoreCase("string")) {
-            return "java.lang.String";
-        } else if (className.equalsIgnoreCase("int") || className.equalsIgnoreCase("integer")) {
-            return "java.lang.Integer";
-        } else if (className.equalsIgnoreCase("long")) {
-            return "java.lang.Long";
-        } else if (className.equalsIgnoreCase("float")) {
-            return "java.lang.Float";
-        } else if (className.equalsIgnoreCase("double")) {
-            return "java.lang.Double";
-        } else if (className.equalsIgnoreCase("bool") || className.equalsIgnoreCase("boolean")) {
-            return "java.lang.Boolean";
-        } else if (className.equalsIgnoreCase("byte")) {
-            return "java.lang.Byte";
-        } else if (className.equalsIgnoreCase("char") || className.equalsIgnoreCase("character")) {
-            return "java.lang.Character";
-        } else if (className.equalsIgnoreCase("object")) {
-            return "java.lang.Object";
-        } else {
-            return className;
-        }
+        return BrooklynTypeNameResolution.getClassForBuiltInTypeName(className).transform(c -> c.getName())
+                .or(className);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.util.core.ClassLoaderUtils;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.javalang.Boxing;
+import org.apache.brooklyn.util.time.Duration;
+
+/**
+ * Entity initializer which adds a sensor to an entity.
+ *
+ * @since 0.7.0 */
+@Beta
+interface AddSensorInitializerAbstractProto<T> extends EntityInitializer {
+
+    public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey("name", "The name of the sensor to create");
+    public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newConfigKey(Duration.class, "period", "Period, including units e.g. 1m or 5s or 200ms; default 5 minutes", Duration.FIVE_MINUTES);
+    public static final ConfigKey<String> SENSOR_TYPE = ConfigKeys.newStringConfigKey("targetType", "Target type for the value; default String", "java.lang.String");
+
+    @SuppressWarnings("unchecked")
+    static <T> Class<T> getType(Entity entity, String className, String name, Object contextInstanceForClassloading) {
+        try {
+            // TODO use OSGi loader (low priority however); also ensure that allows primitives
+            Maybe<Class<?>> primitive = Boxing.getPrimitiveType(className);
+            if (primitive.isPresent()) return (Class<T>) primitive.get();
+
+            return (Class<T>) new ClassLoaderUtils(contextInstanceForClassloading, entity).loadClass(className);
+        } catch (ClassNotFoundException e) {
+            if (!className.contains(".")) {
+                // could be assuming "java.lang" package; try again with that
+                try {
+                    return (Class<T>) Class.forName("java.lang."+className);
+                } catch (ClassNotFoundException e2) {
+                    throw new IllegalArgumentException("Invalid target type for sensor "+name+": " + className+" (also tried java.lang."+className+")");
+                }
+            } else {
+                throw new IllegalArgumentException("Invalid target type for sensor "+name+": " + className);
+            }
+        }
+    }
+
+    static String getFullClassName(String className) {
+        if (className.equalsIgnoreCase("string")) {
+            return "java.lang.String";
+        } else if (className.equalsIgnoreCase("int") || className.equalsIgnoreCase("integer")) {
+            return "java.lang.Integer";
+        } else if (className.equalsIgnoreCase("long")) {
+            return "java.lang.Long";
+        } else if (className.equalsIgnoreCase("float")) {
+            return "java.lang.Float";
+        } else if (className.equalsIgnoreCase("double")) {
+            return "java.lang.Double";
+        } else if (className.equalsIgnoreCase("bool") || className.equalsIgnoreCase("boolean")) {
+            return "java.lang.Boolean";
+        } else if (className.equalsIgnoreCase("byte")) {
+            return "java.lang.Byte";
+        } else if (className.equalsIgnoreCase("char") || className.equalsIgnoreCase("character")) {
+            return "java.lang.Character";
+        } else if (className.equalsIgnoreCase("object")) {
+            return "java.lang.Object";
+        } else {
+            return className;
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/effector/CompositeEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/CompositeEffector.java
@@ -43,7 +43,7 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 
 @Beta
-public class CompositeEffector extends AddEffector {
+public class CompositeEffector extends AddEffectorInitializerAbstract {
 
     private static final Logger LOG = LoggerFactory.getLogger(CompositeEffector.class);
     private static final String ORIGINAL_PREFIX = "original-";
@@ -60,25 +60,23 @@ public class CompositeEffector extends AddEffector {
             "Wheter additional defined effectors should override pre-existing effector with same name or not (default: false)",
             Boolean.FALSE);
 
-    public CompositeEffector(ConfigBag params) {
-        super(newEffectorBuilder(params).build());
-    }
-
+    private CompositeEffector() {}
+    public CompositeEffector(ConfigBag params) { super(params); }
     public CompositeEffector(Map<?, ?> params) {
         this(ConfigBag.newInstance(params));
     }
 
-    public static EffectorBuilder<List> newEffectorBuilder(ConfigBag params) {
-        EffectorBuilder<List> eff = AddEffector.newEffectorBuilder(List.class, params);
-        eff.impl(new Body(eff.buildAbstract(), params));
+    public EffectorBuilder<List> newEffectorBuilder() {
+        EffectorBuilder<List> eff = newAbstractEffectorBuilder(List.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
         return eff;
     }
 
     @Override
     public void apply(EntityLocal entity) {
-        Maybe<Effector<?>> effectorMaybe = entity.getEntityType().getEffectorByName(effector.getName());
+        Maybe<Effector<?>> effectorMaybe = entity.getEntityType().getEffectorByName(effector().getName());
         if (!effectorMaybe.isAbsentOrNull()) {
-            Effector<?> original = Effectors.effector(effectorMaybe.get()).name(ORIGINAL_PREFIX + effector.getName()).build();
+            Effector<?> original = Effectors.effector(effectorMaybe.get()).name(ORIGINAL_PREFIX + effector().getName()).build();
             ((EntityInternal) entity).getMutableEntityType().addEffector(original);
         }
         super.apply(entity);

--- a/core/src/main/java/org/apache/brooklyn/core/effector/ProxyEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/ProxyEffector.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-public class ProxyEffector extends AddEffector {
+public class ProxyEffector extends AddEffectorInitializerAbstract {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProxyEffector.class);
 
@@ -45,17 +45,17 @@ public class ProxyEffector extends AddEffector {
     public static final ConfigKey<String> TARGET_EFFECTOR_NAME = ConfigKeys.newStringConfigKey(
             "targetEffector", "The effector to invoke on the target entity");
 
+    private ProxyEffector() {}
     public ProxyEffector(ConfigBag params) {
-        super(newEffectorBuilder(params).build());
+        super(params);
     }
-
     public ProxyEffector(Map<?, ?> params) {
         this(ConfigBag.newInstance(params));
     }
 
-    public static EffectorBuilder<Object> newEffectorBuilder(ConfigBag params) {
-        EffectorBuilder<Object> eff = AddEffector.newEffectorBuilder(Object.class, params);
-        eff.impl(new Body(eff.buildAbstract(), params));
+    public EffectorBuilder<Object> newEffectorBuilder() {
+        EffectorBuilder<Object> eff = newAbstractEffectorBuilder(Object.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
         return eff;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/http/HttpCommandEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/http/HttpCommandEffector.java
@@ -38,7 +38,7 @@ import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
-import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.AddEffectorInitializerAbstract;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
 import org.apache.brooklyn.core.entity.EntityInitializers;
@@ -71,7 +71,7 @@ import com.jayway.jsonpath.JsonPath;
  *
  * It allows to specify the URI, the HTTP verb, credentials for authentication and HTTP headers.
  * 
- * It deals with some {@link HttpHeaders.CONTENT_TYPE} namely 'application/json' (as default) and 'application/x-www-form-urlencoded'. 
+ * It deals with some {@link HttpHeaders#CONTENT_TYPE} namely 'application/json' (as default) and 'application/x-www-form-urlencoded'.
  * In the latter case, a map payload will be URLEncoded in a single string
  * 
  * With optional JSON_PATH config key, the effector will extract a section of the json response. 
@@ -79,7 +79,7 @@ import com.jayway.jsonpath.JsonPath;
  * Using JSON_PATHS_AND_SENSORS, it is possible to extract one or more values from a json response, and publish them in sensors
  */
 @Beta
-public final class HttpCommandEffector extends AddEffector {
+public final class HttpCommandEffector extends AddEffectorInitializerAbstract {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpCommandEffector.class);
 
@@ -105,13 +105,12 @@ public final class HttpCommandEffector extends AddEffector {
         GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE
     }
 
-    public HttpCommandEffector(ConfigBag params) {
-        super(newEffectorBuilder(params).build());
-    }
+    private HttpCommandEffector() {}
+    public HttpCommandEffector(ConfigBag params) { super(params); }
 
-    public static EffectorBuilder<String> newEffectorBuilder(ConfigBag params) {
-        EffectorBuilder<String> eff = AddEffector.newEffectorBuilder(String.class, params);
-        eff.impl(new Body(eff.buildAbstract(), params));
+    public EffectorBuilder<String> newEffectorBuilder() {
+        EffectorBuilder<String> eff = newAbstractEffectorBuilder(String.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
         return eff;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffector.java
@@ -182,7 +182,7 @@ public final class SshCommandEffector extends AddEffector {
 
         @SuppressWarnings("unchecked")
         private Map<String, Object> resolveEnv(MutableMap<String, Object> env) throws ExecutionException, InterruptedException {
-            return (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, entity().getExecutionContext());
+            return (Map<String, Object>) Tasks.resolveDeepValueWithoutCoercion(env, entity().getExecutionContext());
         }
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshCommandEffector.java
@@ -29,7 +29,7 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
-import org.apache.brooklyn.core.effector.AddEffector;
+import org.apache.brooklyn.core.effector.AddEffectorInitializerAbstract;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
@@ -53,7 +53,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 
-public final class SshCommandEffector extends AddEffector {
+public final class SshCommandEffector extends AddEffectorInitializerAbstract {
 
     public static final ConfigKey<String> EFFECTOR_COMMAND = ConfigKeys.newStringConfigKey("command");
     public static final ConfigKey<String> EFFECTOR_EXECUTION_DIR = SshCommandSensor.SENSOR_EXECUTION_DIR;
@@ -70,17 +70,15 @@ public final class SshCommandEffector extends AddEffector {
         + "in the latter cases the sets are filtered by entities which have a machine and are not stopping.",
         ExecutionTarget.ENTITY);
 
+    private SshCommandEffector() {}
     public SshCommandEffector(ConfigBag params) {
-        super(newEffectorBuilder(params).build());
+        super(params);
     }
 
-    public SshCommandEffector(Map<String,String> params) {
-        this(ConfigBag.newInstance(params));
-    }
-
-    public static EffectorBuilder<String> newEffectorBuilder(ConfigBag params) {
-        EffectorBuilder<String> eff = AddEffector.newEffectorBuilder(String.class, params);
-        eff.impl(new Body(eff.buildAbstract(), params));
+    @Override
+    public EffectorBuilder<String> newEffectorBuilder() {
+        EffectorBuilder<String> eff = newAbstractEffectorBuilder(String.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
         return eff;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityInitializers.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityInitializers.java
@@ -18,12 +18,23 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.objs.BasicConfigurableObject;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.internal.ConfigKeySelfExtracting;
 import org.apache.brooklyn.util.core.task.BasicExecutionContext;
@@ -34,7 +45,8 @@ public class EntityInitializers {
 
     public static class AddTags implements EntityInitializer {
         public final List<Object> tags;
-        
+
+        private AddTags() { tags = null; }
         public AddTags(Object... tags) {
             this.tags = ImmutableList.copyOf(tags);
         }
@@ -75,4 +87,149 @@ public class EntityInitializers {
         }
         return configBag.get(key);
     }
+
+    /**
+     * Pattern for an abstract superclass for EntityInitializers like {@link InitializerPatternWithConfigKeys}
+     * but for where the config map should not be kept or accessible after initialization,
+     * and the code prefers to use fields.
+     * <p>
+     * An implementer of this pattern should declare config keys as per {@link InitializerPatternWithConfigKeys},
+     * and also an initializer block invoking {@link #addInitConfigMapping(ConfigKey, Function)} for each config key,
+     * giving a setter function (eg <code>v -> myField = v</code>).
+     * Subsequently they access their fields directly because there is no access to the parameters after instantiation.
+     * <p>
+     * The main reason to do this instead of {@link InitializerPatternWithConfigKeys} is legacy code that depended on fields,
+     * but it might allow for cleaner code to have fields.
+     **/
+    public abstract static class InitializerPatternWithFieldsFromConfigKeys extends InitializerPatternHandlingConfigNeatlyOnSerializeAndDeserialize {
+        protected InitializerPatternWithFieldsFromConfigKeys() {}
+        protected InitializerPatternWithFieldsFromConfigKeys(ConfigBag params) { super(params); }
+
+        @JsonIgnore
+        private List<BiConsumer<ConfigBag,Boolean>> configKeyInitRules = MutableList.of();
+        protected <T> void addInitConfigMapping(ConfigKey<T> key, Function<T,T> setter) {
+            addInitConfigRule( (ConfigBag config, Boolean isFirst) -> {
+                config.ifPresent(key).transformNow((Function)setter)
+                        .or(()->{
+                            if (isFirst && key.hasDefaultValue()) {
+                                setter.apply(key.getDefaultValue());
+                            }
+                            return null;
+                        });
+            });
+        }
+        protected <T> void addInitConfigRule(BiConsumer<ConfigBag,Boolean> rule) {
+            configKeyInitRules.add(rule);
+            rule.accept(initParams(), true);
+        }
+
+        protected void initFromConfigBag(ConfigBag params) {
+            if (configKeyInitRules!=null) configKeyInitRules.forEach( c -> c.accept(params, false) );
+            super.initFromConfigBag(params);
+        }
+
+        /** convenience for where {@link #addInitConfigMapping(ConfigKey, Function)} and {@link #addInitConfigRule(BiConsumer)} are being used,
+         * to allow clients to check there is no unused config supplied, and fail if so;
+         * note this must not be done in any constructor or initializer block which might be subclassed
+         * as the subclass blocks which add new rules may not have been defined yet.
+         * thus it is recommended to call this only on usage, not during construction.
+         * if rules/mappings are not being used, the constraints are stronger:
+         * it should only be called once code expects to have accessed all supported parameters.
+         **/
+        protected void initParamsFailIfAnyUnused() {
+            if (!initParams().getUnusedConfig().isEmpty()) {
+                throw new IllegalArgumentException("Unused parameters in "+this+": "+ initParams().getUnusedConfig());
+            }
+        }
+    }
+    /**
+     * Preferred pattern for an abstract superclass for EntityInitializers that provide conveniences for working with config keys,
+     * This ensures json / bean-with-type creation works, either in brooklyn.config or not, under a <code>brooklyn.initializers</code> block.
+     * <p>
+     * In many cases simply extending <code>EntityInitializer</code> directly and not using this pattern is fine.
+     * However config keys are useful for declarative reflection, programmatic initialization, and additional coercion.
+     * This superclass pattern does all the wiring for serialization and deserialization.
+     * <p>
+     * Note that fields should not be used in classes that extend this; not a big deal if they are but it can
+     * cause some surprises during deserialization (from CAMP YAML) or during persistence.
+     * See {@link InitializerPatternWithFieldsFromConfigKeys} for support for fields.
+     * <p>
+     * An implementer of this pattern should declare config keys, then
+     * access them with {@link #initParam(ConfigKey)} for one or {@link #initParams()} for the bag.
+     * <p>
+     * The implementer should provide two constructors as per the ones here (one no-arg for json / bean-with-type creation,
+     * and one taking a ConfigBag for programmatic use and prior convention).
+     * <p>
+     * Developers can then write the {@link #apply(EntityLocal)} method from {@link EntityInitializer}
+     * as normal, using fields of {@link #initParam(ConfigKey)}.
+     **/
+    public abstract static class InitializerPatternWithConfigKeys extends InitializerPatternHandlingConfigNeatlyOnSerializeAndDeserialize {
+        protected InitializerPatternWithConfigKeys() {}
+        protected InitializerPatternWithConfigKeys(ConfigBag params) { super(params); }
+
+        protected <T> T initParam(ConfigKey<T> key) { return initParams().get(key); }
+        protected ConfigBag initParams() { return super.initParams(); }
+
+        @JsonProperty("brooklyn.config")
+        protected Map<String, Object> getBrooklynConfig() {
+            return initParams().getAllConfig();
+        }
+    }
+    // internal superclass for the above two
+    private abstract static class InitializerPatternHandlingConfigNeatlyOnSerializeAndDeserialize implements EntityInitializer, Serializable {
+        protected InitializerPatternHandlingConfigNeatlyOnSerializeAndDeserialize() {}
+        protected InitializerPatternHandlingConfigNeatlyOnSerializeAndDeserialize(ConfigBag params) { initFromConfigBag(params); }
+
+        protected void initFromConfigBag(ConfigBag params) {
+            if (params!=null && !params.isEmpty()) {
+                initParams.putAll(params);
+            }
+        }
+
+        @JsonIgnore
+        private ConfigBag initParams = ConfigBag.newInstance();
+
+        ConfigBag initParams() { return initParams; }
+
+        @JsonAnySetter
+        protected void initField(String key, Object value) {
+            initFromConfigBag(ConfigBag.newInstance(MutableMap.of(key, value)));
+        }
+
+        @JsonProperty("brooklyn.config")
+        private void initBrooklynConfig(Map<String,Object> params) {
+            initFromConfigBag(ConfigBag.newInstance(params));
+        }
+
+        // introduced in 1.1 for legacy compatibility
+        protected Object readResolve() {
+            if (initParams==null) initParams = ConfigBag.newInstance();
+            return this;
+        }
+    }
+
+    /**
+     * Pattern for an abstract superclass for EntityInitializers that provides a {@link org.apache.brooklyn.api.objs.Configurable}
+     * interface.  Other than the availability of {@link #config()} this acts as per {@link InitializerPatternWithFieldsFromConfigKeys}.
+     **/
+    public abstract static class InitializerPatternForConfigurable extends BasicConfigurableObject implements EntityInitializer {
+        protected InitializerPatternForConfigurable() {}
+        protected InitializerPatternForConfigurable(ConfigBag params) { initFromConfigBag(params); }
+
+        protected void initFromConfigBag(ConfigBag params) {
+            if (params!=null) params.forEach((k,v)->
+                config().set(ConfigKeys.newConfigKey(Object.class, k), v) );
+        }
+
+        @JsonAnySetter
+        private void initField(String key, Object value) {
+            config().set(ConfigKeys.newConfigKey(Object.class, key), value);
+            initFromConfigBag(ConfigBag.newInstance(MutableMap.of(key, value)));
+        }
+        @JsonProperty("brooklyn.config")
+        private void initBrooklynConfig(Map<String,Object> params) {
+            initFromConfigBag(ConfigBag.newInstance(params));
+        }
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
@@ -37,7 +37,7 @@ import com.google.common.base.Objects;
 public class OsgiBrooklynClassLoadingContext extends AbstractBrooklynClassLoadingContext {
 
     private final String catalogItemId;
-    private boolean hasBundles = false;
+    private final boolean hasBundles;
     private transient Collection<? extends OsgiBundleWithUrl> _bundles;
 
     public OsgiBrooklynClassLoadingContext(ManagementContext mgmt, String catalogItemId, Collection<? extends OsgiBundleWithUrl> bundles) {
@@ -51,13 +51,16 @@ public class OsgiBrooklynClassLoadingContext extends AbstractBrooklynClassLoadin
     }
 
     public Collection<? extends OsgiBundleWithUrl> getBundles() {
-        if (_bundles!=null || !hasBundles) return _bundles;
-        RegisteredType item = mgmt.getTypeRegistry().get(catalogItemId);
-        if (item==null) {
-            throw new IllegalStateException("Catalog item not found for "+catalogItemId+"; cannot create loading context");
+        if (hasBundles) return _bundles;
+        if (catalogItemId!=null) {
+            RegisteredType item = mgmt.getTypeRegistry().get(catalogItemId);
+            if (item == null) {
+                throw new IllegalStateException("Catalog item not found for " + catalogItemId + "; cannot create loading context");
+            }
+            _bundles = item.getLibraries();
+            return _bundles;
         }
-        _bundles = item.getLibraries();
-        return _bundles;
+        return Collections.emptyList();
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
@@ -22,9 +22,11 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.OsgiBundleWithUrl;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
@@ -43,6 +45,9 @@ public class OsgiBrooklynClassLoadingContext extends AbstractBrooklynClassLoadin
         this._bundles = bundles;
         this.hasBundles = bundles!=null && !bundles.isEmpty();
         this.catalogItemId = catalogItemId;
+    }
+    public OsgiBrooklynClassLoadingContext(Entity entity) {
+        this(((EntityInternal)entity).getManagementContext(), entity.getCatalogItemId(), null);
     }
 
     public Collection<? extends OsgiBundleWithUrl> getBundles() {

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -129,7 +129,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
         Maybe<Object> resolved = Tasks.resolving(unresolved)
                 .as(Object.class)
                 .immediately(true)
-                .deep(true, true)
+                .deep(true, true, true)
                 .context(getContext())
                 .description("Resolving raw value of simple config "+key)
                 .getMaybe();

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -129,7 +129,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
         Maybe<Object> resolved = Tasks.resolving(unresolved)
                 .as(Object.class)
                 .immediately(true)
-                .deep(true, true, true)
+                .deep()
                 .context(getContext())
                 .description("Resolving raw value of simple config "+key)
                 .getMaybe();

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -26,7 +26,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 
 import org.apache.brooklyn.api.catalog.CatalogConfig;
 import org.apache.brooklyn.api.entity.Entity;
@@ -54,7 +53,6 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -258,7 +256,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
 
             boolean hasType = type!=null;
 
-            TypeToken typeToken = inferType(type, loader);
+            TypeToken typeToken = resolveType(type, loader);
             Object immutableDefaultValue = tryToImmutable(defaultValue, typeToken);
 
             Builder builder = BasicConfigKey.builder(typeToken)
@@ -301,9 +299,10 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
             }
         }
         
-        private static TypeToken<?> inferType(String typeRaw, BrooklynClassLoadingContext loader) {
+        private static TypeToken<?> resolveType(String typeRaw, BrooklynClassLoadingContext loader) {
             if (typeRaw == null) return TypeToken.of(String.class);
-            return BrooklynTypeNameResolution.getTypeTokenForBuiltInAndJava(typeRaw, "parameter", loader);
+            return new BrooklynTypeNameResolution.BrooklynTypeNameResolver("parameter", loader, true, true)
+                    .getTypeToken(typeRaw);
         }
 
         @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BasicSpecParameter.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,9 +52,9 @@ import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
-import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,48 +198,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
         return type;
     }
 
-    /** Allows extensions to define additional types that are supported for parameters in YAML.
-     * Rules should return a TypeToken if the given name is known, null if not handled, or 
-     * throw if the name is decisively problematic. Handlers will throw if no rules match. 
-     */
-    @Beta
-    public static void addCustomTypeNameInference(String ruleName, BiFunction<String,BrooklynClassLoadingContext,TypeToken<?>> rule) {
-        ParseYamlInputs.customTypeNameInferencing.put(ruleName, rule);
-    }
-    
     private static final class ParseYamlInputs {
-        private static final String DEFAULT_TYPE = "string";
-        private static final Map<String, Class<?>> BUILT_IN_TYPES = ImmutableMap.<String, Class<?>>builder()
-                .put(DEFAULT_TYPE, String.class)
-                .put("bool", Boolean.class)
-                .put("boolean", Boolean.class)
-                .put("byte", Byte.class)
-                .put("char", Character.class)
-                .put("character", Character.class)
-                .put("short", Short.class)
-                .put("integer", Integer.class)
-                .put("int", Integer.class)
-                .put("long", Long.class)
-                .put("float", Float.class)
-                .put("double", Double.class)
-                .put("duration", Duration.class)
-                .put("timestamp", Date.class)
-                .put("port", PortRange.class)
-                .build();
-
-        /** Map of rule-name to rule; see {@link BasicSpecParameter#addCustomTypeNameInference(String, BiFunction)} */
-        public static Map<String,BiFunction<String,BrooklynClassLoadingContext,TypeToken<?>>> customTypeNameInferencing = MutableMap.of();
-        static {
-            customTypeNameInferencing.put("simple types ("+Strings.join(BUILT_IN_TYPES.keySet(), ", ")+")", 
-                (name, loaderContext) -> BUILT_IN_TYPES.containsKey(name.toLowerCase()) ? 
-                    TypeToken.of(BUILT_IN_TYPES.get(name.toLowerCase())) : null);
-            customTypeNameInferencing.put("Java types", (name, loaderContext) -> {
-                // Assume it's a Java type
-                Maybe<Class<?>> inputType = loaderContext.tryLoadClass(name);
-                return inputType.isPresent() ? TypeToken.of(inputType.get()) : null;
-            });
-        }
-
         private static List<SpecParameter<?>> parseParameters(List<?> inputsRaw, Function<Object, Object> specialFlagTransformer, BrooklynClassLoadingContext loader) {
             if (inputsRaw == null) return ImmutableList.of();
             List<SpecParameter<?>> inputs = new ArrayList<>(inputsRaw.size());
@@ -343,16 +301,9 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
             }
         }
         
-        private static TypeToken inferType(String typeRaw, BrooklynClassLoadingContext loader) {
+        private static TypeToken<?> inferType(String typeRaw, BrooklynClassLoadingContext loader) {
             if (typeRaw == null) return TypeToken.of(String.class);
-            String type = typeRaw.trim();
-            for (BiFunction<String,BrooklynClassLoadingContext,TypeToken<?>> f: customTypeNameInferencing.values()) {
-                TypeToken<?> result = f.apply(type, loader);
-                if (result!=null) return result;
-            }
-            throw new IllegalArgumentException("The type '" + type + "' for a parameter is not recognised; supported items are: "
-                + Strings.join(customTypeNameInferencing.keySet(), ", "));
-
+            return BrooklynTypeNameResolution.getTypeTokenForBuiltInAndJava(typeRaw, "parameter", loader);
         }
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -473,7 +424,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
      * {@link AbstractBrooklynObjectSpec spec}, and if spec has no parameters it 
      * also generates a list from the spec
      *
-     * @see EntitySpec#parameters(List)
+     * @see EntitySpec#parameters(Iterable)
      */
     @Beta
     public static void initializeSpecWithExplicitParameters(AbstractBrooklynObjectSpec<?, ?> spec, List<? extends SpecParameter<?>> explicitParams, BrooklynClassLoadingContext loader) {
@@ -528,7 +479,7 @@ public class BasicSpecParameter<T> implements SpecParameter<T>{
     }
 
     /** instance of {@link SpecParameter} which includes information about what fields are explicitly set,
-     * for use with a subsequent merge with ancestor config keys; see {@link #resolveParameters(Collection, Collection, AbstractBrooklynObjectSpec)}*/
+     * for use with a subsequent merge with ancestor config keys; see {@link #resolveParameters(Collection, AbstractBrooklynObjectSpec)}*/
     @SuppressWarnings("serial")
     @Beta
     static class SpecParameterIncludingDefinitionForInheritance<T> extends BasicSpecParameter<T> {

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.resolve.jackson;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.BeanProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -30,9 +31,13 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer;
 import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeSerializer;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.HasBaseType;
 import org.apache.brooklyn.util.javalang.Reflections;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class AsPropertyIfAmbiguous {
@@ -41,7 +46,14 @@ public class AsPropertyIfAmbiguous {
     }
 
     /**
-     * Type serializer which omits the type if it's unambiguous
+     * Type serializer which omits the type if it's unambiguous.
+     *
+     * Lists, maps, and arrays are always written without type information.
+     *
+     * Deserialization of a map with a property that indicates a type normally returns the type;
+     * however in some places, e.g. when expecting an object (no type info) and we get a list or a map,
+     * if there is a map containing a type property within it, that is _not_ interpreted as the type.
+     * See PerverseSerializationTest.testDeserializeListMapWithType
      */
     public static class AsPropertyIfAmbiguousTypeSerializer extends AsPropertyTypeSerializer {
 
@@ -51,17 +63,42 @@ public class AsPropertyIfAmbiguous {
 
         @Override
         public WritableTypeId writeTypePrefix(JsonGenerator g, WritableTypeId idMetadata) throws IOException {
-            //if (g.getCurrentValue())
+            boolean skip = false;
+            Object currentObject = idMetadata.forValue;
+            Class<?> currentClass = currentObject==null ? null : currentObject.getClass();
             if (_idResolver instanceof HasBaseType) {
-                if (((HasBaseType) _idResolver).getBaseType().getRawClass().equals(g.getCurrentValue().getClass())) {
-                    // skip type id if the expected type matches the actual type
-                    g.writeStartObject(idMetadata.forValue);
-                    return idMetadata;
+                JavaType impliedType = ((HasBaseType) _idResolver).getBaseType();
+                Class<?> impliedClass = impliedType==null ? null : impliedType.getRawClass();
+                if (Objects.equals(currentClass, impliedClass)) {
+//                if (g.getCurrentValue()!=null) {
+//                    if (impliedType.getRawClass().equals(g.getCurrentValue().getClass())) {
+                        // skip type id if the expected type matches the actual type
+                    skip = true;
                 }
+                if (!skip && impliedClass!=null) {
+                    skip = impliedType.isCollectionLikeType() || Map.class.isAssignableFrom(impliedClass);
+                }
+                if (!skip && currentClass!=null) {
+                    skip = List.class.isAssignableFrom(currentClass) || Map.class.isAssignableFrom(currentClass) || currentClass.isArray();
+                }
+            }
+            if (skip) {
+                _generateTypeId(idMetadata);
+                if (idMetadata.valueShape == JsonToken.START_OBJECT) {
+                    g.writeStartObject(idMetadata.forValue);
+                } else if (idMetadata.valueShape == JsonToken.START_ARRAY) {
+                    g.writeStartArray();
+                }
+                return idMetadata;
             }
             return super.writeTypePrefix(g, idMetadata);
         }
 
+        @Override
+        public AsPropertyTypeSerializer forProperty(BeanProperty prop) {
+            return (_property == prop) ? this :
+                    new AsPropertyIfAmbiguousTypeSerializer(this._idResolver, prop, this._typePropertyName);
+        }
     }
 
     /** Type deserializer which ignores the 'type' property if it conflicts with a field on the class and which uses the base type if no type is specified */
@@ -75,6 +112,11 @@ public class AsPropertyIfAmbiguous {
         }
 
         @Override
+        public Object deserializeTypedFromArray(JsonParser jp, DeserializationContext ctxt) throws IOException {
+            return super.deserializeTypedFromArray(jp, ctxt);
+        }
+
+        @Override
         public Object deserializeTypedFromObject(JsonParser p, DeserializationContext ctxt) throws IOException {
             if (_idResolver instanceof HasBaseType) {
                 if (Reflections.findFieldMaybe(((HasBaseType)_idResolver).getBaseType().getRawClass(), _typePropertyName).isPresent()) {
@@ -83,6 +125,7 @@ public class AsPropertyIfAmbiguous {
                     return deser.deserialize(p, ctxt);
                 }
 
+                // TODO MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL should do this
                 if (!Objects.equals(_defaultImpl, ((HasBaseType) _idResolver).getBaseType())) {
                     AsPropertyButNotIfFieldConflictTypeDeserializer delegate = new AsPropertyButNotIfFieldConflictTypeDeserializer(_baseType, _idResolver, _typePropertyName, _typeIdVisible, ((HasBaseType) _idResolver).getBaseType(), _inclusion);
                     return delegate.deserializeTypedFromObject(p, ctxt);
@@ -96,5 +139,24 @@ public class AsPropertyIfAmbiguous {
         public TypeDeserializer forProperty(BeanProperty prop) {
             return (prop == _property) ? this : new AsPropertyButNotIfFieldConflictTypeDeserializer(this, prop);
         }
+
+        // deserialize list-like things
+        protected Object _deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.isExpectedStartArrayToken()) {
+                // when we suppress types for collections, the deserializer
+                // doesn't differentiate and so expects another array start.
+                // we assume the default impl
+                String typeId = _idResolver.idFromBaseType();
+                JsonDeserializer<Object> deser = _findDeserializer(ctxt, typeId);
+
+                if (p.currentToken() == JsonToken.END_ARRAY) {
+                    return deser.getNullValue(ctxt);
+                }
+                return deser.deserialize(p, ctxt);
+            } else {
+                return super._deserialize(p, ctxt);
+            }
+        }
+
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeSerializer;
+import org.apache.brooklyn.util.javalang.Reflections;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class AsPropertyIfAmbiguous {
+    public interface HasBaseType {
+        JavaType getBaseType();
+    }
+
+    /**
+     * Type serializer which omits the type if it's unambiguous
+     */
+    public static class AsPropertyIfAmbiguousTypeSerializer extends AsPropertyTypeSerializer {
+
+        public AsPropertyIfAmbiguousTypeSerializer(TypeIdResolver idRes, BeanProperty property, String propName) {
+            super(idRes, property, propName);
+        }
+
+        @Override
+        public WritableTypeId writeTypePrefix(JsonGenerator g, WritableTypeId idMetadata) throws IOException {
+            //if (g.getCurrentValue())
+            if (_idResolver instanceof HasBaseType) {
+                if (((HasBaseType) _idResolver).getBaseType().getRawClass().equals(g.getCurrentValue().getClass())) {
+                    // skip type id if the expected type matches the actual type
+                    g.writeStartObject(idMetadata.forValue);
+                    return idMetadata;
+                }
+            }
+            return super.writeTypePrefix(g, idMetadata);
+        }
+
+    }
+
+    /** Type deserializer which ignores the 'type' property if it conflicts with a field on the class and which uses the base type if no type is specified */
+    public static class AsPropertyButNotIfFieldConflictTypeDeserializer extends AsPropertyTypeDeserializer {
+        public AsPropertyButNotIfFieldConflictTypeDeserializer(JavaType bt, TypeIdResolver idRes, String typePropertyName, boolean typeIdVisible, JavaType defaultImpl, As inclusion) {
+            super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl, inclusion);
+        }
+
+        public AsPropertyButNotIfFieldConflictTypeDeserializer(AsPropertyButNotIfFieldConflictTypeDeserializer src, BeanProperty prop) {
+            super(src, prop);
+        }
+
+        @Override
+        public Object deserializeTypedFromObject(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (_idResolver instanceof HasBaseType) {
+                if (Reflections.findFieldMaybe(((HasBaseType)_idResolver).getBaseType().getRawClass(), _typePropertyName).isPresent()) {
+                    // don't read type id, just deserialize
+                    JsonDeserializer<Object> deser = ctxt.findContextualValueDeserializer(((HasBaseType)_idResolver).getBaseType(), _property);
+                    return deser.deserialize(p, ctxt);
+                }
+
+                if (!Objects.equals(_defaultImpl, ((HasBaseType) _idResolver).getBaseType())) {
+                    AsPropertyButNotIfFieldConflictTypeDeserializer delegate = new AsPropertyButNotIfFieldConflictTypeDeserializer(_baseType, _idResolver, _typePropertyName, _typeIdVisible, ((HasBaseType) _idResolver).getBaseType(), _inclusion);
+                    return delegate.deserializeTypedFromObject(p, ctxt);
+                }
+            }
+
+            return super.deserializeTypedFromObject(p, ctxt);
+        }
+
+        @Override
+        public TypeDeserializer forProperty(BeanProperty prop) {
+            return (prop == _property) ? this : new AsPropertyButNotIfFieldConflictTypeDeserializer(this, prop);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypePlanTransformer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
+import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry.RegisteredTypeKind;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
+import org.apache.brooklyn.core.typereg.AbstractTypePlanTransformer;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.yaml.Yamls;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class BeanWithTypePlanTransformer extends AbstractTypePlanTransformer {
+
+    public static final String FORMAT = BeanWithTypeUtils.FORMAT;
+
+    public BeanWithTypePlanTransformer() {
+        super(FORMAT, "Brooklyn YAML serialized with type",
+                "Bean serialization format read/written as YAML or JSON as per Jackson with one trick that the 'type' field specifies the type or supertype");
+    }
+
+    @Override
+    protected double scoreForNullFormat(Object o, RegisteredType registeredType, RegisteredTypeLoadingContext registeredTypeLoadingContext) {
+        if (registeredType.getKind()!= RegisteredTypeKind.SPEC && Strings.toString(o).contains("type:")) {
+            return 0.2;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    protected double scoreForNonmatchingNonnullFormat(String s, Object o, RegisteredType registeredType, RegisteredTypeLoadingContext registeredTypeLoadingContext) {
+        return 0;
+    }
+
+    @Override
+    protected AbstractBrooklynObjectSpec<?, ?> createSpec(RegisteredType registeredType, RegisteredTypeLoadingContext registeredTypeLoadingContext) throws Exception {
+        throw new IllegalStateException("spec not supported by this transformer");
+    }
+
+    @Override
+    protected Object createBean(RegisteredType registeredType, RegisteredTypeLoadingContext registeredTypeLoadingContext) throws Exception {
+        Map<String,Object> definition;
+        try {
+            Iterable<Object> parsed;
+            parsed = Yamls.parseAll((String)registeredType.getPlan().getPlanData());
+            Iterator<Object> pi = parsed.iterator();
+            if (!pi.hasNext()) throw new IllegalStateException("No data");
+            definition = (Map<String, Object>) pi.next();
+            if (pi.hasNext()) throw new IllegalStateException("YAML contained multiple items");
+        } catch (Exception e) {
+            throw Exceptions.propagateAnnotated("Invalid YAML in definition of '"+registeredType.getId()+"'", e);
+        }
+        return BeanWithTypeUtils.newMapper(mgmt).readValue(
+                BeanWithTypeUtils.newSimpleMapper().writeValueAsString(definition), Object.class);
+    }
+
+    // TODO experimental on spec, not used
+    @Override
+    public double scoreForTypeDefinition(String s, Object o) {
+        return 0;
+    }
+    @Override
+    public List<RegisteredType> createFromTypeDefinition(String s, Object o) {
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypePlanTransformer.java
@@ -72,7 +72,7 @@ public class BeanWithTypePlanTransformer extends AbstractTypePlanTransformer {
         } catch (Exception e) {
             throw Exceptions.propagateAnnotated("Invalid YAML in definition of '"+registeredType.getId()+"'", e);
         }
-        return BeanWithTypeUtils.newMapper(mgmt).readValue(
+        return BeanWithTypeUtils.newMapper(mgmt, true, true).readValue(
                 BeanWithTypeUtils.newSimpleMapper().writeValueAsString(definition), Object.class);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.ConfigurableBeanDeserializerModifier;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.Boxing;
@@ -40,8 +42,11 @@ public class BeanWithTypeUtils {
 
         BrooklynRegisteredTypeJacksonSerialization.apply(mapper, mgmt, allowRegisteredTypes, allowJavaTypes);
         WrappedValuesSerialization.apply(mapper);
-
-        //TODO DslSerializationAsToString
+        mapper = new ConfigurableBeanDeserializerModifier()
+                .addDeserializerWrapper(
+                        d -> new JsonDeserializerForCommonBrooklynThings(d)
+                        //TODO DslSerializationAsToString - see CustomTypeConfigYamlTest
+                ).apply(mapper);
 
         return mapper;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.util.guava.Maybe;
+
+import java.util.Map;
+
+public class BeanWithTypeUtils {
+
+    public static final String FORMAT = "bean-with-type";
+
+    public static ObjectMapper newMapper(ManagementContext mgmt) {
+        JsonMapper mapper = newSimpleMapper();
+
+        BrooklynRegisteredTypeJacksonSerialization.apply(mapper, mgmt);
+        WrappedValuesSerialization.apply(mapper);
+
+        return mapper;
+    }
+
+    public static JsonMapper newSimpleMapper() {
+        // for use with json maps (no special type resolution, even the field "type" is ignored)
+        return JsonMapper.builder().build();
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -18,8 +18,10 @@
  */
 package org.apache.brooklyn.core.resolve.jackson;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.util.guava.Maybe;
 
@@ -41,5 +43,45 @@ public class BeanWithTypeUtils {
     public static JsonMapper newSimpleMapper() {
         // for use with json maps (no special type resolution, even the field "type" is ignored)
         return JsonMapper.builder().build();
+    }
+
+    public static <T> T convert(ManagementContext mgmt, Map<?,?> map, TypeToken<T> type) throws JsonProcessingException {
+        ObjectMapper m = newMapper(mgmt);
+        return m.readValue(m.writeValueAsString(map), BrooklynJacksonSerializationUtils.asTypeReference(type));
+    }
+
+    public static <T> Maybe<T> tryConvertOrAbsent(ManagementContext mgmt, Maybe<Object> inputMap, TypeToken<T> type) {
+        if (inputMap.isAbsent()) return (Maybe<T>)inputMap;
+
+        Object o = inputMap.get();
+        if (!(o instanceof Map)) {
+            if (type.isAssignableFrom(o.getClass())) {
+                return (Maybe<T>)inputMap;
+            }  else {
+                return Maybe.absent(() -> new RuntimeException("BeanWithType cannot convert from "+o.getClass()+" to "+type));
+            }
+        }
+
+        Maybe<T> fallback = null;
+        if (type.isAssignableFrom(Object.class)) {
+            // returning the input is valid
+            fallback = (Maybe<T>)inputMap;
+            // and if there isn't a 'type' key there is no point in converting
+            if (!((Map<?, ?>) o).containsKey("type")) return fallback;
+        } else if (type.isAssignableFrom(Map.class)) {
+            // skip conversion for a map if it isn't an object
+            return (Maybe<T>)inputMap;
+        }
+
+        try {
+            return Maybe.of(convert(mgmt, (Map<?,?>)o, type));
+        } catch (Exception e) {
+            if (fallback!=null) return fallback;
+            return Maybe.absent("BeanWithType cannot convert given map to "+type, e);
+        }
+    }
+
+    public static <T> Maybe<T> tryConvertOrOriginal(ManagementContext mgmt, Maybe<Object> inputMap, TypeToken<T> type) {
+        return tryConvertOrAbsent(mgmt, inputMap, type).or((Maybe<T>)inputMap);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import org.apache.brooklyn.util.collections.MutableList;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+public class BrooklynJacksonSerializationUtils {
+
+    public static class ConfigurableBeanDeserializerModifier extends BeanDeserializerModifier {
+        List<Function<Object,Object>> postConstructFunctions = MutableList.of();
+
+        public ConfigurableBeanDeserializerModifier addPostConstructFunction(Function<Object,Object> f) {
+            postConstructFunctions.add(f);
+            return this;
+        }
+
+        private class JsonDeserializerInvokingPostConstruct extends DelegatingDeserializer {
+            public JsonDeserializerInvokingPostConstruct(JsonDeserializer<?> deserializer) {
+                super(deserializer);
+            }
+
+            @Override
+            protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> newDelegatee) {
+                return new JsonDeserializerInvokingPostConstruct(newDelegatee);
+            }
+
+            @Override
+            public Object deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+                return postConstructFunctions.stream().reduce(Function::andThen).orElse(x -> x).apply( _delegatee.deserialize(jp, ctxt) );
+            }
+        }
+
+        public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config,
+                                                      BeanDescription beanDesc,
+                                                      final JsonDeserializer<?> deserializer) {
+            return new JsonDeserializerInvokingPostConstruct(deserializer);
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
@@ -19,19 +19,31 @@
 package org.apache.brooklyn.core.resolve.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.util.collections.MutableList;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.function.Function;
 
 public class BrooklynJacksonSerializationUtils {
+
+    public static <T> TypeReference<T> asTypeReference(TypeToken<T> typeToken) {
+        return new TypeReference<T>() {
+            @Override
+            public Type getType() {
+                return typeToken.getType();
+            }
+        };
+    }
 
     public static class ConfigurableBeanDeserializerModifier extends BeanDeserializerModifier {
         List<Function<Object,Object>> postConstructFunctions = MutableList.of();

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
@@ -38,10 +38,13 @@ import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyButNotIfFieldConflictTypeDeserializer;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyIfAmbiguousTypeSerializer;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.HasBaseType;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.BrooklynRegisteredTypeAndClassNameIdResolver;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.RegisteredTypeDeserializers;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.*;
 
 public class BrooklynRegisteredTypeJacksonSerialization {
 
@@ -102,21 +105,34 @@ public class BrooklynRegisteredTypeJacksonSerialization {
 
     static class BrooklynRegisteredTypeAndClassNameIdResolver extends ClassNameIdResolver implements HasBaseType {
         private final ManagementContext mgmt;
+        private final boolean allowRegisteredTypes;
+        private final boolean allowJavaTypes;
 
-        public BrooklynRegisteredTypeAndClassNameIdResolver(JavaType baseType, MapperConfig<?> config, PolymorphicTypeValidator subtypeValidator, ManagementContext mgmt) {
+        public BrooklynRegisteredTypeAndClassNameIdResolver(JavaType baseType, MapperConfig<?> config, PolymorphicTypeValidator subtypeValidator, ManagementContext mgmt,
+                boolean allowRegisteredTypes, boolean allowJavaTypes) {
             super(baseType, config.getTypeFactory(), subtypeValidator);
             this.mgmt = mgmt;
+            this.allowRegisteredTypes = allowRegisteredTypes;
+            this.allowJavaTypes = allowJavaTypes;
         }
 
         @Override
         public JavaType typeFromId(DatabindContext context, String id) throws IOException {
-            if (mgmt!=null) {
+            if (allowRegisteredTypes && mgmt!=null) {
                 RegisteredType rt = mgmt.getTypeRegistry().get(id);
                 if (rt != null) {
                     return new BrooklynJacksonType(mgmt, rt);
                 }
             }
-            return super.typeFromId(context, id);
+            if (allowJavaTypes) {
+                return super.typeFromId(context, id);
+            }
+
+            // copied from super if it fails to find the type
+            if (context instanceof DeserializationContext) {
+                return ((DeserializationContext) context).handleUnknownTypeId(_baseType, id, this, "no such class found");
+            }
+            return null;
         }
 
         @Override
@@ -127,8 +143,10 @@ public class BrooklynRegisteredTypeJacksonSerialization {
 
     static class BrtTypeResolverBuilder extends DefaultTypeResolverBuilder {
         private final ManagementContext mgmt;
+        private final boolean allowRegisteredTypes;
+        private final boolean allowJavaTypes;
 
-        public BrtTypeResolverBuilder(ManagementContext mgmt) {
+        public BrtTypeResolverBuilder(ManagementContext mgmt, boolean allowRegisteredTypes, boolean allowJavaTypes) {
             super(DefaultTyping.NON_FINAL, LaissezFaireSubTypeValidator.instance);
             this.mgmt = mgmt;
 
@@ -138,18 +156,25 @@ public class BrooklynRegisteredTypeJacksonSerialization {
             init(JsonTypeInfo.Id.CLASS, null);
             inclusion(As.PROPERTY);
             typeProperty("type");
-
+            this.allowRegisteredTypes = allowRegisteredTypes;
+            this.allowJavaTypes = allowJavaTypes;
         }
 
         @Override
         protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType, PolymorphicTypeValidator subtypeValidator, Collection<NamedType> subtypes, boolean forSer, boolean forDeser) {
-            return new BrooklynRegisteredTypeAndClassNameIdResolver(baseType, config, subtypeValidator, mgmt);
+            return new BrooklynRegisteredTypeAndClassNameIdResolver(baseType, config, subtypeValidator, mgmt, allowRegisteredTypes, allowJavaTypes);
         }
 
         @Override
         public TypeSerializer buildTypeSerializer(SerializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
             if (!useForType(baseType)) return null;
             if (baseType.isPrimitive()) {
+                return null;
+            }
+            if (baseType.isCollectionLikeType() || baseType.isMapLikeType()) {
+//                List.class.isAssignableFrom(baseType.getRawClass()) ||
+//                        Map.class.isAssignableFrom(baseType.getRawClass())
+                // never serialize these types
                 return null;
             }
             TypeIdResolver idRes = idResolver(config, baseType, subTypeValidator(config),
@@ -172,18 +197,31 @@ public class BrooklynRegisteredTypeJacksonSerialization {
             // above is copied from parents; below is to provide the serializer we want
             return new AsPropertyButNotIfFieldConflictTypeDeserializer(baseType, idRes, _typeProperty, _typeIdVisible, defaultImpl, _includeAs);
         }
+
+        @Override
+        protected JavaType defineDefaultImpl(DeserializationConfig config, JavaType baseType) {
+            JavaType result = super.defineDefaultImpl(config, baseType);
+            if (result!=null) return result;
+            if (baseType.isMapLikeType()) return config.constructType(LinkedHashMap.class);
+            if (baseType.isCollectionLikeType()) return config.constructType(LinkedList.class);
+            return null;
+        }
     }
 
-    public static ObjectMapper apply(ObjectMapper mapper, ManagementContext mgmt) {
+    public static ObjectMapper apply(ObjectMapper mapper, ManagementContext mgmt, boolean allowRegisteredTypes, boolean allowJavaTypes) {
         // the type resolver is extended to recognise brooklyn registered type names
         // and return a subtype of jackson JavaType
-        mapper.setDefaultTyping(new BrtTypeResolverBuilder(mgmt));
+        mapper.setDefaultTyping(new BrtTypeResolverBuilder(mgmt, allowRegisteredTypes, allowJavaTypes));
 
         SimpleModule module = new SimpleModule();
-        module.setDeserializers(new RegisteredTypeDeserializers());
+        if (allowRegisteredTypes) {
+            module.setDeserializers(new RegisteredTypeDeserializers());
+        }
 
         // the module defines how to deserialize the registered type id
         mapper.registerModule(module);
+
+        // preferred defaults
         mapper.setSerializationInclusion(Include.NON_NULL);
 
         return mapper;

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTypeResolverBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.jsontype.*;
+import com.fasterxml.jackson.databind.jsontype.impl.ClassNameIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.module.SimpleDeserializers;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyButNotIfFieldConflictTypeDeserializer;
+import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyIfAmbiguousTypeSerializer;
+import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.HasBaseType;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class BrooklynRegisteredTypeJacksonSerialization {
+
+    static class BrooklynJacksonType extends SimpleType {
+        private final ManagementContext mgmt;
+        private final RegisteredType type;
+        public BrooklynJacksonType(ManagementContext mgmt, RegisteredType type) {
+            super(pickSuperType(type));
+            this.mgmt = mgmt;
+            this.type = type;
+        }
+        private static Class<?> pickSuperType(RegisteredType t) {
+            for (Object x : t.getSuperTypes()) {
+                if (x instanceof Class) return (Class<?>) x;
+            }
+            return Object.class;
+        }
+
+        public RegisteredType getRegisteredType() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return "BrooklynJacksonType{" + type.getId() + '/' + _class + "}";
+        }
+    }
+
+    static class RegisteredTypeDeserializer<T> extends JsonDeserializer<T> {
+        private final BrooklynJacksonType type;
+
+        public RegisteredTypeDeserializer(BrooklynJacksonType type) {
+            this.type = type;
+        }
+
+        @Override
+        public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            try {
+                Object target = type.mgmt.getTypeRegistry().createBean(type.type, null, null);
+                JsonDeserializer<Object> delegate = ctxt.findContextualValueDeserializer(ctxt.constructType(target.getClass()), null);
+                delegate.deserialize(p, ctxt, target);
+                return (T)target;
+            } catch (Exception e) {
+                throw Exceptions.propagate(e);
+            }
+        }
+    }
+
+    static class RegisteredTypeDeserializers extends SimpleDeserializers {
+        @Override
+        public JsonDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config, BeanDescription beanDesc) throws JsonMappingException {
+            if (type instanceof BrooklynJacksonType) {
+                return new RegisteredTypeDeserializer<>((BrooklynJacksonType)type);
+            }
+            return super.findBeanDeserializer(type, config, beanDesc);
+        }
+    }
+
+    static class BrooklynRegisteredTypeAndClassNameIdResolver extends ClassNameIdResolver implements HasBaseType {
+        private final ManagementContext mgmt;
+
+        public BrooklynRegisteredTypeAndClassNameIdResolver(JavaType baseType, MapperConfig<?> config, PolymorphicTypeValidator subtypeValidator, ManagementContext mgmt) {
+            super(baseType, config.getTypeFactory(), subtypeValidator);
+            this.mgmt = mgmt;
+        }
+
+        @Override
+        public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+            if (mgmt!=null) {
+                RegisteredType rt = mgmt.getTypeRegistry().get(id);
+                if (rt != null) {
+                    return new BrooklynJacksonType(mgmt, rt);
+                }
+            }
+            return super.typeFromId(context, id);
+        }
+
+        @Override
+        public JavaType getBaseType() {
+            return _baseType;
+        }
+    }
+
+    static class BrtTypeResolverBuilder extends DefaultTypeResolverBuilder {
+        private final ManagementContext mgmt;
+
+        public BrtTypeResolverBuilder(ManagementContext mgmt) {
+            super(DefaultTyping.NON_FINAL, LaissezFaireSubTypeValidator.instance);
+            this.mgmt = mgmt;
+
+            // normally custom resolvers are passed to the init method below, one instance used through the entire parse --
+            // unlike Jackson's internal resolvers which are aware of the current baseType;
+            // to allow our resolver to have the baseType we instead generate our resolver in the overridden idResolver method above
+            init(JsonTypeInfo.Id.CLASS, null);
+            inclusion(As.PROPERTY);
+            typeProperty("type");
+
+        }
+
+        @Override
+        protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType, PolymorphicTypeValidator subtypeValidator, Collection<NamedType> subtypes, boolean forSer, boolean forDeser) {
+            return new BrooklynRegisteredTypeAndClassNameIdResolver(baseType, config, subtypeValidator, mgmt);
+        }
+
+        @Override
+        public TypeSerializer buildTypeSerializer(SerializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+            if (!useForType(baseType)) return null;
+            if (baseType.isPrimitive()) {
+                return null;
+            }
+            TypeIdResolver idRes = idResolver(config, baseType, subTypeValidator(config),
+                    subtypes, true, false);
+
+            // above is copied from parents; below is to provide the serializer we want
+            return new AsPropertyIfAmbiguousTypeSerializer(idRes, null, _typeProperty);
+        }
+
+        @Override
+        public TypeDeserializer buildTypeDeserializer(DeserializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+            if (!useForType(baseType)) return null;
+            if (baseType.isPrimitive()) {
+                return null;
+            }
+            final PolymorphicTypeValidator subTypeValidator = verifyBaseTypeValidity(config, baseType);
+            TypeIdResolver idRes = idResolver(config, baseType, subTypeValidator, subtypes, false, true);
+            JavaType defaultImpl = defineDefaultImpl(config, baseType);
+
+            // above is copied from parents; below is to provide the serializer we want
+            return new AsPropertyButNotIfFieldConflictTypeDeserializer(baseType, idRes, _typeProperty, _typeIdVisible, defaultImpl, _includeAs);
+        }
+    }
+
+    public static ObjectMapper apply(ObjectMapper mapper, ManagementContext mgmt) {
+        // the type resolver is extended to recognise brooklyn registered type names
+        // and return a subtype of jackson JavaType
+        mapper.setDefaultTyping(new BrtTypeResolverBuilder(mgmt));
+
+        SimpleModule module = new SimpleModule();
+        module.setDeserializers(new RegisteredTypeDeserializers());
+
+        // the module defines how to deserialize the registered type id
+        mapper.registerModule(module);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+
+        return mapper;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.SimpleType;
+import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyButNotIfFieldConflictTypeDeserializer;
@@ -41,10 +42,12 @@ import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.HasBaseTyp
 import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.BrooklynRegisteredTypeAndClassNameIdResolver;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.RegisteredTypeDeserializers;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
 import java.io.IOException;
 import java.util.*;
+import org.apache.brooklyn.util.guava.Maybe;
 
 public class BrooklynRegisteredTypeJacksonSerialization {
 
@@ -118,6 +121,11 @@ public class BrooklynRegisteredTypeJacksonSerialization {
 
         @Override
         public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+            Maybe<Class<?>> builtin = BrooklynTypeNameResolution.getClassForBuiltInTypeName(id);
+            if (builtin.isPresent()) {
+                return context.constructType(builtin.get());
+            }
+
             if (allowRegisteredTypes && mgmt!=null) {
                 RegisteredType rt = mgmt.getTypeRegistry().get(id);
                 if (rt != null) {

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Wraps a value which might be constant or might come from a supplier.
+ * The pattern where fields are of this type is used to assist with (de)serialization
+ * where values might come from a DSL.
+ */
+//@JsonSerialize(using = WrappedValueSerializer.class)
+//@JsonDeserialize(using = WrappedValueDeserializer.class)
+public class WrappedValue<T> implements Supplier<T> {
+    final static WrappedValue<?> NULL_WRAPPED_VALUE = new WrappedValue<>(null, false);
+    final T value;
+    final Supplier<T> supplier;
+
+    private WrappedValue(Object x, boolean isSupplier) {
+        if (isSupplier) {
+            supplier = (Supplier<T>) x;
+            value = null;
+        } else {
+            value = (T) x;
+            supplier = null;
+        }
+    }
+
+    public static <T> WrappedValue<T> of(Object x) {
+        return new WrappedValue<>(x, x instanceof Supplier);
+    }
+    public static <T> WrappedValue<T> ofConstant(T x) {
+        return new WrappedValue<>(x, false);
+    }
+    public static <T> WrappedValue<T> ofSupplier(Supplier<T> x) { return new WrappedValue<>(x, true); }
+    public static <T> WrappedValue<T> ofNull() { return (WrappedValue<T>)NULL_WRAPPED_VALUE; }
+
+    public T get() {
+        return supplier != null ? supplier.get() : value;
+    }
+
+    public Supplier<T> getSupplier() {
+        return supplier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WrappedValue<?> that = (WrappedValue<?>) o;
+        return Objects.equals(value, that.value) && Objects.equals(supplier, that.supplier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, supplier);
+    }
+
+    /** Convenience superclass to ensure all WrappedValue fields are initialized at creation time */
+    public static class WrappedValuesInitialized {
+        public WrappedValuesInitialized() {
+            WrappedValuesSerialization.ensureWrappedValuesInitialized(this);
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerialization.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.cfg.SerializerFactoryConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
+import com.fasterxml.jackson.databind.ser.PropertyBuilder;
+import com.fasterxml.jackson.databind.ser.SerializerFactory;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.BrooklynRegisteredTypeAndClassNameIdResolver;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.javalang.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class WrappedValuesSerialization {
+
+    private static final Logger log = LoggerFactory.getLogger(WrappedValuesSerialization.class);
+
+    public static class WrappedValueDeserializer extends JsonDeserializer {
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            return deserializeWithType(p, ctxt, null);
+        }
+        @Override
+        public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            return WrappedValue.of(deserializeWithTypeUnwrapped(p, ctxt, typeDeserializer));
+        }
+        Object deserializeWithTypeUnwrapped(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+            List<Exception> exceptions = MutableList.of();
+            try {
+                TokenBuffer b = new TokenBuffer(p, ctxt);
+                b.copyCurrentStructure(p);
+                try {
+//                        // could do this first for primitives, but no need as the object serializer below will do the same
+//                        TreeNode v = b.asParserOnFirstToken().readValueAsTree();
+//                        if (v instanceof ValueNode) return ((ValueNode)v).asText();  // this makes strings for everything; would need to do all the subtypes of ValueNode
+
+                    // this should work for primitives, objects, and suppliers (which will declare type)
+                    // only time it won't is where generics are used to drop the type declaration during serialization
+                    JavaType genericType = getGenericType(typeDeserializer);
+                    if (genericType != null) {
+                        return ctxt.findNonContextualValueDeserializer(genericType).deserialize(b.asParserOnFirstToken(), ctxt);
+                    }
+                } catch (Exception e) {
+                    exceptions.add(e);
+                }
+
+                // fall back to just using object
+                try {
+                    return ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class)).deserialize(b.asParserOnFirstToken(), ctxt);
+                } catch (Exception e) {
+                    exceptions.add(e);
+                }
+
+                throw new IllegalStateException("Cannot parse wrapper data and contextual type info not available: "+exceptions, exceptions.stream().findFirst().orElse(null));
+            } finally {
+                if (!exceptions.isEmpty() && log.isTraceEnabled()) {
+                    log.trace("Exceptions encountered while deserializing: "+exceptions);
+                    exceptions.forEach(e -> log.trace("- ", e));
+                }
+            }
+        }
+    }
+
+    public static class WrappedValueSerializer<T> extends JsonSerializer<WrappedValue<T>> {
+        @Override
+        public void serialize(WrappedValue<T> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            serializeWithType(value, gen, serializers, null);
+        }
+
+        @Override
+        public void serializeWithType(WrappedValue<T> value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer) throws IOException {
+            JavaType baseType = getGenericType(typeSer);
+            Object valueToWrite;
+
+            if (value.getSupplier() != null) {
+                // could use the generic type here and get a serializer for Supplier<t> --
+                // but normally suppliers will have their own serialization and deserialization
+                baseType = serializers.constructType(Supplier.class);
+                valueToWrite = value.getSupplier();
+            } else {
+                if (baseType==null) {
+                    baseType = serializers.constructType(Object.class);
+                }
+                valueToWrite = value.get();
+            }
+            if (valueToWrite==null) {
+                // should be omitted
+                gen.writeNull();
+            } else {
+                serializers.findValueSerializer(serializers.constructType(valueToWrite.getClass())).serializeWithType(valueToWrite, gen, serializers, serializers.findTypeSerializer(baseType));
+            }
+        }
+    }
+
+    private static JavaType getGenericType(TypeDeserializer typeDeserializer) {
+        if (!(typeDeserializer instanceof TypeDeserializerBase)) return null;
+        return getSingleGenericArgumentJavaType(((TypeDeserializerBase) typeDeserializer).baseType());
+    }
+    private static JavaType getGenericType(TypeSerializer typeSerializer) {
+        if (typeSerializer==null) return null;
+        if (!(typeSerializer.getTypeIdResolver() instanceof BrooklynRegisteredTypeAndClassNameIdResolver)) return null;
+        return getSingleGenericArgumentJavaType( ((BrooklynRegisteredTypeAndClassNameIdResolver)typeSerializer.getTypeIdResolver()).getBaseType() );
+    }
+    private static JavaType getSingleGenericArgumentJavaType(JavaType x) {
+        return x.getBindings().getTypeParameters().stream().findFirst().orElse(null);
+    }
+
+    static class NullWrappedValueSuppressingPropertyBuilder extends PropertyBuilder {
+        public NullWrappedValueSuppressingPropertyBuilder(SerializationConfig config, BeanDescription beanDesc) {
+            super(config, beanDesc);
+        }
+
+        @Override
+        protected BeanPropertyWriter buildWriter(SerializerProvider prov, BeanPropertyDefinition propDef, JavaType declaredType, JsonSerializer<?> ser, TypeSerializer typeSer, TypeSerializer contentTypeSer, AnnotatedMember am, boolean defaultUseStaticTyping) throws JsonMappingException {
+            BeanPropertyWriter bpw = super.buildWriter(prov, propDef, declaredType, ser, typeSer, contentTypeSer, am, defaultUseStaticTyping);
+            if (WrappedValue.class.isAssignableFrom(bpw.getMember().getRawType())) {
+                bpw = new BeanPropertyWriter(propDef,
+                    am, _beanDesc.getClassAnnotations(), declaredType,
+                    ser, typeSer, bpw.getSerializationType(), bpw.willSuppressNulls(),
+                    WrappedValue.ofNull(), bpw.getViews());
+            }
+            return bpw;
+        }
+    }
+
+    static class NullWrappedValueSuppressingBeanSerializerFactory extends BeanSerializerFactory {
+        protected NullWrappedValueSuppressingBeanSerializerFactory(SerializerFactoryConfig config) {
+            super(config);
+        }
+
+        public static NullWrappedValueSuppressingBeanSerializerFactory extending(SerializerFactory factory) {
+            if (factory == null) return new NullWrappedValueSuppressingBeanSerializerFactory(null);
+            if (factory instanceof NullWrappedValueSuppressingBeanSerializerFactory) return (NullWrappedValueSuppressingBeanSerializerFactory) factory;
+            if (factory.getClass() == BeanSerializerFactory.class) return new NullWrappedValueSuppressingBeanSerializerFactory( ((BeanSerializerFactory) factory).getFactoryConfig() );
+            throw new IllegalStateException("Cannot extend "+factory);
+        }
+
+        @Override
+        protected PropertyBuilder constructPropertyBuilder(SerializationConfig config, BeanDescription beanDesc) {
+            return new NullWrappedValueSuppressingPropertyBuilder(config, beanDesc);
+        }
+
+        public SerializerFactory withConfig(SerializerFactoryConfig config) {
+            if (_factoryConfig == config) return this;
+            return new NullWrappedValueSuppressingBeanSerializerFactory(config);
+        }
+    }
+
+    public static <T> T ensureWrappedValuesInitialized(T x) {
+        if (x == null) return x;
+        Reflections.findFields(x.getClass(), f -> WrappedValue.class.isAssignableFrom(f.getType()), null)
+                .forEach(f -> {
+                    try {
+                        if (Reflections.getFieldValueMaybe(x, f).isNull()) {
+                            f.set(x, WrappedValue.of(null));
+                        }
+                    } catch (IllegalAccessException e) {
+                        Exceptions.propagate(e);
+                    }
+                });
+        return x;
+    }
+
+    public static ObjectMapper apply(ObjectMapper mapper) {
+        if (mapper.getSerializationConfig().getDefaultTyper(null) == null) {
+            throw new IllegalStateException("Mapper must be set up to use a TypeResolverBuilder including type info for wrapped value serialization to work.");
+        }
+        return mapper
+            .setSerializerFactory(NullWrappedValueSuppressingBeanSerializerFactory.extending(mapper.getSerializerFactory()))
+            // we need to see private fields for this to work
+            .setVisibility(new VisibilityChecker.Std(Visibility.ANY, Visibility.ANY, Visibility.ANY, Visibility.ANY, Visibility.ANY))
+            .registerModule(new SimpleModule()
+                .addSerializer(WrappedValue.class, new WrappedValueSerializer())
+                .addDeserializer(WrappedValue.class, new WrappedValueDeserializer())
+//                .setDeserializerModifier(new ConfigurableBeanDeserializerModifier()
+//                        .addPostConstructFunction(WrappedValuesSerialization::ensureWrappedValuesInitialized)
+//                )
+            );
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AbstractAddSensorFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AbstractAddSensorFeed.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.sensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.effector.AddSensorInitializer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.time.Duration;
 
@@ -30,7 +31,7 @@ import com.google.common.annotations.Beta;
  * Super-class for entity initializers that add feeds.
  */
 @Beta
-public abstract class AbstractAddSensorFeed<T> extends AddSensor<T> {
+public abstract class AbstractAddSensorFeed<T> extends AddSensorInitializer<T> {
 
     public static final ConfigKey<Boolean> SUPPRESS_DUPLICATES = ConfigKeys.newBooleanConfigKey(
             "suppressDuplicates", 
@@ -50,6 +51,7 @@ public abstract class AbstractAddSensorFeed<T> extends AddSensor<T> {
             "Length of time, after a successful poll, before a subsequent failure can be logged at WARN.",
             Duration.millis(0));
 
+    protected AbstractAddSensorFeed() {}
     public AbstractAddSensorFeed(final ConfigBag params) {
         super(params);
     }

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/function/FunctionSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/function/FunctionSensor.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.sensor.function;
 import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.EntityInitializers;
@@ -57,16 +58,17 @@ public final class FunctionSensor<T> extends AbstractAddSensorFeed<T> {
     public FunctionSensor(final ConfigBag params) {
         super(params);
     }
+    protected FunctionSensor() {}
 
     @Override
     public void apply(final EntityLocal entity) {
-        super.apply(entity);
+        AttributeSensor<T> sensor = addSensor(entity);
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Adding HTTP JSON sensor {} to {}", name, entity);
+            LOG.debug("Adding HTTP JSON sensor {} to {}", initParam(SENSOR_NAME), entity);
         }
 
-        final ConfigBag allConfig = ConfigBag.newInstanceCopying(this.params).putAll(params);
+        final ConfigBag allConfig = ConfigBag.newInstanceCopying(initParams());
         
         final Callable<?> function = EntityInitializers.resolve(allConfig, FUNCTION);
         final Boolean suppressDuplicates = EntityInitializers.resolve(allConfig, SUPPRESS_DUPLICATES);
@@ -79,7 +81,7 @@ public final class FunctionSensor<T> extends AbstractAddSensorFeed<T> {
                 .suppressDuplicates(Boolean.TRUE.equals(suppressDuplicates))
                 .logWarningGraceTimeOnStartup(logWarningGraceTimeOnStartup)
                 .logWarningGraceTime(logWarningGraceTime)
-                .period(period);
+                .period(initParam(SENSOR_PERIOD));
 
         FunctionFeed feed = FunctionFeed.builder().entity(entity)
                 .poll(pollConfig)

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
@@ -45,7 +46,7 @@ import com.google.common.base.Supplier;
 
 /**
  * Configurable {@link org.apache.brooklyn.api.entity.EntityInitializer} which adds an HTTP sensor feed to retrieve the
- * {@link JSONObject} from a JSON response in order to populate the sensor with the data at the {@code jsonPath}.
+ * {@link net.minidev.json.JSONObject} from a JSON response in order to populate the sensor with the data at the {@code jsonPath}.
  *
  * @see SshCommandSensor
  */
@@ -65,19 +66,22 @@ public final class HttpRequestSensor<T> extends AbstractAddSensorFeed<T> {
             "Whether to pre-emptively including a basic-auth header of the username:password (rather than waiting for a challenge)",
             Boolean.FALSE);
 
+    protected HttpRequestSensor() {}
     public HttpRequestSensor(final ConfigBag params) {
         super(params);
     }
 
     @Override
     public void apply(final EntityLocal entity) {
-        super.apply(entity);
+        AttributeSensor<T> sensor = addSensor(entity);
+
+        String name = initParam(SENSOR_NAME);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Adding HTTP JSON sensor {} to {}", name, entity);
         }
 
-        final ConfigBag allConfig = ConfigBag.newInstanceCopying(this.params).putAll(params);
+        final ConfigBag allConfig = ConfigBag.newInstanceCopying(initParams());
         
         // TODO Keeping anonymous inner class for backwards compatibility with persisted state
         new Supplier<URI>() {
@@ -112,7 +116,7 @@ public final class HttpRequestSensor<T> extends AbstractAddSensorFeed<T> {
                 .suppressDuplicates(Boolean.TRUE.equals(suppressDuplicates))
                 .logWarningGraceTimeOnStartup(logWarningGraceTimeOnStartup)
                 .logWarningGraceTime(logWarningGraceTime)
-                .period(period);
+                .period(initParam(SENSOR_PERIOD));
 
         HttpFeed.Builder httpRequestBuilder = HttpFeed.builder().entity(entity)
                 .baseUri(uri)

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/password/CreatePasswordSensor.java
@@ -26,38 +26,30 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.AddSensor;
+import org.apache.brooklyn.core.effector.AddSensorInitializer;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Identifiers;
 
-public class CreatePasswordSensor extends AddSensor<String> {
+public class CreatePasswordSensor extends AddSensorInitializer<String> {
 
     public static final ConfigKey<Integer> PASSWORD_LENGTH = ConfigKeys.newIntegerConfigKey("password.length", "The length of the password to be created", 12);
-
     public static final ConfigKey<String> ACCEPTABLE_CHARS = ConfigKeys.newStringConfigKey("password.chars", "The characters allowed in password");
-
     public static final ConfigKey<List<String>> CHARACTER_GROUPS = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {}, "password.character.groups", "A list of strings, where each string is a character group (such as letters, or numbers). The password will be constructed using only characters from these strings, and will use at least one character from each group. When using this option, `password.length` must be at least as long as the number of character groups given.");
 
-    private Integer passwordLength;
-    private String acceptableChars;
-    private List<String> characterGroups;
-
-    public CreatePasswordSensor(Map<String, String> params) {
-        this(ConfigBag.newInstance(params));
-    }
-
-    public CreatePasswordSensor(ConfigBag params) {
-        super(params);
-        passwordLength = params.get(PASSWORD_LENGTH);
-        acceptableChars = params.get(ACCEPTABLE_CHARS);
-        characterGroups = params.get(CHARACTER_GROUPS);
-    }
+    private CreatePasswordSensor() {}
+    public CreatePasswordSensor(Map<String, String> params) { this(ConfigBag.newInstance(params)); }
+    public CreatePasswordSensor(ConfigBag params) { super(params); }
 
     @Override
     public void apply(EntityLocal entity) {
-        super.apply(entity);
+        AttributeSensor<String> sensor = addSensor(entity);
+        List<String> characterGroups = initParam(CHARACTER_GROUPS);
+        String acceptableChars = initParam(ACCEPTABLE_CHARS);
+        Integer passwordLength = initParam(PASSWORD_LENGTH);
 
         boolean isCharacterGroupsPresent = characterGroups != null
                 && characterGroups.size() > 0;

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
@@ -142,7 +142,7 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
 
                 // Try to resolve the configuration in the env Map
                 try {
-                    env = (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, ((EntityInternal) entity).getExecutionContext());
+                    env = (Map<String, Object>) Tasks.resolveDeepValueWithoutCoercion(env, ((EntityInternal) entity).getExecutionContext());
                 } catch (InterruptedException | ExecutionException e) {
                     Exceptions.propagateIfFatal(e);
                 }
@@ -220,7 +220,7 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
 
             // Try to resolve the configuration in the env Map
             try {
-                env = (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, ((EntityInternal) entity).getExecutionContext());
+                env = (Map<String, Object>) Tasks.resolveDeepValueWithoutCoercion(env, ((EntityInternal) entity).getExecutionContext());
             } catch (InterruptedException | ExecutionException e) {
                 Exceptions.propagateIfFatal(e);
             }

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.MapConfigKey;
@@ -77,22 +78,17 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
             "Value to be used if an error occurs whilst executing the ssh command", null);
     public static final MapConfigKey<Object> SENSOR_SHELL_ENVIRONMENT = BrooklynConfigKeys.SHELL_ENVIRONMENT;
 
-    // Fields are kept for deserialization purposes; however will rely on the values being
-    // re-computed from the config map, rather than being restored from persistence.
-    @SuppressWarnings("unused")
-    private String command;
-    @SuppressWarnings("unused")
-    private String executionDir;
-    @SuppressWarnings("unused")
-    private Map<String,Object> sensorEnv;
-    
-    public SshCommandSensor(final ConfigBag params) {
+    protected SshCommandSensor() {}
+    public SshCommandSensor(ConfigBag params) {
         super(params);
     }
 
     @Override
     public void apply(final EntityLocal entity) {
-        super.apply(entity);
+        AttributeSensor<T> sensor = addSensor(entity);
+
+        ConfigBag params = initParams();
+        String name = initParam(SENSOR_NAME);
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Adding SSH sensor {} to {}", name, entity);
@@ -107,7 +103,7 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
         Supplier<String> commandSupplier = new CommandSupplier(entity, params);
 
         CommandPollConfig<T> pollConfig = new CommandPollConfig<T>(sensor)
-                .period(period)
+                .period(initParam(SENSOR_PERIOD))
                 .env(envSupplier)
                 .command(commandSupplier)
                 .suppressDuplicates(Boolean.TRUE.equals(suppressDuplicates))
@@ -137,7 +133,7 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
                 Map<String, Object> env = MutableMap.copyOf(entity.getConfig(BrooklynConfigKeys.SHELL_ENVIRONMENT));
 
                 // Add the shell environment entries from our configuration
-                Map<String,Object> sensorEnv = params.get(SENSOR_SHELL_ENVIRONMENT);
+                Map<String,Object> sensorEnv = initParams().get(SENSOR_SHELL_ENVIRONMENT);
                 if (sensorEnv != null) env.putAll(sensorEnv);
 
                 // Try to resolve the configuration in the env Map
@@ -160,8 +156,8 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
                 // Note that entity may be null during rebind (e.g. if this SshFeed is orphaned, with no associated entity):
                 // See https://issues.apache.org/jira/browse/BROOKLYN-568.
                 // We therefore guard against null in makeCommandExecutingInDirectory.
-                String command = Preconditions.checkNotNull(EntityInitializers.resolve(params, SENSOR_COMMAND));
-                String dir = EntityInitializers.resolve(params, SENSOR_EXECUTION_DIR);
+                String command = Preconditions.checkNotNull(EntityInitializers.resolve(initParams(), SENSOR_COMMAND));
+                String dir = EntityInitializers.resolve(initParams(), SENSOR_EXECUTION_DIR);
                 return makeCommandExecutingInDirectory(command, dir, entity);
             }
         };
@@ -259,4 +255,23 @@ public final class SshCommandSensor<T> extends AbstractAddSensorFeed<T> {
             return makeCommandExecutingInDirectory(command, dir, entity);
         }
     }
+
+    private String command;
+    private String executionDir;
+    private Map<String,Object> sensorEnv;
+    // introduced in 1.1 for legacy compatibility
+    protected Object readResolve() {
+        super.readResolve();
+        initFromConfigBag(ConfigBag.newInstance()
+                .putIfAbsentAndNotNull(SENSOR_COMMAND, command)
+                .putIfAbsentAndNotNull(SENSOR_EXECUTION_DIR, executionDir)
+                .putIfAbsentAndNotNull(SENSOR_SHELL_ENVIRONMENT, sensorEnv)
+        );
+        command = null;
+        executionDir = null;
+        sensorEnv = null;
+
+        return this;
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/JavaClassNameTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/JavaClassNameTypePlanTransformer.java
@@ -18,12 +18,14 @@
  */
 package org.apache.brooklyn.core.typereg;
 
+import java.lang.reflect.Constructor;
 import java.util.List;
 
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Identifiers;
 
 /**
@@ -68,7 +70,14 @@ public class JavaClassNameTypePlanTransformer extends AbstractTypePlanTransforme
 
     @Override
     protected Object createBean(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {
-        return getType(type, context).newInstance();
+        Class<?> clz = getType(type, context);
+        Constructor<?> constr;
+        try {
+            constr = clz.getDeclaredConstructor();
+        } catch (Exception e) {
+            throw Exceptions.propagateAnnotated("No 0-arg constructor found for "+clz+" for "+type.getId(), e);
+        }
+        return constr.newInstance();
     }
 
     private Class<?> getType(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -134,7 +134,6 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
         return (U) Tasks.resolving(rawVal).as(targetSensor.getTypeToken())
                 .context(entity)
                 .description("Computing sensor "+targetSensor+" from "+rawVal)
-                // TODO convert again
                 .deep(true, true, false)
                 .immediately(true)
                 .getMaybe().orNull();

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -134,7 +134,8 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
         return (U) Tasks.resolving(rawVal).as(targetSensor.getTypeToken())
                 .context(entity)
                 .description("Computing sensor "+targetSensor+" from "+rawVal)
-                .deep(true, false)
+                // TODO convert again
+                .deep(true, true, false)
                 .immediately(true)
                 .getMaybe().orNull();
     }

--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/Transformer.java
@@ -134,7 +134,7 @@ public class Transformer<T,U> extends AbstractTransformer<T,U> {
         return (U) Tasks.resolving(rawVal).as(targetSensor.getTypeToken())
                 .context(entity)
                 .description("Computing sensor "+targetSensor+" from "+rawVal)
-                .deep(true, true, false)
+                .deep()
                 .immediately(true)
                 .getMaybe().orNull();
     }

--- a/core/src/main/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/SshCommandMembershipTrackingPolicy.java
@@ -186,7 +186,7 @@ public class SshCommandMembershipTrackingPolicy extends AbstractMembershipTracki
 
         // Try to resolve the configuration in the env Map
         try {
-            env = (Map<String, Object>) Tasks.resolveDeepValue(env, Object.class, getExecutionContext());
+            env = (Map<String, Object>) Tasks.resolveDeepValueWithoutCoercion(env, getExecutionContext());
         } catch (InterruptedException | ExecutionException e) {
             throw Exceptions.propagate(e);
         }

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.ConcurrentModificationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
@@ -222,7 +223,16 @@ public class ConfigBag {
     }
     
     public ConfigBag putAll(ConfigBag addlConfig) {
-        return putAll(addlConfig.getAllConfig());
+        if (addlConfig!=null) {
+            addlConfig.forEach((k,v)->{
+                putStringKey(k, v, !addlConfig.unusedConfig.containsKey(k));
+            });
+        }
+        return this;
+    }
+
+    public void forEach(BiConsumer<String,Object> action) {
+        getAllConfig().forEach(action);
     }
     
     public <T> ConfigBag putIfAbsent(ConfigKey<T> key, T value) {
@@ -305,14 +315,25 @@ public class ConfigBag {
      * (e.g. when copying a map) where we want to put a string key directly 
      */
     public synchronized Object putStringKey(String key, Object value) {
-        if (sealed) 
+        if (sealed)
             throw new IllegalStateException("Cannot insert "+key+"="+value+": this config bag has been sealed and is now immutable.");
         boolean isNew = !config.containsKey(key);
         boolean isUsed = !isNew && !unusedConfig.containsKey(key);
         Object old = config.put(key, value);
-        if (!isUsed) 
+        if (!isUsed)
             unusedConfig.put(key, value);
-        //if (!isNew && !isUsed) log.debug("updating config value which has already been used");
+        return old;
+    }
+    protected synchronized Object putStringKey(String key, Object value, boolean valueBeingSetIsAlreadyUsed) {
+        if (!valueBeingSetIsAlreadyUsed) {
+            return putStringKey(key, value);
+        }
+        if (sealed) {
+            if (Objects.equal(value, config.get(key))) return value;
+            throw new IllegalStateException("Cannot insert " + key + "=" + value + ": this config bag has been sealed and is now immutable.");
+        }
+        Object old = config.put(key, value);
+        unusedConfig.remove(key);
         return old;
     }
     public Object putStringKeyIfHasValue(String key, Maybe<?> value) {
@@ -366,7 +387,7 @@ public class ConfigBag {
     public Maybe<Object> getObjKeyMaybe(Object key) {
         if (key instanceof HasConfigKey<?>) key = ((HasConfigKey<?>)key).getConfigKey();
         if (key instanceof ConfigKey<?>) {
-            return getKeyMaybe((ConfigKey<?>)key, true);
+            return getKeyMaybeUncoercedIfPresent((ConfigKey<?>)key, true);
         } else if (key instanceof String) {
             return getStringKeyMaybe((String)key, true);
         } else {
@@ -513,8 +534,15 @@ public class ConfigBag {
         // TODO for now, no evaluation -- maps / closure content / other smart (self-extracting) keys are NOT supported
         // (need a clean way to inject that behaviour, as well as desired TypeCoercions)
         // this method, and the coercion, is not synchronized, nor does it need to be, because the "get" is synchronized.
-        Maybe<Object> val = getKeyMaybe(key, markUsed);
+        Maybe<Object> val = getKeyMaybeUncoercedIfPresent(key, markUsed);
         return coerceFirstNonNullKeyValue(key, val.orNull());
+    }
+
+    /** If the key is set, return the type-correct (coerced) value, but not any default; otherwise returns absent */
+    public <T> Maybe<T> ifPresent(ConfigKey<T> key) {
+        Maybe<Object> val = getKeyMaybeUncoercedIfPresent(key, true);
+        if (val.isAbsent()) return ((Maybe<T>)val);
+        return Maybe.of(coerceFirstNonNullKeyValue(key, val.get()));
     }
 
     /** returns the first non-null value to be the type indicated by the key, or the keys default value if no non-null values are supplied */
@@ -574,7 +602,7 @@ public class ConfigBag {
     /**
      * @return Unresolved configuration value. May be overridden to provide resolution - @see {@link ResolvingConfigBag#getStringKeyMaybe(String, boolean)}
      */
-    protected synchronized Maybe<Object> getKeyMaybe(ConfigKey<?> key, boolean markUsed) {
+    protected synchronized Maybe<Object> getKeyMaybeUncoercedIfPresent(ConfigKey<?> key, boolean markUsed) {
         return getKeyMaybeInternal(key, name -> getStringKeyMaybe(name, markUsed));
     }
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ResolvingConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ResolvingConfigBag.java
@@ -164,8 +164,8 @@ public class ResolvingConfigBag extends ConfigBag {
     }
 
     @Override
-    protected synchronized Maybe<Object> getKeyMaybe(ConfigKey<?> key, boolean markUsed) {
-        Maybe<Object> result = super.getKeyMaybe(key, markUsed);
+    protected synchronized Maybe<Object> getKeyMaybeUncoercedIfPresent(ConfigKey<?> key, boolean markUsed) {
+        Maybe<Object> result = super.getKeyMaybeUncoercedIfPresent(key, markUsed);
         return (result.isPresent()) ? Maybe.of(getTransformer().apply(result.get())) : result;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.flags;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.brooklyn.api.location.PortRange;
+import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.commons.lang3.reflect.TypeUtils;
+
+public class BrooklynTypeNameResolution {
+
+    private static final Map<String, Class<?>> BUILT_IN_TYPES = ImmutableMap.<String, Class<?>>builder()
+            .put("string", String.class)
+            .put("bool", Boolean.class)
+            .put("boolean", Boolean.class)
+            .put("byte", Byte.class)
+            .put("char", Character.class)
+            .put("character", Character.class)
+            .put("short", Short.class)
+            .put("integer", Integer.class)
+            .put("int", Integer.class)
+            .put("long", Long.class)
+            .put("float", Float.class)
+            .put("double", Double.class)
+
+            .put("map", Map.class)
+            .put("list", List.class)
+
+            .put("duration", Duration.class)
+            .put("timestamp", Date.class)
+            .put("port", PortRange.class)
+            .build();
+
+    public static Maybe<TypeToken<?>> getTypeTokenForBuiltInTypeName(String className) {
+        return getClassForBuiltInTypeName(className).transform(TypeToken::of);
+    }
+
+    public static Maybe<Class<?>> getClassForBuiltInTypeName(String className) {
+        if (className==null) return Maybe.absent(new NullPointerException("className is null"));
+        return Maybe.ofDisallowingNull(BUILT_IN_TYPES.get(className.trim().toLowerCase()));
+    }
+
+    public static Map<String, Class<?>> standardTypesMap() {
+        return BUILT_IN_TYPES;
+    }
+
+    private static final Set<String> BUILT_IN_TYPE_RESERVED_WORDS = MutableSet.copyOf(BUILT_IN_TYPES.keySet())
+            .putAll(BUILT_IN_TYPES.values().stream().map(c -> c.getName().toLowerCase()).collect(Collectors.toList()))
+            .asUnmodifiable();
+
+    public static boolean isBuiltInType(String s) {
+        return BUILT_IN_TYPE_RESERVED_WORDS.contains(s.trim().toLowerCase());
+    }
+
+    public static TypeToken<?> getTypeTokenForBuiltInAndJava(String typeName, String context, BrooklynClassLoadingContext loader) {
+        return parseTypeToken(typeName, newTypeResolverComposite(context, loader));
+    }
+
+    static Function<String,Type> newTypeResolverComposite(String context, BrooklynClassLoadingContext loaderContext) {
+        Map<String,Function<String,Maybe<Class<?>>>> rules = MutableMap.of(
+                "simple types ("+Strings.join(BrooklynTypeNameResolution.standardTypesMap().keySet(), ", ")+")",
+                    BrooklynTypeNameResolution::getClassForBuiltInTypeName,
+                "Java types", loaderContext::tryLoadClass);
+
+        Function<String,Maybe<Class<?>>> composite = s -> {
+            for (Function<String, Maybe<Class<?>>> r : rules.values()) {
+                Maybe<Class<?>> candidate = r.apply(s);
+                if (candidate.isPresent()) return candidate;
+            }
+            return Maybe.absent(() -> new IllegalArgumentException("Invalid type for "+context+": '"+s+"' not found in "+rules.keySet()));
+        };
+
+        return s -> composite.apply(s).get();
+    }
+
+    static GenericsRecord parseTypeGenerics(String s) { return parseTypeGenerics(s, (String t, List<GenericsRecord> tt) -> new GenericsRecord(t, tt)); }
+    static TypeToken<?> parseTypeToken(String s, Function<String,Type> typeLookup) {
+        return TypeToken.of(parseTypeGenerics(s, (String t, List<Type> tt) -> {
+            Type c = typeLookup.apply(t);
+            if (tt.isEmpty()) {
+                return c;
+            }
+            if (c instanceof Class) {
+                return TypeUtils.parameterize((Class<?>)c, tt.toArray(new Type[0]));
+            }
+            throw new IllegalStateException("Cannot make generic type with base '"+t+"' and generic parameters "+tt);
+        }));
+    }
+
+    static <T> T parseTypeGenerics(String s, BiFunction<String,List<T>,T> baseTypeConverter) {
+        GenericsRecord.Parser<T> p = new GenericsRecord.Parser<T>();
+        p.s = s;
+        p.baseTypeConverter = baseTypeConverter;
+        return p.parse(0);
+    }
+
+    static class GenericsRecord {
+        String baseName;
+        List<GenericsRecord> params;
+
+        GenericsRecord(String baseName, List<GenericsRecord> params) {
+            this.baseName = baseName;
+            this.params = params;
+        }
+
+        @Override
+        public String toString() {
+            return baseName + (!params.isEmpty() ? "<" + Strings.join(params, ",") + ">" : "");
+        }
+
+        static class Parser<T> {
+            String s;
+            BiFunction<String,List<T>,T> baseTypeConverter;
+
+            private void skipWhitespace() {
+                while (index<s.length() && Character.isWhitespace(s.charAt(index))) index++;
+            }
+
+            int index = 0;
+
+            T parse(int depth) {
+                int baseNameStart = index;
+                MutableList<T> params = MutableList.of();
+                int baseNameEnd = -1;
+                while (index<s.length()) {
+                    char c = s.charAt(index);
+                    if (c=='<') {
+                        baseNameEnd = index;
+                        index++;
+                        do {
+                            params.add(parse(depth+1));
+                            c = s.charAt(index);
+                            index++;
+                            skipWhitespace();
+                        } while (c==',');
+                        if (c!='>') {
+                            // shouldn't happen
+                            throw new IllegalArgumentException("Invalid type '"+s+"': unexpected character preceeding position "+index);
+                        }
+                        // skip spaces
+                        break;
+                    }
+                    if (depth>0) {
+                        if (c==',' || c=='>') {
+                            baseNameEnd = index;
+                            break;
+                        }
+                    }
+                    index++;
+                }
+                if (depth==0) {
+                    if (index < s.length()) {
+                        throw new IllegalArgumentException("Invalid type '"+s+"': characters not permitted after generics at position "+index);
+                    }
+                    if (baseNameEnd<0) {
+                        baseNameEnd = s.length();
+                    }
+                } else {
+                    if (index >= s.length()) {
+                        throw new IllegalArgumentException("Invalid type '"+s+"': unterminated generics for argument starting at position "+baseNameStart);
+                    }
+                }
+                String baseName = s.substring(baseNameStart, baseNameEnd).trim();
+                if (baseName.isEmpty()) throw new IllegalArgumentException("Invalid type '"+s+"': missing base type name at position "+baseNameStart);
+                return baseTypeConverter.apply(baseName, params.asUnmodifiable());
+            }
+        }
+
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -132,7 +133,8 @@ public class BrooklynTypeNameResolution {
                     BrooklynTypeNameResolution::getClassForBuiltInTypeName);
 
             if (allowJavaType) {
-                rules.put("Java types", loader::tryLoadClass);
+                rules.put("Java types visible to bundles", loader::tryLoadClass);
+                rules.put("Java types", JavaBrooklynClassLoadingContext.create(mgmt)::tryLoadClass);
             }
 
             if (allowRegisteredTypes) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -169,7 +169,7 @@ public class Tasks {
     /** As @see #resolveDeepValueExactly(Object, TypeToken, ExecutionContext, String) but without any coercion
      * (ie resolving {@link DeferredSupplier} values only) */
     public static Object resolveDeepValueWithoutCoercion(Object v, ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
-        return new ValueResolver<>(v, TypeToken.of(Object.class)).context(exec).deep(true, true, true).description(contextMessage).get();
+        return new ValueResolver<>(v, TypeToken.of(Object.class)).context(exec).deep().description(contextMessage).get();
     }
     /** @see #resolveDeepValue(Object, Class, ExecutionContext, String) */
     public static Object resolveDeepValueWithoutCoercion(Object v, ExecutionContext exec) throws ExecutionException, InterruptedException {
@@ -252,15 +252,18 @@ public class Tasks {
      */
     public static <T> T resolveDeepValueCoerced(Object value, TypeToken<T> type, ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
         if (ValueResolver.supportsDeepResolution(value)) {
-            Object resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);
+            Object resultO;
             try {
-                if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE!= LegacyDeepResolutionMode.ONLY_LEGACY) {
-                    resultO = resolveValueShallow(resultO, type, exec, "Resolving typed " + contextMessage);
+                if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE != LegacyDeepResolutionMode.ONLY_LEGACY) {
+                    resultO = new ValueResolver<>(value, type).context(exec).deep().description(contextMessage).get();
+                } else {
+                    resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);
                 }
             } catch (Exception e) {
                 if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE == LegacyDeepResolutionMode.DISALLOW_LEGACY) {
                     throw Exceptions.propagate(e);
                 }
+                resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);
                 if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE == LegacyDeepResolutionMode.WARN) {
                     log.warn("Conversion of '" + contextMessage + "' (" + value + ") to " + type + " failed; leaving as deep container type for legacy compatibility, but this feature may be removed in future");
                 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -228,8 +228,13 @@ public class Tasks {
         public static enum LegacyDeepResolutionMode {
             WARN, DISALLOW_LEGACY, ALLOW_LEGACY, ONLY_LEGACY
         }
+
+        /** Being aggressive at breaking the legacy deep resolution mode, where a map is generic and the value doesn't fit even after coercion;
+         * have confirmed the extent of these breakages is minor. And if it's a real problem, there is a way (by a plugin which changes this static),
+         * for users to revert to the old behaviour.
+         */
         @VisibleForTesting @Beta
-        public static LegacyDeepResolutionMode LEGACY_DEEP_RESOLUTION_MODE = LegacyDeepResolutionMode.ONLY_LEGACY;
+        public static LegacyDeepResolutionMode LEGACY_DEEP_RESOLUTION_MODE = LegacyDeepResolutionMode.DISALLOW_LEGACY;
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -251,7 +251,7 @@ public class Tasks {
      * See also {@link #resolveDeepValueWithoutCoercion(Object, ExecutionContext, String)}
      */
     public static <T> T resolveDeepValueCoerced(Object value, TypeToken<T> type, ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
-        if (ValueResolver.supportsDeepResolution(value)) {
+        if (ValueResolver.supportsDeepResolution(value, null)) {
             Object resultO;
             try {
                 if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE != LegacyDeepResolutionMode.ONLY_LEGACY) {
@@ -265,7 +265,7 @@ public class Tasks {
                 }
                 resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);
                 if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE == LegacyDeepResolutionMode.WARN) {
-                    log.warn("Conversion of '" + contextMessage + "' (" + value + ") to " + type + " failed; leaving as deep container type for legacy compatibility, but this feature may be removed in future");
+                    log.warn("Conversion of '" + contextMessage + "' (" + value + ") to " + type + " failed; leaving as map/list type for legacy compatibility, but this feature may be removed in future");
                 }
             }
             return (T) resultO;

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/Tasks.java
@@ -130,11 +130,11 @@ public class Tasks {
     /** creates a {@link ValueResolver} instance which allows significantly more customization than
      * the various {@link #resolveValue(Object, Class, ExecutionContext)} methods here */
     public static <T> ValueResolver<T> resolving(Object v, TypeToken<T> type) {
-        return new ValueResolver<T>(v, type);
+        return new ValueResolver<>(v, type);
     }
     /** @see #resolving(Object, TypeToken) */
     public static <T> ValueResolver<T> resolving(Object v, Class<T> type) {
-        return new ValueResolver<T>(v, TypeToken.of(type));
+        return new ValueResolver<>(v, TypeToken.of(type));
     }
 
     public static ValueResolver.ResolverBuilderPretype resolving(Object v) {
@@ -147,9 +147,9 @@ public class Tasks {
 
     /** @see #resolveValue(Object, TypeToken, ExecutionContext, String) */
     public static <T> T resolveValue(Object v, TypeToken<T> type, @Nullable ExecutionContext exec) throws ExecutionException, InterruptedException {
-        return new ValueResolver<T>(v, type).context(exec).get();
+        return new ValueResolver<>(v, type).context(exec).get();
     }
-    /** @see #resolveValue(Object, TypeToken) */
+    /** @see #resolveValue(Object, TypeToken, ExecutionContext) */
     public static <T> T resolveValue(Object v, Class<T> type, @Nullable ExecutionContext exec) throws ExecutionException, InterruptedException {
         return resolveValue(v, TypeToken.of(type), exec);
     }
@@ -159,7 +159,7 @@ public class Tasks {
      * contextMessage (optional) will be displayed in status reports while it waits (e.g. the name of the config key being looked up).
      * if no execution context supplied (null) this method will throw an exception if the object is an unsubmitted task */
     public static <T> T resolveValue(Object v, TypeToken<T> type, @Nullable ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
-        return new ValueResolver<T>(v, type).context(exec).description(contextMessage).get();
+        return new ValueResolver<>(v, type).context(exec).description(contextMessage).get();
     }
     /** @see #resolveValue(Object, TypeToken, ExecutionContext, String) */
     public static <T> T resolveValue(Object v, Class<T> type, @Nullable ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
@@ -200,7 +200,7 @@ public class Tasks {
     }
 
     public static <T> T resolveValueShallow(Object v, TypeToken<T> type, @Nullable ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
-        return new ValueResolver<T>(v, type).context(exec).description(contextMessage).deep(false, false, false).get();
+        return new ValueResolver<>(v, type).context(exec).description(contextMessage).deep(false, false, false).get();
     }
 
     @VisibleForTesting @Beta
@@ -243,17 +243,16 @@ public class Tasks {
      * their values. This expects a type token parameterized with generics, and those generics
      * will be used to coerce the keys and entries.
      *
-     *
      * For example, the following will return a list containing a map with "1": Boolean.TRUE:
      *
-     *   {@code Object result = resolveDeepValue(ImmutableList.of(ImmutableMap.of(1, "true")),
-     *      new TypeToken<List<Map<String,Boolean>>>() {}, exec)}
+     *   {@code Object result = resolveDeepValueCoerced(ImmutableList.of(ImmutableMap.of(1, "true")),
+     *      new TypeToken<List<Map<String,Boolean>>>() {}, exec, "sample")}
      *
-     * For a simpler mechanism, see {@link #resolveDeepValue(Object, Class, ExecutionContext, String)}.
+     * See also {@link #resolveDeepValueWithoutCoercion(Object, ExecutionContext, String)}
      */
     public static <T> T resolveDeepValueCoerced(Object value, TypeToken<T> type, ExecutionContext exec, String contextMessage) throws ExecutionException, InterruptedException {
         if (ValueResolver.supportsDeepResolution(value)) {
-            Object resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);            // TODO
+            Object resultO = resolveDeepValueWithoutCoercion(value, exec, "Resolving deep "+ contextMessage);
             try {
                 if (ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE!= LegacyDeepResolutionMode.ONLY_LEGACY) {
                     resultO = resolveValueShallow(resultO, type, exec, "Resolving typed " + contextMessage);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
@@ -55,7 +55,7 @@ import com.google.common.reflect.TypeToken;
 /** 
  * Resolves a given object, as follows:
  * <li> If it is a {@link Tasks} or a {@link DeferredSupplier} then get its contents
- * <li> If it's a map/iterable and {@link #deep(boolean, Boolean)} is requested, it applies resolution to contents
+ * <li> If it's a map/iterable depending on {@link #deep(boolean, boolean, Boolean)}, it can apply resolution to contents
  * <li> It applies coercion
  * <p>
  * Fluent-style API exposes a number of other options.
@@ -116,6 +116,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
     Duration timeout;
     boolean immediately;
     boolean recursive = true;
+    boolean allowDeepResolution = true;
     boolean isTransientTask = true;
     
     T defaultValue = null;
@@ -185,7 +186,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
         ValueResolver<S> result = new ValueResolver<S>(newValue, superType)
             .context(exec).description(description)
             .embedResolutionInTask(embedResolutionInTask)
-            .deep(forceDeep, deepTraversalUsesRootType)
+            .deep(allowDeepResolution, forceDeep, deepTraversalUsesRootType)
             .timeout(timeout)
             .immediately(immediately)
             .recursive(recursive);
@@ -249,27 +250,29 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
         this.isTransientTask = isTransientTask;
         return this;
     }
-    
+
     public Maybe<T> getDefault() {
         if (returnDefaultOnGet) return Maybe.of(defaultValue);
         else return Maybe.absent("No default value set");
     }
-    
+
     /** causes nested structures (maps, lists) to be descended and nested unresolved values resolved.
      * for legacy reasons this sets deepTraversalUsesRootType.
-     * @deprecated use {@link #deep(boolean, boolean)} */
-    public ValueResolver<T> deep(boolean forceDeep) {
-        return deep(true, true);
-    }
+     * @deprecated use {@link #deep(boolean, boolean, Boolean)} */
+    @Deprecated public ValueResolver<T> deep(boolean forceDeep) { return deep(true, true, true); }
+    /* @deprecated use {@link #deep(boolean, boolean, Boolean)} */
+    @Deprecated public ValueResolver<T> deep(boolean forceDeep, Boolean deepTraversalUsesRootType) { return deep(true,true,true); }
     /** causes nested structures (maps, lists) to be descended and nested unresolved values resolved.
      * if the second argument is true, the type specified here is used against non-map/iterable items
      * inside maps and iterables encountered. if false, any generic signature on the supplied type
      * is traversed to match contained items. if null (default), it is inferred from the type,
-     * those with generics imply false, and those without imply true. 
-     * 
-     * see {@link Tasks#resolveDeepValue(Object, Class, ExecutionContext, String)} and 
-     * {@link Tasks#resolveDeepValueExactly(Object, TypeToken, ExecutionContext, String)}. */
-    public ValueResolver<T> deep(boolean forceDeep, Boolean deepTraversalUsesRootType) {
+     * those with generics imply false, and those without imply true.
+     *
+     * see {@link #allowDeepResolution}, {@link Tasks#resolveDeepValue(Object, Class, ExecutionContext, String)} and
+     * {@link Tasks#resolveDeepValueCoerced(Object, TypeToken, ExecutionContext, String)}. */
+    // TODO cf allowDeepResolution
+    public ValueResolver<T> deep(boolean allowDeepResolution, boolean forceDeep, Boolean deepTraversalUsesRootType) {
+        this.allowDeepResolution = allowDeepResolution;
         this.forceDeep = forceDeep;
         this.deepTraversalUsesRootType = deepTraversalUsesRootType;
         return this;
@@ -285,7 +288,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
         this.embedResolutionInTask = embedResolutionInTask;
         return this;
     }
-    
+
     /** sets a time limit on executions
      * <p>
      * used for {@link Task} and {@link DeferredSupplier} instances.
@@ -320,8 +323,23 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
         return this;
     }
 
+    /**
+     * Whether the value should be resolved deeply, if it's a map or collection, by looking inside it.
+     * The default here is true (mainly for legacy reasons).
+     * If used, and {@link #deepTraversalUsesRootType} is set (which it often is),
+     * the type supplied is used to convert keys _and_ values of the map or collection,
+     * rather than the overall return type (so set false if trying to convert a map to another type).
+     * There is not currently any support for entry schemas on the map,
+     * not even by supplying a generically typed map (eg Map<String,Integer>).
+     */
+    @Beta
+    public ValueResolver<T> allowDeepResolution(boolean val) {
+        this.allowDeepResolution = val;
+        return this;
+    }
+
     protected void checkTypeNotNull() {
-        if (typeT==null) 
+        if (typeT==null)
             throw new NullPointerException("type must be set to resolve, for '"+value+"'"+(description!=null ? ", "+description : ""));
     }
 
@@ -345,52 +363,52 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
         }
         return result;
     }
-    
+
     protected boolean isEvaluatingImmediately() {
         return immediately || BrooklynTaskTags.hasTag(Tasks.current(), BrooklynTaskTags.IMMEDIATE_TASK_TAG);
     }
-    
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     protected Maybe<T> getMaybeInternal() {
         if (started.getAndSet(true))
             throw new IllegalStateException("ValueResolver can only be used once");
-        
+
         if (expired) return Maybe.absent("Nested resolution of "+getOriginalValue()+" did not complete within "+timeout);
-        
+
         ExecutionContext exec = this.exec;
         if (exec==null) {
             // if execution context not specified, take it from the current task if present
             exec = BasicExecutionContext.getCurrentExecutionContext();
         }
-        
+
         if (!recursive && typeT.getRawType() != Object.class) {
             throw new IllegalStateException("When non-recursive resolver requested the return type must be Object " +
                     "as the immediately resolved value could be a number of (deferred) types.");
         }
-        
+
         CountdownTimer timerU = parentTimer;
         if (timerU==null && timeout!=null)
             timerU = timeout.countdownTimer();
         final CountdownTimer timer = timerU;
         if (timer!=null && !timer.isNotPaused())
             timer.start();
-        
+
         checkTypeNotNull();
         Object v = this.value;
-        
+
         //if the expected type is what we have, we're done (or if it's null);
         //but not allowed to return a future or DeferredSupplier as the resolved value,
         //and not if generics signatures might be different
         if (v==null || (!forceDeep && TypeToken.of(typeT.getRawType()).equals(typeT) && typeT.getRawType().isInstance(v) && !Future.class.isInstance(v) && !DeferredSupplier.class.isInstance(v) && !TaskFactory.class.isInstance(v)))
             return Maybe.of((T) v);
-        
+
         try {
             boolean allowImmediateExecution = false;
             boolean bailOutAfterImmediateExecution = false;
-            
+
             if (v instanceof ImmediateSupplier || v instanceof DeferredSupplier) {
                 allowImmediateExecution = true;
-                
+
             } else {
                 if (v instanceof TaskFactory<?>) {
                     v = ((TaskFactory<?>)v).newTask();
@@ -398,7 +416,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                     bailOutAfterImmediateExecution = true;
                     BrooklynTaskTags.setTransient(((TaskAdaptable<?>)v).asTask());
                 }
-                
+
                 //if it's a task or a future, we wait for the task to complete
                 if (v instanceof TaskAdaptable<?>) {
                     v = ((TaskAdaptable<?>) v).asTask();
@@ -407,22 +425,22 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
 
             if (allowImmediateExecution && isEvaluatingImmediately()) {
                 // Feb 2017 - many things now we try to run immediate; notable exceptions are:
-                // * where the target isn't safe to run again (such as a Task which someone else might need), 
+                // * where the target isn't safe to run again (such as a Task which someone else might need),
                 // * or where he can't be run in an "interrupting" mode even if non-blocking (eg Future.get(), some other tasks)
                 // (the latter could be tried here, with bailOut false, but in most cases it will just throw so we still need to
                 // have the timings as in SHORT_WAIT etc as a fallack)
-                
+
                 // TODO svet suggested at https://github.com/apache/brooklyn-server/pull/565#pullrequestreview-27124074
                 // that we might flip the immediately bit if interrupted -- or maybe instead (alex's idea)
                 // enter this block
                 // if (allowImmediateExecution && (isEvaluatingImmediately() || Thread.isInterrupted())
-                // -- feels right, and would help with some recursive immediate values but no compelling 
+                // -- feels right, and would help with some recursive immediate values but no compelling
                 // use case yet and needs some deep thought which we're deferring for now
-                
+
                 Maybe<T> result = null;
                 try {
                     result = exec.getImmediately(v);
-                    
+
                     return (result.isPresent())
                         ? recursive
                             ? new ValueResolver<T>(result.get(), typeT, this).getMaybe()
@@ -441,7 +459,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                     return ImmediateSupplier.ImmediateValueNotAvailableException.newAbsentWithExceptionSupplier();
                 }
             }
-            
+
             if (v instanceof Task) {
                 //if it's a task, we make sure it is submitted
                 Task<?> task = (Task<?>) v;
@@ -472,7 +490,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                     if (isEvaluatingImmediately()) {
                         return ImmediateSupplier.ImmediateValueNotAvailableException.newAbsentWithExceptionSupplier();
                     }
-                    
+
                     Callable<Maybe> callable = new Callable<Maybe>() {
                         @Override
                         public Maybe call() throws Exception {
@@ -486,7 +504,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
 
                 } else {
                     v = vfuture.get();
-                    
+
                 }
 
             } else if (v instanceof DeferredSupplier<?>) {
@@ -495,7 +513,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                 if ((!Boolean.FALSE.equals(embedResolutionInTask) && (exec!=null || timeout!=null)) || Boolean.TRUE.equals(embedResolutionInTask)) {
                     if (exec==null)
                         return Maybe.absent("Embedding in task needed for '"+getDescription()+"' but no execution context available");
-                        
+
                     Callable<Object> callable = new Callable<Object>() {
                         @Override
                         public Object call() throws Exception {
@@ -512,14 +530,14 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                             .displayName("Resolving dependent value of deferred supplier")
                             .description(description);
                     if (isTransientTask) tb.tag(BrooklynTaskTags.TRANSIENT_TASK_TAG);
-                    
+
                     // immediate resolution is handled above
                     Task<Object> vt = exec.submit(tb.build());
                     Maybe<Object> vm = Durations.get(vt, timer);
                     vt.cancel(true);
                     if (vm.isAbsent()) return (Maybe<T>)vm;
                     v = vm.get();
-                    
+
                 } else {
                     try {
                         Tasks.setBlockingDetails("Retrieving (non-task) "+ds);
@@ -530,13 +548,13 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                 }
 
             } else {
-                if (supportsDeepResolution(v)) {
+                if (allowDeepResolution && supportsDeepResolution(v)) {
 
                     // allows user to resolveValue(map, String) with the effect
                     // that things _in_ the collection would be resolved as string.
                     // alternatively use generics.
                     boolean useRootObect = typeT.getRawType()==Object.class || Boolean.TRUE.equals(deepTraversalUsesRootType);
-                    
+
                     TypeToken<?>[] innerTypes = new TypeToken<?>[0];
                     if (!useRootObect) {
                         if (!TypeToken.of(typeT.getRawType()).equals(typeT)) {
@@ -551,10 +569,10 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                             }
                         }
                     }
-                        
+
                     // restrict deep resolution to the same set of types as calling code;
                     // in particular need to avoid for "interesting iterables" such as PortRange
-                    
+
                     if (v instanceof Map) {
                         TypeToken<?> keyT = typeT;
                         TypeToken<?> valT = typeT;
@@ -583,7 +601,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                             result.put(kk.get(), vv.get());
                         }
                         return Maybe.of((T) result);
-        
+
                     } else if (v instanceof Iterable) {
                         TypeToken<?> entryT = typeT;
                         if (!useRootObect) {
@@ -596,7 +614,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                                     + "Should correctly request conversion to generic TypeToken<Map<...>>.");
                             }
                         }
-                        
+
                         Collection<Object> result = v instanceof Set ? MutableSet.of() : Lists.newArrayList();
                         int count = 0;
                         for (Object it : (Iterable)v) {
@@ -610,13 +628,13 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                         return Maybe.of((T) result);
                     }
                 }
-                
+
                 return TypeCoercions.tryCoerce(v, typeT);
             }
 
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
-            
+
             String msg = "Error resolving "+(description!=null ? description+", " : "")+v+", in "+exec;
             String eTxt = Exceptions.collapseText(e);
             IllegalArgumentException problem = eTxt.startsWith(msg) ? new IllegalArgumentException(e) : new IllegalArgumentException(msg+": "+eTxt, e);
@@ -629,7 +647,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                 log.debug("Resolution of "+this+" failed, throwing: "+e);
             throw problem;
         }
-        
+
         if (recursive) {
             return new ValueResolver(v, typeT, this).getMaybe();
         } else {
@@ -642,7 +660,7 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
     public static boolean supportsDeepResolution(Object v) {
         return (v instanceof Map || v instanceof Collection);
     }
-    
+
     protected String getDescription() {
         return description!=null ? description : ""+value;
     }

--- a/core/src/main/resources/META-INF/services/org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer
+++ b/core/src/main/resources/META-INF/services/org.apache.brooklyn.core.typereg.BrooklynTypePlanTransformer
@@ -17,3 +17,4 @@
 # under the License.
 #
 org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer
+org.apache.brooklyn.core.resolve.jackson.BeanWithTypePlanTransformer

--- a/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyDeprecationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/ConfigKeyDeprecationTest.java
@@ -18,10 +18,11 @@
  */
 package org.apache.brooklyn.core.config;
 
+import org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithFieldsFromConfigKeys;
 import static org.testng.Assert.assertEquals;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.ImplementedBy;
@@ -297,19 +298,21 @@ public class ConfigKeyDeprecationTest extends BrooklynAppUnitTestSupport {
                 .build();
     }
     
-    public static class MyEntityInitializer implements EntityInitializer {
+    public static class MyEntityInitializer extends InitializerPatternWithFieldsFromConfigKeys {
         public static final ConfigKey<String> KEY_1 = ConfigKeys.builder(String.class, "key1")
                 .deprecatedNames("oldKey1", "oldKey1b")
                 .build();
         
         private String key1;
-
-        public MyEntityInitializer(ConfigBag params) {
-            this.key1 = params.get(KEY_1);
+        {
+            addInitConfigMapping(KEY_1, v -> key1 = v);
         }
+
+        public MyEntityInitializer(ConfigBag params) { super(params); }
 
         @Override
         public void apply(EntityLocal entity) {
+            initParamsFailIfAnyUnused();
             entity.config().set(KEY_1, key1);
         }
     }

--- a/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
@@ -41,9 +41,12 @@ import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.Tasks.ForTestingAndLegacyCompatibilityOnly.LegacyDeepResolutionMode;
 import org.apache.brooklyn.util.core.task.ValueResolver;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.testng.Assert;
@@ -254,7 +257,8 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     public void testSetConfigKeyAddItemMod() throws Exception {
         entity.config().set(TestEntity.CONF_SET_THING.subKey(), "aval");
         entity.config().set((ConfigKey)TestEntity.CONF_SET_THING, SetModifications.addItem(ImmutableList.of("bval", "cval")));
-        assertEquals(entity.getConfig(TestEntity.CONF_SET_THING), ImmutableSet.of("aval",ImmutableList.of("bval","cval")));
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ONLY_LEGACY,
+                () -> Asserts.assertSameUnorderedContents(entity.getConfig(TestEntity.CONF_SET_THING), ImmutableSet.of("aval",ImmutableList.of("bval","cval"))));
     }
     @Test
     public void testSetConfigKeyListMod() throws Exception {
@@ -303,8 +307,7 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     public void testListConfigKeyAddMod() throws Exception {
         entity.config().set(TestEntity.CONF_LIST_THING.subKey(), "aval");
         entity.config().set(TestEntity.CONF_LIST_THING, ListModifications.add("bval", "cval"));
-        //assertEquals(entity.getConfig(TestEntity.CONF_LIST_THING), ["aval","bval","cval"])
-        assertEquals(ImmutableSet.copyOf(entity.getConfig(TestEntity.CONF_LIST_THING)), ImmutableSet.of("aval","bval","cval"));
+        Asserts.assertSameUnorderedContents(entity.getConfig(TestEntity.CONF_LIST_THING), ImmutableSet.of("aval","bval","cval"));
     }
 
     @Test // ListConfigKey deprecated, as order no longer guaranteed
@@ -312,22 +315,21 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
         entity.config().set(TestEntity.CONF_LIST_THING.subKey(), "aval");
         entity.config().set(TestEntity.CONF_LIST_THING, ListModifications.addAll(ImmutableList.of("bval", "cval")));
         //assertEquals(entity.getConfig(TestEntity.CONF_LIST_THING), ["aval","bval","cval"])
-        assertEquals(ImmutableSet.copyOf(entity.getConfig(TestEntity.CONF_LIST_THING)), ImmutableSet.of("aval","bval","cval"));
+        Asserts.assertSameUnorderedContents(entity.getConfig(TestEntity.CONF_LIST_THING), ImmutableSet.of("aval","bval","cval"));
     }
     
     @Test // ListConfigKey deprecated, as order no longer guaranteed
     public void testListConfigKeyAddItemMod() throws Exception {
         entity.config().set(TestEntity.CONF_LIST_THING.subKey(), "aval");
         entity.config().set((ConfigKey)TestEntity.CONF_LIST_THING, ListModifications.addItem(ImmutableList.of("bval", "cval")));
-        //assertEquals(entity.getConfig(TestEntity.CONF_LIST_THING), ["aval",["bval","cval"]])
-        assertEquals(ImmutableSet.copyOf(entity.getConfig(TestEntity.CONF_LIST_THING)), ImmutableSet.of("aval",ImmutableList.of("bval","cval")));
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ONLY_LEGACY,
+                () -> Asserts.assertSameUnorderedContents(entity.getConfig(TestEntity.CONF_LIST_THING), ImmutableSet.of("aval",ImmutableList.of("bval","cval"))));
     }
     
     @Test // ListConfigKey deprecated, as order no longer guaranteed
     public void testListConfigKeyListMod() throws Exception {
         entity.config().set(TestEntity.CONF_LIST_THING.subKey(), "aval");
         entity.config().set(TestEntity.CONF_LIST_THING, ListModifications.set(ImmutableList.of("bval", "cval")));
-        //assertEquals(entity.getConfig(TestEntity.CONF_LIST_THING), ["bval","cval"])
         assertEquals(ImmutableSet.copyOf(entity.getConfig(TestEntity.CONF_LIST_THING)), ImmutableSet.of("bval","cval"));
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
@@ -401,7 +401,7 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     public void testInterestingIterableConfig() throws Exception {
         PortRange r12 = PortRanges.fromString("1-2");
         // previously VR would act on iterables such as PRs inside maps and lists, but not on those at top level, so this test failed
-        Assert.assertFalse(ValueResolver.supportsDeepResolution(r12));
+        Assert.assertFalse(ValueResolver.supportsDeepResolution(r12, null));
         
         entity.config().set(TestEntity.CONF_OBJECT, r12);
         entity.config().set(TestEntity.CONF_MAP_OBJ_THING.subKey("r"), r12);

--- a/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/MapListAndOtherStructuredConfigKeyTest.java
@@ -175,14 +175,8 @@ public class MapListAndOtherStructuredConfigKeyTest extends BrooklynAppUnitTestS
     public void testConfigKeyStringWontStoreAndRetrieveMaps() throws Exception {
         Map<String, String> v1 = ImmutableMap.of("a", "1", "b", "bb");
         //it only allows strings
-        try {
-            entity.config().set((ConfigKey)TestEntity.CONF_MAP_THING.subKey("akey"), v1);
-            fail();
-        } catch (Exception e) {
-            ClassCastException cce = Exceptions.getFirstThrowableOfType(e, ClassCastException.class);
-            if (cce == null) throw e;
-            if (!cce.getMessage().contains("Cannot coerce type")) throw e;
-        }
+        Asserts.assertFailsWith(() -> entity.config().set((ConfigKey)TestEntity.CONF_MAP_THING.subKey("akey"), v1),
+            e -> Asserts.expectedFailureContainsIgnoreCase(e, "cannot coerce", "map to ", "String", "test.confMapThing", "akey"));
     }
     
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/effector/CompositeEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/CompositeEffectorTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.List;
 
 import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.effector.http.HttpCommandEffector;
@@ -229,10 +230,10 @@ public class CompositeEffectorTest extends BrooklynAppUnitTestSupport {
 
    @Test(expectedExceptions = NullPointerException.class)
    public void testMissingEffectors() {
-      compositeEffector = new CompositeEffector(ConfigBag.newInstance()
+      new CompositeEffector(ConfigBag.newInstance()
               .configure(CompositeEffector.EFFECTOR_NAME, EFFECTOR_COMPOSITE.getName())
               .configure(CompositeEffector.EFFECTORS, null)
-      );
+      ).newEffectorBuilder();
    }
 
    @Test(expectedExceptions = PropagatedRuntimeException.class)
@@ -254,9 +255,9 @@ public class CompositeEffectorTest extends BrooklynAppUnitTestSupport {
       Asserts.assertEquals(results.size(), 2);
    }
 
-   private EntitySpec<TestEntity> buildEntitySpec(AddEffector... effectors) {
+   private EntitySpec<TestEntity> buildEntitySpec(EntityInitializer... effectors) {
       EntitySpec<TestEntity> testEntitySpec = EntitySpec.create(TestEntity.class);
-      for (AddEffector effector : effectors) {
+      for (EntityInitializer effector : effectors) {
          testEntitySpec.addInitializer(effector);
       }
       return testEntitySpec;

--- a/core/src/test/java/org/apache/brooklyn/core/effector/ProxyEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/ProxyEffectorTest.java
@@ -76,7 +76,8 @@ public class ProxyEffectorTest extends BrooklynAppUnitTestSupport {
         new ProxyEffector(MutableMap.of(
                 AddEffector.EFFECTOR_NAME, "proxy-effector",
                 ProxyEffector.TARGET_ENTITY, null,
-                ProxyEffector.TARGET_EFFECTOR_NAME, "kajnfksjdnfkjsdnf"));
+                ProxyEffector.TARGET_EFFECTOR_NAME, "kajnfksjdnfkjsdnf"))
+        .newEffectorBuilder();
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -84,7 +85,8 @@ public class ProxyEffectorTest extends BrooklynAppUnitTestSupport {
         new ProxyEffector(MutableMap.of(
                 AddEffector.EFFECTOR_NAME, "proxy-effector",
                 ProxyEffector.TARGET_ENTITY, app,
-                ProxyEffector.TARGET_EFFECTOR_NAME, null));
+                ProxyEffector.TARGET_EFFECTOR_NAME, null))
+        .newEffectorBuilder();
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/effector/SampleManyTasksEffector.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/SampleManyTasksEffector.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.api.mgmt.TaskAdaptable;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.EffectorTasks.EffectorTaskFactory;
+import org.apache.brooklyn.core.effector.Effectors.EffectorBuilder;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
@@ -58,16 +59,21 @@ services:
 </pre>
 
  */
-public class SampleManyTasksEffector extends AddEffector {
+public class SampleManyTasksEffector extends AddEffectorInitializerAbstract {
 
     public static final ConfigKey<Integer> RANDOM_SEED = ConfigKeys.newIntegerConfigKey("random.seed");
 
-    public SampleManyTasksEffector(ConfigBag params) {
-        super(Effectors.effector(String.class, params.get(EFFECTOR_NAME)).name("eatand").impl(body(params)).build());
+    private SampleManyTasksEffector() {}
+    public SampleManyTasksEffector(ConfigBag params) { super(params); }
+
+    @Override
+    protected EffectorBuilder<String> newEffectorBuilder() {
+        return Effectors.effector(String.class, initParam(EFFECTOR_NAME)).name("eatand").impl(body(initParams()));
     }
 
+    @Deprecated
     public Effector<?> getEffector() {
-        return effector;
+        return super.effector();
     }
     
     private static EffectorTaskFactory<String> body(ConfigBag params) {

--- a/core/src/test/java/org/apache/brooklyn/core/effector/http/HttpCommandEffectorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/effector/http/HttpCommandEffectorTest.java
@@ -109,18 +109,18 @@ public class HttpCommandEffectorTest extends BrooklynAppUnitTestSupport {
 
    @Test(expectedExceptions = NullPointerException.class)
    public void testMissingURI() {
-      httpCommandEffector = new HttpCommandEffector(ConfigBag.newInstance()
+      new HttpCommandEffector(ConfigBag.newInstance()
               .configure(HttpCommandEffector.EFFECTOR_NAME, EFFECTOR_HTTP_COMMAND.getName())
               .configure(HttpCommandEffector.EFFECTOR_HTTP_VERB, "GET")
-      );
+      ).newEffectorBuilder();
    }
 
    @Test(expectedExceptions = NullPointerException.class)
    public void testMissingVerb() {
-      httpCommandEffector = new HttpCommandEffector(ConfigBag.newInstance()
+      new HttpCommandEffector(ConfigBag.newInstance()
               .configure(HttpCommandEffector.EFFECTOR_NAME, EFFECTOR_HTTP_COMMAND.getName())
               .configure(HttpCommandEffector.EFFECTOR_URI, url(""))
-      );
+      ).newEffectorBuilder();
    }
 
    @Test(expectedExceptions = ExecutionException.class)

--- a/core/src/test/java/org/apache/brooklyn/core/entity/DynamicEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/DynamicEntityTest.java
@@ -37,24 +37,14 @@ public class DynamicEntityTest extends BrooklynAppUnitTestSupport {
     @Test
     public void testEffectorAddedDuringInit() {
         BasicEntity entity = app.createAndManageChild(EntitySpec.create(BasicEntity.class)
-                .addInitializer(new EntityInitializer() {
-                    @Override
-                    public void apply(EntityLocal entity) {
-                        ((EntityInternal) entity).getMutableEntityType().addEffector(EffectorTaskTest.DOUBLE_1);
-                    }
-                }));
+                .addInitializer(ent -> ((EntityInternal) ent).getMutableEntityType().addEffector(EffectorTaskTest.DOUBLE_1)));
         assertEquals(entity.invoke(EffectorTaskTest.DOUBLE_BODYLESS, MutableMap.of("numberToDouble", 5)).getUnchecked(), (Integer) 10);
     }
 
     @Test
     public void testEffectorRemovedDuringInit() {
         TestEntity entity = app.createAndManageChild(EntitySpec.create(TestEntity.class)
-                .addInitializer(new EntityInitializer() {
-                    @Override
-                    public void apply(EntityLocal entity) {
-                        ((EntityInternal) entity).getMutableEntityType().removeEffector(TestEntity.IDENTITY_EFFECTOR);
-                    }
-                }));
+                .addInitializer(ent -> ((EntityInternal) ent).getMutableEntityType().removeEffector(TestEntity.IDENTITY_EFFECTOR)));
         assertFalse(entity.getMutableEntityType().getEffectors().containsKey(TestEntity.IDENTITY_EFFECTOR.getName()));
     }
     

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -256,9 +256,8 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
                 Asserts.assertFailsWith(
                         () -> entity.config().get(TestEntity.CONF_MAP_THING),
                         e -> Asserts.expectedFailureContainsIgnoreCase(e,
+                                // exception used to come on coercion of map result, but now BasicConfigKey.resolve also does some coercion
                                 "confMapThing",
-                                "generic type mismatch",
-                                "Map<java.lang.String, java.lang.String>",
                                 "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
                                 "{sub2=4}")));
     }
@@ -279,10 +278,9 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
                         () -> entity.config().get(TestEntity.CONF_MAP_THING),
                         e -> Asserts.expectedFailureContainsIgnoreCase(e,
                                 "confMapThing",
-                                "generic type mismatch",
-                                "Map<java.lang.String, java.lang.String>",
                                 "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
-                                "{sub2=4}")));
+                                "{sub2=4}")
+                ));
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -258,8 +258,9 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
                         e -> Asserts.expectedFailureContainsIgnoreCase(e,
                                 // exception used to come on coercion of map result, but now BasicConfigKey.resolve also does some coercion
                                 "confMapThing",
-                                "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
-                                "{sub2=4}")));
+                                "Cannot coerce", "map to java.lang.String",
+                                "{sub2=4}")
+                ));
     }
 
     @Test
@@ -278,7 +279,7 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
                         () -> entity.config().get(TestEntity.CONF_MAP_THING),
                         e -> Asserts.expectedFailureContainsIgnoreCase(e,
                                 "confMapThing",
-                                "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
+                                "Cannot coerce", "map to java.lang.String",
                                 "{sub2=4}")
                 ));
     }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -40,8 +40,13 @@ import org.apache.brooklyn.api.mgmt.ExecutionManager;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeyDeprecationTest.MyBaseEntity;
+import org.apache.brooklyn.core.config.ConfigKeyDeprecationTest.MyBaseEntityImpl;
+import org.apache.brooklyn.core.config.ConfigKeyDeprecationTest.MySubEntity;
+import org.apache.brooklyn.core.config.ConfigKeyDeprecationTest.MySubEntityImpl;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.config.ConfigPredicates;
+import org.apache.brooklyn.core.config.MapConfigKey;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.IntegerAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestEntity;
@@ -55,6 +60,7 @@ import org.apache.brooklyn.util.core.task.ImmediateSupplier;
 import org.apache.brooklyn.util.core.task.InterruptingImmediateSupplier;
 import org.apache.brooklyn.util.core.task.TaskBuilder;
 import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.Tasks.ForTestingAndLegacyCompatibilityOnly.LegacyDeepResolutionMode;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
@@ -80,6 +86,7 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
 
     private ExecutorService executor;
     private ExecutionManager executionManager;
+    private LegacyDeepResolutionMode legacyDeepResolutionModeOriginal;
 
     @BeforeMethod(alwaysRun=true)
     @Override
@@ -87,11 +94,15 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
         super.setUp();
         executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
         executionManager = mgmt.getExecutionManager();
+
+        legacyDeepResolutionModeOriginal = Tasks.ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE;
+        Tasks.ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE = LegacyDeepResolutionMode.DISALLOW_LEGACY;
     }
 
     @AfterMethod(alwaysRun=true)
     @Override
     public void tearDown() throws Exception {
+        Tasks.ForTestingAndLegacyCompatibilityOnly.LEGACY_DEEP_RESOLUTION_MODE = legacyDeepResolutionModeOriginal;
         if (executor != null) executor.shutdownNow();
         super.tearDown();
     }
@@ -225,31 +236,95 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
     }
     
     @Test
-    public void testGetConfigMapWithCoercedStringToMap() throws Exception {
+    public void testGetConfigMapStringCoercionFromString() throws Exception {
         TestEntity entity = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
                 .configure(TestEntity.CONF_MAP_THING.getName(), "{mysub: myval}"));
         assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", "myval"));
-        
-        TestEntity entity2 = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
-                .configure(TestEntity.CONF_MAP_THING.getName(), "{mysub: {sub2: myval}}"));
-        assertEquals(entity2.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", ImmutableMap.of("sub2", "myval")));
     }
-    
+
     @Test
-    public void testGetConfigMapWithSubValueAsStringNotCoerced() throws Exception {
+    public void testGetConfigMapStringCoercionFromStringSubtypeIgnoredForTypedConfigSet() throws Exception {
+        TestEntity entity = Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY,
+                () -> (TestEntity) mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
+                        .configure( (MapConfigKey) TestEntity.CONF_MAP_THING, "{mysub: {sub2: 4}}")));
+
+        assertTrue(entity.config().getLocalRaw(TestEntity.CONF_MAP_THING).isAbsent());
+        assertEquals(entity.config().getLocalRaw(TestEntity.CONF_MAP_THING.subKey("mysub")).get(), ImmutableMap.of("sub2", 4));        // legacy code
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY, () ->
+                assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", ImmutableMap.of("sub2", 4))));
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.DISALLOW_LEGACY, ()->
+                Asserts.assertFailsWith(
+                        () -> entity.config().get(TestEntity.CONF_MAP_THING),
+                        e -> Asserts.expectedFailureContainsIgnoreCase(e,
+                                "confMapThing",
+                                "generic type mismatch",
+                                "Map<java.lang.String, java.lang.String>",
+                                "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
+                                "{sub2=4}")));
+    }
+
+    @Test
+    public void testGetConfigMapStringCoercionFromStringSubtypeIgnoredForAnonymousConfigSet() throws Exception {
+        // behaviour no different to above
+        TestEntity entity = Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY,
+                () -> (TestEntity) mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
+                        .configure( TestEntity.CONF_MAP_THING.getName(), "{mysub: {sub2: 4}}")));
+
+        assertTrue(entity.config().getLocalRaw(TestEntity.CONF_MAP_THING).isAbsent());
+        assertEquals(entity.config().getLocalRaw(TestEntity.CONF_MAP_THING.subKey("mysub")).get(), ImmutableMap.of("sub2", 4));        // legacy code
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY, () ->
+                assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", ImmutableMap.of("sub2", 4))));
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.DISALLOW_LEGACY, ()->
+                Asserts.assertFailsWith(
+                        () -> entity.config().get(TestEntity.CONF_MAP_THING),
+                        e -> Asserts.expectedFailureContainsIgnoreCase(e,
+                                "confMapThing",
+                                "generic type mismatch",
+                                "Map<java.lang.String, java.lang.String>",
+                                "Cannot coerce type java.util.LinkedHashMap to java.lang.String",
+                                "{sub2=4}")));
+    }
+
+    @Test
+    public void testGetConfigMapStringNoCoercionIfSubtypeMatches() throws Exception {
+        String v = "{a: b}";
         TestEntity entity = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
-                .configure(TestEntity.CONF_MAP_THING, ImmutableMap.of("mysub", "{a: b}")));
-        assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", "{a: b}"));
+                .configure(TestEntity.CONF_MAP_THING, ImmutableMap.of("mysub", v)));
+
+        assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", v));
         
         TestEntity entity2 = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
-                .configure(TestEntity.CONF_MAP_THING.subKey("mysub"), "{a: b}"));
-        assertEquals(entity2.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", "{a: b}"));
+                .configure(TestEntity.CONF_MAP_THING.subKey("mysub"), v));
+        assertEquals(entity2.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", v));
         
         TestEntity entity3 = mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
-                .configure(TestEntity.CONF_MAP_THING.getName(), ImmutableMap.of("mysub", "{a: b}")));
-        assertEquals(entity3.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", "{a: b}"));
+                .configure(TestEntity.CONF_MAP_THING.getName(), ImmutableMap.of("mysub", v)));
+        assertEquals(entity3.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", v));
     }
-    
+
+    @Test
+    public void testGetConfigMapStringNoCoercionIfSubtypeDoesntMatchExceptWhenSettingSubtypeInLegacyDeepResolutionMode() throws Exception {
+        ImmutableMap<String, String> v = ImmutableMap.of("a", "b");
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY, () -> {
+                    TestEntity entity = (TestEntity) mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
+                            .configure((MapConfigKey) TestEntity.CONF_MAP_THING, ImmutableMap.of("mysub", v)));
+
+                    assertEquals(entity.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", v));
+                });
+
+        // this fails even in legacy mode
+        Asserts.assertFailsWith(() -> Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY,
+                    () -> mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
+                            .configure((ConfigKey) TestEntity.CONF_MAP_THING.subKey("mysub"), v))),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "cannot coerce", "confMapThing.mysub", "String"));
+
+        Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY, () -> {
+            TestEntity entity3 = (TestEntity) mgmt.getEntityManager().createEntity(EntitySpec.create(TestEntity.class)
+                .configure(TestEntity.CONF_MAP_THING.getName(), ImmutableMap.of("mysub", v)));
+            assertEquals(entity3.config().get(TestEntity.CONF_MAP_THING), ImmutableMap.of("mysub", v));
+        });
+    }
+
     // TODO This now fails because the task has been cancelled, in entity.config().get().
     // But it used to pass (e.g. with commit 56fcc1632ea4f5ac7f4136a7e04fabf501337540).
     // It failed after the rename of CONF_MAP_THING_OBJ to CONF_MAP_OBJ_THING, which 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerExceptionHandlerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerExceptionHandlerTest.java
@@ -23,6 +23,9 @@ import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.Tasks.ForTestingAndLegacyCompatibilityOnly.LegacyDeepResolutionMode;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -32,10 +35,15 @@ public class RebindManagerExceptionHandlerTest extends RebindTestFixtureWithApp 
     @Override
     protected TestApplication createApp() {
         TestApplication app = super.createApp();
-        app.createAndManageChild(EntitySpec.create(TestEntity.class)
-                .configure(TestEntity.CONF_MAP_THING.getName(), 
-                     // misconfigured map value, should be a string key, but forced (by using a flag) so failure won't be enforced until persist/rebind
-                    ImmutableMap.of("keyWithMapValue", ImmutableMap.of("minRam", 4))));
+        try {
+            Tasks.ForTestingAndLegacyCompatibilityOnly.withLegacyDeepResolutionMode(LegacyDeepResolutionMode.ALLOW_LEGACY, () ->
+                    app.createAndManageChild(EntitySpec.create(TestEntity.class)
+                            .configure(TestEntity.CONF_MAP_THING.getName(),
+                                    // misconfigured map value, should be a string key, but forced (by using a flag) so failure won't be enforced until persist/rebind
+                                    ImmutableMap.of("keyWithMapValue", ImmutableMap.of("minRam", 4)))));
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
         return app;
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynMiscJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynMiscJacksonSerializationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Supplier;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.ConfigurableBeanDeserializerModifier;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.NestedLoggingDeserializer;
+import org.apache.brooklyn.core.resolve.jackson.WrappedValue.WrappedValuesInitialized;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BrooklynMiscJacksonSerializationTest implements MapperTestFixture {
+
+    public ObjectMapper mapper() {
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, true);
+
+        return mapper;
+    }
+
+    // baseline
+
+    static class EmptyObject {}
+
+    @Test
+    public void testMapperDoesntBreakBasicThings() throws Exception {
+        Asserts.assertEquals(deser("\"hello\""), "hello");
+        Asserts.assertInstanceOf(deser("{\"type\":\""+EmptyObject.class.getName()+"\"}"), EmptyObject.class);
+    }
+
+    @Test
+    public void testMapperAllowsBrooklynTypeCoercionsOfStrings() throws Exception {
+        Asserts.assertEquals(deser("\"1m\"", Duration.class), Duration.minutes(1));
+    }
+
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
+import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
+import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer;
+import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BrooklynRegisteredTypeJacksonSerializationTest extends BrooklynMgmtUnitTestSupport implements MapperTestFixture {
+
+    // public because of use of JavaClassNameTypePlanTransformer
+    public static class SampleBean {
+        String x;
+        String y;
+        String z;
+        SampleBean bean;
+    }
+
+    public ObjectMapper mapper() {
+        return BeanWithTypeUtils.newMapper(mgmt());
+    }
+
+    @Test
+    public void testSerializeSampleBean() throws Exception {
+        SampleBean a = new SampleBean();
+        a.x = "hello";
+        Assert.assertEquals(ser(a), "{\"type\":\""+SampleBean.class.getName()+"\",\"x\":\"hello\"}");
+    }
+
+    @Test
+    public void testDeserializeSampleBean() throws Exception {
+        Object impl = deser("{\"type\":\""+SampleBean.class.getName()+"\",\"x\":\"hello\"}");
+        Asserts.assertInstanceOf(impl, SampleBean.class);
+        Asserts.assertEquals(((SampleBean)impl).x, "hello");
+    }
+
+    @Test
+    public void testDeserializeAlias() throws Exception {
+        RegisteredType rt = RegisteredTypes.bean("sample", "1",
+                new BasicTypeImplementationPlan(JavaClassNameTypePlanTransformer.FORMAT, SampleBean.class.getName()));
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(rt, false);
+
+        Object impl = deser("{\"type\":\"sample\",\"x\":\"hello\"}");
+        Asserts.assertInstanceOf(impl, SampleBean.class);
+        Asserts.assertEquals(((SampleBean)impl).x, "hello");
+    }
+
+    @Test
+    public void testSimpleBeanRegisteredType() throws Exception {
+        RegisteredType rt = RegisteredTypes.bean("sample-hello", "1",
+                new BasicTypeImplementationPlan(BeanWithTypeUtils.FORMAT,
+                        "type: " + SampleBean.class.getName() + "\n" +
+                        "x: hello\n" +
+                        "y: hi"
+        ));
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(rt, false);
+        Object impl = mgmt().getTypeRegistry().create(rt, null, null);
+        Asserts.assertInstanceOf(impl, SampleBean.class);
+        Asserts.assertEquals(((SampleBean)impl).x, "hello");
+        Asserts.assertEquals(((SampleBean)impl).y, "hi");
+
+        impl = mgmt().getTypeRegistry().createBeanFromPlan(BeanWithTypePlanTransformer.FORMAT,
+                    "type: sample-hello\n"+
+                    "y: yo\n"+
+                    "z: zzz", null, null);
+        Asserts.assertInstanceOf(impl, SampleBean.class);
+        Asserts.assertEquals(((SampleBean)impl).x, "hello");
+        Asserts.assertEquals(((SampleBean)impl).y, "yo");
+        Asserts.assertEquals(((SampleBean)impl).z, "zzz");
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
@@ -33,14 +33,14 @@ public class BrooklynRegisteredTypeJacksonSerializationTest extends BrooklynMgmt
 
     // public because of use of JavaClassNameTypePlanTransformer
     public static class SampleBean {
-        String x;
+        public String x;
         String y;
         String z;
         SampleBean bean;
     }
 
     public ObjectMapper mapper() {
-        return BeanWithTypeUtils.newMapper(mgmt());
+        return BeanWithTypeUtils.newMapper(mgmt(), true, true);
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/LoggingSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/LoggingSerializationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.ConfigurableBeanDeserializerModifier;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.NestedLoggingDeserializer;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+public class LoggingSerializationTest implements MapperTestFixture {
+
+    public ObjectMapper mapper() {
+        ObjectMapper mapper = BeanWithTypeUtils.newSimpleMapper();
+        StringBuilder d1 = new StringBuilder("D1");
+        StringBuilder d2 = new StringBuilder("D2");
+        mapper = new ConfigurableBeanDeserializerModifier()
+                .addDeserializerWrapper(
+                        d -> new NestedLoggingDeserializer(d1, d),
+                        d -> new JsonDeserializerForCommonBrooklynThings(d),
+                        d -> new NestedLoggingDeserializer(d2, d)
+                ).apply(mapper);
+        return mapper;
+    }
+
+    static class WrappedDuration {
+        @JsonProperty
+        Duration x;
+    }
+
+    @Test
+    public void testSeeErrorLoggedAndCorrected() throws Exception {
+        // main point of this test is to inspect it in the console, and experiment with other configurations
+        Asserts.assertEquals(deser("{\"x\":\"1m\"}", WrappedDuration.class).x, Duration.minutes(1));
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/MapperTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/MapperTestFixture.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.yaml.Yamls;
+
+public interface MapperTestFixture {
+
+    ObjectMapper mapper();
+
+    default String ser(Object v) {
+        return ser(v, Object.class);
+    }
+
+    default <T> String ser(T v, Class<T> type) {
+        try {
+            return mapper().writerFor(type).writeValueAsString(v);
+        } catch (JsonProcessingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    default <T> T deser(String v, Class<T> type) {
+        try {
+            return mapper().readValue(v, type);
+        } catch (JsonProcessingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    default <T> T deser(String v) {
+        return (T) deser(v, Object.class);
+    }
+
+    default String json(String yaml) {
+        try {
+            return BeanWithTypeUtils.newSimpleMapper().writeValueAsString( Iterables.getOnlyElement(Yamls.parseAll(yaml)) );
+        } catch (JsonProcessingException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/PerverseSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/PerverseSerializationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PerverseSerializationTest implements MapperTestFixture {
+
+    private static class BeanWithFieldCalledType {
+        String type;
+    }
+
+    @Test
+    public void testFieldCalledTypeMakesInvalidJson() throws Exception {
+        BeanWithFieldCalledType a = new BeanWithFieldCalledType();
+        a.type = "not my type";
+        Assert.assertEquals(ser(a),
+                "{\"type\":\""+ BeanWithFieldCalledType.class.getName()+"\",\"type\":\"not my type\"}");
+    }
+
+    private final static class BeanWithFieldCalledTypeHolder {
+        BeanWithFieldCalledType bean;
+    }
+
+    public ObjectMapper mapper() {
+        return BeanWithTypeUtils.newMapper(null);
+    }
+
+    @Test
+    public void testFieldCalledTypeOkayIfTypeConcrete() throws Exception {
+        BeanWithFieldCalledType a = new BeanWithFieldCalledType();
+        a.type = "not my type";
+        BeanWithFieldCalledTypeHolder b = new BeanWithFieldCalledTypeHolder();
+        b.bean = a;
+        String expected = "{\"type\":\"" + BeanWithFieldCalledTypeHolder.class.getName() + "\"," +
+                "\"bean\":{\"type\":\"not my type\"}" +
+                "}";
+        Assert.assertEquals(ser(b), expected);
+
+        BeanWithFieldCalledTypeHolder b2 = deser(expected);
+        Assert.assertEquals(b2.bean.type, "not my type");
+    }
+
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
@@ -33,16 +33,6 @@ public class WrappedValuesSerializationTest implements MapperTestFixture {
         return BeanWithTypeUtils.newMapper(null, false, true);
     }
 
-    // baseline
-
-    static class EmptyObject {}
-
-    @Test
-    public void testMapperDoesntBreakBasicThings() throws Exception {
-        Asserts.assertEquals(deser("\"hello\""), "hello");
-        Asserts.assertInstanceOf(deser("{\"type\":\""+EmptyObject.class.getName()+"\"}"), EmptyObject.class);
-    }
-
     // basic serialization / deserialization of wrapped values
     static class ObjectWithWrappedValueString extends WrappedValuesInitialized {
         private WrappedValue<String> x;

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.apache.brooklyn.core.resolve.jackson.WrappedValue.WrappedValuesInitialized;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+public class WrappedValuesSerializationTest implements MapperTestFixture {
+
+    public ObjectMapper mapper() {
+        return
+                WrappedValuesSerialization.apply(
+                    BrooklynRegisteredTypeJacksonSerialization.apply(
+                        JsonMapper.builder().build(), null )
+                );
+    }
+
+    // baseline
+
+    static class EmptyObject {}
+
+    @Test
+    public void testMapperDoesntBreakBasicThings() throws Exception {
+        Asserts.assertEquals(deser("\"hello\""), "hello");
+        Asserts.assertInstanceOf(deser("{\"type\":\""+EmptyObject.class.getName()+"\"}"), EmptyObject.class);
+    }
+
+    // basic serialization / deserialization of wrapped values
+    static class ObjectWithWrappedValueString extends WrappedValuesInitialized {
+        private WrappedValue<String> x;
+    }
+
+    @Test
+    public void testDeserializeSimpleWrappedValue() throws Exception {
+        Object impl = deser("{\"type\":\""+ ObjectWithWrappedValueString.class.getName()+"\",\"x\":\"hello\"}");
+        Asserts.assertEquals(((ObjectWithWrappedValueString)impl).x.get(), "hello");
+        impl = deser("{\"type\":\""+ ObjectWithWrappedValueString.class.getName()+"\",\"x\":\"4\"}");
+        Asserts.assertEquals(((ObjectWithWrappedValueString)impl).x.get(), "4");
+    }
+
+    @Test
+    public void testDeserializeSimpleWrappedValueWhenTypeKnown() throws Exception {
+        ObjectWithWrappedValueString impl = deser("{\"x\":\"hello\"}", ObjectWithWrappedValueString.class);
+        Asserts.assertEquals(impl.x.get(), "hello");
+    }
+
+    @Test
+    public void testSerializeSimpleWrappedValue() throws Exception {
+        ObjectWithWrappedValueString a = new ObjectWithWrappedValueString();
+        a.x = WrappedValue.of("hello");
+        Assert.assertEquals(a.x.get(), "hello");
+        Assert.assertEquals(ser(a),
+                "{\"type\":\""+ ObjectWithWrappedValueString.class.getName()+"\",\"x\":\"hello\"}");
+    }
+
+    // null values populated as wrapped null and omitted on serialization
+
+    @Test
+    public void testDeserializeSetsWrappedNull() throws Exception {
+        ObjectWithWrappedValueString impl = deser("{}", ObjectWithWrappedValueString.class);
+        Asserts.assertNotNull(impl.x);
+        Asserts.assertNull(impl.x.get());
+    }
+
+    @Test
+    public void testSerializeWrappedNullOmits() throws Exception {
+        ObjectWithWrappedValueString a = new ObjectWithWrappedValueString();
+        a.x = WrappedValue.of(null);
+        Assert.assertEquals(ser(a, ObjectWithWrappedValueString.class), "{}");
+    }
+
+    // when supplier is used
+
+    static class HelloSupplier implements Supplier<String> {
+        @Override
+        public String get() {
+            return "hello";
+        }
+    }
+
+    @Test
+    public void testSerializeSupplier() throws Exception {
+        ObjectWithWrappedValueString a = new ObjectWithWrappedValueString();
+        a.x = WrappedValue.of(new HelloSupplier());
+        Assert.assertEquals(a.x.get(), "hello");
+        Assert.assertEquals(ser(a),
+                "{\"type\":\""+ ObjectWithWrappedValueString.class.getName()+"\",\"x\":" +
+                        "{\"type\":\""+HelloSupplier.class.getName()+"\"}" +
+                        "}");
+    }
+
+    static class ObjectWithWrappedValueObject {
+        private WrappedValue<ObjectWithWrappedValueString> x;
+    }
+
+    @Test
+    public void testWrappedValueObject() throws Exception {
+        ObjectWithWrappedValueObject b = new ObjectWithWrappedValueObject();
+        b.x = WrappedValue.of(new ObjectWithWrappedValueString());
+        b.x.get().x = WrappedValue.of("hello");
+        String expected = "{" +
+                "\"type\":\"" + ObjectWithWrappedValueObject.class.getName() + "\"," +
+                "\"x\":" +
+                "{" +
+                // "\"type\":\"" + ObjectWithWrappedValueString.class.getName() + "\"," +    // suppressed now because it's implied!
+                "\"x\":\"hello\"}" +
+                "}";
+        Assert.assertEquals(ser(b), expected);
+        ObjectWithWrappedValueObject b2 = deser(expected);
+        Assert.assertEquals(b2.x.get().x.get(), "hello");
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
@@ -30,11 +30,7 @@ import java.util.function.Supplier;
 public class WrappedValuesSerializationTest implements MapperTestFixture {
 
     public ObjectMapper mapper() {
-        return
-                WrappedValuesSerialization.apply(
-                    BrooklynRegisteredTypeJacksonSerialization.apply(
-                        JsonMapper.builder().build(), null )
-                );
+        return BeanWithTypeUtils.newMapper(null, false, true);
     }
 
     // baseline

--- a/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/BrooklynMgmtUnitTestSupport.java
@@ -40,6 +40,8 @@ public class BrooklynMgmtUnitTestSupport {
 
     protected ManagementContextInternal mgmt;
 
+    protected ManagementContextInternal mgmt() { return mgmt; }
+
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
         if (mgmt == null) {

--- a/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedIntegrationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/feed/ssh/SshFeedIntegrationTest.java
@@ -181,9 +181,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
     public void testAddedEarly() throws Exception {
         final TestEntity entity2 = app.addChild(EntitySpec.create(TestEntity.class)
             .location(machine)
-            .addInitializer(new EntityInitializer() {
-                @Override
-                public void apply(EntityLocal entity) {
+            .addInitializer(entity -> {
                     SshFeed.builder()
                         .entity(entity)
                         .onlyIfServiceUp()
@@ -191,8 +189,7 @@ public class SshFeedIntegrationTest extends BrooklynAppUnitTestSupport {
                             .command("echo hello")
                             .onSuccess(SshValueFunctions.stdout()))
                         .build();
-                }
-            }));
+                }));
 
         // TODO would be nice to hook in and assert no errors
         EntityAsserts.assertAttributeEqualsContinually(entity2, SENSOR_STRING, null);

--- a/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/location/ssh/SshMachineLocationTest.java
@@ -222,11 +222,9 @@ public class SshMachineLocationTest extends BrooklynAppUnitTestSupport {
 
         EntitySpec<TestApplication> appSpec = EntitySpec.create(TestApplication.class)
                 .configure(BrooklynConfigKeys.SKIP_ON_BOX_BASE_DIR_RESOLUTION, true)
-                .addInitializer(new EntityInitializer() {
-                        @Override
-                        public void apply(EntityLocal entity) {
+                .addInitializer(entity -> {
                             ((EntityInternal)entity).getMutableEntityType().addEffector(EffectorTaskTest.DOUBLE_1);
-                        }});
+                        });
 
         TestApplication app = mgmt.getEntityManager().createEntity(appSpec);
 

--- a/core/src/test/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolutionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolutionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.flags;
+
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import java.util.List;
+import java.util.function.Function;
+import static org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution.parseTypeGenerics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class BrooklynTypeNameResolutionTest {
+
+    public static final Logger log = LoggerFactory.getLogger(BrooklynTypeNameResolutionTest.class);
+
+    @Test
+    public void testParse() throws NoSuchFieldException {
+        Assert.assertEquals(parseTypeGenerics("t1").toString(), "t1");
+        Assert.assertEquals(parseTypeGenerics(" t1 ").toString(), "t1");
+
+        Assert.assertEquals(parseTypeGenerics(" t1 < a >").toString(), "t1<a>");
+        Assert.assertEquals(parseTypeGenerics(" t1 < a >").baseName.toString(), "t1");
+        Assert.assertEquals(Iterables.getOnlyElement(parseTypeGenerics(" t1 < a >").params).toString(), "a");
+
+        Assert.assertEquals(parseTypeGenerics(" t1 < t2<t3>, t4,t5< t6 > >").toString(), "t1<t2<t3>,t4,t5<t6>>");
+    }
+
+    @Test
+    public void testMakeTypeToken() throws NoSuchFieldException {
+        Function<String,TypeToken<?>> parse = s1 -> BrooklynTypeNameResolution.parseTypeToken(s1, s2 -> BrooklynTypeNameResolution.getClassForBuiltInTypeName(s2).get());
+
+        Assert.assertEquals(parse.apply("string"), TypeToken.of(String.class));
+        Assert.assertEquals(parse.apply("list<string>"), new TypeToken<List<String>>() {});
+    }
+
+}

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/DefaultConnectivityResolver.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternForConfigurable;
 import org.apache.brooklyn.core.location.LocationConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.objs.BasicConfigurableObject;
@@ -93,7 +94,7 @@ import com.google.common.net.HostAndPort;
  * This class is annotated @Beta and is likely to change in the future.
  */
 @Beta
-public class DefaultConnectivityResolver extends BasicConfigurableObject implements ConnectivityResolver, EntityInitializer {
+public class DefaultConnectivityResolver extends InitializerPatternForConfigurable implements ConnectivityResolver, EntityInitializer {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultConnectivityResolver.class);
 
@@ -137,16 +138,10 @@ public class DefaultConnectivityResolver extends BasicConfigurableObject impleme
     public DefaultConnectivityResolver() {
         this(ImmutableMap.of());
     }
-
     public DefaultConnectivityResolver(Map<?, ?> params) {
         this(ConfigBag.newInstance(params));
     }
-
-    public DefaultConnectivityResolver(final ConfigBag params) {
-        for (Map.Entry<String, Object> entry : params.getAllConfig().entrySet()) {
-            config().set(ConfigKeys.newConfigKey(Object.class, entry.getKey()), entry.getValue());
-        }
-    }
+    public DefaultConnectivityResolver(final ConfigBag params) { super(params); }
 
     // --------------------------------------------------------------------------------------
 

--- a/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
+++ b/locations/jclouds/src/main/java/org/apache/brooklyn/location/jclouds/templates/customize/TemplateOptionsOption.java
@@ -50,7 +50,7 @@ public class TemplateOptionsOption implements TemplateOptionCustomizer {
                 try {
                     final ExecutionContext exec = BrooklynTaskTags.getCurrentExecutionContext();
                     if (exec != null) {
-                        optionValue = Tasks.resolveDeepValue(optionValue, Object.class, exec);
+                        optionValue = Tasks.resolveDeepValueWithoutCoercion(optionValue, exec);
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     Exceptions.propagate(e);

--- a/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
+++ b/server-cli/src/main/java/org/apache/brooklyn/cli/ItemLister.java
@@ -207,6 +207,7 @@ public class ItemLister {
             List<Map<?,?>> enrichers = new ArrayList<>();
             List<Map<?,?>> locations = new ArrayList<>();
             List<Object> locationResolvers = new ArrayList<>();
+            List<Map<?,?>> beans = new ArrayList<>();
 
             if (!getJars().isEmpty() || yamlToScan.isEmpty()) {
                 List<URL> urls = getJarUrls();
@@ -245,6 +246,8 @@ public class ItemLister {
                             policies.add(itemDescriptor);
                         } else if (item.getCatalogItemType() == CatalogItem.CatalogItemType.LOCATION) {
                             locations.add(itemDescriptor);
+                        } else if (item.getCatalogItemType() == CatalogItem.CatalogItemType.BEAN) {
+                            beans.add(itemDescriptor);
                         } else {
                             LOG.warn("Skipping unknown catalog item type "+item.getCatalogItemType()+": "+item);
                             itemCount--;
@@ -261,6 +264,7 @@ public class ItemLister {
                     .put("enrichers", enrichers)
                     .put("locations", locations)
                     .put("locationResolvers", locationResolvers)
+                    .put("beans", beans)
                     .build();
             return result;
         }

--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
@@ -108,7 +108,7 @@ public final class WinRmCommandSensor<T> extends AbstractAddSensorFeed<T> {
 
                 // Try to resolve the configuration in the env Map
                 try {
-                    env = Tasks.resolveDeepValueExactly(env, new TypeToken<Map<String,String>>() {}, ((EntityInternal) entity).getExecutionContext());
+                    env = Tasks.resolveDeepValueCoerced(env, new TypeToken<Map<String,String>>() {}, ((EntityInternal) entity).getExecutionContext(), "WinRM environment");
                 } catch (InterruptedException | ExecutionException e) {
                     Exceptions.propagateIfFatal(e);
                 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WindowsPerformanceCounterSensors.java
@@ -22,10 +22,11 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.annotations.Beta;
-import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers.InitializerPatternWithFieldsFromConfigKeys;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.reflect.TypeToken;
 
 @Beta
-public class WindowsPerformanceCounterSensors implements EntityInitializer {
+public class WindowsPerformanceCounterSensors extends InitializerPatternWithFieldsFromConfigKeys {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsPerformanceCounterSensors.class);
 
@@ -53,17 +54,17 @@ public class WindowsPerformanceCounterSensors implements EntityInitializer {
             "poll period",
             Duration.seconds(30));
 
-    protected final Set<Map<String, String>> sensors;
-    protected final Duration period;
-
-    public WindowsPerformanceCounterSensors(ConfigBag params) {
-        sensors = params.get(PERFORMANCE_COUNTERS);
-        period = params.get(PERIOD);
+    protected Set<Map<String, String>> sensors;
+    protected Duration period;
+    {
+        addInitConfigMapping(PERFORMANCE_COUNTERS, v -> sensors = v);
+        addInitConfigMapping(PERIOD, v -> period = v);
     }
 
-    public WindowsPerformanceCounterSensors(Map<String, String> params) {
-        this(ConfigBag.newInstance(params));
-    }
+    private WindowsPerformanceCounterSensors() {}
+    public WindowsPerformanceCounterSensors(ConfigBag params) { super(params); }
+
+    public WindowsPerformanceCounterSensors(Map<String, String> params) { this(ConfigBag.newInstance(params)); }
 
     @Override
     public void apply(EntityLocal entity) {

--- a/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WinRmFeedLiveTest.java
+++ b/software/winrm/src/test/java/org/apache/brooklyn/feed/windows/WinRmFeedLiveTest.java
@@ -190,9 +190,7 @@ public class WinRmFeedLiveTest extends BrooklynAppLiveTestSupport {
     public void testAddedEarly() throws Exception {
         final TestEntity entity2 = app.addChild(EntitySpec.create(TestEntity.class)
             .location(machine)
-            .addInitializer(new EntityInitializer() {
-                @Override
-                public void apply(EntityLocal entity) {
+            .addInitializer(entity -> {
                     CmdFeed.builder()
                         .entity(entity)
                         .onlyIfServiceUp()
@@ -200,8 +198,7 @@ public class WinRmFeedLiveTest extends BrooklynAppLiveTestSupport {
                             .command("echo hello")
                             .onSuccess(SshValueFunctions.stdout()))
                         .build();
-                }
-            }));
+                }));
 
         // TODO would be nice to hook in and assert no errors
         EntityAsserts.assertAttributeEqualsContinually(entity2, SENSOR_STRING, null);

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1281,35 +1281,38 @@ public class Asserts {
     /** Tests {@link #expectedFailure(Throwable)} and that the <code>toString</code>
      * satisfies {@link #assertStringContains(String, String, String...)}.
      * @return as per {@link #expectedFailureOfType(Throwable, Class...)} */
-    public static void expectedFailureContains(Throwable e, String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
+    public static boolean expectedFailureContains(Throwable e, String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
         if (e instanceof ShouldHaveFailedPreviouslyAssertionError) throw (Error)e;
         try {
             assertStringContains(Exceptions.collapseText(e), phrase1ToContain, optionalOtherPhrasesToContain);
         } catch (AssertionError ee) {
             rethrowPreferredException(e, ee);
         }
+        return true;
     }
 
     /** As {@link #expectedFailureContains(Throwable, String, String...)} but case insensitive */
-    public static void expectedFailureContainsIgnoreCase(Throwable e, String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
+    public static boolean expectedFailureContainsIgnoreCase(Throwable e, String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
         if (e instanceof ShouldHaveFailedPreviouslyAssertionError) throw (Error)e;
         try {
             assertStringContainsIgnoreCase(Exceptions.collapseText(e), phrase1ToContain, optionalOtherPhrasesToContain);
         } catch (AssertionError ee) {
             rethrowPreferredException(e, ee);
         }
+        return true;
     }
 
     /** Tests {@link #expectedFailure(Throwable)} and that the <code>toString</code>
      * satisfies {@link #assertStringContains(String, String, String...)}.
      * @return as per {@link #expectedFailureOfType(Throwable, Class...)} */
-    public static void expectedFailureDoesNotContain(Throwable e, String phrase1ToNotContain, String ...optionalOtherPhrasesToNotContain) {
+    public static boolean expectedFailureDoesNotContain(Throwable e, String phrase1ToNotContain, String ...optionalOtherPhrasesToNotContain) {
         if (e instanceof ShouldHaveFailedPreviouslyAssertionError) throw (Error)e;
         try {
             assertStringDoesNotContain(Exceptions.collapseText(e), phrase1ToNotContain, optionalOtherPhrasesToNotContain);
         } catch (AssertionError ee) {
             rethrowPreferredException(e, ee);
         }
+        return true;
     }
     
     /** Implements the return behavior for {@link #expectedFailureOfType(Throwable, Class...)} and others,

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/TypeTokens.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/TypeTokens.java
@@ -100,5 +100,5 @@ public class TypeTokens {
             throw new IllegalStateException("Invalid types, token is "+typeToken+" (raw "+typeToken.getRawType()+") but class is "+type);
         }
     }
-    
+
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/Reflections.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.util.collections.MutableList;
@@ -702,7 +703,7 @@ public class Reflections {
         }
     }
 
-    public static Maybe<Object> getFieldValueMaybe(Object instance, Field field) {
+    @Nonnull public static Maybe<Object> getFieldValueMaybe(Object instance, Field field) {
         try {
             if (instance==null) return null;
             if (field==null) return null;

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercerExtensible.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercerExtensible.java
@@ -239,6 +239,12 @@ public class TypeCoercerExtensible implements TypeCoercer {
             // it might be nice to have more than just the first error but for now that's all we remember
             return firstError;
         }
+        if (value instanceof Map) {
+            if (((Map)value).containsKey("type")) {
+                return Maybe.absent(new ClassCoercionException("Cannot coerce map containing {type: \""+((Map)value).get("type")+"\"} to "+targetTypeToken+": type not known or not supported here"));
+            }
+            return Maybe.absent(new ClassCoercionException("Cannot coerce map to "+targetTypeToken+" ("+value+"): no adapter known"));
+        }
         return Maybe.absent(new ClassCoercionException("Cannot coerce type "+value.getClass().getCanonicalName()+" to "+targetTypeToken+" ("+value+"): no adapter known"));
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercerExtensible.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/javalang/coerce/TypeCoercerExtensible.java
@@ -256,12 +256,12 @@ public class TypeCoercerExtensible implements TypeCoercer {
         for (Map.Entry<?,?> entry : ((Map<?,?>) value).entrySet()) {
             Maybe<?> k = tryCoerce(entry.getKey(), mapKeyType);
             if (k.isAbsent()) return Maybe.absent(new ClassCoercionException(
-                "Could not coerce key of entry "+i+" ("+entry.getKey()+") to "+targetTypeToken,
+                "Could not coerce key of entry "+i+" ("+entry.getKey()+") to "+mapKeyType+" in "+targetTypeToken,
                 ((Maybe.Absent<T>)k).getException()));
 
             Maybe<?> v = tryCoerce(entry.getValue(), mapValueType);
             if (v.isAbsent()) return Maybe.absent(new ClassCoercionException(
-                "Could not coerce value of entry "+i+" ("+entry.getValue()+") to "+targetTypeToken,
+                "Could not coerce value of entry "+i+" ("+entry.getValue()+") to "+mapValueType+" in "+targetTypeToken,
                 ((Maybe.Absent<T>)v).getException()));
             
             coerced.put(k.get(), v.get());

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
@@ -198,20 +198,20 @@ public class Strings {
      * Removes everything after the marker, optionally also removing the marker.
      * If marker not found the string is unchanged.
      */
-    public static String removeAfter(String string, String marker, boolean includeMarker) {
-        int i = string.indexOf(marker);
-        if (i==-1) return string;
-        return string.substring(0, i + (includeMarker ? marker.length() : 0));
+    public static String removeAfter(String input, String marker, boolean keepMarker) {
+        int i = input.indexOf(marker);
+        if (i==-1) return input;
+        return input.substring(0, i + (keepMarker ? marker.length() : 0));
     }
     
     /**
      * Removes everything before the marker, optionally also removing the marker.
      * If marker not found the string is unchanged.
      */
-    public static String removeBefore(String string, String marker, boolean includeMarker) {
-        int i = string.indexOf(marker);
-        if (i==-1) return string;
-        return string.substring(i + (includeMarker ? 0 : marker.length()));
+    public static String removeBefore(String input, String marker, boolean keepMarker) {
+        int i = input.indexOf(marker);
+        if (i==-1) return input;
+        return input.substring(i + (keepMarker ? 0 : marker.length()));
     }
     
     /** convenience for {@link com.google.common.base.Joiner} */


### PR DESCRIPTION
See the change to instructions in https://github.com/apache/brooklyn-docs/pull/309 and the tests added here.

In short, you can now add arbitrary types and values for their fields to the catalog, and then use those in config and in initializers.

This can be quite useful eg if you have an initializer which adds an effector you want to add in many places, add that initializer to the catalog as a bean, and then simply refer to that type in any initializer block where you want to use it!