### PR TITLE
SMART-153 - Fixes around sealed/unavailable vault

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
@@ -56,11 +56,10 @@ public class VaultUserPassExternalConfigSupplier extends VaultExternalConfigSupp
         String path = "v1/auth/userpass/login/" + username;
         ImmutableMap<String, String> requestData = ImmutableMap.of("password", password);
         ImmutableMap<String, String> headers = MINIMAL_HEADERS;
-        try{
+        try {
             JsonObject response = apiPost(path, headers, requestData);
             return response.getAsJsonObject("auth").get("client_token").getAsString();
-        }
-        catch (Throwable e){
+        } catch (Throwable e) {
             Exceptions.propagateIfFatal(e);
             LOG.warn("Error encountered when retrieving vault token: " + e + ".");
             return "";

--- a/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/external/vault/VaultUserPassExternalConfigSupplier.java
@@ -62,8 +62,7 @@ public class VaultUserPassExternalConfigSupplier extends VaultExternalConfigSupp
         }
         catch (Throwable e){
             Exceptions.propagateIfFatal(e);
-            LOG.warn("Error encountered when retrieving vault token. Startup will continue but vault might not be available. Recover attempt will be made on next vault access.");
-            LOG.trace("Error details:", e);
+            LOG.warn("Error encountered when retrieving vault token: " + e + ".");
             return "";
         }
     }

--- a/core/src/test/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplierLiveTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/external/vault/VaultExternalConfigSupplierLiveTest.java
@@ -165,5 +165,4 @@ public class VaultExternalConfigSupplierLiveTest {
                 ImmutableMap.of("endpoint", endpoint, "appId", appId, "path", path, "userId", userId));
         assertEquals(ecs.get(propertyName), propertyExpectedValue);
     }
-
 }


### PR DESCRIPTION
SMART-153 Notes/Testing done
Original behaviour:
- Brooklyn does not start when vault is set up but sealed or not running

Implementation notes: 
- Brooklyn not prevented from starting up with vault sealed/unavailable.
- Attempt to recover from bad state done when vault is accessed (either during deployment or while app running).
- Deployment/Effector fails if vault unavailable.
- Re-try mechanism that tries to recover from a bad state in 1s intervals, up to a specified number of times.
- Number of retries specified in a new property config as below, optional with a default value of 10.
"brooklyn.external.vault.recoverTryCount=X"

TESTING
1. Startup
1.1 Vault unavailable
	* login successful
	* token set to ""
	
1.2 Vault running and sealed
	* login successful
	* token set to ""
	
1.3 Vault running and unsealed
	* login successful
	* token pulled from vault

2. Deployment with secret pulled from vault on start
2.1 Vault unavailable at point of deployment, tested with all 3 login scenarios as per 1.
	* deployment fails
	
2.2 Vault running and sealed at point of deployment, tested with all 3 login scenarios as per 1.
	* deployment fails
	
2.3 Vault running and unsealed at point of deployment, tested with all 3 login scenarios as per 1.
	* successful recovery from bad state
	* deployment successful
	* secret pulled from vault correctly
	
2.4 Vault restarted, running and unsealed, tested with 1.3 (token different after restart)
	* successful update of token
	* deployment successful
	* secret pulled from vault correctly
	
2.5 Vault becomes available (unsealed) while retrying, tested with 1.1 and 1.2
	* successful recovery from bad state
	* deployment successful
	* secret pulled from vault correctly

3. Accessing vault secret while application is running - stop effector
3.1 Vault unavailable at point of invocation
	* operation fails

3.2 Vault running and sealed at point of invocation
	* operation fails
	
3.3 Vault running and unsealed at point of invocation
	* effector successful
	* secret pulled from vault correctly
	
3.4 Vault restarted, running and unsealed (different token than during deployment)
	* successful update of token
	* effector successful
	* secret pulled from vault correctly