### PR TITLE
There are shared utility functions no longer public

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.Map;
 
 @Beta
-abstract class AddEffectorInitializerAbstractProto extends EntityInitializers.InitializerPatternWithConfigKeys {
+public abstract class AddEffectorInitializerAbstractProto extends EntityInitializers.InitializerPatternWithConfigKeys {
 
     public static final ConfigKey<String> EFFECTOR_NAME = ConfigKeys.newStringConfigKey("name");
     public static final ConfigKey<String> EFFECTOR_DESCRIPTION = ConfigKeys.newStringConfigKey("description");

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddEffectorInitializerAbstractProto.java
@@ -70,7 +70,7 @@ public abstract class AddEffectorInitializerAbstractProto extends EntityInitiali
         return result;
     }
 
-    static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
+    protected static <T> EffectorBuilder<T> newEffectorBuilder(Class<T> type, ConfigBag params) {
         String name = Preconditions.checkNotNull(params.get(EFFECTOR_NAME), "name must be supplied when defining an effector: %s", params);
         EffectorBuilder<T> eff = Effectors.effector(type, name);
         eff.description(params.get(EFFECTOR_DESCRIPTION));

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializerAbstractProto.java
@@ -38,7 +38,7 @@ import org.apache.brooklyn.util.time.Duration;
  *
  * @since 0.7.0 */
 @Beta
-interface AddSensorInitializerAbstractProto<T> extends EntityInitializer {
+public interface AddSensorInitializerAbstractProto<T> extends EntityInitializer {
 
     public static final ConfigKey<String> SENSOR_NAME = ConfigKeys.newStringConfigKey("name", "The name of the sensor to create");
     public static final ConfigKey<Duration> SENSOR_PERIOD = ConfigKeys.newConfigKey(Duration.class, "period", "Period, including units e.g. 1m or 5s or 200ms; default 5 minutes", Duration.FIVE_MINUTES);


### PR DESCRIPTION
This makes AddEffectorInitializerAbstractProto public as a recent change
had made it private.  Alternatively we could have pushed the utility
functions to the implementation.