### PR TITLE
Ldap login changes

### DIFF
--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderLiveTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderLiveTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.rest.security.provider;
+
+import org.junit.Assert;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpSession;
+
+import java.util.function.Supplier;
+
+/**
+ * Some helper tests for use in development
+ */
+public class LdapSecurityProviderLiveTest {
+
+    /**
+     * Use this for testing against an local openldap or Apache Directory Studio test server
+     * @throws SecurityProvider.SecurityProviderDeniedAuthentication
+     */
+    @Test(groups = {"live"})
+    public void testLiveLdapServerADStudio() throws SecurityProvider.SecurityProviderDeniedAuthentication {
+        boolean authenticated = isAuthenticated("ldap://localhost:10389/", "example.com", "Users", "username", "password");
+
+        Assert.assertTrue(authenticated);
+    }
+
+    /**
+     * Use these tests for testing against an active directory providing ldap
+     *
+     * Modify the following constants to work with your DC
+     *
+     */
+
+    public static final String LDAP_URL = "ldap://IP_ADDRESSS:389/";
+    public static final String LDAP_REALM = "dc2.example.org";
+    public static final String ORGANIZATION_UNIT = "MyUsers";
+    public static final String PASSWORD = "password";
+
+    @Test(groups = {"live"})
+    public void testLiveLdapServerAD() throws SecurityProvider.SecurityProviderDeniedAuthentication {
+        boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "My Common Name", PASSWORD);
+
+        Assert.assertTrue(authenticated);
+    }
+
+    @Test(groups = {"live"})
+    public void testLiveLdapServerADOld() throws SecurityProvider.SecurityProviderDeniedAuthentication {
+        boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "DOMAIN\\MyUser", PASSWORD);
+
+        Assert.assertTrue(authenticated);
+    }
+
+    @Test(groups = {"live"})
+    public void testLiveLdapServerUserAtFQDN() throws SecurityProvider.SecurityProviderDeniedAuthentication {
+        boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "MyUser@" + LDAP_REALM, PASSWORD);
+
+        Assert.assertTrue(authenticated);
+    }
+
+    private boolean isAuthenticated(String ldapUrl, String ldapRealm, String organizationUnit, String s, String s2) throws SecurityProvider.SecurityProviderDeniedAuthentication {
+        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider(ldapUrl, ldapRealm, organizationUnit);
+
+        return ldapSecurityProvider.authenticate(null, new Supplier<HttpSession>() {
+            @Override
+            public HttpSession get() {
+                return Mockito.mock(HttpSession.class);
+            }
+        }, s, s2);
+    }
+}

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderLiveTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderLiveTest.java
@@ -35,7 +35,7 @@ public class LdapSecurityProviderLiveTest {
      * Use this for testing against an local openldap or Apache Directory Studio test server
      * @throws SecurityProvider.SecurityProviderDeniedAuthentication
      */
-    @Test(groups = {"live"})
+    @Test(groups = {"Live"})
     public void testLiveLdapServerADStudio() throws SecurityProvider.SecurityProviderDeniedAuthentication {
         boolean authenticated = isAuthenticated("ldap://localhost:10389/", "example.com", "Users", "username", "password");
 
@@ -54,21 +54,21 @@ public class LdapSecurityProviderLiveTest {
     public static final String ORGANIZATION_UNIT = "MyUsers";
     public static final String PASSWORD = "password";
 
-    @Test(groups = {"live"})
+    @Test(groups = {"Live"})
     public void testLiveLdapServerAD() throws SecurityProvider.SecurityProviderDeniedAuthentication {
         boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "My Common Name", PASSWORD);
 
         Assert.assertTrue(authenticated);
     }
 
-    @Test(groups = {"live"})
+    @Test(groups = {"Live"})
     public void testLiveLdapServerADOld() throws SecurityProvider.SecurityProviderDeniedAuthentication {
         boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "DOMAIN\\MyUser", PASSWORD);
 
         Assert.assertTrue(authenticated);
     }
 
-    @Test(groups = {"live"})
+    @Test(groups = {"Live"})
     public void testLiveLdapServerUserAtFQDN() throws SecurityProvider.SecurityProviderDeniedAuthentication {
         boolean authenticated = isAuthenticated(LDAP_URL, LDAP_REALM, ORGANIZATION_UNIT, "MyUser@" + LDAP_REALM, PASSWORD);
 

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProviderTest.java
@@ -18,56 +18,38 @@
  */
 package org.apache.brooklyn.rest.security.provider;
 
-import org.junit.rules.ExpectedException;
+import org.junit.Assert;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import javax.naming.NamingException;
+import javax.servlet.http.HttpSession;
+
+import java.util.function.Supplier;
 
 import static org.testng.Assert.*;
 
 public class LdapSecurityProviderTest {
 
     @Test
-    public void testNoDomain() throws NamingException {
+    public void testNoRealm() throws NamingException {
         LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", "Users");
 
-        assertEquals(ldapSecurityProvider.getUserDN("Me"), "cn=Me,ou=Users,dc=example,dc=org");
+        assertEquals(ldapSecurityProvider.getSecurityPrincipal("Me"), "cn=Me,ou=Users,dc=example,dc=org");
     }
 
     @Test
-    public void testAllowedDomainByRegexDirectMatch() throws NamingException {
-        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", "MyDomain", "Users");
+    public void testDomain() throws NamingException {
+        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", null, "Users");
 
-        assertEquals(ldapSecurityProvider.getUserDN("MyDomain\\Me"), "cn=Me,ou=Users,dc=mydomain");
+        assertEquals(ldapSecurityProvider.getSecurityPrincipal("MyDomain\\Me"), "MyDomain\\Me");
     }
 
     @Test
     public void testAllowedDomainByRegexListMatch() throws NamingException {
-        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", "MyDomain|OtherDomain", "Users");
+        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", null, "Users");
 
-        assertEquals(ldapSecurityProvider.getUserDN("MyDomain\\Me"), "cn=Me,ou=Users,dc=mydomain");
-    }
-
-    @Test
-    public void testAllowedDomainByRegexWildcardMatch() throws NamingException {
-        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", ".*Domain", "Users");
-
-        assertEquals(ldapSecurityProvider.getUserDN("MyDomain\\Me"), "cn=Me,ou=Users,dc=mydomain");
-        assertEquals(ldapSecurityProvider.getUserDN("OtherDomain\\Me"), "cn=Me,ou=Users,dc=otherdomain");
-    }
-
-    @Test
-    public void testDefaultDomainIsAlsoAnAllowedDomainInUserString() throws NamingException{
-        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", "MyDomain", "Users");
-
-        assertEquals(ldapSecurityProvider.getUserDN("example.org\\Me"), "cn=Me,ou=Users,dc=example,dc=org");
-    }
-
-    @Test(expectedExceptions=NamingException.class)
-    public void testNotAllowedDomain() throws NamingException {
-        LdapSecurityProvider ldapSecurityProvider = new LdapSecurityProvider("url", "example.org", "MyDomain", "Users");
-
-        ldapSecurityProvider.getUserDN("OtherDomain\\Me");
+        assertEquals(ldapSecurityProvider.getSecurityPrincipal("username@example.org"), "username@example.org");
     }
 
 }


### PR DESCRIPTION
Updated login approach was a bit rubbish and doesn't really make sense.
New approach keeps the CN with configured realm and ou as before.
If the username contains a \ or @ then the username is used as the
security principal.  This allows NETBIOS\username or username@realm for
the username field.