### PR TITLE
More on catalog bundle resolvers - support format, compatibility fixes

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -143,6 +143,8 @@ public interface BrooklynCatalog {
      * <p>
      * A null bundle can be supplied although that will cause oddness in production installations
      * that assume bundles for persistence, lookup and other capabilities. (But it's fine for tests.)
+     * <p>
+     * Most callers will want to use the OsgiManager to install a bundle. This is primarily to support that.
      */
     @Beta  // method may move elsewhere, or return type may change
     public void addTypesFromBundleBom(String yaml, @Nullable ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result);
@@ -154,6 +156,8 @@ public interface BrooklynCatalog {
      * and the type registry may have some of the items updated.  It is the caller's responsibility to clean up if required
      * (note, clean up is only possible if an empty results map is supplied to collect the items, and even then finding the bundle needs work;
      * or, most commonly, where the management context is just being thrown away, like in tests).
+     * <p>
+     * Most callers will want to use the OsgiManager to install a bundle. This is primarily to support that.
      */
     @Beta
     Collection<RegisteredType> addTypesAndValidateAllowInconsistent(String catalogYaml, @Nullable Map<RegisteredType, RegisteredType> result, boolean forceUpdate);
@@ -176,7 +180,7 @@ public interface BrooklynCatalog {
 
     /** As {@link #addItems(String, boolean, boolean)}
      *
-     * @deprecated since 1.1, use {@link #addTypesAndValidateAllowInconsistent(String, Map, boolean)}
+     * @deprecated since 1.1, use {@link #addTypesAndValidateAllowInconsistent(String, Map, boolean)} for direct access to catalog (non-OSGi, eg tests) or use the OsgiManager
      * (Used in tests.)
      */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml);
@@ -192,7 +196,7 @@ public interface BrooklynCatalog {
      *
      * @throws IllegalArgumentException if the yaml was invalid
      *
-     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)};
+     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)} for direct access to catalog (non/partial-OSGi, eg tests) or use the OsgiManager
      * (Used for REST API, a few tests, and legacy-compatibility additions.)
      */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, boolean validate, boolean forceUpdate);
@@ -207,7 +211,7 @@ public interface BrooklynCatalog {
      *
      * @throws IllegalArgumentException if the yaml was invalid
      *
-     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)};
+     * @deprecated Since 1.1, use {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)} for direct access to catalog (non/partial-OSGi, eg tests) or use the OsgiManager
      * (Only used for legacy OSGi bundles.) */
     Iterable<? extends CatalogItem<?,?>> addItems(String yaml, ManagedBundle bundle, boolean forceUpdate);
     
