### PR TITLE
Added support for tagged bundles

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -569,6 +569,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         itemDef.remove("brooklyn.catalog");
         catalogMetadata.remove("item");
         catalogMetadata.remove("items");
+        catalogMetadata.remove("tags");
         if (!itemDef.isEmpty()) {
             // AH - i forgot we even supported this. probably no point anymore,
             // now that catalog defs can reference an item yaml and things can be bundled together?

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -571,7 +571,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         catalogMetadata.remove("items");
         catalogMetadata.remove("tags");
         if (!itemDef.isEmpty()) {
-            // AH - i forgot we even supported this. probably no point anymore,
+            // AH - i forgot we even supported this. probably no point anymore,§
             // now that catalog defs can reference an item yaml and things can be bundled together?
             log.warn("Deprecated read of catalog item from sibling keys of `brooklyn.catalog` section, "
                 + "instead of the more common appraoch of putting inside an `item` within it. "

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
@@ -120,7 +120,7 @@ public class BrooklynBomYamlCatalogBundleResolver extends AbstractCatalogBundleR
                     null, BrooklynBomBundleCatalogBundleResolver.FORMAT,
                     null, null);
             // if the submitted blueprint contains tags, we set them on the bundle, so they can be picked up and used to tag the plan.
-            if( cm.containsKey("tags")) {
+            if( cm.containsKey("tags") && cm.get("tags") instanceof Iterable) {
                 basicManagedBundle.tags().addTags((Iterable<?>)cm.get("tags"));
             }
             result = ((ManagementContextInternal)mgmt).getOsgiManager().get().installBrooklynBomBundle(

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
@@ -115,10 +115,16 @@ public class BrooklynBomYamlCatalogBundleResolver extends AbstractCatalogBundleR
 
         OsgiBundleInstallationResult result;
         try {
+
+            BasicManagedBundle basicManagedBundle = new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(),
+                    null, BrooklynBomBundleCatalogBundleResolver.FORMAT,
+                    null, null);
+            // if the submitted blueprint contains tags, we set them on the bundle, so they can be picked up and used to tag the plan.
+            if( cm.containsKey("tags")) {
+                basicManagedBundle.tags().addTags((Iterable<?>)cm.get("tags"));
+            }
             result = ((ManagementContextInternal)mgmt).getOsgiManager().get().installBrooklynBomBundle(
-                    new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(),
-                            null, BrooklynBomBundleCatalogBundleResolver.FORMAT,
-                            null, null), InputStreamSource.of("ZIP generated for "+vn+": "+bf, bf), options.isStart(), options.isLoadCatalogBom(), options.isForceUpdateOfNonSnapshots()).get();
+                    basicManagedBundle, InputStreamSource.of("ZIP generated for "+vn+": "+bf, bf), options.isStart(), options.isLoadCatalogBom(), options.isForceUpdateOfNonSnapshots()).get();
         } finally {
             bf.delete();
         }


### PR DESCRIPTION
Tags added to the blueprint in composer, are set on the bundle when added to the catalog. 
This PR should be merged together with this one: https://github.com/apache/brooklyn-ui/pull/219