### PR TITLE
Winrmtaskfactory - Similar to SshTaskFactory

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/location/MachineLocation.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/MachineLocation.java
@@ -48,19 +48,7 @@ public interface MachineLocation extends AddressableLocation, HasNetworkAddresse
 
     String getUser();
 
-    int execCommands(String summaryForLogging, List<String> commands);
-
-    int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands);
-
-    int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env);
-
     int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env);
-
-    int execScript(String summaryForLogging, List<String> commands);
-
-    int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands);
-
-    int execScript(String summaryForLogging, List<String> commands, Map<String, ?> env);
 
     int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env);
 }

--- a/api/src/main/java/org/apache/brooklyn/api/location/MachineLocation.java
+++ b/api/src/main/java/org/apache/brooklyn/api/location/MachineLocation.java
@@ -19,6 +19,8 @@
 package org.apache.brooklyn.api.location;
 
 import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.brooklyn.util.net.HasNetworkAddresses;
 
@@ -44,4 +46,21 @@ public interface MachineLocation extends AddressableLocation, HasNetworkAddresse
      */
     MachineDetails getMachineDetails();
 
+    String getUser();
+
+    int execCommands(String summaryForLogging, List<String> commands);
+
+    int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands);
+
+    int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env);
+
+    int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env);
+
+    int execScript(String summaryForLogging, List<String> commands);
+
+    int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands);
+
+    int execScript(String summaryForLogging, List<String> commands, Map<String, ?> env);
+
+    int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env);
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshEffectorTasks.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/ssh/SshEffectorTasks.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.StringConfigMap;
@@ -105,7 +106,7 @@ public class SshEffectorTasks {
         public SshEffectorTaskFactory(String ...commands) {
             super(commands);
         }
-        public SshEffectorTaskFactory(SshMachineLocation machine, String ...commands) {
+        public SshEffectorTaskFactory(MachineLocation machine, String ...commands) {
             super(machine, commands);
         }
         @Override

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -514,6 +514,7 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
         return HostAndPort.fromParts(host, port);
     }
 
+    @Override
     public String getUser() {
         if (!groovyTruth(user)) {
             if (config().getLocalRaw(SshTool.PROP_USER).isPresent()) {
@@ -698,16 +699,20 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
      * and/or {@code commandPrepend} and {@code commandAppend} similar to
      * (currently supported in SshjTool) {@code separator}.)
      */
+    @Override
     public int execCommands(String summaryForLogging, List<String> commands) {
         return execCommands(MutableMap.<String,Object>of(), summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    public int execCommands(Map<String,?> props, String summaryForLogging, List<String> commands) {
+    @Override
+    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands) {
         return execCommands(props, summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    public int execCommands(String summaryForLogging, List<String> commands, Map<String,?> env) {
+    @Override
+    public int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env) {
         return execCommands(MutableMap.<String,Object>of(), summaryForLogging, commands, env);
     }
-    public int execCommands(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
+    @Override
+    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
         return newExecWithLoggingHelpers().execCommands(augmentPropertiesWithSshConfigGivenToProps(props), summaryForLogging, commands, env);
     }
 
@@ -718,15 +723,19 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
      * flags 'noStdoutLogging' and 'noStderrLogging' are set. To set a logging prefix, use
      * the flag 'logPrefix'.
      */
+    @Override
     public int execScript(String summaryForLogging, List<String> commands) {
         return execScript(MutableMap.<String,Object>of(), summaryForLogging, commands, MutableMap.<String,Object>of());
     }
+    @Override
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands) {
         return execScript(props, summaryForLogging, commands, MutableMap.<String,Object>of());
     }
+    @Override
     public int execScript(String summaryForLogging, List<String> commands, Map<String,?> env) {
         return execScript(MutableMap.<String,Object>of(), summaryForLogging, commands, env);
     }
+    @Override
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands, Map<String,?> env) {
         return newExecWithLoggingHelpers().execScript(augmentPropertiesWithSshConfigGivenToProps(props), summaryForLogging, commands, env);
     }
@@ -869,7 +878,7 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
             PipedInputStream insO = new PipedInputStream(); OutputStream outO = new PipedOutputStream(insO);
             PipedInputStream insE = new PipedInputStream(); OutputStream outE = new PipedOutputStream(insE);
             StreamGobbler sgsO = new StreamGobbler(insO, null, LOG); sgsO.setLogPrefix("[curl @ "+address+":stdout] ").start();
-            StreamGobbler sgsE = new StreamGobbler(insE, null, LOG); sgsE.setLogPrefix("[curl @ "+address+":stdout] ").start();
+            StreamGobbler sgsE = new StreamGobbler(insE, null, LOG); sgsE.setLogPrefix("[curl @ "+address+":stderr] ").start();
             Map<String, ?> sshProps = MutableMap.<String, Object>builder().putAll(props).put("out", outO).put("err", outE).build();
             int result = execScript(sshProps, "copying remote resource "+url+" to server",  ImmutableList.of(
                     BashCommands.INSTALL_CURL, // TODO should hold the 'installing' mutex

--- a/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/ssh/SshMachineLocation.java
@@ -699,15 +699,12 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
      * and/or {@code commandPrepend} and {@code commandAppend} similar to
      * (currently supported in SshjTool) {@code separator}.)
      */
-    @Override
     public int execCommands(String summaryForLogging, List<String> commands) {
         return execCommands(MutableMap.<String,Object>of(), summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    @Override
     public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands) {
         return execCommands(props, summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    @Override
     public int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env) {
         return execCommands(MutableMap.<String,Object>of(), summaryForLogging, commands, env);
     }
@@ -723,15 +720,12 @@ public class SshMachineLocation extends AbstractMachineLocation implements Machi
      * flags 'noStdoutLogging' and 'noStderrLogging' are set. To set a logging prefix, use
      * the flag 'logPrefix'.
      */
-    @Override
     public int execScript(String summaryForLogging, List<String> commands) {
         return execScript(MutableMap.<String,Object>of(), summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    @Override
     public int execScript(Map<String,?> props, String summaryForLogging, List<String> commands) {
         return execScript(props, summaryForLogging, commands, MutableMap.<String,Object>of());
     }
-    @Override
     public int execScript(String summaryForLogging, List<String> commands, Map<String,?> env) {
         return execScript(MutableMap.<String,Object>of(), summaryForLogging, commands, env);
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/internal/AbstractSshExecTaskFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/internal/AbstractSshExecTaskFactory.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.util.core.task.ssh.internal;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskFactory;
@@ -35,7 +36,7 @@ public abstract class AbstractSshExecTaskFactory<T extends AbstractProcessTaskFa
     }
 
     /** convenience constructor to supply machine immediately */
-    public AbstractSshExecTaskFactory(SshMachineLocation machine, String ...commands) {
+    public AbstractSshExecTaskFactory(MachineLocation machine, String ...commands) {
         this(commands);
         machine(machine);
     }

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/system/ProcessTaskFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/system/ProcessTaskFactory.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.util.core.task.system;
 
 import java.util.Map;
 
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.api.mgmt.TaskFactory;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
@@ -30,7 +31,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Function;
 
 public interface ProcessTaskFactory<T> extends TaskFactory<ProcessTaskWrapper<T>> {
-    public ProcessTaskFactory<T> machine(SshMachineLocation machine);
+    public ProcessTaskFactory<T> machine(MachineLocation machine);
     public ProcessTaskFactory<T> add(String ...commandsToAdd);
     public ProcessTaskFactory<T> add(Iterable<String> commandsToAdd);
     public ProcessTaskFactory<T> requiringExitCodeZero();

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/system/ProcessTaskStub.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/system/ProcessTaskStub.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
@@ -35,7 +36,7 @@ public class ProcessTaskStub {
     
     protected final List<String> commands = new ArrayList<String>();
     /** null for localhost */
-    protected SshMachineLocation machine;
+    protected MachineLocation machine;
     
     // config data
     protected String summary;
@@ -75,7 +76,7 @@ public class ProcessTaskStub {
     }
     
     /** null for localhost */
-    public SshMachineLocation getMachine() {
+    public MachineLocation getMachine() {
         return machine;
     }
     

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/system/internal/AbstractProcessTaskFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/system/internal/AbstractProcessTaskFactory.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.util.core.task.system.internal;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.config.ConfigKey;
@@ -68,7 +69,7 @@ public abstract class AbstractProcessTaskFactory<T extends AbstractProcessTaskFa
     }
     
     @Override
-    public T machine(SshMachineLocation machine) {
+    public T machine(MachineLocation machine) {
         markDirty();
         this.machine = machine;
         return self();

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/system/internal/SystemProcessTaskFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/system/internal/SystemProcessTaskFactory.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.util.core.task.system.internal;
 
 import java.io.File;
 
+import org.apache.brooklyn.api.location.MachineLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.core.config.Sanitizer;
@@ -57,7 +58,7 @@ public class SystemProcessTaskFactory<T extends SystemProcessTaskFactory<T,RET>,
     }
     
     @Override
-    public T machine(SshMachineLocation machine) {
+    public T machine(MachineLocation machine) {
         log.warn("Not permitted to set machines on "+this+" (ignoring - "+machine+")");
         if (log.isDebugEnabled())
             log.debug("Source of attempt to set machines on "+this+" ("+machine+")",

--- a/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
@@ -170,37 +170,7 @@ public class SimulatedLocation extends AbstractLocation implements MachineProvis
     }
 
     @Override
-    public int execCommands(String summaryForLogging, List<String> commands) {
-        return 0;
-    }
-
-    @Override
-    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands) {
-        return 0;
-    }
-
-    @Override
-    public int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env) {
-        return 0;
-    }
-
-    @Override
     public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
-        return 0;
-    }
-
-    @Override
-    public int execScript(String summaryForLogging, List<String> commands) {
-        return 0;
-    }
-
-    @Override
-    public int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands) {
-        return 0;
-    }
-
-    @Override
-    public int execScript(String summaryForLogging, List<String> commands, Map<String, ?> env) {
         return 0;
     }
 

--- a/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
+++ b/core/src/test/java/org/apache/brooklyn/core/location/SimulatedLocation.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.core.location;
 
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -162,7 +163,52 @@ public class SimulatedLocation extends AbstractLocation implements MachineProvis
         OsDetails osDetails = BasicOsDetails.Factory.ANONYMOUS_LINUX;
         return new BasicMachineDetails(hardwareDetails, osDetails);
     }
-    
+
+    @Override
+    public String getUser() {
+        return null;
+    }
+
+    @Override
+    public int execCommands(String summaryForLogging, List<String> commands) {
+        return 0;
+    }
+
+    @Override
+    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands) {
+        return 0;
+    }
+
+    @Override
+    public int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env) {
+        return 0;
+    }
+
+    @Override
+    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
+        return 0;
+    }
+
+    @Override
+    public int execScript(String summaryForLogging, List<String> commands) {
+        return 0;
+    }
+
+    @Override
+    public int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands) {
+        return 0;
+    }
+
+    @Override
+    public int execScript(String summaryForLogging, List<String> commands, Map<String, ?> env) {
+        return 0;
+    }
+
+    @Override
+    public int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
+        return 0;
+    }
+
     private RuntimeException newException(String msg) {
         try {
             Exception result = getConfig(EXCEPTION_CLAZZ).getConstructor(String.class).newInstance(msg);

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <jax-rs-api.version>2.1.1</jax-rs-api.version> <!-- differs from jclouds 2.1.2, which depends on v2.0.1 -->
         <maxmind.version>2.8.0-rc1</maxmind.version>
         <maxmind-db.version>1.2.1</maxmind-db.version>
-        <winrm4j.version>0.9.0</winrm4j.version> <!--  FIXME NO CHECK IN -->
+        <winrm4j.version>0.9.0-SNAPSHOT</winrm4j.version> <!--  FIXME NO CHECK IN -->
         <felix-osgi-compendium.version>1.4.0</felix-osgi-compendium.version>
         <kubernetes-client.version>4.9.0</kubernetes-client.version>
 

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/PlainWinRMExecTaskFactory.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/PlainWinRMExecTaskFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.winrm;
+
+import com.google.common.base.Function;
+import org.apache.brooklyn.util.core.task.ssh.internal.AbstractSshExecTaskFactory;
+import org.apache.brooklyn.util.core.task.ssh.internal.PlainSshExecTaskFactory;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
+
+import java.util.List;
+
+public class PlainWinRMExecTaskFactory<RET> extends AbstractSshExecTaskFactory<PlainSshExecTaskFactory<RET>,RET> {
+
+    /** constructor where machine will be added later */
+    public PlainWinRMExecTaskFactory(String ...commands) {
+        super(commands);
+    }
+
+    /** convenience constructor to supply machine immediately */
+    public PlainWinRMExecTaskFactory(WinRmMachineLocation machine, String ...commands) {
+        this(commands);
+        machine(machine);
+    }
+
+    /** Constructor where machine will be added later */
+    public PlainWinRMExecTaskFactory(List<String> commands) {
+        this(commands.toArray(new String[commands.size()]));
+    }
+
+    /** Convenience constructor to supply machine immediately */
+    public PlainWinRMExecTaskFactory(WinRmMachineLocation machine, List<String> commands) {
+        this(machine, commands.toArray(new String[commands.size()]));
+    }
+
+    @Override
+    public <T2> PlainWinRMExecTaskFactory<T2> returning(ScriptReturnType type) {
+        return (PlainWinRMExecTaskFactory<T2>) super.<T2>returning(type);
+    }
+
+    @Override
+    public <RET2> PlainWinRMExecTaskFactory<RET2> returning(Function<ProcessTaskWrapper<?>, RET2> resultTransformation) {
+        return (PlainWinRMExecTaskFactory<RET2>) super.returning(resultTransformation);
+    }
+
+    @Override
+    public PlainWinRMExecTaskFactory<Boolean> returningIsExitCodeZero() {
+        return (PlainWinRMExecTaskFactory<Boolean>) super.returningIsExitCodeZero();
+    }
+
+    @Override
+    public PlainWinRMExecTaskFactory<String> requiringZeroAndReturningStdout() {
+        return (PlainWinRMExecTaskFactory<String>) super.requiringZeroAndReturningStdout();
+    }
+}
+
+

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRMTasks.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRMTasks.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.location.winrm;
+
+import org.apache.brooklyn.api.mgmt.TaskAdaptable;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
+import org.apache.brooklyn.location.winrm.PlainWinRMExecTaskFactory;
+import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskFactory;
+import org.apache.brooklyn.util.net.Urls;
+
+import java.util.Map;
+
+public class WinRMTasks {
+    public static ProcessTaskFactory<Integer> newWinrmExecTaskFactory(org.apache.brooklyn.location.winrm.WinRmMachineLocation winRmMachineLocation, String ...commands) {
+        return new PlainWinRMExecTaskFactory<>(winRmMachineLocation, commands);
+    }
+
+    public static TaskFactory<?> installFromUrl(final ResourceUtils utils, final Map<String, ?> props, final WinRmMachineLocation location, final String url, final String destPath) {
+        return new TaskFactory<TaskAdaptable<?>>() {
+            @Override
+            public TaskAdaptable<?> newTask() {
+                return Tasks.<Void>builder().displayName("installing "+ Urls.getBasename(url)).description("installing "+url+" to "+destPath).body(new Runnable() {
+                    @Override
+                    public void run() {
+                        int result = location.installTo(utils, props, url, destPath);
+                        if (result!=0)
+                            throw new IllegalStateException("Failed to install '"+url+"' to '"+destPath+"' at "+location+": exit code "+result);
+                    }
+                }).build();
+            }
+        };
+    }
+}

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -205,39 +205,9 @@ public class WinRmMachineLocation extends AbstractMachineLocation implements Mac
     }
 
     @Override
-    public int execCommands(String summaryForLogging, List<String> commands) {
-        return executeCommand(commands).getStatusCode();
-    }
-
-    @Override
-    public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands) {
-        return executeCommand(props, commands).getStatusCode();
-    }
-
-    @Override
-    public int execCommands(String summaryForLogging, List<String> commands, Map<String, ?> env) {
-        return executeCommand(ImmutableMap.of(Winrm4jTool.ENVIRONMENT, env),commands).getStatusCode();
-    }
-
-    @Override
     public int execCommands(Map<String, ?> props, String summaryForLogging, List<String> commands, Map<String, ?> env) {
         ImmutableMap<Object, Object> properties = ImmutableMap.builder().putAll(props).put(Winrm4jTool.ENVIRONMENT, env).build();
         return executeCommand(properties, commands).getStatusCode();
-    }
-
-    @Override
-    public int execScript(String summaryForLogging, List<String> commands) {
-        return executePsScript(commands).getStatusCode();
-    }
-
-    @Override
-    public int execScript(Map<String, ?> props, String summaryForLogging, List<String> commands) {
-        return executePsScript(props, commands).getStatusCode();
-    }
-
-    @Override
-    public int execScript(String summaryForLogging, List<String> commands, Map<String, ?> env) {
-        return executePsScript(ImmutableMap.of(Winrm4jTool.ENVIRONMENT,env), commands).getStatusCode();
     }
 
     @Override
@@ -556,12 +526,12 @@ public class WinRmMachineLocation extends AbstractMachineLocation implements Mac
             sgsO.setLogPrefix("[curl @ "+getAddress()+":stdout] ").start();
             sgsE.setLogPrefix("[curl @ "+getAddress()+":stderr] ").start();
             Map<String, ?> winrmProps = MutableMap.<String, Object>builder().putAll(props).put("out", outO).put("err", outE).build();
-//            int result = execScript(winrmProps,"",ImmutableList.of(
-//                    "$WebClient = New-Object System.Net.WebClient",
-//                    "$WebClient.DownloadFile(" + url + "," + destPath + ")"
-//            ));
-
-            int result = 1;
+            ImmutableList<String> commands = ImmutableList.of(
+                    "echo $WebClient = New-Object System.Net.WebClient > C:\\temp.ps1",
+                    "echo $WebClient.DownloadFile(" + url + "," + destPath + ") >> C:\\temp.ps1",
+                    "powershell -c c:\\temp.ps1"
+            );
+            int result = execCommands(winrmProps,"", commands, ImmutableMap.of());
 
             if (result != 0) {
                 LOG.debug("installing {} to {} on {}, curl failed, attempting local fetch and copy", new Object[] { url, destPath, this });

--- a/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/location/winrm/WinRmMachineLocation.java
@@ -556,10 +556,12 @@ public class WinRmMachineLocation extends AbstractMachineLocation implements Mac
             sgsO.setLogPrefix("[curl @ "+getAddress()+":stdout] ").start();
             sgsE.setLogPrefix("[curl @ "+getAddress()+":stderr] ").start();
             Map<String, ?> winrmProps = MutableMap.<String, Object>builder().putAll(props).put("out", outO).put("err", outE).build();
-            int result = execScript(winrmProps,"",ImmutableList.of(
-                    "$WebClient = New-Object System.Net.WebClient",
-                    "$WebClient.DownloadFile(" + url + "," + destPath + ")"
-            ));
+//            int result = execScript(winrmProps,"",ImmutableList.of(
+//                    "$WebClient = New-Object System.Net.WebClient",
+//                    "$WebClient.DownloadFile(" + url + "," + destPath + ")"
+//            ));
+
+            int result = 1;
 
             if (result != 0) {
                 LOG.debug("installing {} to {} on {}, curl failed, attempting local fetch and copy", new Object[] { url, destPath, this });

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/WinRmTool.java
@@ -105,6 +105,6 @@ public interface WinRmTool {
     WinRmToolResponse executeCommand(List<String> commands);
 
     WinRmToolResponse executePs(List<String> commands);
-    
+
     WinRmToolResponse copyToServer(InputStream source, String destination);
 }

--- a/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/util/core/internal/winrm/winrm4j/Winrm4jTool.java
@@ -141,7 +141,11 @@ public class Winrm4jTool implements org.apache.brooklyn.util.core.internal.winrm
     public org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse executePs(final List<String> commands) {
         return exec(new Function<io.cloudsoft.winrm4j.winrm.WinRmTool, io.cloudsoft.winrm4j.winrm.WinRmToolResponse>() {
             @Override public WinRmToolResponse apply(io.cloudsoft.winrm4j.winrm.WinRmTool tool) {
-                return tool.executePs(commands);
+                OutputStream outputStream = bag.get(ShellTool.PROP_OUT_STREAM);
+                OutputStream errorStream = bag.get(ShellTool.PROP_ERR_STREAM);
+                Writer out = outputStream != null ? new OutputStreamWriter(outputStream): new StringWriter();
+                Writer err = errorStream != null ? new OutputStreamWriter(errorStream): new StringWriter();
+                return tool.executePs(commands, out, err);
             }
         });
     }


### PR DESCRIPTION
So this gives us a WinrmTaskFactory which can be used in the same way as the sshtaskfactory. Some generalisations of MachineLocation etc were required which I think is a good thing.

e.g.

                WinRmTasks.newWinrmExecTaskFactory(winRmMachineLocation, "my command").runAsCommand().summary();
