### PR TITLE
Misc minor - recording SSH track task, and $brooklyn:object accept string

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -21,12 +21,10 @@ package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import java.util.*;
 import org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils;
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -343,6 +341,23 @@ public class BrooklynDslCommon {
                 return new DslObject(type, factoryMethodName, factoryMethodArgs, objectFields, brooklynConfig);
             }
         }
+    }
+
+    @DslAccessible
+    public static Object object(String argumentsMapAsYamlStringOrShorthand) {
+        Object arg = Yamls.parseAll(argumentsMapAsYamlStringOrShorthand).iterator().next();
+        if (arg instanceof Map) return object( (Map<String,Object>)arg );
+        if (arg instanceof Collection) {
+            List argL = MutableList.copyOf((Collection)arg);
+            if (argL.size()>=1) {
+                return object(MutableMap.of("type", argL.remove(0), "constructor.args", argL));
+            }
+        }
+        if (arg instanceof String) {
+            return object(MutableMap.of("type", arg, "constructor.args", Collections.emptyList()));
+        }
+
+        throw new IllegalArgumentException("Argument to object should be a map, or shorthand type name as string, or type name and constructor arguments as list");
     }
 
     // String manipulation

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -91,8 +91,12 @@ public class BrooklynDslCommon {
     private static final Logger LOG = LoggerFactory.getLogger(BrooklynDslCommon.class);
 
     public static final String PREFIX = "$brooklyn:";
-    static {
+
+    public static void registerSerializationHooks() {
         BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings.BROOKLYN_PARSE_DSL_FUNCTION = DslUtils::parseBrooklynDsl;
+    }
+    static {
+        registerSerializationHooks();
     }
     
     // Access specific entities

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlOsgiTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlOsgiTest.java
@@ -54,4 +54,10 @@ public class CustomTypeConfigYamlOsgiTest extends CustomTypeConfigYamlTest {
         Object b1n = Reflections.getFieldValueMaybe(b1, "number").get();
         Asserts.assertEquals(b1n, 1);
     }
+
+    @Override // multiple type works in OSGi
+    @Test
+    public void TestRegisteredType_Inherited_OneStep_FailsInPojo() {
+        doTestRegisteredType_Inherited();
+    }
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -331,7 +331,7 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
                 });
     }
 
