### PR TITLE
Fix issue where vault not ready on init

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -98,22 +98,25 @@ public class DelegatingSecurityProvider implements SecurityProvider {
                 log.info("Brooklyn security: using security provider " + className + " from " + bundle+":"+bundleVersion);
                 BundleContext bundleContext = ((ManagementContextInternal)mgmt).getOsgiManager().get().getFramework().getBundleContext();
                 delegate = loadProviderFromBundle(mgmt, bundleContext, bundle, bundleVersion, className);
+                saveDelegate();
             } else {
                 log.info("Brooklyn security: using security provider " + className);
                 ClassLoaderUtils clu = new ClassLoaderUtils(this, mgmt);
                 Class<? extends SecurityProvider> clazz = (Class<? extends SecurityProvider>) clu.loadClass(className);
                 delegate = createSecurityProviderInstance(mgmt, clazz);
+                saveDelegate();
             }
         } catch (Exception e) {
             log.warn("Brooklyn security: unable to instantiate security provider " + className + "; all logins are being disallowed", e);
             delegate = new BlackholeSecurityProvider();
         }
+        return delegate;
+    }
 
+    private void saveDelegate() {
         // Deprecated in 0.11.0. Add to release notes and remove in next release.
         ((BrooklynProperties)mgmt.getConfig()).put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
         mgmt.getScratchpad().put(BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE, delegate);
-
-        return delegate;
     }
 
     public static SecurityProvider loadProviderFromBundle(

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/DelegatingSecurityProvider.java
@@ -47,24 +47,9 @@ public class DelegatingSecurityProvider implements SecurityProvider {
 
     public DelegatingSecurityProvider(ManagementContext mgmt) {
         this.mgmt = mgmt;
-        mgmt.addPropertiesReloadListener(new PropertiesListener());
     }
     
     private SecurityProvider delegate;
-    private final AtomicLong modCount = new AtomicLong();
-
-    private class PropertiesListener implements ManagementContext.PropertiesReloadListener {
-        private static final long serialVersionUID = 8148722609022378917L;
-
-        @Override
-        public void reloaded() {
-            log.debug("{} reloading security provider", DelegatingSecurityProvider.this);
-            synchronized (DelegatingSecurityProvider.this) {
-                loadDelegate();
-                invalidateExistingSessions();
-            }
-        }
-    }
 
     public synchronized SecurityProvider getDelegate() {
         if (delegate == null) {
@@ -195,13 +180,6 @@ public class DelegatingSecurityProvider implements SecurityProvider {
             throw new ClassCastException("Delegate is either not a security provider or has an incompatible classloader: "+delegateO);
         }
         return (SecurityProvider) delegateO;
-    }
-
-    /**
-     * Causes all existing sessions to be invalidated.
-     */
-    protected void invalidateExistingSessions() {
-        modCount.incrementAndGet();
     }
 
     @Override


### PR DESCRIPTION
If vault is used for security provider and is not ready on startup then
the security provider will fail and will be replaced by the
BlackholeSecurityProvider. This change means that whenever a security
provider fails, the DelegatingSecurityProvider will attempt to
re-initialize it on subsequent authorization attempts.

This change does mean that, when failing over to the BlackholeSecurityProvider, it could be slower to let no one authenticate.

I have added a second change as I noticed a fairly impressive memory leak in how the security provider was used.  Again I'm pretty sure no behaviour was changed here.