@@ -217,7 +221,6 @@ public interface BrooklynCatalog {
      *
      * @deprecated since 0.7.0 Construct catalogs with yaml (referencing OSGi bundles) instead
      */
-    // TODO maybe this should stay on the API? -AH Apr 2015 
     @Deprecated
     void addItem(CatalogItem<?,?> item);
 
@@ -249,6 +252,10 @@ public interface BrooklynCatalog {
     @VisibleForTesting
     CatalogItem<?,?> addItem(Class<?> clazz);
 
+    /** @deprecated since 1.1 remove all bundles, that should clear the catalog
+     * Used for legacy catalog initialization and rebind.
+     */
+    @Deprecated
     void reset(Collection<CatalogItem<?, ?>> entries);
 
 }

--- a/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
+++ b/api/src/main/java/org/apache/brooklyn/api/catalog/BrooklynCatalog.java
@@ -149,7 +149,7 @@ public interface BrooklynCatalog {
     @Beta  // method may move elsewhere, or return type may change
     public void addTypesFromBundleBom(String yaml, @Nullable ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result);
 
-    /** As {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)} followed by {@link #validateType(RegisteredType, RegisteredTypeLoadingContext)}
+    /** As {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)} followed by {@link #validateType(RegisteredType, RegisteredTypeLoadingContext, boolean)}
      * e.g. for use in tests and ad hoc setup when there is just a YAML file.  In OSGi mode this adds a bundle; otherwise it uses legacy catalog item addition mode.
      * <p>
      * Note that if addition or validation fails, this throws, unlike {@link #addTypesFromBundleBom(String, ManagedBundle, boolean, Map)},
@@ -162,8 +162,8 @@ public interface BrooklynCatalog {
     @Beta
     Collection<RegisteredType> addTypesAndValidateAllowInconsistent(String catalogYaml, @Nullable Map<RegisteredType, RegisteredType> result, boolean forceUpdate);
 
-    /** As {@link #validateType(RegisteredType, RegisteredTypeLoadingContext)} but taking a set of types, returning a map whose keys are
-     * those types where validation failed, mapped to the collection of errors validating that type. 
+    /** As {@link #validateType(RegisteredType, RegisteredTypeLoadingContext, boolean)} allowing unresolved, taking a set of types,
+     * and returning a map whose keys are those types where validation failed, mapped to the collection of errors validating that type.
      * An empty map result indicates no validation errors in the types passed in. 
      */
     @Beta  // method may move elsewhere
@@ -176,7 +176,7 @@ public interface BrooklynCatalog {
      * for the given registered type.
      */
     @Beta  // method may move elsewhere
-    Collection<Throwable> validateType(RegisteredType typeToValidate, @Nullable RegisteredTypeLoadingContext optionalConstraint);
+    Collection<Throwable> validateType(RegisteredType typeToValidate, @Nullable RegisteredTypeLoadingContext optionalConstraint, boolean allowUnresolved);
 
     /** As {@link #addItems(String, boolean, boolean)}
      *

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -251,9 +251,7 @@ public abstract class AbstractYamlTest {
     }
 
     protected void addCatalogItems(String catalogYaml) {
-        mgmt().getCatalog().
-                addTypesAndValidateAllowInconsistent(catalogYaml, null, forceUpdate);
-//                addItems(catalogYaml, true, forceUpdate);
+        mgmt().getCatalog().addTypesAndValidateAllowInconsistent(catalogYaml, null, forceUpdate);
     }
 
     /*

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlEntityTest.java
@@ -245,7 +245,7 @@ public class CatalogOsgiYamlEntityTest extends AbstractYamlTest {
                 "    type: " + SIMPLE_ENTITY_TYPE);
             Asserts.shouldHaveFailedPreviously();
         } catch (Exception e) {
-            Asserts.expectedFailureContainsIgnoreCase(e, "both name and version are required");
+            Asserts.expectedFailureContainsIgnoreCase(e, "name", "version");
         }
         try {
             addCatalogItems(
@@ -259,7 +259,7 @@ public class CatalogOsgiYamlEntityTest extends AbstractYamlTest {
                 "    type: " + SIMPLE_ENTITY_TYPE);
             Asserts.shouldHaveFailedPreviously();
         } catch (Exception e) {
-            Asserts.expectedFailureContainsIgnoreCase(e, "both name and version are required");
+            Asserts.expectedFailureContainsIgnoreCase(e, "name", "version");
         }
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityOsgiTypeRegistryTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlEntityOsgiTypeRegistryTest.java
@@ -52,8 +52,11 @@ public class CatalogYamlEntityOsgiTypeRegistryTest extends CatalogYamlEntityTest
         switch (itemsInstallMode!=null ? itemsInstallMode : 
             // this is the default because some "bundles" aren't resolvable or library BOMs loadable in test context
             CatalogItemsInstallationMode.BUNDLE_BUT_NOT_STARTED) {
-        case ADD_YAML_ITEMS_UNBUNDLED: super.addCatalogItems(catalogYaml); break;
-        case BUNDLE_BUT_NOT_STARTED: 
+        case ADD_YAML_ITEMS_UNBUNDLED:
+            super.addCatalogItems(catalogYaml);
+            break;
+        case BUNDLE_BUT_NOT_STARTED:
+            // TODO if id/bundle set in catalog yaml use that
             addCatalogItemsAsOsgiWithoutStartingBundles(mgmt(), catalogYaml, new VersionedName(bundleName(), bundleVersion()), isForceUpdate());
             break;
         case USUAL_OSGI_WAY_AS_BUNDLE_WITH_DEFAULT_NAME:

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlVersioningTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogYamlVersioningTest.java
@@ -310,14 +310,16 @@ public class CatalogYamlVersioningTest extends AbstractYamlTest {
     private void addCatalogEntity(String symbolicName, String version, String type, String iconUrl) {
         addCatalogItems(
             "brooklyn.catalog:",
-            "  id: " + symbolicName,
-            (version != null ? "  version: " + version : ""),
-            "  itemType: entity",
-            "  name: My Catalog App",
-            "  description: My description",
-            "  icon_url: "+iconUrl,
-            "  item:",
-            "    type: " + type);
+//            "  items:",
+//            "  - ",
+            "    id: " + symbolicName,
+            (version != null ? "    version: " + version : ""),
+            "    itemType: entity",
+            "    name: My Catalog App",
+            "    description: My description",
+            "    icon_url: "+iconUrl,
+            "    item:",
+            "      type: " + type);
     }
 
     protected void addCatalogEntityWithoutBundle(String symbolicName, String version) {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -1660,7 +1660,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         // (validation normally done by osgi load routines)
         Map<String,Collection<Throwable>> errors = MutableMap.of();
         for (CatalogItemDtoAbstract<?, ?> item: result) {
-            Collection<Throwable> errorsInItem = validateType(RegisteredTypes.of(item), null);
+            Collection<Throwable> errorsInItem = validateType(RegisteredTypes.of(item), null, true);
             if (!errorsInItem.isEmpty()) {
                 errors.put(item.getCatalogItemId(), errorsInItem);
             }
@@ -1710,7 +1710,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
             log.debug("Catalog load, starting validation cycle, "+typesRemainingToValidate.size()+" to validate");
             Map<RegisteredType,Collection<Throwable>> result = MutableMap.of();
             for (RegisteredType t: typesRemainingToValidate) {
-                Collection<Throwable> tr = validateType(t, null);
+                Collection<Throwable> tr = validateType(t, null, true);
                 if (!tr.isEmpty()) {
                     result.put(t, tr);
                 }
@@ -1727,10 +1727,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     }
     
     @Override @Beta
-    public Collection<Throwable> validateType(RegisteredType typeToValidate, RegisteredTypeLoadingContext constraint) {
+    public Collection<Throwable> validateType(RegisteredType typeToValidate, RegisteredTypeLoadingContext constraint, boolean allowUnresolved) {
         ReferenceWithError<RegisteredType> result = validateResolve(typeToValidate, constraint);
         if (result.hasError()) {
-            if (RegisteredTypes.isTemplate(typeToValidate)) {
+            if (allowUnresolved && RegisteredTypes.isTemplate(typeToValidate)) {
                 // ignore for templates
                 return Collections.emptySet();
             }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -500,26 +500,52 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         return getFirstAsMap(itemDef, "brooklyn.catalog").orNull();        
     }
     
-    /** @deprecated since 0.12.0 - use {@link #getVersionedName(Map, boolean)} */
-    @Deprecated
-    public static VersionedName getVersionedName(Map<?,?> catalogMetadata) {
-        return getVersionedName(catalogMetadata, true);
-    }
-    
     public static VersionedName getVersionedName(Map<?,?> catalogMetadata, boolean required) {
+        // for better legacy compatibility, if id specified at root use that for bundle symbolic name and optionally for version
+        VersionedName idV = null;
+        String idS = getFirstAs(catalogMetadata, String.class, "id").orNull();
+        if (Strings.isNonBlank(idS)) {
+            idV = VersionedName.fromString(idS);
+        }
+
         String version = getFirstAs(catalogMetadata, String.class, "version").orNull();
         String bundle = getFirstAs(catalogMetadata, String.class, "bundle").orNull();
+        if (bundle==null) {
+            // if bundle not specified, ID indicates bundle name, and version if specified must match
+            if (idV!=null) {
+                bundle = idV.getSymbolicName();
+                if (Strings.isNonBlank(idV.getVersionString())) {
+                    if (version!=null) {
+                        if (!Objects.equal(version, idV.getVersionString()) && !Objects.equal(version, idV.getOsgiVersionString())) {
+                            throw new IllegalStateException("Catalog BOM using ID '" + idV + "' to define bundle does not match declared version '" + version + "'");
+                        }
+                    } else {
+                        version = idV.getVersionString();
+                    }
+                } else {
+                    if (required) {
+                        throw new IllegalStateException("Catalog BOM must define bundle name and version or include version as part of the id '" + bundle + "' (eg '" + bundle + ":1.0')");
+                    } else {
+                        // allow null version
+                    }
+                }
+            }
+        }
+
         if (Strings.isBlank(bundle) && Strings.isBlank(version)) {
             if (!required) return null;
-            throw new IllegalStateException("Catalog BOM must define bundle and version");
+            throw new IllegalStateException("Catalog BOM must define bundle name and version");
         }
         if (Strings.isBlank(bundle)) {
             if (!required) return null;
-            throw new IllegalStateException("Catalog BOM must define bundle");
+            throw new IllegalStateException("Catalog BOM must define bundle (or id)");
         }
         if (Strings.isBlank(version)) {
-            throw new IllegalStateException("Catalog BOM must define version if bundle is defined");
+            if (required) {
+                throw new IllegalStateException("Catalog BOM must define version where bundle name '" + bundle + "' is defined");
+            }
         }
+
         return new VersionedName(bundle, version);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BasicExternalConfigSupplierRegistry.java
@@ -58,18 +58,12 @@ public class BasicExternalConfigSupplierRegistry implements ExternalConfigSuppli
 
     public BasicExternalConfigSupplierRegistry(ManagementContext mgmt) {
         addProvider(DEMO_SAMPLE_PROVIDER, new InPlaceExternalConfigSupplier(mgmt, DEMO_SAMPLE_PROVIDER,
-                MutableMap.of(DEMO_SAMPLE_PROVIDER_PASSWORD_KEY, DEMO_SAMPLE_PROVIDER_PASSWORD_VALUE)),
-                /** suppress logging when running this from ide; a nicer way would be to remove this altogether in most tests */
-                !BrooklynVersion.isDevelopmentEnvironment());
+                MutableMap.of(DEMO_SAMPLE_PROVIDER_PASSWORD_KEY, DEMO_SAMPLE_PROVIDER_PASSWORD_VALUE)));
         updateFromBrooklynProperties(mgmt);
     }
 
     @Override
     public void addProvider(String name, ExternalConfigSupplier supplier) {
-        addProvider(name, supplier, true);
-    }
-
-    protected void addProvider(String name, ExternalConfigSupplier supplier, boolean logInfo) {
         synchronized (providersMapMutex) {
             if (providersByName.containsKey(name) && !DEMO_SAMPLE_PROVIDER.equals(name)) {
                 // allow demo to be overridden
@@ -77,7 +71,7 @@ public class BasicExternalConfigSupplierRegistry implements ExternalConfigSuppli
             }
             providersByName.put(name, supplier);
         }
-        LOG.info("Added external config supplier named '" + name + "': " + supplier);
+        LOG.debug("Added external config supplier named '" + name + "': " + supplier);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractCatalogBundleResolver.java
@@ -106,7 +106,7 @@ public abstract class AbstractCatalogBundleResolver implements BrooklynCatalogBu
 
         private byte[] bytesRead = new byte[0];
 
-        protected FileTypeDetector(Supplier<InputStream> streamSupplier) {
+        public FileTypeDetector(Supplier<InputStream> streamSupplier) {
             this.streamSupplier = streamSupplier;
         }
 

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractCatalogBundleResolver.java
@@ -18,14 +18,12 @@
  */
 package org.apache.brooklyn.core.typereg;
 
-import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
@@ -91,7 +89,7 @@ public abstract class AbstractCatalogBundleResolver implements BrooklynCatalogBu
     @Override
     public double scoreForBundle(String format, Supplier<InputStream> f) {
         if (getFormatCode().equals(format)) return 1;
-        if (format==null)
+        if (Strings.isBlank(format))
             return scoreForNullFormat(f);
         else
             return scoreForNonmatchingNonnullFormat(format, f);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractTypePlanTransformer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/AbstractTypePlanTransformer.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public abstract class AbstractTypePlanTransformer implements BrooklynTypePlanTra
     @Override
     public double scoreForType(RegisteredType type, RegisteredTypeLoadingContext context) {
         if (getFormatCode().equals(type.getPlan().getPlanFormat())) return 1;
-        if (type.getPlan().getPlanFormat()==null)
+        if (Strings.isBlank(type.getPlan().getPlanFormat()))
             return scoreForNullFormat(type.getPlan().getPlanData(), type, context);
         else
             return scoreForNonmatchingNonnullFormat(type.getPlan().getPlanFormat(), type.getPlan().getPlanData(), type, context);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -258,6 +258,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 }
                 type = mgmt.getTypeRegistry().get(type.getSymbolicName(), type.getVersion());
                 if (type==null || type.getKind()==RegisteredTypeKind.UNRESOLVED) {
+                    // TODO show the resolution error
                     throw new ReferencedUnresolvedTypeException(type);
                 }
                 return createSpec(type, constraint, specSuperType);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -252,13 +252,13 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
                 
             } else {
                 // try just-in-time validation
-                Collection<Throwable> validationErrors = mgmt.getCatalog().validateType(type, constraint);
+                Collection<Throwable> validationErrors = mgmt.getCatalog().validateType(type, constraint, false);
                 if (!validationErrors.isEmpty()) {
                     throw new ReferencedUnresolvedTypeException(type, true, Exceptions.create(validationErrors));
                 }
                 type = mgmt.getTypeRegistry().get(type.getSymbolicName(), type.getVersion());
                 if (type==null || type.getKind()==RegisteredTypeKind.UNRESOLVED) {
-                    // TODO show the resolution error
+                    // shouldn't come here
                     throw new ReferencedUnresolvedTypeException(type);
                 }
                 return createSpec(type, constraint, specSuperType);

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomBundleCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomBundleCatalogBundleResolver.java
@@ -55,18 +55,18 @@ public class BrooklynBomBundleCatalogBundleResolver extends AbstractCatalogBundl
 
     @Override
     public ReferenceWithError<OsgiBundleInstallationResult> install(Supplier<InputStream> input, BundleInstallationOptions options) {
-        LOG.debug("Installing bundle from stream - known details: "+(options==null ? null : options.knownBundleMetadata));
+        LOG.debug("Installing bundle from stream - known details: "+(options==null ? null : options.getKnownBundleMetadata()));
 
         BrooklynBomOsgiArchiveInstaller installer = new BrooklynBomOsgiArchiveInstaller(
                 ((ManagementContextInternal)mgmt).getOsgiManager().get(),
-                (options==null ? null : options.knownBundleMetadata), input.get());
+                (options==null ? null : options.getKnownBundleMetadata()), input.get());
         installer.setCatalogBomText(FORMAT, null);
         if (options!=null) {
-            installer.setStart(options.start);
-            installer.setLoadCatalogBom(options.loadCatalogBom);
-            installer.setForce(options.forceUpdateOfNonSnapshots);
-            installer.setDeferredStart(options.deferredStart);
-            installer.setValidateTypes(options.validateTypes);
+            installer.setStart(options.isStart());
+            installer.setLoadCatalogBom(options.isLoadCatalogBom());
+            installer.setForce(options.isForceUpdateOfNonSnapshots());
+            installer.setDeferredStart(options.isDeferredStart());
+            installer.setValidateTypes(options.isValidateTypes());
         }
 
         return installer.install();

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolver.java
@@ -121,6 +121,34 @@ public interface BrooklynCatalogBundleResolver extends ManagementContextInjectab
         public void setKnownBundleMetadata(ManagedBundle knownBundleMetadata) {
             this.knownBundleMetadata = knownBundleMetadata;
         }
+
+        public String getFormat() {
+            return format;
+        }
+
+        public ManagedBundle getKnownBundleMetadata() {
+            return knownBundleMetadata;
+        }
+
+        public boolean isDeferredStart() {
+            return deferredStart;
+        }
+
+        public boolean isForceUpdateOfNonSnapshots() {
+            return forceUpdateOfNonSnapshots;
+        }
+
+        public boolean isLoadCatalogBom() {
+            return loadCatalogBom;
+        }
+
+        public boolean isStart() {
+            return start;
+        }
+
+        public boolean isValidateTypes() {
+            return validateTypes;
+        }
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolvers.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolvers.java
@@ -171,10 +171,11 @@ public class BrooklynCatalogBundleResolvers {
                 exception = failuresFromResolvers.size() == 1 ? Exceptions.create(null, failuresFromResolvers) :
                         Exceptions.create("All applicable bundle resolvers failed", failuresFromResolvers);
             } else {
+                String prefix = Strings.isBlank(options.format) ? "Invalid bundle" : "Invalid '"+options.format+"' bundle";
                 if (resolvers.isEmpty()) {
-                    exception = new UnsupportedTypePlanException("Invalid bundle; format could not be recognized, none of the available resolvers " + all(mgmt) + " support it");
+                    exception = new UnsupportedTypePlanException(prefix + "; format could not be recognized, none of the available resolvers " + all(mgmt) + " support it");
                 } else {
-                    exception = new UnsupportedTypePlanException("Invalid bundle; potentially applicable resolvers " + resolvers + " do not support it, and other available resolvers " +
+                    exception = new UnsupportedTypePlanException(prefix + "; potentially applicable resolvers " + resolvers + " do not support it, and other available resolvers " +
 //                    // the removeAll call below won't work until "all" caches it
 //                    MutableList.builder().addAll(all(mgmt)).removeAll(transformers).build()+" "+
                             "do not accept it");

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
@@ -142,11 +142,12 @@ public class TypePlanTransformers {
             result = failuresFromTransformers.size()==1 ? Exceptions.create(null, failuresFromTransformers) :
                 Exceptions.create("All applicable plan transformers failed", failuresFromTransformers);
         } else {
+            String prefix = Strings.isBlank(type.getPlan().getPlanFormat()) ? "Invalid plan" : "Invalid '"+type.getPlan().getPlanFormat()+"' plan]";
             if (transformers.isEmpty()) {
-                result = new UnsupportedTypePlanException("Invalid plan; format could not be recognized, none of the available transformers "+all(mgmt)+" support "+
+                result = new UnsupportedTypePlanException(prefix + "; format could not be recognized, none of the available transformers "+all(mgmt)+" support "+
                     (type.getId()!=null ? type.getId() : "plan:\n"+type.getPlan().getPlanData()));
             } else {
-                result = new UnsupportedTypePlanException("Invalid plan; potentially applicable transformers "+transformers+" do not support it, and other available transformers "+
+                result = new UnsupportedTypePlanException(prefix + "; potentially applicable transformers "+transformers+" do not support it, and other available transformers "+
 //                    // the removeAll call below won't work until "all" caches it
 //                    MutableList.builder().addAll(all(mgmt)).removeAll(transformers).build()+" "+
                     "do not accept it");

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -134,17 +134,11 @@ public interface ApplicationApi {
                     required = true)
             @PathParam("application") String application);
 
+    /** @deprecated since 1.1 use {@link #createWithFormat(byte[], String)} instead */
+    @Deprecated
     @POST
-    @Consumes({"application/x-yaml",
-            // see http://stackoverflow.com/questions/332129/yaml-mime-type
-            "text/yaml", "text/x-yaml", "application/yaml"})
-    @ApiOperation(
-            value = "Create and start a new application from YAML",
-            response = org.apache.brooklyn.rest.domain.TaskSummary.class
-    )
-    @ApiResponses(value = {
-            @ApiResponse(code = 404, message = "Undefined entity or location"),
-    })
+    @Consumes("application/deprecated-yaml-app-spec")
+    @ApiOperation(value = "(deprecated)", hidden = true)
     public Response createFromYaml(
             @ApiParam(
                     name = "applicationSpec",
@@ -152,7 +146,15 @@ public interface ApplicationApi {
                     required = true)
             String yaml);
 
-    @Beta
+    /** @deprecated since 1.1 use {@link #createFromYamlWithAppId(String, String, String)}  instead */
+    @Deprecated
+    @POST
+    @Consumes("application/deprecated-yaml-app-spec")
+    @ApiOperation(value = "(deprecated)", hidden = true)
+    public Response createFromYamlWithAppId(
+            @ApiParam(name = "applicationSpec", value = "App spec in CAMP YAML format", required = true) String yaml,
+            @ApiParam(name = "application", value = "Application id", required = true) @PathParam("application") String appId);
+
     @PUT
     @Path("/{application}")
     @Consumes({"application/x-yaml",
@@ -167,18 +169,15 @@ public interface ApplicationApi {
             @ApiResponse(code = 409, message = "Application already registered")
     })
     public Response createFromYamlWithAppId(
-            @ApiParam(name = "applicationSpec", value = "App spec in CAMP YAML format", required = true) String yaml,
+            @ApiParam(name = "plan", value = "Plan", required = true) String yaml,
+            @ApiParam(name = "format", value = "Format eg broolyn-camp", required = false) String format,
             @ApiParam(name = "application", value = "Application id", required = true) @PathParam("application") String appId);
 
+    /** @deprecated since 1.1 use {@link #createWithFormat(byte[], String)} instead */
+    @Deprecated
     @POST
-    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM, MediaType.TEXT_PLAIN})
-    @ApiOperation(
-            value = "Create and start a new application from miscellaneous types, including JSON either new CAMP format or legacy AppSpec format",
-            response = org.apache.brooklyn.rest.domain.TaskSummary.class
-    )
-    @ApiResponses(value = {
-            @ApiResponse(code = 404, message = "Undefined entity or location")
-    })
+    @Consumes("application/deprecated-yaml-app-spec")
+    @ApiOperation(value = "(deprecated)", hidden = true)
     public Response createPoly(
             @ApiParam(
                     name = "applicationSpec",
@@ -201,6 +200,21 @@ public interface ApplicationApi {
                     value = "App spec in form-encoded YAML, JSON, or other (auto-detected) format",
                     required = true)
             @Valid String contents);
+
+    @Beta
+    @POST
+    @Consumes
+    @ApiOperation(
+            value = "Create and start a new application from YAML",
+            response = org.apache.brooklyn.rest.domain.TaskSummary.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Undefined entity or location")
+    })
+    public Response createWithFormat(
+            @ApiParam(name = "plan", value = "Application plan to deploy", required = true) byte[] plan,
+            @ApiParam(name = "format", value = "Type plan format e.g. brooklyn-camp", required = false) String format);
+
 
     @DELETE
     @Path("/{application}")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
@@ -151,18 +151,11 @@ public interface BundleApi {
         @QueryParam("force") @DefaultValue("false")
         Boolean force);
 
+    /** @deprecated since 1.1 use {@link #create(byte[], String, Boolean)} instead */
+    @Deprecated
     @POST
-    @Consumes({MediaType.APPLICATION_JSON, "application/x-yaml",
-        // see http://stackoverflow.com/questions/332129/yaml-mime-type
-        "text/yaml", "text/x-yaml", "application/yaml"})
-    @ApiOperation(
-            value = "Adds types to the registry from a given BOM YAML/JSON descriptor (creating a bundle with just this file in it)",
-            response = BundleInstallationRestResult.class
-    )
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Error processing the given YAML"),
-            @ApiResponse(code = 201, message = "Items added successfully")
-    })
+    @Consumes("application/deprecated-yaml")
+    @ApiOperation(value = "(deprecated)", hidden = true)
     public Response createFromYaml(
             @ApiParam(name = "yaml", value = "BOM YAML declaring the types to be installed", required = true)
             @Valid String yaml,
@@ -170,17 +163,11 @@ public interface BundleApi {
             @QueryParam("force") @DefaultValue("false")
             Boolean forceUpdate);
 
+    /** @deprecated since 1.1 use {@link #create(byte[], String, Boolean)} instead */
+    @Deprecated
     @POST
-    @Consumes({"application/x-zip", "application/x-jar"})
-    @ApiOperation(
-            value = "Adds types to the registry from a given JAR or ZIP",
-            notes = "Accepts either an OSGi bundle JAR, or ZIP which will be turned into bundle JAR. Either format must "
-                    + "contain a catalog.bom at the root of the archive, which must contain the bundle and version key.",
-            response = BundleInstallationRestResult.class)
-    @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "Error processing the given archive, or the catalog.bom is invalid"),
-            @ApiResponse(code = 201, message = "Catalog items added successfully")
-    })
+    @Consumes({"application/deprecated-zip"})
+    @ApiOperation(value = "(deprecated)", hidden = true)
     public Response createFromArchive(
             @ApiParam(
                     name = "archive",
@@ -190,5 +177,32 @@ public interface BundleApi {
             @ApiParam(name = "force", value = "Whether to forcibly remove it, even if in use and/or errors", required = false, defaultValue = "false")
             @QueryParam("force") @DefaultValue("false")
             Boolean force);
+
+    /** @deprecated since 1.1 use {@link #create(byte[], String, Boolean)} instead */
+    @Deprecated
+    @POST
+    @Consumes // anything - now autodetect is done for everything unless 'format' is specified
+    // (mime type is ignored; though it could be useful in the "score" function, and probably is available on the thread)
+    @ApiOperation(
+            value = "Add a bundle of types (entities, etc) to the type registry",
+            notes = "This will auto-detect the format, with the 'brooklyn-bom-bundle' being common and consisting of "
+                    + "a ZIP/JAR containing a catalog.bom",
+            response = BundleInstallationRestResult.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Error processing the given archive, or the catalog.bom is invalid"),
+            @ApiResponse(code = 201, message = "Catalog items added successfully")
+    })
+    public Response create(
+            @ApiParam(
+                    name = "archive",
+                    value = "Bundle contents to install, eg for brooklyn-catalog-bundle a ZIP or JAR containing a catalog.bom file",
+                    required = true)
+                    byte[] archive,
+            @ApiParam(name = "format", value="Specify the format to indicate a specific resolver for handling this", required=false)
+            @QueryParam("format") @DefaultValue("")
+                    String format,
+            @ApiParam(name = "force", value = "Whether to forcibly remove it, even if in use and/or errors", required = false, defaultValue = "false")
+            @QueryParam("force") @DefaultValue("false")
+                    Boolean force);
 
 }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ApplicationResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/ApplicationResourceTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.rest.resources;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.find;
+import org.apache.brooklyn.util.text.Strings;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -126,7 +127,12 @@ public class ApplicationResourceTest extends BrooklynRestResourceTest {
      */
 
     private static final Logger log = LoggerFactory.getLogger(ApplicationResourceTest.class);
-    
+
+    @Override
+    protected boolean useOsgi() {
+        return true;
+    }
+
     private final ApplicationSpec simpleSpec = ApplicationSpec.builder().name("simple-app")
           .entities(ImmutableSet.of(
                   new EntitySpec("simple-ent", RestMockSimpleEntity.class.getName()),
@@ -238,8 +244,13 @@ public class ApplicationResourceTest extends BrooklynRestResourceTest {
 
     @Test
     public void testReferenceCatalogEntity() throws Exception {
-        getManagementContext().getCatalog().addItems("{ name: "+BasicEntity.class.getName()+", "
-            + "services: [ { type: "+BasicEntity.class.getName()+" } ] }");
+        getManagementContext().getCatalog().addItems(Strings.lines(
+                "brooklyn.catalog:",
+                "  id: test-reference",
+                "  version: 0.0.1",
+                "  item:",
+                "    name: "+BasicEntity.class.getName(),
+                "    services: [ { type: "+BasicEntity.class.getName()+" } ]"));
 
         String yaml = "{ name: simple-app-yaml, location: localhost, services: [ { type: " + BasicEntity.class.getName() + " } ] }";
 

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
@@ -601,7 +601,7 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
                 .post(Streams.readFully(new FileInputStream(f)));
 
         assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
-        Asserts.assertStringContainsIgnoreCase(response.readEntity(String.class), "Catalog BOM must define version");
+        Asserts.assertStringContainsIgnoreCase(response.readEntity(String.class), "BOM", "bundle", "version");
     }
 
     @Test

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
@@ -660,7 +660,7 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
                 .post(Streams.readFully(new FileInputStream(f)));
 
         assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
-        Asserts.assertStringContainsIgnoreCase(response.readEntity(String.class), "Catalog BOM must define version");
+        Asserts.assertStringContainsIgnoreCase(response.readEntity(String.class), "BOM", "bundle", "version");
     }
 
     @Test

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/LocationResourceTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.rest.resources;
 
+import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -66,6 +68,11 @@ public class LocationResourceTest extends BrooklynRestResourceTest {
     private String configDisplayName = "config_displayName";
     private String testsDisplayName = "tests_displayName";
     private String byonHostname = "10.10.10.102";
+
+    @Override
+    protected boolean useOsgi() {
+        return true;
+    }
 
     @Test
     @Deprecated

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/testing/BrooklynRestApiTest.java
@@ -131,6 +131,10 @@ public abstract class BrooklynRestApiTest {
         }
     }
 
+    protected boolean useOsgi() {
+        return useLocalScannedCatalog() || false;
+    }
+
     protected boolean useLocalScannedCatalog() {
         return false;
     }
@@ -141,13 +145,15 @@ public abstract class BrooklynRestApiTest {
 
     protected synchronized ManagementContext getManagementContext() {
         if (manager==null) {
-            if (useLocalScannedCatalog()) {
+            if (useOsgi()) {
                 manager = LocalManagementContextForTests.builder(true)
                         .enableOsgiReusable()
                         .build();
-                forceUseOfDefaultCatalogWithJavaClassPath();
             } else {
                 manager = new LocalManagementContextForTests();
+            }
+            if (useLocalScannedCatalog()) {
+                forceUseOfDefaultCatalogWithJavaClassPath();
             }
             manager.getHighAvailabilityManager().disabled(false);
             ((LocalManagementContext)manager).generateManagementPlaneId();

--- a/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableList.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableList.java
@@ -59,7 +59,11 @@ public class MutableList<V> extends ArrayList<V> {
         MutableList<V> result = new MutableList<V>();
         result.add(v1);
         result.add(v2);
-        for (V v: vv) result.add(v);
+        if (vv==null) {
+            result.add(null);
+        } else {
+            for (V v : vv) result.add(v);
+        }
         return result;
     }
 
@@ -135,7 +139,11 @@ public class MutableList<V> extends ArrayList<V> {
         public Builder<V> add(V value1, V value2, V ...values) {
             result.add(value1);
             result.add(value2);
-            for (V v: values) result.add(v);
+            if (values==null) {
+                result.add(null);
+            } else {
+                for (V v : values) result.add(v);
+            }
             return this;
         }
 
@@ -145,7 +153,9 @@ public class MutableList<V> extends ArrayList<V> {
         }
         
         public Builder<V> addAll(Iterable<? extends V> iterable) {
-            if (iterable instanceof Collection) {
+            if (iterable==null) {
+                // nothing
+            } else if (iterable instanceof Collection) {
                 result.addAll((Collection<? extends V>) iterable);
             } else {
                 for (V v : iterable) {
@@ -156,21 +166,27 @@ public class MutableList<V> extends ArrayList<V> {
         }
 
         public Builder<V> addAll(Iterator<? extends V> iter) {
-            while (iter.hasNext()) {
-                add(iter.next());
+            if (iter!=null) {
+                while (iter.hasNext()) {
+                    add(iter.next());
+                }
             }
             return this;
         }
 
         public Builder<V> addAll(V[] vals) {
-            for (V v : vals) {
-                result.add(v);
+            if (vals!=null) {
+                for (V v : vals) {
+                    result.add(v);
+                }
             }
             return this;
         }
 
         public Builder<V> removeAll(Iterable<? extends V> iterable) {
-            if (iterable instanceof Collection) {
+            if (iterable==null) {
+                // nothing
+            } else if (iterable instanceof Collection) {
                 result.removeAll((Collection<? extends V>) iterable);
             } else {
                 for (V v : iterable) {
@@ -181,7 +197,9 @@ public class MutableList<V> extends ArrayList<V> {
         }
 
         public Builder<V> retainAll(Iterable<? extends V> iterable) {
-            if (iterable instanceof Collection) {
+            if (iterable==null) {
+                // nothing
+            } else if (iterable instanceof Collection) {
                 result.retainAll((Collection<? extends V>) iterable);
             } else {
                 List<V> toretain = Lists.newArrayList(iterable);
@@ -199,8 +217,10 @@ public class MutableList<V> extends ArrayList<V> {
         }
 
         public Builder<V> addLists(Iterable<? extends V> ...items) {
-            for (Iterable<? extends V> item: items) {
-                addAll(item);
+            if (items!=null) {
+                for (Iterable<? extends V> item : items) {
+                    addAll(item);
+                }
             }
             return this;
         }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableSet.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/collections/MutableSet.java
@@ -60,7 +60,11 @@ public class MutableSet<V> extends LinkedHashSet<V> {
         result.add(v1);
         result.add(v2);
         result.add(v3);
-        for (V vi: vMore) result.add(vi);
+        if (vMore==null) {
+            result.add(null);
+        } else {
+            for (V vi : vMore) result.add(vi);
+        }
         return result;
     }
 
@@ -126,7 +130,11 @@ public class MutableSet<V> extends LinkedHashSet<V> {
         public Builder<V> add(V v1, V v2, @SuppressWarnings("unchecked") V ...values) {
             result.add(v1);
             result.add(v2);
-            for (V value: values) result.add(value);
+            if (values==null) {
+                result.add(null);
+            } else {
+                for (V value : values) result.add(value);
+            }
             return this;
         }
 


### PR DESCRIPTION
support `format` on the REST API for catalog bundles and deployment plans.

this can give better error messages than auto-detect, if auto-detect picks the wrong type.

also make the osgi bundle version logic compatible with logic where a BOM was added, allowing `id` to indicate bundle name.