### PR TITLE
Better validation for config keys

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -205,7 +205,7 @@ public class BrooklynDslCommon {
             }
             String keyNameS = resolveKeyName(true);
             ConfigKey<Object> key = ConfigKeys.newConfigKey(Object.class, keyNameS);
-            Maybe<? extends Object> result = ((AbstractConfigurationSupportInternal)obj.config()).getNonBlocking(key);
+            Maybe<? extends Object> result = ((AbstractConfigurationSupportInternal)obj.config()).getNonBlocking(key, true);
             return Maybe.<Object>cast(result);
         }
 

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -612,7 +612,7 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
                     ConfigKey<?> key = targetEntity.getEntityType().getConfigKey(keyNameS);
                     if (key==null) key = ConfigKeys.newConfigKey(Object.class, keyNameS);
                     if (immediate) {
-                        return ((EntityInternal)targetEntity).config().getNonBlocking(key);
+                        return ((EntityInternal)targetEntity).config().getNonBlocking(key, true);
                     } else {
                         return targetEntity.getConfig(key);
                     }

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
@@ -91,6 +91,10 @@ public abstract class ConfigConstraints<T> {
         assertValid(new EntityConfigConstraints(entity), entity, key, value);
     }
 
+    public static <T> void assertValid(EntityAdjunct adj, ConfigKey<T> key, T value) {
+        assertValid(new EntityAdjunctConstraints(adj), adj, key, value);
+    }
+
     public static <T> void assertValid(Location location, ConfigKey<T> key, T value) {
         assertValid(new LocationConfigConstraints(location), location, key, value);
     }
@@ -261,7 +265,7 @@ public abstract class ConfigConstraints<T> {
         @Override
         public Maybe<?> getValue(ConfigKey<?> configKey) {
             // getNonBlocking method coerces the value to the config key's type.
-            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey);
+            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey, false);
         }
 
         @Nullable
@@ -290,7 +294,7 @@ public abstract class ConfigConstraints<T> {
         @Override
         public Maybe<?> getValue(ConfigKey<?> configKey) {
             // getNonBlocking method coerces the value to the config key's type.
-            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey);
+            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey, false);
         }
 
         @Nullable
@@ -318,13 +322,13 @@ public abstract class ConfigConstraints<T> {
         @Override
         public Maybe<?> getValue(ConfigKey<?> configKey) {
             // getNonBlocking method coerces the value to the config key's type.
-            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey);
+            return ((BrooklynObjectInternal)getSource()).config().getNonBlocking(configKey, false);
         }
 
         @Nullable
         @Override
         public ExecutionContext getExecutionContext() {
-            return getSource() instanceof AbstractEntityAdjunct ? ((AbstractEntityAdjunct)getSource()).getExecutionContext() : null;
+            return null;
         }
     }
 
