### PR TITLE
DSL serialization and deserialization

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.io.Serializable;
 import java.util.concurrent.ExecutionException;
 
@@ -73,10 +74,10 @@ public abstract class BrooklynDslDeferredSupplier<T> implements DeferredSupplier
     private static final Logger log = LoggerFactory.getLogger(BrooklynDslDeferredSupplier.class);
 
     // TODO json of this object should *be* this, not wrapped this ($brooklyn:literal is a bit of a hack, though it might work!)
-    @JsonInclude
+    @JsonInclude(Include.NON_NULL)
     @JsonProperty(value="$brooklyn:literal")
     // currently marked transient because it's only needed for logging
-    private transient Object dsl = "(gone)";
+    private transient Object dsl = null;
 
     public BrooklynDslDeferredSupplier() {
         PlanInterpretationNode sourceNode = BrooklynDslInterpreter.currentNode();

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/BrooklynDslDeferredSupplier.java
@@ -76,11 +76,11 @@ public abstract class BrooklynDslDeferredSupplier<T> implements DeferredSupplier
     /** The original DSL which generated the expression, if available.
      * Note the {@link #toString()} should create an equivalent expression.
      */
-    // not required in persistence, but potentially interesting.
-    // xstream deserialization may use this or the toString.
-    // jackson deserialization relies on the presence of this field if reading an Object,
+    // not required in persistence; potentially interesting, but increases size significantly
+    // xstream deserialization should use the toString, and skips transients;
+    // jackson deserialization includes this, and relies on it if reading an Object,
     // but if reading to a Supplier it will correctly instantiate based on the type field.
-    private Object dsl = null;
+    private transient Object dsl = null;
 
     public BrooklynDslDeferredSupplier() {
         PlanInterpretationNode sourceNode = BrooklynDslInterpreter.currentNode();

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslDeferredFunctionCall.java
@@ -15,6 +15,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -54,7 +55,7 @@ public class DslDeferredFunctionCall extends BrooklynDslDeferredSupplier<Object>
         this.args = args;
     }
 
-    @Override
+    @Override @JsonIgnore
     public Maybe<Object> getImmediately() {
         return invokeOnDeferred(object, true);
     }

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslUtils.java
@@ -78,12 +78,7 @@ public class DslUtils {
                 value = Iterables.getOnlyElement( Yamls.parseAll((String)value) );
             }
             
-            // The 'dsl' key is arbitrary, but the interpreter requires a map
-            ImmutableMap<String, Object> inputToPdpParse = ImmutableMap.of("dsl", value);
-            Map<String, Object> resolvedConfigMap = BrooklynCampPlatform.findPlatform(mgmt)
-                    .pdp()
-                    .applyInterpreters(inputToPdpParse);
-            value = resolvedConfigMap.get("dsl");
+            value = parseBrooklynDsl(mgmt, value);
             // TODO if it fails log a warning -- eg entitySpec with root.war that doesn't exist
 
             if (specForCatalogItemIdContext!=null) {
@@ -105,8 +100,22 @@ public class DslUtils {
         }
     }
 
-    /** Resolve an object which might be (or contain in a map or list) a $brooklyn DSL string expression,
-     * attempting to coerce if a type is supplied (unless it is a {@link DeferredSupplier}) */
+    /** Parses a Brooklyn DSL expression, returning a Brooklyn DSL deferred supplier if appropriate; otherwise the value is unchanged. Will walk maps/lists.  */
+    // our code uses CAMP PDP to evaluate this, which is probably unnecessary, but it means the mgmt context is required and CAMP should be installed
+    public static Object parseBrooklynDsl(ManagementContext mgmt, Object value) {
+        // The 'dsl' key is arbitrary, but the interpreter requires a map
+        ImmutableMap<String, Object> inputToPdpParse = ImmutableMap.of("dsl", value);
+        Map<String, Object> resolvedConfigMap = BrooklynCampPlatform.findPlatform(mgmt)
+                .pdp()
+                .applyInterpreters(inputToPdpParse);
+        value = resolvedConfigMap.get("dsl");
+        return value;
+    }
+
+    /** Resolve an object which might be (or contain in a map or list or inside a json string) a $brooklyn DSL string expression,
+     * and if a type is supplied, attempting to resolve/evaluate/coerce (unless requested type is itself a {@link DeferredSupplier}).
+     * If type is not supplied acts similar to {@link #parseBrooklynDsl(ManagementContext, Object)} but with more support for
+     * looking within json strings of maps/lists. */
     public static Optional<Object> resolveBrooklynDslValue(Object originalValue, @Nullable TypeToken<?> desiredType, @Nullable ManagementContext mgmt, @Nullable AbstractBrooklynObjectSpec<?,?> specForCatalogItemIdContext) {
         return resolveBrooklynDslValueInternal(originalValue, desiredType, mgmt, specForCatalogItemIdContext, false);
         

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
@@ -180,7 +181,7 @@ public class BrooklynDslCommon {
                 .get();
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             if (obj instanceof Entity) {
                 // Shouldn't worry too much about it since DSL can fetch objects from same app only.
@@ -403,7 +404,7 @@ public class BrooklynDslCommon {
             this.arg = arg;
         }
 
-        @Override
+        @Override @JsonIgnore
         public final Maybe<String> getImmediately() {
             return DependentConfiguration.urlEncodeImmediately(arg);
         }
@@ -449,7 +450,7 @@ public class BrooklynDslCommon {
             this.args = args;
         }
 
-        @Override
+        @Override @JsonIgnore
         public final Maybe<String> getImmediately() {
             return DependentConfiguration.formatStringImmediately(pattern, args);
         }
@@ -493,7 +494,7 @@ public class BrooklynDslCommon {
             this.source = source;
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<String> getImmediately() {
             return DependentConfiguration.regexReplacementImmediately(source, pattern, replacement);
         }
@@ -603,7 +604,7 @@ public class BrooklynDslCommon {
         }
 
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             final Class<?> clazz = getOrLoadType();
             final ExecutionContext executionContext = entity().getExecutionContext();
@@ -768,7 +769,7 @@ public class BrooklynDslCommon {
             this.key = key;
         }
 
-        @Override
+        @Override @JsonIgnore
         public final Maybe<Object> getImmediately() {
             // Note this call to getConfig() is different from entity.getConfig.
             // We expect it to not block waiting for other entities.
@@ -848,7 +849,7 @@ public class BrooklynDslCommon {
                 this.replacement = replacement;
             }
 
-            @Override
+            @Override @JsonIgnore
             public Maybe<Function<String, String>> getImmediately() {
                 return DependentConfiguration.regexReplacementImmediately(pattern, replacement);
             }
@@ -890,7 +891,7 @@ public class BrooklynDslCommon {
                 this.entityId = entityId;
             }
 
-            @Override
+            @Override @JsonIgnore
             public Maybe<Entity> getImmediately() {
                 EntityInternal entity = entity();
                 if (entity == null) {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils;
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
 
 import java.util.Arrays;
@@ -51,6 +52,7 @@ import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.DeserializingClassRenamesProvider;
 import org.apache.brooklyn.core.objs.AbstractConfigurationSupportInternal;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.util.collections.Jsonya;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -91,6 +93,9 @@ public class BrooklynDslCommon {
     private static final Logger LOG = LoggerFactory.getLogger(BrooklynDslCommon.class);
 
     public static final String PREFIX = "$brooklyn:";
+    static {
+        BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings.BROOKLYN_PARSE_DSL_FUNCTION = DslUtils::parseBrooklynDsl;
+    }
     
     // Access specific entities
 

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
 
 import java.util.Collection;
@@ -150,6 +152,14 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         this(null, scope, componentIdSupplier);
     }
 
+    // for JSON deserialization only
+    private DslComponent() {
+        this.scopeComponent = null;
+        this.componentId = null;
+        this.componentIdSupplier = null;
+        this.scope = null;
+    }
+
     /**
      * Resolve componentId in scope relative to scopeComponent.
      */
@@ -178,7 +188,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         return scope;
     }
     
-    @Override
+    @Override @JsonIgnore
     public final Maybe<Entity> getImmediately() {
         return new EntityInScopeFinder(scopeComponent, scope, componentId, componentIdSupplier).getImmediately();
     }
@@ -205,7 +215,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             this.componentIdSupplier = componentIdSupplier;
         }
 
-        @Override 
+        @Override @JsonIgnore
         public Maybe<Entity> getImmediately() {
             try {
                 return callImpl(true);
@@ -419,7 +429,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             this.component = Preconditions.checkNotNull(component);
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             Maybe<Entity> targetEntityMaybe = component.getImmediately();
             if (targetEntityMaybe.isAbsent()) return ImmediateValueNotAvailableException.newAbsentWrapping("Target entity is not available: "+component, targetEntityMaybe);
@@ -461,6 +471,11 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         @XStreamConverter(ObjectWithDefaultStringImplConverter.class)
         private final Object sensorName;
 
+        // JSON deserialization only
+        private AttributeWhenReady() {
+            this.component = null;
+            this.sensorName = null;
+        }
         public AttributeWhenReady(DslComponent component, Object sensorName) {
             this.component = Preconditions.checkNotNull(component);
             this.sensorName = sensorName;
@@ -479,7 +494,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                 .get();
         }
         
-        @Override
+        @Override @JsonIgnore
         public final Maybe<Object> getImmediately() {
             Maybe<Entity> targetEntityMaybe = component.getImmediately();
             if (targetEntityMaybe.isAbsent()) return ImmediateValueNotAvailableException.newAbsentWrapping("Target entity not available: "+component, targetEntityMaybe);
@@ -535,6 +550,11 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         private final Object keyName;
         private static final long serialVersionUID = -4735177561947722511L;
 
+        // JSON-only constructor
+        private DslConfigSupplier() {
+            component = null;
+            keyName = null;
+        }
         public DslConfigSupplier(DslComponent component, Object keyName) {
             this.component = Preconditions.checkNotNull(component);
             this.keyName = keyName;
@@ -553,7 +573,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                 .get();
         }
         
-        @Override
+        @Override @JsonIgnore
         public final Maybe<Object> getImmediately() {
             Maybe<Object> maybeWrappedMaybe = findExecutionContext(this).getImmediately(newCallableReturningImmediateMaybeOrNonImmediateValue(true));
             // the answer will be wrapped twice due to the callable semantics;
@@ -638,7 +658,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             this.sensorName = sensorIndicator;
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Sensor<?>> getImmediately() {
             return getImmediately(sensorName, false);
         }
@@ -741,7 +761,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
             this.index = index;
         }
 
-        @Override
+        @Override @JsonIgnore
         public final Maybe<Object> getImmediately() {
             Callable<Object> job = new Callable<Object>() {
                 @Override public Object call() {
@@ -894,7 +914,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                     .get();
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             String resolvedTemplate = resolveTemplate(true);
             Map<String, ?> resolvedSubstitutions = resolveSubstitutions(true);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -191,7 +191,7 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
     //      if the java type exactly matches the expected type)
 
     // TODO DSL expressions inside these types might mess things up
-    // they might just work, or maybe just when wrapped in ValueSupplier, or maybe they break horribly ...
+    // they might just work, or maybe just when wrapped in WrappedValue, or maybe they break horribly ...
     // can make jackson serialize and deserialize them specially, either pass-through or as strings TBD
     // see reference to DslSerializationAsToString in BeanWithTypeUtils
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -180,8 +180,8 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
                 "foo", "bar");
     }
 
-    // TODO - implicit typing - deserialization base type implied by key type.  on creation?  or on access?
-    // probably on access, by config lookup.  though that will need custom logic for initializers and maybe others,
+    // NOTE, re implicit typing - deserialization base type implied by key type.  on creation?  or on access?
+    // mainly done on access, by config lookup.  though that will need custom logic for initializers and maybe others,
     // in addition to the obvious place(s) where it is done for entities
     //
     // test:  type declared on a parameter; get as object it recasts it as official type, and coerces
@@ -190,11 +190,8 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
     // (and change testJavaTypeDeclaredInValueOfAnonymousConfigKey_IgnoresType_FailsCoercionToCustomType,
     //      if the java type exactly matches the expected type)
 
-    // TODO DSL expressions inside these types might mess things up
-    // they might just work, or maybe just when wrapped in WrappedValue, or maybe they break horribly ...
-    // can make jackson serialize and deserialize them specially, either pass-through or as strings TBD
-    // see reference to DslSerializationAsToString in BeanWithTypeUtils
-
+    // NOTE,re DSL expressions; currently if implied by context, or if a $brooklyn:literal key is present, the DSL is parsed and restored;
+    // see in JsonDeserializerForCommonBrooklynThings.  See DslSerializationTest .
 
     @Test
     public void testRegisteredTypeMalformed_GoodError() throws Exception {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseTest.java
@@ -19,6 +19,8 @@
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.common.reflect.TypeToken;
 import java.util.Map;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
@@ -81,50 +83,6 @@ public class DslParseTest {
         assertEquals( ((FunctionWithArgs)fx1).getArgs(), ImmutableList.of(new QuotedString("\"x\"")) );
         assertEquals( ((FunctionWithArgs)fx2).getFunction(), "g" );
         assertTrue( ((FunctionWithArgs)fx2).getArgs().isEmpty() );
-    }
-
-    @Test
-    public void testSerializeAttributeWhenReady() throws Exception {
-        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").attributeWhenReady("my_sensor");
-        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
-
-        String out = mapper.writerFor(Object.class).writeValueAsString(awr);
-        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
-        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
-
-        Object supplier2 = mapper.readValue(out, Object.class);
-        Asserts.assertInstanceOf(supplier2, BrooklynDslDeferredSupplier.class);
-    }
-
-    @Test
-    public void testSerializeDslConfigSupplierInMapObject() throws Exception {
-        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
-        Map<String,Object> stuff = MutableMap.<String,Object>of("stuff", awr);
-
-        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
-
-        String out = mapper.writerFor(Object.class).writeValueAsString(stuff);
-        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
-        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
-
-        Object stuff2 = mapper.readValue(out, Object.class);
-        Object stuff2I = ((Map<?, ?>) stuff2).get("stuff");
-        Asserts.assertInstanceOf(stuff2I, BrooklynDslDeferredSupplier.class);
-    }
-
-    @Test
-    public void testSerializeDslConfigSupplierInWrappedValue() throws Exception {
-        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
-        WrappedValue<Object> stuff = WrappedValue.of(awr);
-
-        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
-
-        String out = mapper.writeValueAsString(stuff);
-        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
-        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
-
-        WrappedValue<?> stuff2 = mapper.readValue(out, WrappedValue.class);
-        Asserts.assertInstanceOf(stuff2.getSupplier(), BrooklynDslDeferredSupplier.class);
     }
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslParseTest.java
@@ -18,6 +18,15 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.Assert;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -73,6 +82,49 @@ public class DslParseTest {
         assertEquals( ((FunctionWithArgs)fx2).getFunction(), "g" );
         assertTrue( ((FunctionWithArgs)fx2).getArgs().isEmpty() );
     }
-    
+
+    @Test
+    public void testSerializeAttributeWhenReady() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").attributeWhenReady("my_sensor");
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writerFor(Object.class).writeValueAsString(awr);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        Object supplier2 = mapper.readValue(out, Object.class);
+        Asserts.assertInstanceOf(supplier2, BrooklynDslDeferredSupplier.class);
+    }
+
+    @Test
+    public void testSerializeDslConfigSupplierInMapObject() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
+        Map<String,Object> stuff = MutableMap.<String,Object>of("stuff", awr);
+
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writerFor(Object.class).writeValueAsString(stuff);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        Object stuff2 = mapper.readValue(out, Object.class);
+        Object stuff2I = ((Map<?, ?>) stuff2).get("stuff");
+        Asserts.assertInstanceOf(stuff2I, BrooklynDslDeferredSupplier.class);
+    }
+
+    @Test
+    public void testSerializeDslConfigSupplierInWrappedValue() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
+        WrappedValue<Object> stuff = WrappedValue.of(awr);
+
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writeValueAsString(stuff);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        WrappedValue<?> stuff2 = mapper.readValue(out, WrappedValue.class);
+        Asserts.assertInstanceOf(stuff2.getSupplier(), BrooklynDslDeferredSupplier.class);
+    }
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslSerializationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslSerializationTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.camp.brooklyn.spi.dsl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
@@ -88,17 +89,17 @@ public class DslSerializationTest extends AbstractYamlTest {
     }
 
     @Test
-    public void testSerializeDslConfigSupplierInWrappedValueFailsWithoutBrooklynLiteralMarker() throws Exception {
+    public void testSerializeDslConfigSupplierInWrappedValueWorksWithoutBrooklynLiteralMarker() throws Exception {
         BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
         WrappedValue<Object> stuff = WrappedValue.of(awr);
         ObjectMapper mapper = newMapper();
 
         String out = mapper.writeValueAsString(stuff);
-        Assert.assertTrue(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
         Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
 
         WrappedValue<?> stuff2 = mapper.readValue(out, WrappedValue.class);
-        Asserts.assertInstanceOf(stuff2.getSupplier(), BrooklynDslDeferredSupplier.class);
+        Asserts.assertInstanceOf(stuff2.getSupplier(), Supplier.class);
     }
 
     @Test
@@ -113,7 +114,7 @@ public class DslSerializationTest extends AbstractYamlTest {
         Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
 
         WrappedValue<?> stuff2 = mapper.readValue(out, WrappedValue.class);
-        Asserts.assertInstanceOf(stuff2.getSupplier(), BrooklynDslDeferredSupplier.class);
+        Asserts.assertInstanceOf(stuff2.getSupplier(), Supplier.class);
     }
 
     @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslSerializationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslSerializationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.spi.dsl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import java.util.Map;
+import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslComponent.Scope;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.Assert;
+import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
+import org.testng.annotations.Test;
+
+@Test
+public class DslSerializationTest extends AbstractYamlTest {
+
+    @Test
+    public void testSerializeAttributeWhenReady() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").attributeWhenReady("my_sensor");
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writerFor(Object.class).writeValueAsString(awr);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        Object supplier2 = mapper.readValue(out, Object.class);
+        Asserts.assertInstanceOf(supplier2, BrooklynDslDeferredSupplier.class);
+    }
+
+    @Test
+    public void testSerializeDslConfigSupplierInMapObject() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr = new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
+        Map<String,Object> stuff = MutableMap.<String,Object>of("stuff", awr);
+
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writerFor(Object.class).writeValueAsString(stuff);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        Object stuff2 = mapper.readValue(out, Object.class);
+        Object stuff2I = ((Map<?, ?>) stuff2).get("stuff");
+        Asserts.assertInstanceOf(stuff2I, BrooklynDslDeferredSupplier.class);
+    }
+
+    @Test
+    public void testSerializeDslConfigSupplierInWrappedValue() throws Exception {
+        BrooklynDslDeferredSupplier<?> awr =
+                (BrooklynDslDeferredSupplier<?>) DslUtils.resolveBrooklynDslValue("$brooklyn:component(\"entity_id\").config(\"my_config\")", null, mgmt(), null).get();
+                //new DslComponent(Scope.GLOBAL, "entity_id").config("my_config");
+        WrappedValue<Object> stuff = WrappedValue.of(awr);
+
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(null, false, null, true);
+
+        String out = mapper.writeValueAsString(stuff);
+        Assert.assertFalse(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        WrappedValue<?> stuff2 = mapper.readValue(out, WrappedValue.class);
+        Asserts.assertInstanceOf(stuff2.getSupplier(), BrooklynDslDeferredSupplier.class);
+    }
+
+    @Test
+    public void testSerializeDslLiteral() throws Exception {
+        /*
+        options:
+        - ensure DSL only converted at the last mile
+        - ensure DSL read/written as string when reading object
+        - ensure DSL readable from type even when reading object <- if has $brooklyn:literal set then it will
+         */
+        String unwrappedDesiredValue = JavaStringEscapes.wrapJavaString("$brooklyn:literal(" + JavaStringEscapes.wrapJavaString("foo") + ")");
+        Optional<Object> l = DslUtils.resolveBrooklynDslValue("$brooklyn:literal(" +
+                unwrappedDesiredValue
+                + ")", null, mgmt(), null);
+        Assert.assertTrue(l.isPresent());
+        Map<String,Object> stuff = MutableMap.<String,Object>of("stuff", l.get());
+
+        ObjectMapper mapper = BeanWithTypeUtils.newMapper(mgmt(), false, null, true);
+
+        String out = mapper.writerFor(Object.class).writeValueAsString(stuff);
+        Assert.assertTrue(out.toLowerCase().contains("literal"), "serialization had wrong text: "+out);
+        Assert.assertFalse(out.toLowerCase().contains("absent"), "serialization had wrong text: "+out);
+
+        Object stuff2 = mapper.readValue(out, Object.class);
+        Object stuff2I = ((Map<?, ?>) stuff2).get("stuff");
+        Asserts.assertInstanceOf(stuff2I, BrooklynDslDeferredSupplier.class);
+        Assert.assertEquals( ((BrooklynDslDeferredSupplier)stuff2I).get(), unwrappedDesiredValue );
+    }
+}

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/TagsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/TagsYamlTest.java
@@ -129,7 +129,7 @@ public class TagsYamlTest extends AbstractYamlTest {
                 "services:",
                 "- type: " + BasicApplication.class.getName(),
                 "  brooklyn.tags:",
-                "  - $brooklyn:literal(\"myval\")");
+                "  - $brooklyn:formatString(\"myval\")");
         assertTrue(app.tags().getTags().contains("myval"));
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslTestObjects.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslTestObjects.java
@@ -15,6 +15,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.DslAccessible;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.DslFunctionSource;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
@@ -59,7 +60,7 @@ public class DslTestObjects {
             return getImmediately().get();
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             return Maybe.of(value);
         }
@@ -67,7 +68,7 @@ public class DslTestObjects {
 
     public static class DslTestCallable implements DslFunctionSource, DeferredSupplier<TestDslSupplier>, ImmediateSupplier<TestDslSupplier> {
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<TestDslSupplier> getImmediately() {
             throw new IllegalStateException("Not to be called");
         }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -45,7 +45,7 @@ public class BeanWithTypeUtils {
         WrappedValuesSerialization.apply(mapper);
         mapper = new ConfigurableBeanDeserializerModifier()
                 .addDeserializerWrapper(
-                        d -> new JsonDeserializerForCommonBrooklynThings(d)
+                        d -> new JsonDeserializerForCommonBrooklynThings(mgmt, d)
                         //TODO DslSerializationAsToString - see CustomTypeConfigYamlTest
                 ).apply(mapper);
 

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/JacksonBetterDelegatingDeserializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/JacksonBetterDelegatingDeserializer.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.resolve.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.reflect.TypeToken;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Jackson's {@link DelegatingDeserializer} does not get invoked when maps/lists deserialize other maps/lists.
+ * This corrects that, ensuring subclasses of this get invoked on each returned object (as far as we have encountered).
+ */
+public abstract class JacksonBetterDelegatingDeserializer extends DelegatingDeserializer {
+
+    private static final Logger log = LoggerFactory.getLogger(JacksonBetterDelegatingDeserializer.class);
+
+    // longwinded way to detect if it's non-merging
+    public static class UntypedObjectDeserializerInfoAccess extends UntypedObjectDeserializer {
+        public UntypedObjectDeserializerInfoAccess(UntypedObjectDeserializer base) {
+            super(base, null, null, null, null);
+        }
+        public boolean isNonMerging() {
+            return _nonMerging;
+        }
+    }
+
+    public static class CollectionDelegatingUntypedObjectDeserializer extends UntypedObjectDeserializer {
+        DelegatingDeserializer outer;
+        public CollectionDelegatingUntypedObjectDeserializer(UntypedObjectDeserializer base) {
+            super(base, new UntypedObjectDeserializerInfoAccess(base).isNonMerging());
+            if (_mapDeserializer==null) _mapDeserializer = this;
+            if (_listDeserializer==null) _listDeserializer = this;
+        }
+        public void init(DelegatingDeserializer delegator) {
+            outer = delegator;
+        }
+
+        /* This awkward pattern ensures that if the delegatee tries sneakily to deserialize more things (which mapObject and mapArray do)
+         * then it gets redirected to the delegating deserializer
+         */
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return outer.deserialize(p, ctxt);
+        }
+
+        @Override
+        public Object deserialize(JsonParser p, DeserializationContext ctxt, Object intoValue) throws IOException {
+            return outer.deserialize(p, ctxt, intoValue);
+        }
+
+        public Object deserializeReal(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return super.deserialize(p, ctxt);
+        }
+
+        public Object deserializeReal(JsonParser p, DeserializationContext ctxt, Object intoValue) throws IOException {
+            return super.deserialize(p, ctxt, intoValue);
+        }
+    }
+
+    protected final Function<JsonDeserializer<?>, JacksonBetterDelegatingDeserializer> constructor;
+
+    public JacksonBetterDelegatingDeserializer(JsonDeserializer<?> delagatee, Function<JsonDeserializer<?>,JacksonBetterDelegatingDeserializer> constructor) {
+        super(newDelagatee(delagatee));
+        this.constructor = constructor;
+        if (_delegatee instanceof CollectionDelegatingUntypedObjectDeserializer) {
+            ((CollectionDelegatingUntypedObjectDeserializer)_delegatee).init(this);
+        }
+
+    }
+
+    protected static JsonDeserializer<?> newDelagatee(JsonDeserializer<?> delegatee) {
+        if (delegatee instanceof UntypedObjectDeserializer) {
+            return new CollectionDelegatingUntypedObjectDeserializer((UntypedObjectDeserializer)delegatee);
+        }
+        return delegatee;
+    }
+
+    @Override
+    protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> newDelegatee) {
+        return constructor.apply(newDelegatee);
+    }
+
+    @Override
+    public Object deserialize(JsonParser jp1, DeserializationContext ctxt1) throws IOException {
+        return deserializeWrapper(jp1, ctxt1, (jp2, ctxt2) -> _delegatee instanceof CollectionDelegatingUntypedObjectDeserializer
+                    ? ((CollectionDelegatingUntypedObjectDeserializer)_delegatee).deserializeReal(jp2, ctxt2)
+                    : _delegatee.deserialize(jp2, ctxt2));
+    }
+
+    @Override
+    public Object deserialize(JsonParser jp1, DeserializationContext ctxt1, Object intoValue) throws IOException {
+        return deserializeWrapper(jp1, ctxt1, (jp2, ctxt2) -> _delegatee instanceof CollectionDelegatingUntypedObjectDeserializer
+                    ? ((CollectionDelegatingUntypedObjectDeserializer)_delegatee).deserializeReal(jp2, ctxt2, intoValue)
+                    : ((JsonDeserializer<Object>)_delegatee).deserialize(jp2, ctxt2, intoValue));
+    }
+
+    interface BiFunctionThrowsIoException<I1,I2,O> {
+        O apply(I1 i1, I2 i2) throws IOException;
+    }
+
+    protected abstract Object deserializeWrapper(JsonParser jp, DeserializationContext ctxt, BiFunctionThrowsIoException<JsonParser, DeserializationContext, Object> nestedDeserialize) throws IOException;
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.resolve.jackson;
 
+import com.google.common.base.Preconditions;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -26,8 +27,6 @@ import java.util.function.Supplier;
  * The pattern where fields are of this type is used to assist with (de)serialization
  * where values might come from a DSL.
  */
-//@JsonSerialize(using = WrappedValueSerializer.class)
-//@JsonDeserialize(using = WrappedValueDeserializer.class)
 public class WrappedValue<T> implements Supplier<T> {
     final static WrappedValue<?> NULL_WRAPPED_VALUE = new WrappedValue<>(null, false);
     final T value;
@@ -43,13 +42,43 @@ public class WrappedValue<T> implements Supplier<T> {
         }
     }
 
+    public static class GuavaSupplierAsJavaSupplier<T> implements Supplier<T> {
+        final com.google.common.base.Supplier<T> guavaSupplier;
+        private GuavaSupplierAsJavaSupplier() {
+            this.guavaSupplier = null;
+        }
+        public GuavaSupplierAsJavaSupplier(com.google.common.base.Supplier<T> guavaSupplier) {
+            this.guavaSupplier = Preconditions.checkNotNull(guavaSupplier);
+        }
+        @Override
+        public T get() {
+            return guavaSupplier.get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            GuavaSupplierAsJavaSupplier<?> that = (GuavaSupplierAsJavaSupplier<?>) o;
+            return Objects.equals(guavaSupplier, that.guavaSupplier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(guavaSupplier);
+        }
+    }
+
     public static <T> WrappedValue<T> of(Object x) {
-        return new WrappedValue<>(x, x instanceof Supplier);
+        if (x instanceof Supplier) return ofSupplier((Supplier<T>)x);
+        if (x instanceof com.google.common.base.Supplier) return ofSupplier((com.google.common.base.Supplier<T>)x);
+        return new WrappedValue<>(x, false);
     }
     public static <T> WrappedValue<T> ofConstant(T x) {
         return new WrappedValue<>(x, false);
     }
     public static <T> WrappedValue<T> ofSupplier(Supplier<T> x) { return new WrappedValue<>(x, true); }
+    public static <T> WrappedValue<T> ofSupplier(com.google.common.base.Supplier<T> x) { return new WrappedValue<>(new GuavaSupplierAsJavaSupplier<>( (com.google.common.base.Supplier<T>)x ), true); }
     public static <T> WrappedValue<T> ofNull() { return (WrappedValue<T>)NULL_WRAPPED_VALUE; }
 
     public T get() {

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerialization.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.PropertyBuilder;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
+import java.util.Map;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.BrooklynRegisteredTypeAndClassNameIdResolver;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -82,7 +83,18 @@ public class WrappedValuesSerialization {
 
                 // fall back to just using object
                 try {
-                    return ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class)).deserialize(b.asParserOnFirstToken(), ctxt);
+                    return ctxt.findRootValueDeserializer(ctxt.constructType(Object.class)).deserialize(b.asParserOnFirstToken(), ctxt);
+                    // above should be sufficient, but if not we could try the below:
+//                    Object result ctxt.findNonContextualValueDeserializer(ctxt.constructType(Object.class)).deserialize(b.asParserOnFirstToken(), ctxt);
+//                    try {
+//                        if (result instanceof Map) {
+//                            // if we got a map, try reading it as typed
+//                            return ctxt.findRootValueDeserializer(ctxt.constructType(Object.class)).deserialize(b.asParserOnFirstToken(), ctxt);
+//                        }
+//                    } catch (Exception e) {
+//                        exceptions.add(e);
+//                    }
+//                    return result;
                 } catch (Exception e) {
                     exceptions.add(e);
                 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/InterruptingImmediateSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/InterruptingImmediateSupplier.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.util.core.task;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Semaphore;
@@ -52,7 +53,7 @@ public class InterruptingImmediateSupplier<T> implements ImmediateSupplier<T>, D
         this.nestedSupplier = nestedSupplier;
     }
     
-    @Override
+    @Override @JsonIgnore
     public Maybe<T> getImmediately() {
         boolean interrupted = Thread.currentThread().isInterrupted();
         try {

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -425,7 +426,7 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
         
         private DeferredSupplier<String> immediateSupplier(final boolean withSleep) {
             class DeferredImmediateSupplier implements DeferredSupplier<String>, ImmediateSupplier<String> {
-                @Override
+                @Override @JsonIgnore
                 public Maybe<String> getImmediately() {
                     try {
                         sleepIfNeeded();

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/LoggingSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/LoggingSerializationTest.java
@@ -36,7 +36,7 @@ public class LoggingSerializationTest implements MapperTestFixture {
         mapper = new ConfigurableBeanDeserializerModifier()
                 .addDeserializerWrapper(
                         d -> new NestedLoggingDeserializer(d1, d),
-                        d -> new JsonDeserializerForCommonBrooklynThings(d),
+                        d -> new JsonDeserializerForCommonBrooklynThings(null, d),
                         d -> new NestedLoggingDeserializer(d2, d)
                 ).apply(mapper);
         return mapper;

--- a/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/task/ValueResolverTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.util.core.task;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
@@ -453,7 +454,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
             this.failImmediately = failImmediately;
         }
         
-        @Override
+        @Override @JsonIgnore
         public Maybe<CallInfo> getImmediately() {
             if (failImmediately!=null) {
                 throw failImmediately;
@@ -479,7 +480,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
             return getImmediately().get();
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             return Maybe.of(value);
         }
@@ -493,7 +494,7 @@ public class ValueResolverTest extends BrooklynAppUnitTestSupport {
             throw new IllegalStateException("Not to be called");
         }
 
-        @Override
+        @Override @JsonIgnore
         public Maybe<Object> getImmediately() {
             throw new IllegalStateException("Not to be called");
         }

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/AdjunctResourceTest.java
@@ -203,26 +203,26 @@ public class AdjunctResourceTest extends BrooklynRestResourceTest {
         assertEquals(highlightTupleNoTask.getTaskId(), null);
     }
 
-    protected AdjunctDetail doTestAddPolicyExpectX(Function<WebClient,WebClient> mutator, Object postBody) throws Exception {
+    protected AdjunctDetail doTestAddPolicyExpect(Function<WebClient,WebClient> mutator, Object postBody, String expectedValue) throws Exception {
         AdjunctDetail result = mutator.apply(
                 client().path(ENDPOINT)
             ).post(postBody, AdjunctDetail.class);
-        Assert.assertEquals(result.getConfig().get(TestPolicy.CONF_FROM_FUNCTION.getName()), "x");
+        Assert.assertEquals(result.getConfig().get(TestPolicy.CONF_FROM_FUNCTION.getName()), expectedValue);
         return result;
     }
         
     @Test
     public void testAddPolicyX() throws Exception {
-        doTestAddPolicyExpectX(x -> x.query("type", TestPolicy.class.getName()), 
+        doTestAddPolicyExpect(x -> x.query("type", TestPolicy.class.getName()),
             toJsonEntity(MutableMap.of(
-                TestPolicy.CONF_FROM_FUNCTION.getName(), "x")));
+                TestPolicy.CONF_FROM_FUNCTION.getName(), "x")), "x");
     }
     
     @Test
     public void testAddPolicyFn() throws Exception {
-        doTestAddPolicyExpectX(x -> x.query("type", TestPolicy.class.getName()), 
+        doTestAddPolicyExpect(x -> x.query("type", TestPolicy.class.getName()),
             toJsonEntity(MutableMap.of(
-                TestPolicy.CONF_FROM_FUNCTION.getName(), "$brooklyn:literal(\"x\")")));
+                TestPolicy.CONF_FROM_FUNCTION.getName(), "$brooklyn:literal(\"x\")")), "$brooklyn:literal(\"x\")");
     }
 
 //    // TODO support YAML posts


### PR DESCRIPTION
brooklyn DSL expressions could get mangled when used within a bean-with-type; this improves some small details of how DSL is serialized and deserialized by Jackson for bean with type.  it also improves `WrappedValue` deserialization and handling of `$brooklyn:literal` (deferred until needed)