### PR TITLE
Extend Java API for creation to support dry-run and to report-but-not-fail on constraint violations

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/EntityManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/EntityManager.java
@@ -20,7 +20,10 @@ package org.apache.brooklyn.api.mgmt;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.brooklyn.api.entity.Application;
@@ -43,7 +46,7 @@ public interface EntityManager {
      * Returns the type registry, used to identify the entity implementation when instantiating an
      * entity of a given type.
      * 
-     * @see EntityManager.createEntity(EntitySpec)
+     * @see #createEntity(EntitySpec)
      */
     EntityTypeRegistry getEntityTypeRegistry();
     
@@ -53,14 +56,35 @@ public interface EntityManager {
      * @param spec
      * @return A proxy to the created entity (rather than the actual entity itself).
      */
-    <T extends Entity> T createEntity(EntitySpec<T> spec);
-    
+    default <T extends Entity> T createEntity(EntitySpec<T> spec) {
+        return createEntity(spec, new EntityCreationOptions() {});
+    }
+
+    <T extends Entity> T createEntity(EntitySpec<T> spec, EntityCreationOptions options);
+
+    public static interface EntityCreationOptions {
+        /** listener for exceptions, in case caller wants to allow it to proceed on some;
+         * strongly typed exceptions are recommended in those instances, depending on the domain,
+         * such as ConstraintViolationException in core
+         */
+        default <T extends Throwable> void onException(T e, @Nonnull Consumer<? super T> suggestedHandler) {
+            suggestedHandler.accept(e);
+        }
+        /** whether this is just a dry run; there should be no record of anything (entity, task, etc) in the target
+         * after execution; for entities, they will not have an active executor so cannot run tasks,
+         * but their init (and post init if present) methods are called */
+        default boolean isDryRun() { return false; }
+        /** whether the item should have a specific identifier; may fail or return existing if it already exists */
+        default String getRequiredUniqueId() { return null; }
+    }
+
     /**
      * Convenience (particularly for groovy code) to create an entity.
      * Equivalent to {@code createEntity(EntitySpec.create(type).configure(config))}
      * 
-     * @see createEntity(EntitySpec)
+     * @see #createEntity(EntitySpec)
      */
+    @Deprecated /* since 1.1.0 - everyone uses specs */
     <T extends Entity> T createEntity(Map<?,?> config, Class<T> type);
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
@@ -121,7 +121,7 @@ public class ConstraintViolationException extends UserFacingException {
         output.add("Invalid value");
 
         if (key!=null && !Strings.containsLiteralAsWord(supplied, key.getName())) {
-            output.add(" for key "+key.getName());
+            output.add(" for key '"+key.getName()+"'");
         }
 
         if (context!=null && !Strings.containsLiteralAsWord(supplied, ""+context)) {
@@ -129,7 +129,7 @@ public class ConstraintViolationException extends UserFacingException {
         }
 
         if (key!=null && !Strings.containsLiteralAsWord(supplied, ""+value)) {
-            output.add(" " + (value==null ? " (null)" : ": '"+value+"'"));
+            output.add(" " + (value==null ? "(value is null)" : ": '"+value+"'"));
         }
 
         if (supplied!=null) {

--- a/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/ConstraintViolationException.java
@@ -19,12 +19,23 @@
 
 package org.apache.brooklyn.core.config;
 
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.exceptions.UserFacingException;
+import org.apache.brooklyn.util.text.Strings;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
 /**
  * A {@link ConstraintViolationException} indicates one or more problems applying
  * values for {@link org.apache.brooklyn.config.ConfigKey ConfigKeys} when creating
  * a {@link org.apache.brooklyn.api.objs.BrooklynObject}.
  */
-public class ConstraintViolationException extends RuntimeException {
+public class ConstraintViolationException extends UserFacingException {
     private static final long serialVersionUID = -6719912119648996815L;
 
     public ConstraintViolationException(String message) {
@@ -35,4 +46,181 @@ public class ConstraintViolationException extends RuntimeException {
         super(message, cause);
     }
 
+    public ConstraintViolationException(Throwable cause) {
+        super(cause);
+    }
+
+    Object context;
+    ConfigKey<?> key;
+    Object value;
+
+    public static ConstraintViolationException of(Throwable e, Object context, ConfigKey<?> key, Object value) {
+        if (e instanceof ConstraintViolationException) {
+            // don't wrap if it's already the right type
+
+            ConstraintViolationException cve = (ConstraintViolationException)e;
+            // only set value if key or context supplied; otherwise caller might have deliberately omitted it
+            if (cve.value==null) {
+                if (cve.context!=null || cve.key!=null) {
+                    cve.value = value;
+                }
+            }
+
+            if (cve.context==null) cve.context = context;
+            if (cve.key==null) cve.key = key;
+
+            if (Objects.equals(context, cve.context) && Objects.equals(key, cve.key)) {
+                return cve;
+            }
+        }
+
+        return new ConstraintViolationException(e).with(context, key, value);
+    }
+
+    public Object getContext() {
+        return context;
+    }
+    public ConfigKey<?> getKey() {
+        return key;
+    }
+    public Object getValue() {
+        return value;
+    }
+
+    public ConstraintViolationException with(Object context, ConfigKey<?> key, Object value) {
+        setContext(context);
+        setKey(key);
+        setValue(value);
+        return this;
+    }
+    public void setContext(Object context) {
+        this.context = context;
+    }
+    public void setKey(ConfigKey<?> key) {
+        this.key = key;
+    }
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public String getSuppliedMessage() {
+        return super.getMessage();
+    }
+
+    @Override
+    public String getMessage() {
+        String supplied = getSuppliedMessage();
+        String cause = Exceptions.collapseText(getCause());
+        if (cause.contains(supplied)) {
+            supplied = cause;
+        } else {
+            supplied = supplied + "; caused by: "+cause;
+        }
+
+        List<String> output = MutableList.of();
+        output.add("Invalid value");
+
+        if (key!=null && !Strings.containsLiteralAsWord(supplied, key.getName())) {
+            output.add(" for key "+key.getName());
+        }
+
+        if (context!=null && !Strings.containsLiteralAsWord(supplied, ""+context)) {
+            output.add(" on "+context);
+        }
+
+        if (key!=null && !Strings.containsLiteralAsWord(supplied, ""+value)) {
+            output.add(" " + (value==null ? " (null)" : ": '"+value+"'"));
+        }
+
+        if (supplied!=null) {
+            if (output.size()==1) {
+                output = MutableList.of(supplied);
+            } else {
+                output.add("; ");
+                output.add(supplied);
+            }
+        }
+
+        return Strings.join(output, "");
+    }
+
+    public static class CompoundConstraintViolationException extends ConstraintViolationException {
+        private final Collection<Throwable> allViolations;
+
+        protected CompoundConstraintViolationException(String message, Collection<Throwable> causes) {
+            super(message, causes.iterator().next());
+            allViolations = causes;
+        }
+
+        public static CompoundConstraintViolationException of(Object source, Map<ConfigKey<?>, Throwable> violations) {
+            Set<ConstraintViolationException> cves = getCVEs(violations.values());
+
+            StringBuilder message = new StringBuilder();
+            if (source!=null) {
+                message.append("Error configuring ")
+                        .append(source)
+                        .append(": ");
+            }
+
+            if (violations.size() == 1) {
+                message.append(Exceptions.collapseText(Iterables.getOnlyElement(violations.values())));
+            } else {
+                Set<ConfigKey<?>> keys = MutableSet.copyOf(getConfigKeys(cves)).putAll(violations.keySet());
+
+                if (keys.size() > 1) {
+                    message.append("Invalid values for " + keys.stream().map(ConfigKey::getName) + ": ");
+                }
+                if (!violations.isEmpty()) {
+                    message.append(violations.values().stream().map(Throwable::toString).collect(Collectors.toSet()));
+                }
+            }
+
+            CompoundConstraintViolationException result = new CompoundConstraintViolationException(message.toString(), violations.values());
+            result.setContext(source);
+
+            if (source instanceof String || source==null) {
+                // prefer setting the BrooklynObject itself, if it is unique
+                Set<Object> contexts = getContexts(cves);
+                if (contexts.size()==1) result.setContext( Iterables.getOnlyElement(contexts) );
+            }
+
+            return result;
+        }
+
+        private static Set<ConstraintViolationException> getCVEs(Collection<? extends Throwable> violations) {
+            return (Set) violations.stream().filter(t -> t instanceof ConstraintViolationException).collect(Collectors.toSet());
+        }
+
+        private static Set<ConfigKey<?>> getConfigKeys(Collection<? extends Throwable> violations) {
+            return getCVEs(violations).stream().map(ConstraintViolationException::getKey).collect(Collectors.<ConfigKey<?>>toSet());
+        }
+
+        private static Set<Object> getContexts(Collection<? extends Throwable> violations) {
+            return getCVEs(violations).stream().map(ConstraintViolationException::getContext).collect(Collectors.toSet());
+        }
+
+
+        public Set<ConstraintViolationException> getCVEs() {
+            return getCVEs(getAllViolations());
+        }
+
+        public Set<ConfigKey<?>> getConfigKeys() {
+            return getConfigKeys(getAllViolations());
+        }
+
+        public Set<Object> getContexts() {
+            return getContexts(getAllViolations());
+        }
+
+        public Collection<Throwable> getAllViolations() {
+            return allViolations;
+        }
+
+        @Override
+        public String toString() {
+            // suppress causes as they are included
+            return getClass().getName()+": "+getMessage();
+        }
+
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -232,6 +232,8 @@ public class BrooklynGarbageCollector {
     }
 
     public void logUsage(String prefix) {
+        LOG.info(prefix+" - using "+getUsageString());
+
         if (LOG.isDebugEnabled())
             LOG.debug(prefix+" - using "+getUsageString());
     }
@@ -327,7 +329,7 @@ public class BrooklynGarbageCollector {
 
     /**
      * Deletes old tasks. The age/number of tasks to keep is controlled by fields like 
-     * {@link #maxTasksPerTag} and {@link #maxTaskAge}.
+     * {@link #MAX_TASKS_PER_TAG} and {@link #MAX_TASKS_PER_TAG}.
      */
     protected synchronized int gcTasks() {
         // NB: be careful with memory usage here: have seen OOME if we get crazy lots of tasks.

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagerInternal.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagerInternal.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.api.mgmt.EntityManager;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
+import org.apache.brooklyn.util.guava.Maybe;
 
 public interface EntityManagerInternal extends EntityManager, BrooklynObjectManagerInternal<Entity> {
 
@@ -36,9 +37,17 @@ public interface EntityManagerInternal extends EntityManager, BrooklynObjectMana
     /**
      * Same as {@link #createEntity(EntitySpec)}, but takes an optional entity id that will be 
      * used for the entity.
+     *
+     * @deprecated since 1.1.0 use the options
      */
-    @Beta
-    <T extends Entity> T createEntity(EntitySpec<T> spec, Optional<String> entityId);
+    @Beta @Deprecated
+    default <T extends Entity> T createEntity(EntitySpec<T> spec, Optional<String> entityId) {
+        return createEntity(spec, new EntityCreationOptions() {
+            public String getRequiredUniqueId() {
+                return entityId.orNull();
+            }
+        });
+    }
     
     /**
      * Similar to {@link #unmanage(Entity)}, but used to discard partially constructed entities.

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentEntityManager.java
@@ -53,18 +53,9 @@ public class NonDeploymentEntityManager implements EntityManagerInternal {
     }
     
     @Override
-    public <T extends Entity> T createEntity(EntitySpec<T> spec) {
+    public <T extends Entity> T createEntity(EntitySpec<T> spec, EntityCreationOptions options) {
         if (isInitialManagementContextReal()) {
-            return initialManagementContext.getEntityManager().createEntity(spec);
-        } else {
-            throw new IllegalStateException("Non-deployment context "+this+" (with no initial management context supplied) is not valid for this operation.");
-        }
-    }
-    
-    @Override
-    public <T extends Entity> T createEntity(EntitySpec<T> spec, Optional<String> entityId) {
-        if (isInitialManagementContextReal()) {
-            return ((EntityManagerInternal)initialManagementContext.getEntityManager()).createEntity(spec, entityId);
+            return initialManagementContext.getEntityManager().createEntity(spec, options);
         } else {
             throw new IllegalStateException("Non-deployment context "+this+" (with no initial management context supplied) is not valid for this operation.");
         }

--- a/core/src/test/java/org/apache/brooklyn/core/entity/proxying/InternalEntityFactoryTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/proxying/InternalEntityFactoryTest.java
@@ -63,7 +63,7 @@ public class InternalEntityFactoryTest {
     @Test
     public void testCreatesEntity() throws Exception {
         EntitySpec<TestApplication> spec = EntitySpec.create(TestApplication.class);
-        TestApplicationImpl app = (TestApplicationImpl) factory.createEntity(spec, Optional.absent());
+        TestApplicationImpl app = (TestApplicationImpl) factory.createEntity(spec);
         
         Entity proxy = app.getProxy();
         assertTrue(proxy instanceof Application, "proxy="+app);
@@ -76,7 +76,7 @@ public class InternalEntityFactoryTest {
     @Test
     public void testCreatesProxy() throws Exception {
         EntitySpec<Application> spec = EntitySpec.create(Application.class).impl(TestApplicationImpl.class);
-        Application app = factory.createEntity(spec, Optional.absent());
+        Application app = factory.createEntity(spec);
         Application proxy = factory.createEntityProxy(spec, app);
         TestApplicationImpl deproxied = (TestApplicationImpl) Entities.deproxy(proxy);
         
@@ -93,7 +93,7 @@ public class InternalEntityFactoryTest {
     @Test
     public void testSetsEntityId() throws Exception {
         EntitySpec<TestApplication> spec = EntitySpec.create(TestApplication.class);
-        TestApplication app = factory.createEntity(spec, Optional.of("myentityid"));
+        TestApplication app = factory.createEntity(spec, "myentityid");
         assertEquals(app.getId(), "myentityid");
     }
     
@@ -102,14 +102,14 @@ public class InternalEntityFactoryTest {
         TestEntity legacy = new TestEntityImpl();
         assertTrue(legacy.isLegacyConstruction());
         
-        TestEntity entity = factory.createEntity(EntitySpec.create(TestEntity.class), Optional.absent());
+        TestEntity entity = factory.createEntity(EntitySpec.create(TestEntity.class));
         assertFalse(entity.isLegacyConstruction());
     }
     
     @Test
     public void testCreatesProxyImplementingAdditionalInterfaces() throws Exception {
         EntitySpec<Application> spec = EntitySpec.create(Application.class).impl(MyApplicationImpl.class).additionalInterfaces(MyInterface.class);
-        Application app = factory.createEntity(spec, Optional.absent());
+        Application app = factory.createEntity(spec);
         Application proxy = factory.createEntityProxy(spec, app);
         
         assertFalse(proxy instanceof MyApplicationImpl, "proxy="+proxy);

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiVersionMoreEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/osgi/OsgiVersionMoreEntityTest.java
@@ -118,7 +118,7 @@ public class OsgiVersionMoreEntityTest implements OsgiTestResources {
 
             @SuppressWarnings("unchecked")
             EntitySpec<Entity> spec = (((EntitySpec<Entity>)EntitySpec.create(bundleInterface))).impl(bundleCls);
-            AbstractEntity entityImpl = (AbstractEntity) factory.createEntity(spec, Optional.absent());
+            AbstractEntity entityImpl = (AbstractEntity) factory.createEntity(spec);
             Entity entityProxy = factory.createEntityProxy(spec, entityImpl);
             
             assertTrue(entityProxy instanceof EntityProxy, "proxy="+entityProxy);

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/Strings.java
@@ -1050,4 +1050,21 @@ public class Strings {
         return Arrays.stream(body.split("\n")).map(s -> prefix + s).collect(Collectors.joining("\n"));
     }
 
+    public static boolean containsLiteralAsWord(String context, String word) {
+        if (context==null || word==null) return false;
+
+        int i=-1;
+        while ((i = context.indexOf(word, i+1)) > -1) {
+            if (i==0 || !isAlphaOrDigit(context.charAt(i-1))) {
+                if (i+word.length()==context.length() || !isAlphaOrDigit(context.charAt(i+word.length()))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isAlphaOrDigit(char c) {
+        return Character.isDigit(c) || Character.isAlphabetic(c);
+    }
 }

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringsTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringsTest.java
@@ -403,4 +403,15 @@ public class StringsTest extends FixedLocaleTest {
         assertEquals(Strings.countOccurrences("aa", 'a'), 2);
         assertEquals(Strings.countOccurrences("abba", 'a'), 2);
     }
+
+    public void testContainsAsWord() {
+        assertTrue(Strings.containsLiteralAsWord("hello cruel world", "cruel"));
+        assertFalse(Strings.containsLiteralAsWord("hello cruel world", "crue"));
+        assertFalse(Strings.containsLiteralAsWord("hello cruel world", "ruel"));
+        assertTrue(Strings.containsLiteralAsWord("hello cruel world", "hello"));
+        assertFalse(Strings.containsLiteralAsWord("hello cruel world", "hell"));
+        assertTrue(Strings.containsLiteralAsWord("hello cruel world", "world"));
+        assertFalse(Strings.containsLiteralAsWord("hello cruel world", "d"));
+    }
+
 }


### PR DESCRIPTION
Useful where we want to see whether there are any runtime validation problems in the spec but not actually start stuff