### PR TITLE
Use the jax-rs annotations to recognize correctly parameters 

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -159,7 +159,7 @@ public interface ApplicationApi {
     @Beta
     @PUT
     @Path("/{application}")
-    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
+    @Consumes({MediaType.MULTIPART_FORM_DATA, MediaType.APPLICATION_FORM_URLENCODED})
     @ApiOperation(
             value = "[BETA] Create and start a new application from YAML, with the given id",
             response = org.apache.brooklyn.rest.domain.TaskSummary.class
@@ -206,7 +206,7 @@ public interface ApplicationApi {
 
     @Beta
     @POST
-    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
+    @Consumes({MediaType.MULTIPART_FORM_DATA, MediaType.APPLICATION_FORM_URLENCODED})
     @ApiOperation(
             value = "[BETA] Create and start a new application from YAML",
             response = org.apache.brooklyn.rest.domain.TaskSummary.class

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -216,7 +216,7 @@ public interface ApplicationApi {
     })
     public Response createWithFormat(
             @ApiParam(name = "plan", value = "Application plan to deploy", required = true)
-            @FormParam("plan") byte[] plan,
+            @FormParam("plan") String plan,
             @ApiParam(name = "format", value = "Type plan format e.g. brooklyn-camp", required = false)
             @FormParam("format") String format);
 

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ApplicationApi.java
@@ -25,6 +25,7 @@ import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -155,11 +156,10 @@ public interface ApplicationApi {
             @ApiParam(name = "applicationSpec", value = "App spec in CAMP YAML format", required = true) String yaml,
             @ApiParam(name = "application", value = "Application id", required = true) @PathParam("application") String appId);
 
+    @Beta
     @PUT
     @Path("/{application}")
-    @Consumes({"application/x-yaml",
-            // see http://stackoverflow.com/questions/332129/yaml-mime-type
-            "text/yaml", "text/x-yaml", "application/yaml"})
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     @ApiOperation(
             value = "[BETA] Create and start a new application from YAML, with the given id",
             response = org.apache.brooklyn.rest.domain.TaskSummary.class
@@ -169,9 +169,12 @@ public interface ApplicationApi {
             @ApiResponse(code = 409, message = "Application already registered")
     })
     public Response createFromYamlWithAppId(
-            @ApiParam(name = "plan", value = "Plan", required = true) String yaml,
-            @ApiParam(name = "format", value = "Format eg broolyn-camp", required = false) String format,
-            @ApiParam(name = "application", value = "Application id", required = true) @PathParam("application") String appId);
+            @ApiParam(name = "plan", value = "Plan", required = true)
+            @FormParam("plan") String yaml,
+            @ApiParam(name = "format", value = "Format eg broolyn-camp", required = false)
+            @FormParam("format") String format,
+            @ApiParam(name = "application", value = "Application id", required = true)
+            @PathParam("application") String appId);
 
     /** @deprecated since 1.1 use {@link #createWithFormat(byte[], String)} instead */
     @Deprecated
@@ -203,17 +206,19 @@ public interface ApplicationApi {
 
     @Beta
     @POST
-    @Consumes
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     @ApiOperation(
-            value = "Create and start a new application from YAML",
+            value = "[BETA] Create and start a new application from YAML",
             response = org.apache.brooklyn.rest.domain.TaskSummary.class
     )
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Undefined entity or location")
     })
     public Response createWithFormat(
-            @ApiParam(name = "plan", value = "Application plan to deploy", required = true) byte[] plan,
-            @ApiParam(name = "format", value = "Type plan format e.g. brooklyn-camp", required = false) String format);
+            @ApiParam(name = "plan", value = "Application plan to deploy", required = true)
+            @FormParam("plan") byte[] plan,
+            @ApiParam(name = "format", value = "Type plan format e.g. brooklyn-camp", required = false)
+            @FormParam("format") String format);
 
 
     @DELETE

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -26,6 +26,7 @@ import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceAbsoluteUriB
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -504,7 +505,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
 
     @Override
     public Response createPoly(byte[] inputToAutodetectType) {
-        return createWithFormat(inputToAutodetectType, null);
+        return createWithFormat(Arrays.toString(inputToAutodetectType), null);
     }
 
     @Override
@@ -514,7 +515,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
     }
 
     @Override
-    public Response createWithFormat(byte[] inputToAutodetectType, String format) {
+    public Response createWithFormat(String inputToAutodetectType, String format) {
         log.debug("Creating app from autodetecting input");
 
         boolean looksLikeLegacy = false;


### PR DESCRIPTION
When POST requests to `/v1/applications` are made, the beta endpoint do not behave as expected. This is because the form parameters were annotated with only the swagger annotation, not jax-rs, making them effectively useless.

Instead, jax-rs took the first parameter as the body (which is its default) and ignored the others.