### PR TITLE
Feature - Terminated Node Deletion from persistence on startup

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecordPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecordPersister.java
@@ -45,6 +45,7 @@ public interface ManagementPlaneSyncRecordPersister {
      * Note that this method is *not* thread safe.
      */
     ManagementPlaneSyncRecord loadSyncRecord() throws IOException;
+    ManagementPlaneSyncRecord loadSyncRecord(Duration terminatedNodeDeletionTimeout) throws IOException;
 
     void setIsStartup(boolean isStartup);
     

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecordPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/ManagementPlaneSyncRecordPersister.java
@@ -45,6 +45,8 @@ public interface ManagementPlaneSyncRecordPersister {
      * Note that this method is *not* thread safe.
      */
     ManagementPlaneSyncRecord loadSyncRecord() throws IOException;
+
+    void setIsStartup(boolean isStartup);
     
     void delta(Delta delta);
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -26,8 +26,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.Date;
 
 import javax.annotation.Nullable;
 
@@ -125,7 +123,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         "Maximum allowable time for detection of a peer's heartbeat; if no sign of master after this time, "
         + "another node may promote itself", Duration.THIRTY_SECONDS);
     public final ConfigKey<Duration> TIMEOUT_FOR_INACTIVE_NODE_REMOVAL_ON_STARTUP = ConfigKeys.newConfigKey(Duration.class, "brooklyn.ha.timeoutForInactiveNodeRemovalOnStartup",
-            "TBD", Duration.ZERO);
+            "Duration threshold for terminated node deletion from persistence (on startup of a server)", Duration.ZERO);
     
     @VisibleForTesting /* only used in tests currently */
     public static interface PromotionListener {
@@ -1032,7 +1030,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
 
         for (int i = 0; i < maxLoadAttempts; i++) {
             try {
-                ManagementPlaneSyncRecord result = persister.loadSyncRecord();
+                ManagementPlaneSyncRecord result = persister.loadSyncRecord(managementContext.getBrooklynProperties().getConfig(TIMEOUT_FOR_INACTIVE_NODE_REMOVAL_ON_STARTUP));
                 
                 if (useLocalKnowledgeForThisNode) {
                     // Report this node's most recent state, and detect AWOL nodes

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -271,6 +271,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         persistenceEnabled = true;
         disabled = false;
         running = true;
+        persister.setIsStartup(true);
         changeMode(startMode, true, true);
     }
     
@@ -662,16 +663,7 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
             // else ex-masters who died are kept around!
             if (!ManagementNodeState.MASTER.equals(node.getValue().getStatus()) || 
                     !Objects.equal(plane.getMasterNodeId(), node.getValue().getNodeId())) {
-                Duration terminatedNodeDeletionTimeout = managementContext.getBrooklynProperties().getConfig(TIMEOUT_FOR_INACTIVE_NODE_REMOVAL_ON_STARTUP);
-                if (terminatedNodeDeletionTimeout.compareTo(Duration.ZERO) == 1){
-                    Date now = new Date();
-                    Duration inactivityDuration = new Duration(now.getTime() - node.getValue().getRemoteTimestamp(), TimeUnit.MILLISECONDS);
-                    if ((inactivityDuration.compareTo(terminatedNodeDeletionTimeout) != 1) || !(node.getValue().getStatus().equals("TERMINATED"))){
-                        continue;
-                    }
-                }
                 db.removedNodeId(node.getKey());
-
             }
         }
         persister.delta(db.build());

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/HighAvailabilityManagerImpl.java
@@ -269,7 +269,9 @@ public class HighAvailabilityManagerImpl implements HighAvailabilityManager {
         persistenceEnabled = true;
         disabled = false;
         running = true;
-        persister.setIsStartup(true);
+        if (persister != null){
+            persister.setIsStartup(true);
+        }
         changeMode(startMode, true, true);
     }
     

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
@@ -109,6 +109,8 @@ public class ManagementPlaneSyncRecordPersisterToObjectStore implements Manageme
 
     protected final AtomicLong checkpointLogCount = new AtomicLong();
     private static final int INITIAL_LOG_WRITES = 5;
+
+    private boolean isStartup = false;
     
     @VisibleForTesting
     /** allows, when testing, to be able to override file times / blobstore times with time from the ticker */
@@ -249,6 +251,11 @@ public class ManagementPlaneSyncRecordPersisterToObjectStore implements Manageme
             nodeFiles.size(),
             Time.makeTimeStringRounded(stopwatch.elapsed(TimeUnit.MILLISECONDS)));
         return builder.build();
+    }
+
+    @Override
+    public void setIsStartup(boolean isStartup){
+        this.isStartup = isStartup;
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
@@ -252,12 +252,12 @@ public class ManagementPlaneSyncRecordPersisterToObjectStore implements Manageme
                     Date now = new Date();
                     Duration inactivityDuration = new Duration(now.getTime() - memento.getRemoteTimestamp(), TimeUnit.MILLISECONDS);
                     if ((inactivityDuration.compareTo(terminatedNodeDeletionTimeout) == 1) && memento.getStatus().name().equals(("TERMINATED"))){
-                        LOG.debug("Last modified date exceeds the provided threshold for: "+memento+"; node will be removed from persistence store");
+                        LOG.debug("Last modified date exceeds the provided threshold for: "+memento+"; node will be removed from persistence store.");
                         try {
                             objectAccessor.delete();
                         }
                         catch (Exception e){
-                            LOG.debug("Exception: " + e + " while trying to remove and old node. Progressing regardless...");
+                            LOG.debug("Exception: " + e + " while trying to remove node: "+memento+". Progressing regardless...");
                         }
                         continue;
                     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
@@ -248,10 +248,10 @@ public class ManagementPlaneSyncRecordPersisterToObjectStore implements Manageme
                     Date lastModifiedDate = objectAccessor.getLastModifiedDate();
                     ((BasicManagementNodeSyncRecord)memento).setRemoteTimestamp(lastModifiedDate!=null ? lastModifiedDate.getTime() : null);
                 }
-                if ((terminatedNodeDeletionTimeout.compareTo(Duration.ZERO) == 1) && isStartup){
+                if ((terminatedNodeDeletionTimeout.compareTo(Duration.ZERO) == 1) && isStartup && memento.getStatus().name().equals(("TERMINATED"))){
                     Date now = new Date();
                     Duration inactivityDuration = new Duration(now.getTime() - memento.getRemoteTimestamp(), TimeUnit.MILLISECONDS);
-                    if ((inactivityDuration.compareTo(terminatedNodeDeletionTimeout) == 1) && memento.getStatus().name().equals(("TERMINATED"))){
+                    if (inactivityDuration.compareTo(terminatedNodeDeletionTimeout) == 1){
                         LOG.debug("Last modified date exceeds the provided threshold for: "+memento+"; node will be removed from persistence store.");
                         try {
                             objectAccessor.delete();


### PR DESCRIPTION
Changes related to automatic terminated node removal on startup.
Requirements:
- new configuration property to specify threshold of inactivity after which terminated nodes are to be removed
- nodes removed from persistence on startup of the server

Implementation Notes:
- property in 'brooklyn.cfg' added: brooklyn.ha.timeoutForInactiveNodeRemovalOnStartup
- format of property is a duration, e.g 1h30m, 2d12h, 30s, etc.
- loadSyncRecord() loads the management node data from persistence store. If property above is specified (not ZERO) and node is terminated, compares if its inactivity period is higher than threshold and if so, removes from the persistence store.
- loadSyncRecord() is also periodically called during run so isStartup property introduced to ensure this code is fired only during startup

Testing:
- Tested locally:
-- terminated nodes correctly removed after inactivity period expires
-- terminated nodes correctly retained if inactivity period not exceeded
-- no terminated nodes removed in case without property present in brooklyn.cfg
-- non-terminated nodes correctly retained
-- other active servers correctly updated in the HA Status table (about page) 
-- tested as master and non-master nodes
-- nodes are not removed as server is running (startup only)

TODO
- Would be nice to introduce a unit test for this. I think this would involve creating a persistence store and making up some nodes in terminated state and simulating startup? Not sure how feasible is that and need to investigate further, but some pointers would be helpful.