### PR TITLE
Fix intermittent unmanagement race

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -268,6 +268,28 @@ public class EntityManagementSupport {
             }
             
             synchronized (this) {
+                if (nonDeploymentManagementContext!=null && nonDeploymentManagementContext.getMode()!=null) {
+                    switch (nonDeploymentManagementContext.getMode()) {
+                        case MANAGEMENT_STARTED:
+                            // normal
+                            break;
+                        case PRE_MANAGEMENT:
+                        case MANAGEMENT_REBINDING:
+                        case MANAGEMENT_STARTING:
+                            // odd, but not a problem
+                            log.warn("Management started invoked on "+entity+" when in unexpected state "+nonDeploymentManagementContext.getMode());
+                            break;
+                        case MANAGEMENT_STOPPING:
+                        case MANAGEMENT_STOPPED:
+                            // problematic
+                            throw new IllegalStateException("Cannot start management of "+entity+" at this time; its management has been told to be "+
+                                    nonDeploymentManagementContext.getMode());
+                    }
+                } else {
+                    // odd - already started
+                    log.warn("Management started invoked on "+entity+" when non-deployment context already cleared");
+                }
+
                 nonDeploymentManagementContext = null;
             }
         } catch (Throwable t) {

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/OnTheFlyDynamicLocationPatternRebindTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/OnTheFlyDynamicLocationPatternRebindTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -44,9 +44,11 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 /**
- * See explanation of what we're testing in {@link StubInfrastructure}.
+ * Allow creation of a location as part of entities then use of it -- useful for Clocker, and other places too.
+ *
+ * See fuller explanation of what we're testing in {@link StubInfrastructure}.
  */
-public class ClockerDynamicLocationPatternRebindTest extends RebindTestFixtureWithApp {
+public class OnTheFlyDynamicLocationPatternRebindTest extends RebindTestFixtureWithApp {
 
     @Override
     protected LocalManagementContext createOrigManagementContext() {

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/OnTheFlyDynamicLocationPatternTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/OnTheFlyDynamicLocationPatternTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -45,9 +45,9 @@ import com.google.common.collect.Iterables;
 /**
  * See explanation of what we're testing in {@link StubInfrastructure}.
  */
-public class ClockerDynamicLocationPatternTest extends BrooklynAppUnitTestSupport {
+public class OnTheFlyDynamicLocationPatternTest extends BrooklynAppUnitTestSupport {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ClockerDynamicLocationPatternTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OnTheFlyDynamicLocationPatternTest.class);
 
     private LocalhostMachineProvisioningLocation loc;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubAttributes.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubAttributes.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainer.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainer.java
@@ -16,23 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
-import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.entity.group.DynamicCluster;
-import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
+import org.apache.brooklyn.entity.stock.BasicStartable;
 
-@ImplementedBy(StubHostImpl.class)
-public interface StubHost extends EmptySoftwareProcess, LocationOwner<StubHostLocation, StubHost> {
+@ImplementedBy(StubContainerImpl.class)
+public interface StubContainer extends BasicStartable, LocationOwner<StubContainerLocation, StubContainer> {
     AttributeSensorAndConfigKey<StubInfrastructure, StubInfrastructure> DOCKER_INFRASTRUCTURE = StubAttributes.DOCKER_INFRASTRUCTURE;
+    AttributeSensorAndConfigKey<StubHost, StubHost> DOCKER_HOST = StubAttributes.DOCKER_HOST;
     
-    AttributeSensor<DynamicCluster> DOCKER_CONTAINER_CLUSTER = Sensors.newSensor(DynamicCluster.class,
-            "docker.container.cluster", "The cluster of Docker containers");
-
     StubInfrastructure getInfrastructure();
-    DynamicCluster getDockerContainerCluster();
+    StubHost getDockerHost();
 }

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainerImpl.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainerImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainerLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubContainerLocation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import org.apache.brooklyn.api.location.LocationDefinition;
 import org.apache.brooklyn.core.location.dynamic.DynamicLocation;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHost.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHost.java
@@ -16,18 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.location.dynamic.LocationOwner;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
-import org.apache.brooklyn.entity.stock.BasicStartable;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
 
-@ImplementedBy(StubContainerImpl.class)
-public interface StubContainer extends BasicStartable, LocationOwner<StubContainerLocation, StubContainer> {
+@ImplementedBy(StubHostImpl.class)
+public interface StubHost extends EmptySoftwareProcess, LocationOwner<StubHostLocation, StubHost> {
     AttributeSensorAndConfigKey<StubInfrastructure, StubInfrastructure> DOCKER_INFRASTRUCTURE = StubAttributes.DOCKER_INFRASTRUCTURE;
-    AttributeSensorAndConfigKey<StubHost, StubHost> DOCKER_HOST = StubAttributes.DOCKER_HOST;
     
+    AttributeSensor<DynamicCluster> DOCKER_CONTAINER_CLUSTER = Sensors.newSensor(DynamicCluster.class,
+            "docker.container.cluster", "The cluster of Docker containers");
+
     StubInfrastructure getInfrastructure();
-    StubHost getDockerHost();
+    DynamicCluster getDockerContainerCluster();
 }

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHostImpl.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHostImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import java.util.Map;
 import org.apache.brooklyn.api.entity.EntitySpec;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHostLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubHostLocation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructure.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructure.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import java.util.List;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructureImpl.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructureImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import java.util.Collection;
 import java.util.List;

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructureLocation.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubInfrastructureLocation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubResolver.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubResolver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubResolverTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubResolverTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import static org.testng.Assert.assertEquals;
 

--- a/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubUtils.java
+++ b/software/base/src/test/java/org/apache/brooklyn/core/location/dynamic/onthefly/StubUtils.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.brooklyn.core.location.dynamic.clocker;
+package org.apache.brooklyn.core.location.dynamic.onthefly;
 
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
And rename tests from `clocker` to `onthefly` because the pattern is more useful than just as used in that downstream project.