### PR TITLE
Add support for downloading bundle as ZIP files

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/BundleApi.java
@@ -90,6 +90,16 @@ public interface BundleApi {
         @PathParam("version")
         String version);
 
+    @Path("/{symbolicName}/{version}/download")
+    @GET
+    @ApiOperation(value = "Download a ZIP archive of a specific bundle given its symbolic name and version")
+    public Response download(
+        @ApiParam(name = "symbolicName", value = "Bundle name to query", required = true)
+        @PathParam("symbolicName")
+        String symbolicName,
+        @ApiParam(name = "version", value = "Version to query", required = true)
+        @PathParam("version")
+        String version);
 
     @Path("/{symbolicName}/{version}/types")
     @GET


### PR DESCRIPTION
This adds a new REST API endpoint to the `BundleResource`, which returns the bundle as a ZIP file when invoked