### PR TITLE
Fixes tests failing on Windows

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/BundleMaker.java
@@ -269,7 +269,8 @@ public class BundleMaker {
     @Deprecated
     public Bundle installBundle(File f, boolean start) {
         try {
-            Bundle b = Osgis.install( framework, "file://"+f.getAbsolutePath() );
+
+            Bundle b = Osgis.install( framework, f.toURI().toString() );
             if (start) {
                 // benefits of start:
                 // a) we get wiring issues thrown here, and

--- a/core/src/test/java/org/apache/brooklyn/core/config/external/PropertiesFileExternalConfigSupplierTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/external/PropertiesFileExternalConfigSupplierTest.java
@@ -68,11 +68,6 @@ public class PropertiesFileExternalConfigSupplierTest {
         doTestFromProperties(f -> f.toURI().toString());
     }
 
-    @Test
-    public void testFromPropertiesTwoSlashAndPathUrl() throws Exception {
-        doTestFromProperties(f -> "file://"+f.getAbsolutePath());
-    }
-
     public void doTestFromProperties(Function<File,String> url) throws Exception {
         String contents =
                 "mykey=myval"+"\n"+


### PR DESCRIPTION
Windows cannot just prepend `file://` to the path returned from a `File` so going via `toURI()` seems more sensible...