### PR TITLE
Resolve some edge cases in dealing with bean with type config 

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -389,7 +389,14 @@ public class BrooklynComponentTemplateResolver {
     }
 
     private <T> Maybe<T> convertConfig(Maybe<Object> input, TypeToken<T> type) {
-        return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false).or((Maybe<T>)(input));
+        if (input.isAbsentOrNull() || type==null) return (Maybe<T>)input;
+        Object t = input.get();
+        if (t instanceof Map && !Map.class.isAssignableFrom(type.getRawType())) {
+            // attempt bean-with-type conversion if we're given a map when a map is not wanted
+            return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false).or((Maybe<T>) (input));
+        }
+        // TODO if type.getRawType is a map, we should check the deeper generics
+        return (Maybe<T>)input;
     }
 
     protected ConfigInheritance getDefaultConfigInheritance() {

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -388,10 +388,11 @@ public class BrooklynComponentTemplateResolver {
     }
 
     private <T> Maybe<T> convertConfig(Maybe<Object> input, TypeToken<T> type) {
-        if (BeanWithTypeUtils.isConversionPlausible(input, type) && BeanWithTypeUtils.isJsonOrDeferredSupplier(input.orNull())) {
-            // attempt bean-with-type conversion if we're given a map when a map is not explicitly wanted
-            return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false).or((Maybe<T>) (input));
-        }
+        // no longer do conversion on set; do it on read instead
+//        if (BeanWithTypeUtils.isConversionPlausible(input, type) && BeanWithTypeUtils.isJsonOrDeferredSupplier(input.orNull())) {
+//            // attempt bean-with-type conversion if we're given a map when a map is not explicitly wanted
+//            return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false).or((Maybe<T>) (input));
+//        }
         return (Maybe<T>)input;
     }
 

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -77,7 +77,6 @@ import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import com.google.common.base.Function;
-import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
@@ -389,13 +388,10 @@ public class BrooklynComponentTemplateResolver {
     }
 
     private <T> Maybe<T> convertConfig(Maybe<Object> input, TypeToken<T> type) {
-        if (input.isAbsentOrNull() || type==null) return (Maybe<T>)input;
-        Object t = input.get();
-        if (t instanceof Map && !Map.class.isAssignableFrom(type.getRawType())) {
-            // attempt bean-with-type conversion if we're given a map when a map is not wanted
+        if (BeanWithTypeUtils.isConversionPlausible(input, type) && BeanWithTypeUtils.isJsonOrDeferredSupplier(input.orNull())) {
+            // attempt bean-with-type conversion if we're given a map when a map is not explicitly wanted
             return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false).or((Maybe<T>) (input));
         }
-        // TODO if type.getRawType is a map, we should check the deeper generics
         return (Maybe<T>)input;
     }
 

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -316,9 +316,9 @@ public class BrooklynComponentTemplateResolver {
             BiFunction<Maybe<Object>, TypeToken<? super Object>, Maybe<Object>> rawConvFn = this::convertConfig;
             if (r.getFlagMaybeValue().isPresent()) {
                 final String flag = r.getFlagName();
-                final ConfigKey<Object> key = (ConfigKey<Object>) r.getConfigKey();
-                if (key==null) ConfigKeys.newConfigKey(Object.class, flag);
-                final Object ownValueF = new SpecialFlagsTransformer(loader, encounteredRegisteredTypeIds).apply(r.getFlagMaybeValue().get());
+                final ConfigKey<Object> key = Maybe.ofDisallowingNull((ConfigKey<Object>) r.getConfigKey()).or(() -> ConfigKeys.newConfigKey(Object.class, flag));
+                final Object ownValue1 = new SpecialFlagsTransformer(loader, encounteredRegisteredTypeIds).apply(r.getFlagMaybeValue().get());
+                final Object ownValueF = rawConvFn.apply(Maybe.ofAllowingNull(ownValue1), key.getTypeToken()).get();
 
                 Function<EntitySpec<?>, Maybe<Object>> rawEvalFn = new Function<EntitySpec<?>,Maybe<Object>>() {
                     @Override
@@ -339,7 +339,8 @@ public class BrooklynComponentTemplateResolver {
 
             if (r.getConfigKeyMaybeValue().isPresent()) {
                 final ConfigKey<Object> key = (ConfigKey<Object>) r.getConfigKey();
-                final Object ownValueF = new SpecialFlagsTransformer(loader, encounteredRegisteredTypeIds).apply(r.getConfigKeyMaybeValue().get());
+                final Object ownValue1 = new SpecialFlagsTransformer(loader, encounteredRegisteredTypeIds).apply(r.getConfigKeyMaybeValue().get());
+                final Object ownValueF = rawConvFn.apply(Maybe.ofAllowingNull(ownValue1), key.getTypeToken()).get();
 
                 Function<EntitySpec<?>, Maybe<Object>> rawEvalFn = new Function<EntitySpec<?>,Maybe<Object>>() {
                     @Override

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils.RegisteredTypeOrTypeToken;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -199,7 +200,7 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
         protected void addDecorationFromJsonMap(Map<?, ?> decorationJson, List<EntityInitializer> decorations) {
             EntityInitializer result;
             try {
-                result = BeanWithTypeUtils.convert(instantiator.getClassLoadingContext().getManagementContext(), decorationJson, TypeToken.of(EntityInitializer.class),
+                result = BeanWithTypeUtils.convert(instantiator.getClassLoadingContext().getManagementContext(), decorationJson, RegisteredTypeOrTypeToken.of(EntityInitializer.class),
                         true, instantiator.getClassLoadingContext(), true);
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -224,24 +224,7 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
         RegisteredTypes.addSuperType(bean, TestingCustomType.class);
         ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(bean, false);
 
-        deployWithTestingCustomTypeObjectConfigAndAssert(true, false, false, "custom-type", CONF1_ANONYMOUS, "foo", "bar");
-    }
-
-    @Test
-    public void testRegisteredType_InheritedFieldsNotSupported_WhenTypeIsInferredFromDeclaredParameterType() throws Exception {
-        // in the above case, fields are correctly inherited from ancestors and overridden
-        RegisteredType bean = RegisteredTypes.bean("custom-type", "1",
-                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
-                        "type: " + TestingCustomType.class.getName() + "\n" +
-                                "x: unfoo\n" +
-                                "y: bar"));
-        RegisteredTypes.addSuperType(bean, TestingCustomType.class);
-        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(bean, false);
-
-        deployWithTestingCustomTypeObjectConfigAndAssert(true, false, false, "custom-type", CONF1_ANONYMOUS,
-                "foo",
-                // NOTE: 'bar' is not available here -- all we preserve from a declared parameter/key type is the java type
-                null);
+        deployWithTestingCustomTypeObjectConfigAndAssert(true, true, false, "custom-type", CONF1_ANONYMOUS, "foo", "bar");
     }
 
     @Test
@@ -263,8 +246,26 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
         Assert.assertNotNull(item);
         Assert.assertEquals(item.getKind(), RegisteredTypeKind.BEAN);
 
-        deployWithTestingCustomTypeObjectConfigAndAssert(true, false, false, "custom-type", CONF1_ANONYMOUS,
+        deployWithTestingCustomTypeObjectConfigAndAssert(true, true, false, "custom-type", CONF1_ANONYMOUS,
                 "foo", "bar");
+    }
+
+    @Test
+    public void testRegisteredType_InheritedFieldsNotSupported_WhenTypeIsInferredFromDeclaredParameterType() throws Exception {
+        // in the above case, fields are correctly inherited from ancestors and overridden
+        RegisteredType bean = RegisteredTypes.bean("custom-type", "1",
+                new BasicTypeImplementationPlan(BeanWithTypePlanTransformer.FORMAT,
+                        "type: " + TestingCustomType.class.getName() + "\n" +
+                                "x: unfoo\n" +
+                                "y: bar"));
+        RegisteredTypes.addSuperType(bean, TestingCustomType.class);
+        ((BasicBrooklynTypeRegistry)mgmt().getTypeRegistry()).addToLocalUnpersistedTypeRegistry(bean, false);
+
+        deployWithTestingCustomTypeObjectConfigAndAssert(true, false, false, "custom-type", CONF1_ANONYMOUS,
+                "foo",
+                // NOTE: 'bar' is not available here -- all we preserve from a declared parameter/key type is the java type
+                // in order to support this, we actually have to record the _registered type_ on the config key
+                null);
     }
 
     @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -132,13 +132,8 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
             Asserts.expectedFailureContainsIgnoreCase(expected, "expected", TestingCustomType.class.getName().toLowerCase(), "but found", "map");
         }
 
-        // and typed-key access also fails, because we con't coerce
-        try {
-            assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_TYPED, "foo", null);
-            Asserts.shouldHaveFailedPreviously();
-        } catch (Throwable expected) {
-            Asserts.expectedFailureContainsIgnoreCase(expected, "cannot coerce map");
-        }
+        // but typed-key access works because now we coerce
+        assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_TYPED, "foo", null);
     }
 
     @Test
@@ -265,13 +260,8 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
             Asserts.expectedFailureContainsIgnoreCase(expected, "expected", TestingCustomType.class.getName().toLowerCase(), "but found", "map");
         }
 
-        // and typed-key access also fails, because we con't coerce
-        try {
-            assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_LIST_TYPED, "foo", null);
-            Asserts.shouldHaveFailedPreviously();
-        } catch (Throwable expected) {
-            Asserts.expectedFailureContainsIgnoreCase(expected, "cannot coerce map");
-        }
+        // but typed-key access works because now we coerce
+        assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_LIST_TYPED, "foo", null);
     }
 
     @Test
