### PR TITLE
don't interrupt tasks related to a deletion/unmanagement

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -278,6 +278,7 @@ public class BrooklynGarbageCollector {
     
     public void deleteTasksForEntity(Entity entity) {
         // remove all references to this entity from tasks
+        // (note that cancellation for most tasks will have been done by LocalEntityManager.stopTasks)
         executionManager.deleteTag(entity);
         executionManager.deleteTag(BrooklynTaskTags.tagForContextEntity(entity));
         executionManager.deleteTag(BrooklynTaskTags.tagForCallerEntity(entity));


### PR DESCRIPTION
allow tasks to unmanage the entity where they are running; improve the logic which was meant to allow this