@@ -400,7 +404,7 @@ public abstract class ConfigConstraints<T> {
                 ConfigKey<Object> otherKey = ConfigKeys.newConfigKey(Object.class, otherKeyName);
                 BrooklynObjectInternal.ConfigurationSupportInternal configInternal = ((BrooklynObjectInternal) context).config();
                 
-                Maybe<?> maybeValue = configInternal.getNonBlocking(otherKey);
+                Maybe<?> maybeValue = configInternal.getNonBlocking(otherKey, false);
                 if (maybeValue.isPresent()) {
                     vals.add(maybeValue.get());
                 } else {

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConfigConstraints.java
@@ -219,22 +219,17 @@ public abstract class ConfigConstraints<T> {
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
             // previously we ignored it if validation threw an error; now we skip the check altogether if the type is wrong (future, or coercible)
-            return ReferenceWithError.newInstanceThrowingError(po, new IllegalArgumentException("Invalid value for " + configKey.getName() + ": " + value, e));
+            return ReferenceWithError.newInstanceThrowingError(po, new IllegalArgumentException("Invalid value for " + configKey.getName() + ": " + value + "; " + Exceptions.collapseText(e), e));
         }
 
         try {
             BrooklynValidation.getInstance().validateIfPresent(value);
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
-            return ReferenceWithError.newInstanceThrowingError(null, new IllegalArgumentException("Invalid value for " + configKey.getName() + ": " + value, e));
+            return ReferenceWithError.newInstanceThrowingError(null, new IllegalArgumentException("Invalid value for " + configKey.getName() + ": " + value + "; " + Exceptions.collapseText(e), e));
         }
         return ReferenceWithError.newInstanceWithoutError(null);
     }
-
-    // TODO
-//    private BrooklynObjectInternal.ConfigurationSupportInternal getConfigurationSupportInternal() {
-//        return ((BrooklynObjectInternal) brooklynObject).config();
-//    }
 
     protected T getSource() {
         return source;

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
@@ -254,7 +254,7 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
         return coerceConfigValAndValidate(key, v, false);
     }
 
-    /** see also {@link #resolveAndCoerce(BrooklynObject, String, Object, TypeToken, ConfigKey, ConfigKey)} */
+    /** see also {@link #resolveCoerceAndValidate(BrooklynObject, String, Object, TypeToken, ConfigKey, ConfigKey)} */
     protected <T> Object coerceConfigValAndValidate(ConfigKey<T> key, Object v, boolean validate) {
         Object result = coerceConfigValPreValidate(key, v);
         // previously validation was only done in a few paths, and before coercion, and cast exceptions were ignored.
@@ -381,7 +381,7 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
 
     /** see also {@link #coerceConfigVal(ConfigKey, Object)} */
     @SuppressWarnings("unchecked")
-    protected <T> T resolveAndCoerce(TContainer container, String name, Object value, TypeToken<T> type, ConfigKey<?> key1, ConfigKey<?> key2) {
+    protected <T> T resolveCoerceAndValidate(TContainer container, String name, Object value, TypeToken<T> type, ConfigKey<?> key1, ConfigKey<?> key2) {
         if (type==null || value==null) return (T) value;
         ExecutionContext exec = getExecutionContext(container);
         try {
@@ -430,7 +430,7 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
                 if (raw || input==null || input.isAbsent()) return (Maybe<T>)input;
                 // use lambda to defer execution if default value not needed.
                 // this coercion should never be persisted so this is safe.
-                return new MaybeSupplier<T>(() -> (resolveAndCoerce(getContainer(), ownKey.getName(), input.get(), type, ownKey, queryKey)));
+                return new MaybeSupplier<T>(() -> (resolveCoerceAndValidate(getContainer(), ownKey.getName(), input.get(), type, ownKey, queryKey)));
             }
         };
         // prefer default and type of ownKey

--- a/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/internal/AbstractConfigMapImpl.java
@@ -250,7 +250,7 @@ public abstract class AbstractConfigMapImpl<TContainer extends BrooklynObject> i
         return getParentInternal().config().getInternalConfigMap().getConfigRaw(key, includeInherited);
     }
 
-    protected Object coerceConfigVal(ConfigKey<?> key, Object v) {
+    protected final Object coerceConfigVal(ConfigKey<?> key, Object v) {
         return coerceConfigValAndValidate(key, v, false);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1169,6 +1169,9 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
         return result;
     }
 
+    // TODO can this be replaced with config().set ?
+    // seems only used for configure(Map) -- where validation might want to be skipped;
+    // and also in a couple places where i don't think it matters
     @SuppressWarnings("unchecked")
     public <T> T setConfigEvenIfOwned(ConfigKey<T> key, T val) {
         return (T) configsInternal.setConfig(key, val);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1101,11 +1101,6 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     public class BasicConfigurationSupport extends AbstractConfigurationSupportInternal {
 
         @Override
-        protected <T> void assertValid(ConfigKey<T> key, T val) {
-            ConfigConstraints.assertValid(AbstractEntity.this, key, val);
-        }
-        
-        @Override
         protected AbstractConfigMapImpl<?> getConfigsInternal() {
             return configsInternal;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/entity/internal/EntityConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/internal/EntityConfigMap.java
@@ -28,7 +28,9 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.internal.AbstractConfigMapImpl;
+import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal.ConfigurationSupportInternal;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -66,6 +68,11 @@ public class EntityConfigMap extends AbstractConfigMapImpl<Entity> {
             entity = null;
         }
         return (EntityInternal) super.getBrooklynObject();
+    }
+
+    @Override
+    public <T> void assertValid(ConfigKey<T> key, T val) {
+        ConfigConstraints.assertValid((Entity) getContainer(), key, val);
     }
 
     protected EntityInternal getEntity() {

--- a/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/AbstractLocation.java
@@ -357,11 +357,6 @@ public abstract class AbstractLocation extends AbstractBrooklynObject implements
         // (now gives us inheritance correctly -- for free!)
 
         @Override
-        protected <T> void assertValid(ConfigKey<T> key, T val) {
-            ConfigConstraints.assertValid(AbstractLocation.this, key, val);
-        }
-
-        @Override
         protected <T> void onConfigChanging(ConfigKey<T> key, Object val) {
         }
         

--- a/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
@@ -96,16 +96,17 @@ public class LocationConfigMap extends AbstractConfigMapImpl<Location> {
     }
 
     @Override
-    protected Object coerceConfigVal(ConfigKey<?> key, Object v) {
+    protected <T> Object coerceConfigValAndValidate(ConfigKey<T> key, Object v, boolean validate) {
         if ((Class.class.isAssignableFrom(key.getType()) || Function.class.isAssignableFrom(key.getType())) && v instanceof String) {
-            // strings can be written where classes/functions are permitted; 
+            // for locations only strings can be written where classes/functions are permitted;
             // this because an occasional pattern only for locations because validation wasn't enforced there
             // (and locations do a lot more config in brooklyn.properties) - eg ImageChooser in jclouds
-            // TODO slowly warn on this then phase it out
+            // TODO phase it out -- just image chooser? since 1.0
+            log.warn("Setting string where class/function is wanted for location, on "+getContainer()+" key "+key+" value "+v+"; key should be changed to take appropriate type");
             return v;
         }
         
-        return super.coerceConfigVal(key, v);
+        return super.coerceConfigValAndValidate(key, v, validate);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/location/internal/LocationConfigMap.java
@@ -29,7 +29,9 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.internal.AbstractConfigMapImpl;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.location.AbstractLocation;
@@ -71,6 +73,11 @@ public class LocationConfigMap extends AbstractConfigMapImpl<Location> {
             if (mgmt==null) return null;
             return mgmt.getServerExecutionContext();
         }
+    }
+
+    @Override
+    public <T> void assertValid(ConfigKey<T> key, T val) {
+        ConfigConstraints.assertValid((Location) getContainer(), key, val);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -163,15 +163,10 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
         return getConfigsInternal().getConfig(key);
     }
 
-    @Deprecated
-    protected <T> T setConfigInternal(ConfigKey<T> key, Object val) {
-        return setConfigInternal(key, val, null);
-    }
-
     @SuppressWarnings("unchecked")
     protected <T> T setConfigInternal(ConfigKey<T> key, Object val, @Nullable Consumer<T> validate) {
         onConfigChanging(key, val);
-        Pair<Object, Object> set = getConfigsInternal().setConfigReturnOldAndNew(key, val, validate);
+        Pair<Object, Object> set = getConfigsInternal().setConfigCoercingAndValidating(key, val, validate);
         onConfigChanged(key, set.getRight());
         return (T) set.getLeft();
     }
@@ -183,7 +178,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
 
     @Override
     public <T> T set(ConfigKey<T> key, Task<T> val) {
-        return setConfigInternal(key, val, null);
+        return setConfigInternal(key, val, null /* validation not done on set for tasks/futures; but is done on retrieval */);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -83,7 +83,7 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
             if (key instanceof StructuredConfigKey || key instanceof SubElementConfigKey) {
                 return getNonBlockingResolvingStructuredKey(key);
             } else {
-                return getNonBlockingResolvingSimple(key);
+                return getNonBlockingResolvingSimple(key).transform(v -> ensureValid(key, v));
             }
         } catch (ImmediateValueNotAvailableException e) {
             return Maybe.absent(e);
@@ -154,13 +154,17 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
 
     protected abstract AbstractConfigMapImpl<? extends BrooklynObject> getConfigsInternal();
     protected abstract <T> void assertValid(ConfigKey<T> key, T val);
+    protected <T> T ensureValid(ConfigKey<T> key, T val) {
+        assertValid(key, val);
+        return val;
+    }
     protected abstract BrooklynObject getContainer();
     protected abstract <T> void onConfigChanging(ConfigKey<T> key, Object val);
     protected abstract <T> void onConfigChanged(ConfigKey<T> key, Object val);
 
     @Override
     public <T> T get(ConfigKey<T> key) {
-        return getConfigsInternal().getConfig(key);
+        return ensureValid( key, (T) getConfigsInternal().getConfig(key) );
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractConfigurationSupportInternal.java
@@ -163,20 +163,22 @@ public abstract class AbstractConfigurationSupportInternal implements BrooklynOb
     }
 
     protected abstract AbstractConfigMapImpl<? extends BrooklynObject> getConfigsInternal();
-    protected final <T> void assertValid(ConfigKey<T> key, T val) {
-        getConfigsInternal().assertValid(key, val);
-    }
+
     protected <T> T ensureValid(ConfigKey<T> key, T val) {
-        assertValid(key, val);
+        if (key!=null) {
+            getConfigsInternal().assertValid(key, val);
+        }
         return val;
     }
+
     protected abstract BrooklynObject getContainer();
     protected abstract <T> void onConfigChanging(ConfigKey<T> key, Object val);
     protected abstract <T> void onConfigChanged(ConfigKey<T> key, Object val);
 
     @Override
     public <T> T get(ConfigKey<T> key) {
-        return ensureValid( key, (T) getConfigsInternal().getConfig(key) );
+        // validation done by getConfig call below
+        return (T) getConfigsInternal().getConfig(key);
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -345,11 +345,6 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
         }
 
         @Override
-        protected <T> void assertValid(ConfigKey<T> key, T val) {
-            ConfigConstraints.assertValid(entity, key, val);
-        }
-
-        @Override
         protected BrooklynObject getContainer() {
             return AbstractEntityAdjunct.this;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctConfigMap.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AdjunctConfigMap.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.mgmt.ExecutionContext;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigConstraints;
 import org.apache.brooklyn.core.config.internal.AbstractConfigMapImpl;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -59,6 +60,11 @@ public class AdjunctConfigMap extends AbstractConfigMapImpl<EntityAdjunct> {
             adjunct = null;
         }
         return super.getContainer();
+    }
+
+    @Override
+    public <T> void assertValid(ConfigKey<T> key, T val) {
+        ConfigConstraints.assertValid((EntityAdjunct) getContainer(), key, val);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/BrooklynObjectInternal.java
@@ -148,15 +148,20 @@ public interface BrooklynObjectInternal extends BrooklynObject, Rebindable {
          * This will include catching {@link ImmediateUnsupportedException} 
          * and returning it as an absence, thus making the semantics here slightly
          * "safer" than that of {@link ImmediateSupplier#getImmediately()}.
+         * <p>
+         * By default does not validate.  Use {@link #getNonBlocking(ConfigKey, boolean)} to invoke validation.
          */
         @Beta
         <T> Maybe<T> getNonBlocking(ConfigKey<T> key);
+
+        <T> Maybe<T> getNonBlocking(ConfigKey<T> key, boolean validate);
 
         /**
          * @see {@link #getNonBlocking(ConfigKey)}
          */
         @Beta
         <T> Maybe<T> getNonBlocking(HasConfigKey<T> key);
+        <T> Maybe<T> getNonBlocking(HasConfigKey<T> key, boolean validate);
 
         /** Adds keys or strings, making anonymous keys from strings; throws on other keys */
         @Beta

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -19,6 +19,15 @@
 package org.apache.brooklyn.core.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.core.policy.basic.BasicPolicyTest.MyPolicy;
+import org.apache.brooklyn.core.policy.basic.BasicPolicyTest.MyPolicyWithDuration;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.DurationPredicates;
+import org.apache.brooklyn.util.time.Time;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -877,5 +886,111 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
         Assert.assertEquals(e2.config().get(MyBaseEntity.SUPER_KEY_1), MyBaseEntity.SUPER_KEY_1.getDefaultValue());
         Assert.assertEquals(e2.config().get(ConfigKeys.newStringConfigKey(MyBaseEntity.SUPER_KEY_1.getName())), MyBaseEntity.SUPER_KEY_1.getDefaultValue());
     }
-    
+
+    @ImplementedBy(MyEntityWithDurationImpl.class)
+    public interface MyEntityWithDuration extends EntityInternal {
+        public static final ConfigKey<Duration> DURATION_POSITIVE = ConfigKeys.builder(Duration.class, "duration").constraint(DurationPredicates.positive()).build();
+    }
+
+    public static class MyEntityWithDurationImpl extends AbstractEntity implements MyEntityWithDuration {
+    }
+
+    @Test
+    public void testDurationConstraintValidAddSpec() throws Exception {
+        MyEntityWithDuration child = app.addChild(EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE, Duration.ONE_MINUTE));
+
+        assertEquals(child.getConfig(MyPolicyWithDuration.DURATION_POSITIVE), Duration.ONE_MINUTE);
+    }
+
+    @Test
+    public void testDurationConstraintInvalidAddSpec() throws Exception {
+        EntitySpec<MyEntityWithDuration> spec = EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE, Duration.minutes(-42));
+
+        Asserts.assertFailsWith(() -> app.addChild(spec),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidCreation() throws Exception {
+        EntitySpec<TestApplication> app2 = EntitySpec.create(TestApplication.class)
+                .child(EntitySpec.create(MyEntityWithDuration.class)
+                        .configure(MyEntityWithDuration.DURATION_POSITIVE, Duration.minutes(-42)));
+
+        Asserts.assertFailsWith(() -> mgmt.getEntityManager().createEntity(app2),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidAddSpecByName() throws Exception {
+        EntitySpec<MyEntityWithDuration> spec = EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), Duration.minutes(-42));
+
+        Asserts.assertFailsWith(() -> app.addChild(spec),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidCreationByName() throws Exception {
+        EntitySpec<TestApplication> app2 = EntitySpec.create(TestApplication.class)
+                .child(EntitySpec.create(MyEntityWithDuration.class)
+                        .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), Duration.minutes(-42)));
+
+        Asserts.assertFailsWith(() -> mgmt.getEntityManager().createEntity(app2),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+
+    @Test
+    public void testDurationConstraintValidAddSpecByNameFromStringCoerced() throws Exception {
+        MyEntityWithDuration child = app.addChild(EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), "1m"));
+
+        assertEquals(child.getConfig(MyPolicyWithDuration.DURATION_POSITIVE), Duration.ONE_MINUTE);
+    }
+
+    @Test
+    public void testDurationConstraintInvalidAddSpecByNameFromStringCoerced() throws Exception {
+        EntitySpec<MyEntityWithDuration> spec = EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), "-42m");
+
+        // TODO below should fail because we should do the validation _after_ coercion
+        Asserts.assertFailsWith(() -> app.addChild(spec),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidCreationFromStringCoerced() throws Exception {
+        EntitySpec<TestApplication> app2 = EntitySpec.create(TestApplication.class)
+                .child(EntitySpec.create(MyEntityWithDuration.class)
+                        .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), "-42m"));
+
+        // TODO below should fail because we should do the validation _after_ coercion
+        Asserts.assertFailsWith(() -> mgmt.getEntityManager().createEntity(app2),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintDeferredSupplier() throws Exception {
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        MyEntityWithDuration child = app.addChild(EntitySpec.create(MyEntityWithDuration.class)
+                .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), new DeferredSupplier<Duration>() {
+                    @Override
+                    public Duration get() {
+                        Time.sleep(Duration.millis(10));
+                        invocationCount.incrementAndGet();
+                        return Duration.minutes(-42);
+                    }
+                }));
+        // shouldn't be accessible on setup due to get immediate semantics
+        Assert.assertEquals(invocationCount.get(), 0);
+
+        // TODO should fail because we should validate on the _get_ if the value is/was deferred
+        Asserts.assertFailsWith(() -> child.getConfig(MyPolicyWithDuration.DURATION_POSITIVE),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+
+        Asserts.assertThat(invocationCount.get(), t -> t>0, "invocation should have happened at least once");
+    }
+
 }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -986,16 +986,10 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
                         .configure(MyEntityWithDuration.DURATION_POSITIVE.getName(), "1m"));
         Entity ent = Iterables.getOnlyElement( mgmt.getEntityManager().createEntity(app2).getChildren() );
 
-        // currently untyped invalid reconfiguration is allowed, but get will fail, whether typed or not
-        // (this could be tightened in future)
         ConfigKey<Object> objKey = ConfigKeys.newConfigKey(Object.class, MyEntityWithDuration.DURATION_POSITIVE.getName());
-        ent.config().set(objKey, "-42m");
 
-        Asserts.assertFailsWith(() -> ent.config().get(MyEntityWithDuration.DURATION_POSITIVE),
-                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
-
-        // 2021-01 untyped access also now does validation (in addition to type coercion)
-        Asserts.assertFailsWith(() -> ent.config().get(objKey),
+        // 2021-01 validation done even for untyped set config
+        Asserts.assertFailsWith(() -> ent.config().set(objKey, "-42m"),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
     }
 
@@ -1016,6 +1010,10 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
         Assert.assertEquals(invocationCount.get(), 0);
 
         Asserts.assertFailsWith(() -> child.getConfig(MyPolicyWithDuration.DURATION_POSITIVE),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+
+        ConfigKey<Object> objKey = ConfigKeys.newConfigKey(Object.class, MyEntityWithDuration.DURATION_POSITIVE.getName());
+        Asserts.assertFailsWith(() -> child.config().get(objKey),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
 
         Asserts.assertThat(invocationCount.get(), t -> t>0, "invocation should have happened at least once");

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntityConfigTest.java
@@ -994,10 +994,9 @@ public class EntityConfigTest extends BrooklynAppUnitTestSupport {
         Asserts.assertFailsWith(() -> ent.config().get(MyEntityWithDuration.DURATION_POSITIVE),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
 
-        // TODO untyped access causes typing but not validation
-        Assert.assertEquals(ent.config().get(objKey), Duration.minutes(-42));
-//        Asserts.assertFailsWith(() -> ent.config().get(objKey),
-//                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+        // 2021-01 untyped access also now does validation (in addition to type coercion)
+        Asserts.assertFailsWith(() -> ent.config().get(objKey),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
@@ -18,9 +18,15 @@
  */
 package org.apache.brooklyn.core.policy.basic;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.EntityConfigTest.MyEntityWithDuration;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.DurationPredicates;
+import org.apache.brooklyn.util.time.Time;
+import org.testng.Assert;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -153,22 +159,70 @@ public class BasicPolicyTest extends BrooklynAppUnitTestSupport {
     }
 
     @Test
-    public void testDurationConstraintInvalidAddInstance() throws Exception {
+    public void testDurationConstraintInvalidSetLive() throws Exception {
         MyPolicyWithDuration policy = new MyPolicyWithDuration();
-        policy.config().set(MyPolicyWithDuration.DURATION_POSITIVE, Duration.minutes(-1));
-
-        app.policies().add(policy);
-        assertTrue(Iterables.tryFind(app.policies(), Predicates.equalTo(policy)).isPresent());
-
-        assertEquals(policy.getConfig(MyPolicyWithDuration.DURATION_POSITIVE), Duration.ONE_MINUTE);
+        Asserts.assertFailsWith(() -> policy.config().set(MyPolicyWithDuration.DURATION_POSITIVE, Duration.minutes(-42)),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
     }
 
     @Test
     public void testDurationConstraintInvalidAddSpec() throws Exception {
-        MyPolicy policy = app.policies().add(PolicySpec.create(MyPolicyWithDuration.class)
-                .configure(MyPolicyWithDuration.DURATION_POSITIVE, Duration.minutes(-1)));
+        PolicySpec<MyPolicyWithDuration> spec = PolicySpec.create(MyPolicyWithDuration.class)
+                .configure(MyPolicyWithDuration.DURATION_POSITIVE, Duration.minutes(-42));
 
-        assertEquals(policy.getConfig(MyPolicyWithDuration.DURATION_POSITIVE), Duration.ONE_MINUTE);
+        Asserts.assertFailsWith(() -> app.policies().add(spec),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidSetLiveByNameCoerced() throws Exception {
+        MyPolicyWithDuration policy = new MyPolicyWithDuration();
+
+        // currently untyped invalid reconfiguration is allowed, but get will fail, whether typed or not
+        // (this could be tightened in future)
+        ConfigKey<Object> objKey = ConfigKeys.newConfigKey(Object.class, MyEntityWithDuration.DURATION_POSITIVE.getName());
+        policy.config().set(objKey, "-42m");
+
+        Asserts.assertFailsWith(() -> policy.config().get(MyEntityWithDuration.DURATION_POSITIVE),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+
+        // TODO untyped access causes typing but not validation
+        Assert.assertEquals(policy.config().get(objKey), Duration.minutes(-42));
+//        Asserts.assertFailsWith(() -> ent.config().get(objKey),
+//                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+
+    }
+
+    @Test
+    public void testDurationConstraintInvalidAddSpecByNameCoerced() throws Exception {
+        PolicySpec<MyPolicyWithDuration> spec = PolicySpec.create(MyPolicyWithDuration.class)
+                .configure(MyPolicyWithDuration.DURATION_POSITIVE.getName(), "-42m");
+
+        Asserts.assertFailsWith(() -> app.policies().add(spec),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+    }
+
+    @Test
+    public void testDurationConstraintInvalidDeferredSupplier() throws Exception {
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        DeferredSupplier<Duration> deferred = new DeferredSupplier<Duration>() {
+            @Override
+            public Duration get() {
+                Time.sleep(Duration.millis(10));
+                invocationCount.incrementAndGet();
+                return Duration.minutes(-42);
+            }
+        };
+        PolicySpec<MyPolicyWithDuration> spec = PolicySpec.create(MyPolicyWithDuration.class)
+                .configure(MyPolicyWithDuration.DURATION_POSITIVE.getName(), deferred);
+        MyPolicyWithDuration policy = app.policies().add(spec);
+        // shouldn't be accessible on setup due to get immediate semantics
+        Assert.assertEquals(invocationCount.get(), 0);
+
+        Asserts.assertFailsWith(() -> policy.getConfig(MyPolicyWithDuration.DURATION_POSITIVE),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
+
+        Asserts.assertThat(invocationCount.get(), t -> t>0, "invocation should have happened at least once");
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
@@ -186,11 +186,9 @@ public class BasicPolicyTest extends BrooklynAppUnitTestSupport {
         Asserts.assertFailsWith(() -> policy.config().get(MyEntityWithDuration.DURATION_POSITIVE),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
 
-        // TODO untyped access causes typing but not validation
-        Assert.assertEquals(policy.config().get(objKey), Duration.minutes(-42));
-//        Asserts.assertFailsWith(() -> ent.config().get(objKey),
-//                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
-
+        // 2021-01 untyped access also now does validation (in addition to type coercion)
+        Asserts.assertFailsWith(() -> policy.config().get(objKey),
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/policy/basic/BasicPolicyTest.java
@@ -178,16 +178,9 @@ public class BasicPolicyTest extends BrooklynAppUnitTestSupport {
     public void testDurationConstraintInvalidSetLiveByNameCoerced() throws Exception {
         MyPolicyWithDuration policy = new MyPolicyWithDuration();
 
-        // currently untyped invalid reconfiguration is allowed, but get will fail, whether typed or not
-        // (this could be tightened in future)
+        // 2021-01 validation done even for untyped set config
         ConfigKey<Object> objKey = ConfigKeys.newConfigKey(Object.class, MyEntityWithDuration.DURATION_POSITIVE.getName());
-        policy.config().set(objKey, "-42m");
-
-        Asserts.assertFailsWith(() -> policy.config().get(MyEntityWithDuration.DURATION_POSITIVE),
-                e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
-
-        // 2021-01 untyped access also now does validation (in addition to type coercion)
-        Asserts.assertFailsWith(() -> policy.config().get(objKey),
+        Asserts.assertFailsWith(() -> policy.config().set(objKey, "-42m"),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "-42m", "positive"));
     }
 

--- a/logging/logback-includes/src/main/resources/brooklyn/logback-appender-stdout.xml
+++ b/logging/logback-includes/src/main/resources/brooklyn/logback-appender-stdout.xml
@@ -21,7 +21,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d %-5level %X{task.id}-%X{entity.ids} %msg%n%xEx{0}</pattern>
+      <pattern>%d %-5level %X{task.id}-%X{entity.ids} %msg%n</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
         <level>INFO</level>

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1280,7 +1280,7 @@ public class Asserts {
     
     /** Tests {@link #expectedFailure(Throwable)} and that the <code>toString</code>
      * satisfies {@link #assertStringContains(String, String, String...)}.
-     * @return as per {@link #expectedFailureOfType(Throwable, Class...)} */
+     * @return as per {@link #expectedFailureOfType(Throwable, Class, Class...)} */
     public static boolean expectedFailureContains(Throwable e, String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
         if (e instanceof ShouldHaveFailedPreviouslyAssertionError) throw (Error)e;
         try {
@@ -1304,7 +1304,7 @@ public class Asserts {
 
     /** Tests {@link #expectedFailure(Throwable)} and that the <code>toString</code>
      * satisfies {@link #assertStringContains(String, String, String...)}.
-     * @return as per {@link #expectedFailureOfType(Throwable, Class...)} */
+     * @return as per {@link #expectedFailureOfType(Throwable, Class, Class...)} */
     public static boolean expectedFailureDoesNotContain(Throwable e, String phrase1ToNotContain, String ...optionalOtherPhrasesToNotContain) {
         if (e instanceof ShouldHaveFailedPreviouslyAssertionError) throw (Error)e;
         try {
@@ -1315,7 +1315,7 @@ public class Asserts {
         return true;
     }
     
-    /** Implements the return behavior for {@link #expectedFailureOfType(Throwable, Class...)} and others,
+    /** Implements the return behavior for {@link #expectedFailureOfType(Throwable, Class, Class...)} and others,
      * to log interesting earlier errors but to suppress those which are internal or redundant. */
     private static void rethrowPreferredException(Throwable earlierPreferredIfFatalElseLogged, Throwable laterPreferredOtherwise) throws AssertionError {
         if (!(earlierPreferredIfFatalElseLogged instanceof AssertionError)) {

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1104,11 +1104,16 @@ public class Asserts {
             c.call();
         } catch (Throwable e) {
             failed = true;
-            if (!exceptionChecker.apply(e)) {
-                log.debug("Test threw invalid exception (failing)", e);
-                fail("Test threw invalid exception: "+e);
+            try {
+                if (!exceptionChecker.apply(e)) {
+                    log.warn("Test threw invalid exception (failing)", e);
+                    fail("Test threw invalid exception: " + e);
+                }
+                log.debug("Test for exception successful (" + e + ")");
+            } catch (Exception e2) {
+                log.warn("Test threw invalid exception (failing)", e);
+                throw Exceptions.propagate(e2);
             }
-            log.debug("Test for exception successful ("+e+")");
         }
         if (!failed) fail("Test code should have thrown exception but did not");
     }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/ReferenceWithError.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/exceptions/ReferenceWithError.java
@@ -61,7 +61,7 @@ public class ReferenceWithError<T> implements Supplier<T> {
         return maskError;
     }
 
-    /** returns the underlying value, throwing if there is an error which is not masked (ie {@link #throwsErrorOnAccess()} is set) */
+    /** returns the underlying value, throwing if there is an error which is not masked (ie {@link #hasError()} is true and {@link #masksErrorIfPresent()} false) */
     @Override
     public T get() {
         if (masksErrorIfPresent()) {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
@@ -470,6 +470,7 @@ public class Time {
             String s = Strings.getLastWord(timeString).toLowerCase();
             timeString = timeString.substring(0, timeString.length()-s.length()).trim();
             int i=0;
+            if (s.startsWith("-")) i++;  //allow negative marker at start
             while (s.length()>i) {
                 char c = s.charAt(i);
                 if (c=='.' || Character.isDigit(c)) i++;

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
@@ -446,53 +446,79 @@ public class Time {
      * Parses a string eg '5s' or '20m 22.123ms', returning the number of milliseconds it represents; 
      * -1 on blank or never or off or false.
      * Assumes unit is millisections if no unit is specified.
-     * 
+     * <p>
+     * Negation is permitted if there is just one unit or if it is at the start with a space.
+     * Negative values are not permitted elsewhere.  So the following are allowed:
+     *
+     * * -1m is clear (-60 seconds) -- initial negation with just one unit
+     * * - 1m 1s = -61 seconds -- ie initial negation _with space_ applies to entire line
+     *
+     * But these are not:
+     *
+     * * -1m 1s
+     * * -1m -1s
+     * * - 1m -1s
+     * * 1m -1s
+     *
      * @throws NullPointerException if arg is null
      * @throws NumberFormatException if cannot be parsed
      */
-    public static double parseElapsedTimeAsDouble(final String timeStringOrig) {
-        String timeString = timeStringOrig;
+    public static double parseElapsedTimeAsDouble(final String timeString) {
+        return parseElapsedTimeAsDouble(timeString, timeString, true, true);
+    }
+
+    private static double parseElapsedTimeAsDouble(final String timeStringOrig, String timeString, boolean allowNonUnit, boolean allowNegative) {
         if (timeString==null)
             throw new NullPointerException("GeneralHelper.parseTimeString cannot parse a null string");
         try {
-            if (timeString.trim().matches(".*[A-Za-z]$")) {
-                // disable parsing eg 1d as a double
-            } else {
-                double d = Double.parseDouble(timeString);
-                return d;
+            if (allowNonUnit) {
+                if (timeString.trim().matches(".*[A-Za-z]$")) {
+                    // disable parsing eg 1d as a double
+                } else {
+                    double d = Double.parseDouble(timeString);
+                    return d;
+                }
             }
         } catch (NumberFormatException e) {
             log.trace("Unable to parse '%s' as pure number. Trying smart parse.", timeStringOrig, e);
         }
+        boolean isNegative = false;
+        String multipleUnitsDisallowedBecause = null;
         try {
             //look for a type marker
             timeString = timeString.trim();
-            String s = Strings.getLastWord(timeString).toLowerCase();
-            timeString = timeString.substring(0, timeString.length()-s.length()).trim();
             int i=0;
-            if (s.startsWith("-")) i++;  //allow negative marker at start
-            while (s.length()>i) {
-                char c = s.charAt(i);
+            if (timeString.startsWith("-")) {
+                if (allowNegative) {
+                    isNegative = true;
+                } else {
+                    throw new NumberFormatException("Negation is not permitted on an individual time unit in a duration");
+                }
+                timeString = timeString.substring(1);
+                if (!timeString.startsWith(" ")) {
+                    multipleUnitsDisallowedBecause = "Negation must have a space after it to apply to mulitple units";
+                } else while (timeString.startsWith(" ")) {
+                    timeString = timeString.substring(1);
+                }
+            }
+            while (i < timeString.length()) {
+                char c = timeString.charAt(i);
                 if (c=='.' || Character.isDigit(c)) i++;
                 else break;
             }
-            String num = s.substring(0, i);
-            if (i==0) {
-                if (Strings.isNonBlank(timeString)) {
-                    num = Strings.getLastWord(timeString).toLowerCase();
-                    timeString = timeString.substring(0, timeString.length()-num.length()).trim();
-                }
-            } else {
-                s = s.substring(i);
-            }
+            String num = timeString.substring(0, i);
+            timeString = timeString.substring(i).trim();
             long multiplier = 0;
-            if (num.length()==0) {
+            if (num.isEmpty()) {
                 //must be never or something
                 // TODO does 'never' work?
-                if (s.equalsIgnoreCase("never") || s.equalsIgnoreCase("off") || s.equalsIgnoreCase("false"))
+                if (allowNegative && !isNegative && (timeString.equalsIgnoreCase("never") || timeString.equalsIgnoreCase("off") || timeString.equalsIgnoreCase("false"))) {
                     return -1;
-                throw new NumberFormatException("unrecognised word  '"+s+"' in time string");
+                }
+                throw new NumberFormatException("Invalid duration string '"+timeStringOrig+"'");
             }
+            String s = Strings.getFirstWord(timeString);
+            timeString = timeString.substring(s.length()).trim();
             if (s.equalsIgnoreCase("ms") || s.equalsIgnoreCase("milli") || s.equalsIgnoreCase("millis")
                 || s.equalsIgnoreCase("millisec") || s.equalsIgnoreCase("millisecs")
                 || s.equalsIgnoreCase("millisecond") || s.equalsIgnoreCase("milliseconds"))
@@ -510,15 +536,19 @@ public class Time {
                 multiplier = 24*60*60*1000;
             else
                 throw new NumberFormatException("Unknown unit '"+s+"' in time string '"+timeStringOrig+"'");
+
             double d = Double.parseDouble(num);
             double dd = 0;
             if (timeString.length()>0) {
-                dd = parseElapsedTimeAsDouble(timeString);
+                if (multipleUnitsDisallowedBecause!=null) {
+                    throw new NumberFormatException(multipleUnitsDisallowedBecause);
+                }
+                dd = parseElapsedTimeAsDouble(timeStringOrig, timeString, false, false);
                 if (dd==-1) {
                     throw new NumberFormatException("Cannot combine '"+timeString+"' with '"+num+" "+s+"'");
                 }
             }
-            return d*multiplier + dd;
+            return (d*multiplier + dd) * (isNegative ? -1 : 1);
         } catch (Exception ex) {
             if (ex instanceof NumberFormatException) throw (NumberFormatException)ex;
             log.trace("Details of parse failure:", ex);

--- a/utils/common/src/test/java/org/apache/brooklyn/util/time/DurationTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/time/DurationTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.util.time;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -41,8 +42,8 @@ public class DurationTest {
 
     public void testStatics() {
         Assert.assertEquals((((4*60+3)*60)+30)*1000, 
-            Duration.ONE_MINUTE.times(3).
-                add(Duration.ONE_HOUR.times(4)).
+            Duration.ONE_MINUTE.multiply(3).
+                add(Duration.ONE_HOUR.multiply(4)).
                 add(Duration.THIRTY_SECONDS).
             toMilliseconds());
     }
@@ -53,12 +54,15 @@ public class DurationTest {
     }
 
     public void testParseNegative() {
+        Assert.assertEquals(Duration.of("- 1 m 1 s"), Duration.seconds(-61));
+
         Assert.assertEquals(Duration.of("-42 m"), Duration.minutes(-42));
         Assert.assertEquals(Duration.of("-42m"), Duration.minutes(-42));
-        // TODO currently these are backwards (ie -1m 1s = 59 seconds -- confusing!)
-//        Assert.assertEquals(Duration.of("-1 m 1 s"), Duration.seconds(-61));
-//        Assert.assertEquals(Duration.of("- 1m 1s"), Duration.seconds(-61));
-//        Assert.assertEquals(Duration.of("-1m -1s"), Duration.seconds(-59));
+        Assert.assertEquals(Duration.of("- 1 m 1 s"), Duration.seconds(-61));
+        Asserts.assertFailsWith(() -> Duration.of("-1m 1s"), e -> Asserts.expectedFailureContainsIgnoreCase(e, "negati", "space"));
+        Asserts.assertFailsWith(() -> Duration.of("1m -1s"), e -> Asserts.expectedFailureContainsIgnoreCase(e, "negati", "individual time unit"));
+        Asserts.assertFailsWith(() -> Duration.of("1m -1 s"), e -> Asserts.expectedFailureContainsIgnoreCase(e, "negati", "individual time unit"));
+        Asserts.assertFailsWith(() -> Duration.of("- 1m - 1s"), e -> Asserts.expectedFailureContainsIgnoreCase(e, "negati", "individual time unit"));
     }
 
     public void testConvesion() {

--- a/utils/common/src/test/java/org/apache/brooklyn/util/time/DurationTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/time/DurationTest.java
@@ -52,6 +52,15 @@ public class DurationTest {
                 Duration.of("4h 3m 30s").toMilliseconds());
     }
 
+    public void testParseNegative() {
+        Assert.assertEquals(Duration.of("-42 m"), Duration.minutes(-42));
+        Assert.assertEquals(Duration.of("-42m"), Duration.minutes(-42));
+        // TODO currently these are backwards (ie -1m 1s = 59 seconds -- confusing!)
+//        Assert.assertEquals(Duration.of("-1 m 1 s"), Duration.seconds(-61));
+//        Assert.assertEquals(Duration.of("- 1m 1s"), Duration.seconds(-61));
+//        Assert.assertEquals(Duration.of("-1m -1s"), Duration.seconds(-59));
+    }
+
     public void testConvesion() {
         Assert.assertEquals(1, Duration.nanos(1).toNanoseconds());
         Assert.assertEquals(1, Duration.nanos(1.1).toNanoseconds());
@@ -103,6 +112,10 @@ public class DurationTest {
         
         Assert.assertTrue(Duration.seconds(1).isLongerThan(Duration.ZERO));
         Assert.assertFalse(Duration.seconds(-1).isLongerThan(Duration.ZERO));
+    }
+
+    public void testIsPositive() {
+        Assert.assertTrue(Duration.minutes(1).isPositive());
     }
 
 }


### PR DESCRIPTION
Previously the enforcement of config key constraints was spotty -- there was an explicit check in a few places, such as entity initialization -- but many places it was skipped.

This now does validation when individual keys are set (although not if a map is set, and not if it is a deferred supplier / future / etc) _and_ when keys are retrieved.  Where config keys are declared by a context (eg an entity) the declared key is looked up and used for constraints, so validation is performed even if anonymous (untyped) config keys are used to set or retrieved.

Extensive tests added.