### PR TITLE
Pass newly created streams to winrm

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/internal/AbstractSshExecTaskFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/ssh/internal/AbstractSshExecTaskFactory.java
@@ -71,12 +71,14 @@ public abstract class AbstractSshExecTaskFactory<T extends AbstractProcessTaskFa
                 richStreamProvider = getRichStreamProvider(tb);
                 if (richStreamProvider==null) {
                     super.initStreams(tb);
+                } else {
+                    super.initStreams(richStreamProvider);
                 }
             }
 
             @Override
             protected ByteArrayOutputStream stderrForReading() {
-                if (richStreamProvider!=null) return richStreamProvider.stderrForReading;
+            if (richStreamProvider!=null) return richStreamProvider.stderrForReading;
                 return super.stderrForReading();
             }
 


### PR DESCRIPTION
Extra streams are created to handle the different windows powershell streams but these were not being passed to winrm.  This fixes that.