### PR TITLE
 Downgraded SSHJ from 0.31.0 back to 0.22.0 because of various issues…

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -158,7 +158,6 @@
         <bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/${xstream.version}</bundle>
         <bundle dependency="true">mvn:org.freemarker/freemarker/${freemarker.version}</bundle>
         <bundle dependency="true">mvn:com.hierynomus/sshj/${sshj.version}</bundle>
-        <bundle dependency="true">wrap:mvn:com.hierynomus/asn-one/${asn1.version}</bundle>
         <bundle dependency="true">mvn:net.i2p.crypto/eddsa/${eddsa.version}</bundle><!-- from com.hierynomous/sshj -->
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jzlib/${jzlib.version}</bundle>
         <bundle dependency="true">mvn:org.bouncycastle/bcprov-ext-jdk15on/${bouncycastle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,7 @@
         <!-- JClouds 2.2.0 imports eddsa 0.1.0 -->
         <eddsa.version>0.2.0</eddsa.version>
         <!-- JClouds 2.2.0 imports ssjj 0.20.0 -->
-        <sshj.version>0.31.0</sshj.version>
-        <asn1.version>0.5.0</asn1.version>  <!-- used by sshj -->
+        <sshj.version>0.22.0</sshj.version>
         <!-- jzlib osgi version is 1.1.3.2, but bundle is 1.1.3_2 ; JClouds 2.2.0 pulls in 1.0.7_1 but is happy with 1.1.3.2 -->
         <jzlib.version>1.1.3_2</jzlib.version>
         <jzlib.osgi.version>1.1.3.2</jzlib.osgi.version>


### PR DESCRIPTION
… among which incompatibility with EDDSA, and being build with JDK9+. 

Generate smaller ssh keys with `ssh-keygen -t rsa -b 2048 -C "your@email.com" -m pem` . 