@@ -288,6 +278,9 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
         } catch (AssertionError expected) {
             Asserts.expectedFailureContainsIgnoreCase(expected, "expected", TestingCustomType.class.getName().toLowerCase(), "but found", "map");
         }
+
+        // but typed-key access works because now we coerce
+        assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_LIST_TYPED, "foo", null);
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
 
@@ -35,6 +36,7 @@ import org.apache.brooklyn.api.entity.EntityTypeRegistry;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
+import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.objs.SpecParameter;
 import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
@@ -234,7 +236,7 @@ public class InternalEntityFactory extends InternalFactory {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     protected <T extends Entity> T loadUnitializedEntity(final T entity, final EntitySpec<T> spec) {
         try {
-            return ((AbstractEntity) entity).getExecutionContext().submit("initialize", () -> {
+            Task<T> initialize = Tasks.create("initialize", () -> {
                 final AbstractEntity theEntity = (AbstractEntity) entity;
                 if (spec.getDisplayName() != null)
                     theEntity.setDisplayName(spec.getDisplayName());
@@ -247,7 +249,7 @@ public class InternalEntityFactory extends InternalFactory {
                 addSpecParameters(spec, theEntity.getMutableEntityType());
 
                 theEntity.configure(MutableMap.copyOf(spec.getFlags()));
-                for (Map.Entry<ConfigKey<?>, Object> entry : spec.getConfig().entrySet()) {
+                for (Entry<ConfigKey<?>, Object> entry : spec.getConfig().entrySet()) {
                     entity.config().set((ConfigKey) entry.getKey(), entry.getValue());
                 }
 
@@ -257,7 +259,9 @@ public class InternalEntityFactory extends InternalFactory {
                     entity.setParent(parent);
                 }
                 return entity;
-            }).get();
+            });
+            BrooklynTaskTags.setTransient(initialize);
+            return ((AbstractEntity) entity).getExecutionContext().get(initialize);
 
         } catch (Exception e) {
             throw Exceptions.propagate(e);

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -89,7 +89,9 @@ public class BeanWithTypeUtils {
 
     /* a lot of consideration over where bean-with-type conversion should take place.
      * it is especially handy for config and for initializers, and sometimes for values _within_ those items.
-     * currently these are done in BrooklynComponentTemplateResolver for config, initializers etc.
+     * currently these are done:
+     * - in BrooklynComponentTemplateResolver for config, initializers etc
+     * - on coercion, when accessing config
      * see esp CustomTypeConfigYamlTest.
      *
      * BrooklynComponentTemplateResolver is also responsible for parsing the DSL, which it does first,

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -22,12 +22,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.reflect.TypeToken;
+import java.util.List;
+import java.util.Map.Entry;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.ConfigurableBeanDeserializerModifier;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.guava.TypeTokens;
 import org.apache.brooklyn.util.javalang.Boxing;
 
 import java.util.Collection;
@@ -46,7 +49,7 @@ public class BeanWithTypeUtils {
         mapper = new ConfigurableBeanDeserializerModifier()
                 .addDeserializerWrapper(
                         d -> new JsonDeserializerForCommonBrooklynThings(mgmt, d)
-                        //TODO DslSerializationAsToString - see CustomTypeConfigYamlTest
+                        // see note below, on convert()
                 ).apply(mapper);
 
         return mapper;
@@ -57,7 +60,7 @@ public class BeanWithTypeUtils {
         return JsonMapper.builder().build();
     }
 
-    public static boolean isPureJsonX(Object o) {
+    public static boolean isPureJson(Object o) {
         return isJsonAndOthers(o, oo -> false);
     }
     public static boolean isJsonAndOthers(Object o, Predicate<Object> acceptOthers) {
@@ -68,12 +71,14 @@ public class BeanWithTypeUtils {
             for (Object oo : (Collection<?>) o) {
                 if (!isJsonAndOthers(oo, acceptOthers)) return false;
             }
+            return true;
         }
         if (o instanceof Map) {
             for (Map.Entry<?,?> oo : ((Map<?,?>) o).entrySet()) {
                 if (!isJsonAndOthers(oo.getKey(), acceptOthers)) return false;
                 if (!isJsonAndOthers(oo.getValue(), acceptOthers)) return false;
             }
+            return true;
         }
         return acceptOthers.test(o);
     }
@@ -81,16 +86,27 @@ public class BeanWithTypeUtils {
         return isJsonAndOthers(o, oo -> oo instanceof DeferredSupplier);
     }
 
-    public static <T> T convert(ManagementContext mgmt, Map<?,?> map, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {
+
+    /* a lot of consideration over where bean-with-type conversion should take place.
+     * it is especially handy for config and for initializers, and sometimes for values _within_ those items.
+     * currently these are done in BrooklynComponentTemplateResolver for config, initializers etc.
+     * see esp CustomTypeConfigYamlTest.
+     *
+     * BrooklynComponentTemplateResolver is also responsible for parsing the DSL, which it does first,
+     * and DSL objects are preserved by bean-with-type transformation --
+     * see in JsonDeserializerForCommonBrooklynThings.  See DslSerializationTest.
+     */
+
+    public static <T> T convert(ManagementContext mgmt, Object mapOrListToSerializeThenDeserialize, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {
         ObjectMapper m = newMapper(mgmt, allowRegisteredTypes, loader, allowJavaTypes);
-        return m.readValue(m.writeValueAsString(map), BrooklynJacksonSerializationUtils.asTypeReference(type));
+        return m.readValue(m.writeValueAsString(mapOrListToSerializeThenDeserialize), BrooklynJacksonSerializationUtils.asTypeReference(type));
     }
 
     public static <T> Maybe<T> tryConvertOrAbsent(ManagementContext mgmt, Maybe<Object> inputMap, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) {
         if (inputMap.isAbsent()) return (Maybe<T>)inputMap;
 
         Object o = inputMap.get();
-        if (!(o instanceof Map)) {
+        if (!(o instanceof Map) && !(o instanceof List)) {
             if (type.isAssignableFrom(o.getClass())) {
                 return (Maybe<T>)inputMap;
             }  else {
@@ -100,21 +116,84 @@ public class BeanWithTypeUtils {
 
         Maybe<T> fallback = null;
         if (type.isAssignableFrom(Object.class)) {
-            // returning the input is valid
+            // the input is already valid, so use it as the fallback result
             fallback = (Maybe<T>)inputMap;
-            // and if there isn't a 'type' key there is no point in converting
-            if (!((Map<?, ?>) o).containsKey("type")) return fallback;
+
+            // there isn't a 'type' key so little obvious point in converting .. might make a difference _inside_ a map or list, but we've not got any generics so it won't
+            if (!(o instanceof Map) || !((Map<?, ?>) o).containsKey("type")) return fallback;
         } else if (type.isAssignableFrom(Map.class)) {
             // skip conversion for a map if it isn't an object
             return (Maybe<T>)inputMap;
         }
 
         try {
-            return Maybe.of(convert(mgmt, (Map<?,?>)o, type, allowRegisteredTypes, loader, allowJavaTypes));
+            return Maybe.of(convert(mgmt, o, type, allowRegisteredTypes, loader, allowJavaTypes));
         } catch (Exception e) {
             if (fallback!=null) return fallback;
-            return Maybe.absent("BeanWithType cannot convert given map to "+type, e);
+            return Maybe.absent("BeanWithType cannot convert given input to "+type, e);
         }
     }
 
+    /** Whether there appears to be an incompatibility and conversion might fix it. */
+    public static <T> boolean isConversionRecommended(Maybe<Object> input, TypeToken<T> type) {
+        return getPotentialConvertibilityScoreInternal(input.orNull(), type) == 1;
+    }
+
+    /** Like {@link #isConversionRecommended(Maybe, TypeToken)} but much weaker,
+     * in particular if Object is expected, this will return true whereas that will return false.
+     * This will return false if there are contents which are simply incompatible. */
+    public static <T> boolean isConversionPlausible(Maybe<Object> input, TypeToken<T> type) {
+        if (input==null || input.isAbsentOrNull() || type==null) return false;
+        return getPotentialConvertibilityScoreInternal(input.get(), type) >= 0;
+    }
+
+    /** -1 if conversion _won't_ fix it. 1 if there is a problem that likely _would_ be fixed. 0 if no obvious need or problem. */
+    private static <T> int getPotentialConvertibilityScoreInternal(Object t, TypeToken<T> type) {
+        // if we want a primitive/string, conversion won't help (coercion would be sufficient); return 0 if type is consistent, or -1 if not
+        if (t==null) {
+            return 0;
+        }
+        if (Boxing.isPrimitiveOrBoxedClass(type.getRawType()) || String.class.equals(type.getRawType())) {
+            return t.getClass().equals(type.getRawType()) ? 0 : -1;
+        }
+        // if we want an object, then no need for conversion nor any problem with conversion
+        if (Object.class.equals(type.getRawType())) return 0;
+
+        if (Map.class.isAssignableFrom(type.getRawType())) {
+            // if map is wanting, superficially we don't want to convert; but if there are generics we need to recurse
+            if (t instanceof Map) {
+                List<TypeToken<?>> generics = TypeTokens.getGenericArguments(type);
+                if (generics!=null) {
+                    for (Entry<?, ?> entry : ((Map<?, ?>) t).entrySet()) {
+                        int k = getPotentialConvertibilityScoreInternal(entry.getKey(), generics.get(0));
+                        if (k!=0) return k;
+                        int v = getPotentialConvertibilityScoreInternal(entry.getValue(), generics.get(1));
+                        if (v!=0) return v;
+                    }
+                }
+                return 0;
+            } else {
+                // conversion won't make a map from a non-map
+                return -1;
+            }
+        }
+
+        if (Collection.class.isAssignableFrom(type.getRawType())) {
+            if (t instanceof Collection) {
+                List<TypeToken<?>> generics = TypeTokens.getGenericArguments(type);
+                if (generics!=null) {
+                    for (Object entry : ((Collection<?>) t)) {
+                        int k = getPotentialConvertibilityScoreInternal(entry, generics.get(0));
+                        if (k != 0) return k;
+                    }
+                }
+                return 0;
+            } else {
+                return -1;
+            }
+        }
+
+        // we want some special object. if we have a map or a string then conversion might sort us out.
+        return (t instanceof Map || t instanceof String) ? 1 : -1;
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -19,16 +19,26 @@
 package org.apache.brooklyn.core.resolve.jackson;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.annotations.Beta;
 import com.google.common.reflect.TypeToken;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
+import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.ConfigurableBeanDeserializerModifier;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
+import org.apache.brooklyn.core.resolve.jackson.BrooklynRegisteredTypeJacksonSerialization.BrooklynJacksonType;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.guava.TypeTokens;
 import org.apache.brooklyn.util.javalang.Boxing;
@@ -86,6 +96,42 @@ public class BeanWithTypeUtils {
         return isJsonAndOthers(o, oo -> oo instanceof DeferredSupplier);
     }
 
+    @Beta
+    public static class RegisteredTypeOrTypeToken<T> {
+        private final TypeToken<T> tt;
+        private final RegisteredType rt;
+        private RegisteredTypeOrTypeToken(TypeToken<T> tt, RegisteredType rt) {
+            this.tt = tt;
+            this.rt = rt;
+        }
+
+        public Class<T> getRawClass() {
+            if (rt!=null) {
+                return (Class<T>) rt.getSuperTypes().stream().filter(i -> i instanceof Class).findAny().orElse(Object.class);
+            }
+            return (Class<T>) tt.getRawType();
+        }
+        public TypeToken<T> getTypeToken() {
+            if (tt!=null) return tt;
+            return TypeToken.of(getRawClass());
+        }
+
+        public Optional<RegisteredType> getRegisteredType() {
+            return Optional.ofNullable(rt);
+        }
+
+        public static <T> RegisteredTypeOrTypeToken<T> of(Class<T> t) {
+            return of(TypeToken.of(t));
+        }
+
+        public static <T> RegisteredTypeOrTypeToken<T> of(TypeToken<T> t) {
+            return new RegisteredTypeOrTypeToken(t, null);
+        }
+
+        public static <T> RegisteredTypeOrTypeToken<T> of(RegisteredType t) {
+            return new RegisteredTypeOrTypeToken(null, t);
+        }
+    }
 
     /* a lot of consideration over where bean-with-type conversion should take place.
      * it is especially handy for config and for initializers, and sometimes for values _within_ those items.
@@ -99,17 +145,29 @@ public class BeanWithTypeUtils {
      * see in JsonDeserializerForCommonBrooklynThings.  See DslSerializationTest.
      */
 
-    public static <T> T convert(ManagementContext mgmt, Object mapOrListToSerializeThenDeserialize, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {
+    public static <T> T convert(ManagementContext mgmt, Object mapOrListToSerializeThenDeserialize, RegisteredTypeOrTypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {
         ObjectMapper m = newMapper(mgmt, allowRegisteredTypes, loader, allowJavaTypes);
-        return m.readValue(m.writeValueAsString(mapOrListToSerializeThenDeserialize), BrooklynJacksonSerializationUtils.asTypeReference(type));
+        String serialization = m.writeValueAsString(mapOrListToSerializeThenDeserialize);
+        if (type.rt!=null) {
+            return m.readValue(serialization, new BrooklynJacksonType(mgmt, type.rt));
+        } else {
+            return m.readValue(serialization, m.constructType(type.tt.getType()));
+        }
     }
 
-    public static <T> Maybe<T> tryConvertOrAbsent(ManagementContext mgmt, Maybe<Object> inputMap, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) {
+    public static <T> Maybe<T> tryConvertOrAbsentUsingContext(Maybe<Object> input, RegisteredTypeOrTypeToken<T> type) {
+        Entity entity = BrooklynTaskTags.getContextEntity(Tasks.current());
+        ManagementContext mgmt = entity != null ? ((EntityInternal) entity).getManagementContext() : null;
+        OsgiBrooklynClassLoadingContext loader = entity != null ? new OsgiBrooklynClassLoadingContext(entity) : null;
+        return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, input, type, true, loader, false);
+    }
+
+    public static <T> Maybe<T> tryConvertOrAbsent(ManagementContext mgmt, Maybe<Object> inputMap, RegisteredTypeOrTypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) {
         if (inputMap.isAbsent()) return (Maybe<T>)inputMap;
 
         Object o = inputMap.get();
         if (!(o instanceof Map) && !(o instanceof List)) {
-            if (type.isAssignableFrom(o.getClass())) {
+            if (type.getTypeToken().isAssignableFrom(o.getClass())) {
                 return (Maybe<T>)inputMap;
             }  else {
                 return Maybe.absent(() -> new RuntimeException("BeanWithType cannot convert from "+o.getClass()+" to "+type));
@@ -117,13 +175,13 @@ public class BeanWithTypeUtils {
         }
 
         Maybe<T> fallback = null;
-        if (type.isAssignableFrom(Object.class)) {
+        if (type.getTypeToken().isAssignableFrom(Object.class)) {
             // the input is already valid, so use it as the fallback result
             fallback = (Maybe<T>)inputMap;
 
             // there isn't a 'type' key so little obvious point in converting .. might make a difference _inside_ a map or list, but we've not got any generics so it won't
             if (!(o instanceof Map) || !((Map<?, ?>) o).containsKey("type")) return fallback;
-        } else if (type.isAssignableFrom(Map.class)) {
+        } else if (type.getTypeToken().isAssignableFrom(Map.class)) {
             // skip conversion for a map if it isn't an object
             return (Maybe<T>)inputMap;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
@@ -141,6 +141,11 @@ public class BrooklynRegisteredTypeJacksonSerialization {
                 return super.typeFromId(context, id);
             }
 
+            // even if we aren't allowed to load java types, if the expected type matches, then we will allow it
+            if (_baseType!=null && _baseType.toCanonical().equals(id)) {
+                return _baseType;
+            }
+
             // copied from super if it fails to find the type
             if (context instanceof DeserializationContext) {
                 return ((DeserializationContext) context).handleUnknownTypeId(_baseType, id, this, "no such class found");

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
@@ -149,7 +149,9 @@ public class BrooklynTypeNameResolution {
                         if (st1.isPresent()) {
                             return Maybe.of( (Class<?>) st1.get() );
                         }
-                        LOG.warn("Attempt to use registered type '"+s+"' as a type but no associated Java type is recorded; skipping");
+                        // tests may not set supertypes which could cause odd behaviour; real OSGi addition should set supertypes so this should be rare IRL
+                        LOG.warn("Attempt to use registered type '"+s+"' as a type but no associated Java type is recorded; returning as Object");
+                        return Maybe.of(Object.class);
                     }
                     return Maybe.absent();
                 });

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/BrooklynTypeNameResolution.java
@@ -39,8 +39,12 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.commons.lang3.reflect.TypeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BrooklynTypeNameResolution {
+
+    private static Logger LOG = LoggerFactory.getLogger(BrooklynTypeNameResolution.class);
 
     private static final Map<String, Class<?>> BUILT_IN_TYPES = ImmutableMap.<String, Class<?>>builder()
             .put("string", String.class)
@@ -145,6 +149,7 @@ public class BrooklynTypeNameResolution {
                         if (st1.isPresent()) {
                             return Maybe.of( (Class<?>) st1.get() );
                         }
+                        LOG.warn("Attempt to use registered type '"+s+"' as a type but no associated Java type is recorded; skipping");
                     }
                     return Maybe.absent();
                 });

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -278,8 +278,9 @@ public class TypeCoercions {
         public CommonAdaptorTypeCoercions registerAllAdapters() {
             super.registerAllAdapters();
             registerWrappedValueAdapters();
+            registerBeanWithTypeAdapter();
 
-            //these are deliberately not included here, but added by routines which need them
+            //// deliberately not included here, but added by routines which need them:
             // registerInstanceForClassnameAdapter
 
             return this;

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -33,6 +33,7 @@ import org.apache.brooklyn.core.internal.BrooklynInitialization;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils.RegisteredTypeOrTypeToken;
 import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
@@ -372,10 +373,7 @@ public class TypeCoercions {
                         return null;
                     }
                     if (BeanWithTypeUtils.isConversionRecommended(Maybe.of(input), type)) {
-                        Entity entity = BrooklynTaskTags.getContextEntity(Tasks.current());
-                        ManagementContext mgmt = entity != null ? ((EntityInternal) entity).getManagementContext() : null;
-                        OsgiBrooklynClassLoadingContext loader = entity != null ? new OsgiBrooklynClassLoadingContext(entity) : null;
-                        return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, Maybe.of(input), type, true, loader, false);
+                        return BeanWithTypeUtils.tryConvertOrAbsentUsingContext(Maybe.of(input), RegisteredTypeOrTypeToken.of(type));
                     }
                     return null;
                 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/flags/TypeCoercions.java
@@ -19,15 +19,20 @@
 package org.apache.brooklyn.util.core.flags;
 
 import java.lang.reflect.Constructor;
+import java.util.Collection;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.Sensor;
+import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.internal.BrooklynInitialization;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
 import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.JavaGroovyEquivalents;
@@ -283,6 +288,7 @@ public class TypeCoercions {
         @SuppressWarnings("rawtypes")
         @Override
         public void registerClassForNameAdapters() {
+            // do we need this one? should it go further and use the context entity to resolve registered types too?
             registerAdapter(String.class, Class.class, new Function<String,Class>() {
                 @Override
                 public Class apply(final String input) {
@@ -295,7 +301,8 @@ public class TypeCoercions {
                 }
             });        
         }
-        
+
+        // very similar to above, but uses configurable loader
         public static <T> void registerInstanceForClassnameAdapter(ClassLoaderUtils loader, Class<T> supertype) {
             TypeCoercions.registerAdapter(String.class, supertype, new Function<String, T>() {
                 @Override public T apply(String input) {
@@ -351,6 +358,25 @@ public class TypeCoercions {
                     }
                     // note, generics on type are not respected
                     return Maybe.of( (T) WrappedValue.ofConstant(input) );
+                }
+            });
+        }
+
+        public void registerBeanWithTypeAdapter() {
+            // if we want to do bean-with-type coercion ... probably nice to do if it doesn't already match
+            registerAdapter("80-bean-with-type", new TryCoercer() {
+                @Override
+                public <T> Maybe<T> tryCoerce(Object input, TypeToken<T> type) {
+                    if (!(input instanceof Map || input instanceof Collection)) {
+                        return null;
+                    }
+                    if (BeanWithTypeUtils.isConversionRecommended(Maybe.of(input), type)) {
+                        Entity entity = BrooklynTaskTags.getContextEntity(Tasks.current());
+                        ManagementContext mgmt = entity != null ? ((EntityInternal) entity).getManagementContext() : null;
+                        OsgiBrooklynClassLoadingContext loader = entity != null ? new OsgiBrooklynClassLoadingContext(entity) : null;
+                        return BeanWithTypeUtils.tryConvertOrAbsent(mgmt, Maybe.of(input), type, true, loader, false);
+                    }
+                    return null;
                 }
             });
         }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ValueResolver.java
@@ -641,10 +641,15 @@ public class ValueResolver<T> implements DeferredSupplier<T>, Iterable<Maybe<Obj
                     }
                 }
 
-                if (exec!=null && (v instanceof Map || v instanceof List)) {
+                if (exec!=null && (
+                        ((v instanceof Map) && !((Map)v).isEmpty())
+                                ||
+                        ((v instanceof List) && !((List)v).isEmpty())) ) {
                     // do type coercion in a task to allow registered types
                     Object vf = v;
-                    return exec.submit("type coercion", () -> TypeCoercions.tryCoerce(vf, typeT)).get();
+                    Task<Maybe<T>> task = Tasks.create("type coercion", () -> TypeCoercions.tryCoerce(vf, typeT));
+                    BrooklynTaskTags.setTransient(task);
+                    return exec.get(task);
                 } else {
                     return TypeCoercions.tryCoerce(v, typeT);
                 }

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsTypeCoercionsWithBuilderTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/location/jclouds/JcloudsTypeCoercionsWithBuilderTest.java
@@ -88,7 +88,7 @@ public class JcloudsTypeCoercionsWithBuilderTest {
             coerce(ImmutableMap.of("arg1", "val1"), MyClazzWithNoNoargBuilderMethod.class);
             Asserts.shouldHaveFailedPreviously();
         } catch (ClassCoercionException e) {
-            Asserts.expectedFailureContains(e, "MyClazzWithNoNoargBuilderMethod", "no adapter known");
+            Asserts.expectedFailureContains(e, "MyClazzWithNoNoargBuilderMethod", "BeanWithType");
         }
     }
 

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
@@ -643,8 +643,18 @@ public abstract class Maybe<T> implements Serializable, Supplier<T> {
         return Objects.equal(get(), other.get());
     }
 
-    /** Finds the {@link Absent#getException()} if {@link #isAbsent()}, or null */
+    /** Finds the {@link Absent#getException()} if {@link #isAbsent()}, or else null */
     public static RuntimeException getException(Maybe<?> t) {
-        return t instanceof Maybe.Absent ? ((Maybe.Absent<?>)t).getException() : null;
+        if (t instanceof Maybe.Absent) return ((Maybe.Absent<?>)t).getException();
+        if (t.isPresent()) return null;
+        if (t instanceof MaybeTransforming) return getException( ((MaybeTransforming)t).input );
+
+        // fall back to attempting access
+        try {
+            t.get();
+        } catch (RuntimeException e) {
+            return e;
+        }
+        return new RuntimeException("Unsupported exception access on maybe type "+t.getClass()+", not present, but not in error: "+t);
     }
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/TypeTokens.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/TypeTokens.java
@@ -18,8 +18,14 @@
  */
 package org.apache.brooklyn.util.guava;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableMap;
@@ -101,4 +107,11 @@ public class TypeTokens {
         }
     }
 
+    public static List<TypeToken<?>> getGenericArguments(TypeToken<?> token) {
+        Type t = token.getType();
+        if (t instanceof ParameterizedType) {
+            return Arrays.stream(((ParameterizedType) t).getActualTypeArguments()).map(TypeToken::of).collect(Collectors.toList());
+        }
+        return null;
+    }
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/guava/TypeTokensTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/guava/TypeTokensTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.guava;
+
+import com.google.common.base.Optional;
+import com.google.common.reflect.TypeToken;
+import java.util.List;
+import java.util.Map;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.exceptions.UserFacingException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TypeTokensTest {
+
+    @Test
+    public void testGetGenericArguments() {
+        TypeToken<?> t = new TypeToken<Map<String,Integer>>() {};
+        List<TypeToken<?>> genericArguments = TypeTokens.getGenericArguments(t);
+        Assert.assertEquals(genericArguments, MutableList.of(TypeToken.of(String.class), TypeToken.of(Integer.class)));
+    }
+
+}


### PR DESCRIPTION
Allow bean-with-type conversion as part of type coercion.  Maintain data as maps in config a little bit longer.

Major rework of `CustomTypeConfigYamlTest` to do a much better job of enumerating different test cases.