### PR TITLE
Added config key 

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.server;
 
+import static org.apache.brooklyn.core.config.ConfigKeys.newBooleanConfigKey;
 import static org.apache.brooklyn.core.config.ConfigKeys.newStringConfigKey;
 
 import java.net.URI;
@@ -64,6 +65,12 @@ public class BrooklynServerConfig {
     public static final ConfigKey<String> PERSISTENCE_DIR = newStringConfigKey(
         "brooklyn.persistence.dir", 
         "Directory or container name for writing persisted state");
+
+    public static final ConfigKey<Boolean> PERSISTENCE_DIR_MUST_EXIST = newBooleanConfigKey(
+            "brooklyn.persistence.dir.required",
+            "Whether the persistence directory should before starting AMP;"
+                    + "if true, it will fail if it can't find the directory;"
+                    + "if false, the persistence directory will be created in case it didn't exist in advance;", false);
 
     public static final ConfigKey<String> PERSISTENCE_LOCATION_SPEC = newStringConfigKey(
         "brooklyn.persistence.location.spec", 

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.core.location.geo.HostGeoInfo;
 import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.LocationWithObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.location.byon.FixedListMachineProvisioningLocation;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -50,6 +51,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.core.internal.ssh.process.ProcessTool;
 import org.apache.brooklyn.util.core.mutex.MutexSupport;
 import org.apache.brooklyn.util.core.mutex.WithMutexes;
+import org.apache.brooklyn.util.exceptions.UserFacingException;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
@@ -363,7 +365,14 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
     @Override
     public PersistenceObjectStore newPersistenceObjectStore(String container) {
         File basedir = new File(container);
-        if (basedir.isFile()) throw new IllegalArgumentException("Destination directory must not be a file");
+        if (basedir.isFile()){
+            throw new IllegalArgumentException("Destination directory must not be a file");
+        }
+        Boolean persistence_dir_must_exist = getManagementContext().getConfig().getConfig(BrooklynServerConfig.PERSISTENCE_DIR_MUST_EXIST);
+        LOG.info("PERSISTENCE_DIR_MUST_EXIST {}", persistence_dir_must_exist);
+        if(persistence_dir_must_exist && !basedir.exists()) {
+            throw new UserFacingException("Destination directory  '" + basedir + "' must exist");
+        }
         return new FileBasedObjectStore(basedir);
     }
     

--- a/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/location/localhost/LocalhostMachineProvisioningLocation.java
@@ -369,9 +369,8 @@ public class LocalhostMachineProvisioningLocation extends FixedListMachineProvis
             throw new IllegalArgumentException("Destination directory must not be a file");
         }
         Boolean persistence_dir_must_exist = getManagementContext().getConfig().getConfig(BrooklynServerConfig.PERSISTENCE_DIR_MUST_EXIST);
-        LOG.info("PERSISTENCE_DIR_MUST_EXIST {}", persistence_dir_must_exist);
         if(persistence_dir_must_exist && !basedir.exists()) {
-            throw new UserFacingException("Destination directory  '" + basedir + "' must exist");
+            throw new IllegalArgumentException("Destination directory  '" + basedir + "' must exist");
         }
         return new FileBasedObjectStore(basedir);
     }


### PR DESCRIPTION
Added new config key `PERSISTENCE_DIR_MUST_EXIST` for make the start up fail when the persistand forlder doesn't exist. 
The default value is false so it doesn't change the default behaviour.

For enable it update the `brooklyn.cfg` file to contain
```
brooklyn.persistence.dir.required = true
```