### PR TITLE
Fix hide 'Too many open files' error executing all tests

### DIFF
--- a/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
+++ b/launcher/src/test/java/org/apache/brooklyn/launcher/BrooklynLauncherTest.java
@@ -268,7 +268,7 @@ public class BrooklynLauncherTest {
         }
     }
 
-    @Test
+    @Test(groups = "Integration") // PERSISTENCE_DIR_MUST_EXIST =  true can show hidden IOException in some environments
     public void testLaunchBrooklynWithoutRequiredPersistenceDir() throws Exception {
         BrooklynProperties brooklynProperties = BrooklynProperties.Factory.newDefault();
         String persistenceDir = "persistenceDir_" + Strings.makeRandomId(8);


### PR DESCRIPTION
Hide 'Too many open files' when it occurs