### PR TITLE
add a post-init hook interface for entities

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1302,6 +1302,14 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
 
     /**
      * Default entity initialization sets ID sensors and calls {@link #initEnrichers()}.
+     * <p>
+     * See superclass Javadoc for more info.
+     * <p>
+     * Note that this is invoked before {@link org.apache.brooklyn.api.entity.EntityInitializer} instances are called,
+     * before policies and enrichers are added,
+     * before descendants are initialized,
+     * before {@link EntityPostInitializable#postInit()},
+     * and before this entity is managed.
      */
     @Override
     public void init() {

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityPostInitializable.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityPostInitializable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.entity;
+
+public interface EntityPostInitializable {
+
+    /**
+     * Invoked on an {@link org.apache.brooklyn.api.entity.Entity} after setting its config,
+     * invoking its {@link org.apache.brooklyn.core.objs.AbstractBrooklynObject#init()} method,
+     * descendants initialized and any {@link #postInit()} method on those invoked,
+     * and any associated {@link org.apache.brooklyn.api.entity.EntityInitializer} instances applied.
+     * <p>
+     * See {@link AbstractEntity#init()} for more detail. */
+    void postInit();
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -40,11 +40,7 @@ import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigConstraints;
-import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.AbstractEntity;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.EntityDynamicType;
-import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.entity.*;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTags.NamedStringTag;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
@@ -146,7 +142,7 @@ public class InternalEntityFactory extends InternalFactory {
      * fully initialized ({@link AbstractEntity#init()} invoked) and ready for
      * management -- commonly the caller will next call 
      * {@link Entities#manage(Entity)} (if it's in a managed application)
-     * or {@link Entities#startManagement(org.apache.brooklyn.api.entity.Application, org.apache.brooklyn.api.management.ManagementContext)}
+     * or {@link Entities#startManagement(org.apache.brooklyn.api.entity.Application, org.apache.brooklyn.api.mgmt.ManagementContext)}
      * (if it's an application) */
     public <T extends Entity> T createEntity(EntitySpec<T> spec, Optional<String> entityId) {
         /* Order is important here. Changed Jul 2014 when supporting children in spec.
@@ -363,16 +359,20 @@ public class InternalEntityFactory extends InternalFactory {
                     // they could be done in parallel, but OTOH initializers should be very quick
                     initEntityAndDescendants(child.getId(), entitiesByEntityId, specsByEntityId);
                 }
+
+                if (entity instanceof EntityPostInitializable) {
+                    ((EntityPostInitializable)entity).postInit();
+                }
             }
         }).build());
     }
     
     /**
      * Constructs an entity, i.e. instantiate the actual class given a spec,
-     * and sets the entity's proxy. Used by this factory to {@link #createEntity(EntitySpec)}
+     * and sets the entity's proxy. Used by this factory to {@link #createEntity(EntitySpec, Optional<String>)}
      * and also used during rebind.
      * <p> 
-     * If {@link EntitySpec#id(String)} was set then uses that to override the entity's id, 
+     * If the entityId is provided, then uses that to override the entity's id,
      * but that behaviour is deprecated.
      * <p>
      * The new-style no-arg constructor is preferred, and   


### PR DESCRIPTION
For use to add extra validation logic after all initializers have run.