-    public void doTestRegisteredType_Inherited() {
+    protected void doTestRegisteredType_Inherited() {
         try {
             addCatalogItems(
                     "brooklyn.catalog:",

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/CustomTypeConfigYamlTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.camp.brooklyn;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
 import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +68,9 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
     }
     
     protected Entity deployWithTestingCustomTypeObjectConfig(boolean declareParameter, boolean declareType, boolean isList, String type, ConfigKey<?> key) throws Exception {
+        return deployWithTestingCustomTypeObjectConfig(declareParameter, declareType, isList, type, key, true);
+    }
+    protected Entity deployWithTestingCustomTypeObjectConfig(boolean declareParameter, boolean declareType, boolean isList, String type, ConfigKey<?> key, boolean includeValue) throws Exception {
         return setupAndCheckTestEntityInBasicYamlWith(
                 declareParameter ? Strings.lines(
                         "  brooklyn.parameters:",
@@ -76,7 +81,7 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
                 isList ? "    - " : "",
                 declareType ?
                         "      type: "+(isList ? Strings.removeAllFromEnd(Strings.removeAllFromStart(type, "list", "<"), ">") : type) : "",
-                "      x: foo");
+                includeValue ? "      x: foo" : "");
     }
 
     protected void assertObjectIsOurCustomTypeWithFieldValues(Object customObj, String x, String y) {
@@ -317,4 +322,55 @@ public class CustomTypeConfigYamlTest extends AbstractYamlTest {
         assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_LIST_TYPED, "foo", null);
     }
 
+    @Test
+    public void TestRegisteredType_Inherited_OneStep_FailsInPojo() {
+        Asserts.assertFailsWith(this::doTestRegisteredType_Inherited,
+                e -> {
+                    Asserts.expectedFailureContainsIgnoreCase(Exceptions.collapseIncludingAllCausalMessages(e), "could not resolve", "custom-type-0");
+                    return true;
+                });
+    }
+
+    public void doTestRegisteredType_Inherited() {
+        try {
+            addCatalogItems(
+                    "brooklyn.catalog:",
+                    "  version: " + TEST_VERSION,
+                    "  items:",
+                    "  - id: custom-type-0",
+                    "    item:",
+                    "      type: " + CustomTypeConfigYamlTest.TestingCustomType.class.getName(),
+                    "      x: foo2",
+                    "  - id: custom-type",
+                    "    item:",
+                    "      type: custom-type-0",
+                    "      y: bar");
+            lastDeployedEntity = deployWithTestingCustomTypeObjectConfig(true, true, false, "custom-type", CONF1_ANONYMOUS, false);
+            assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_ANONYMOUS, "foo2", "bar");
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    @Test
+    public void testRegisteredType_InheritedTwoStep() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: custom-type-0",
+                "    item:",
+                "      type: " + CustomTypeConfigYamlTest.TestingCustomType.class.getName(),
+                "      x: foo2");
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  version: " + TEST_VERSION,
+                "  items:",
+                "  - id: custom-type",
+                "    item:",
+                "      type: custom-type-0",
+                "      y: bar");
+        lastDeployedEntity = deployWithTestingCustomTypeObjectConfig(true, true, false, "custom-type", CONF1_ANONYMOUS, false);
+        assertLastDeployedKeysValueIsOurCustomTypeWithFieldValues(CONF1_ANONYMOUS, "foo2", "bar");
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -55,7 +55,7 @@ public class BeanWithTypeUtils {
         JsonMapper mapper = newSimpleMapper();
 
         BrooklynRegisteredTypeJacksonSerialization.apply(mapper, mgmt, allowRegisteredTypes, loader, allowBasicJavaTypes);
-        WrappedValuesSerialization.apply(mapper);
+        WrappedValuesSerialization.apply(mapper, mgmt);
         mapper = new ConfigurableBeanDeserializerModifier()
                 .addDeserializerWrapper(
                         d -> new JsonDeserializerForCommonBrooklynThings(mgmt, d)

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynJacksonSerializationUtils.java
@@ -157,6 +157,7 @@ public class BrooklynJacksonSerializationUtils {
                 if (BROOKLYN_PARSE_DSL_FUNCTION!=null && mgmt!=null && result instanceof Map) {
                     Map<?, ?> rm = (Map<?, ?>) result;
                     if (Object.class.equals(_valueClass) || _valueClass==null) {
+                        // this marker indicates that a DSL object was serialized and we need to re-parse it to deserialize it
                         Object brooklynLiteral = rm.get("$brooklyn:literal");
                         if (brooklynLiteral != null) {
                             return BROOKLYN_PARSE_DSL_FUNCTION.apply(mgmt, brooklynLiteral);

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/WrappedValue.java
@@ -33,6 +33,8 @@ import org.apache.brooklyn.util.core.task.DeferredSupplier;
  * Any object can be coerced to a {@link WrappedValue} using {@link org.apache.brooklyn.util.core.flags.TypeCoercions}.
  *
  * It will always be unwrapped (attempted) using {@link org.apache.brooklyn.util.core.task.Tasks#resolving(Object)}.
+ *
+ * When deserialized, this will parse Brooklyn DSL expressions.
  */
 public class WrappedValue<T> implements Supplier<T>, com.google.common.base.Supplier<T>, DeferredSupplier<T> {
     final static WrappedValue<?> NULL_WRAPPED_VALUE = new WrappedValue<>(null, false);

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/MapperTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/MapperTestFixture.java
@@ -21,7 +21,12 @@ package org.apache.brooklyn.core.resolve.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterables;
+import org.apache.brooklyn.util.core.task.BasicExecutionContext;
+import org.apache.brooklyn.util.core.task.BasicExecutionManager;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.javalang.JavaClassNames;
 import org.apache.brooklyn.util.yaml.Yamls;
 
 public interface MapperTestFixture {
@@ -58,6 +63,13 @@ public interface MapperTestFixture {
         } catch (JsonProcessingException e) {
             throw Exceptions.propagate(e);
         }
+    }
+
+    default <T> Maybe<T> resolve(Object o, Class<T> type) {
+        BasicExecutionManager execManager = new BasicExecutionManager("test-context-"+ JavaClassNames.niceClassAndMethod());
+        BasicExecutionContext execContext = new BasicExecutionContext(execManager);
+
+        return Tasks.resolving(o).as(type).context(execContext).deep().getMaybe();
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/WrappedValuesSerializationTest.java
@@ -39,8 +39,8 @@ public class WrappedValuesSerializationTest implements MapperTestFixture {
     }
 
     // basic serialization / deserialization of wrapped values
-    static class ObjectWithWrappedValueString extends WrappedValuesInitialized {
-        private WrappedValue<String> x;
+    public static class ObjectWithWrappedValueString extends WrappedValuesInitialized {
+        public WrappedValue<String> x;
     }
 
     @Test
@@ -151,11 +151,12 @@ public class WrappedValuesSerializationTest implements MapperTestFixture {
         Asserts.assertEquals(resolve(a.x, WrappedValue.class).get().get(), "hello");
     }
 
-    protected <T> Maybe<T> resolve(Object o, Class<T> type) {
-        BasicExecutionManager execManager = new BasicExecutionManager("test-context-"+ JavaClassNames.niceClassAndMethod());
-        BasicExecutionContext execContext = new BasicExecutionContext(execManager);
-
-        return Tasks.resolving(o).as(type).context(execContext).deep().getMaybe();
+    @Test
+    public void testDeserializeDsl() throws Exception {
+        // test in CAMP where DSL is registered
+        String dslLiteralFoo = "$brooklyn:literal(\"foo\")";
+        ObjectWithWrappedValueString impl = deser(json("x: " + dslLiteralFoo), ObjectWithWrappedValueString.class);
+        Asserts.assertNotNull(impl.x);
+        Asserts.assertEquals(impl.x.get(), dslLiteralFoo);
     }
-
 }

--- a/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/internal/ssh/RecordingSshTool.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -58,7 +61,7 @@ public class RecordingSshTool implements SshTool {
         public final Map<String, ?> props;
         public final List<String> commands;
         public final Map<String, ?> env;
-        
+
         public ExecParams(Map<?, ?> constructorProps, Map<String, ?> props, List<String> commands, Map<String, ?> env) {
             this.constructorProps = constructorProps;
             this.props = props;
@@ -111,6 +114,7 @@ public class RecordingSshTool implements SshTool {
         public final String summaryForLogging;
         public final List<String> commands;
         public final Map<?,?> env;
+        public final Task<?> task;
         
         ExecCmd(Map<?, ?> constructorProps, Map<String,?> props, String summaryForLogging, List<String> commands, Map<?,?> env) {
             this.constructorProps = constructorProps;
@@ -118,6 +122,7 @@ public class RecordingSshTool implements SshTool {
             this.summaryForLogging = summaryForLogging;
             this.commands = commands;
             this.env = env;
+            this.task = Tasks.current();
         }
         
         @Override
@@ -128,6 +133,7 @@ public class RecordingSshTool implements SshTool {
                     .add("env", env)
                     .add("constructorProps", constructorProps)
                     .add("props", props)
+                    .add("task", task)
                     .toString();
         }
     }


### PR DESCRIPTION
the latter allows us to supply custom objects and then chain additional DSL syntax eg

`$brooklyn:object("[my.CustomType]").attributeWhenReady(...)`

using the normal map argument this is impossible:

```
$brooklyn:object:
  type: my.CustomType
# where does attributeWhenReady(...) hang?
```
