### PR TITLE
Don't auth check when not required.

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/BrooklynSecurityProviderFilterHelper.java
@@ -106,15 +106,6 @@ public class BrooklynSecurityProviderFilterHelper {
 
             abort(e.getResponse());
         }
-        final HttpSession preferredSession1 = preferredSessionWrapper==null ? null : preferredSessionWrapper.getPreferredSession();
-        
-        if (log.isTraceEnabled()) {
-            log.trace("{} checking {}", this, MultiSessionAttributeAdapter.info(webRequest));
-        }
-        if (provider.isAuthenticated(preferredSession1)) {
-            log.trace("{} already authenticated - {}", this, preferredSession1);
-            return;
-        }
 
         String unauthenticatedEndpoints = mgmt.getConfig().getConfig(UNAUTHENTICATED_ENDPOINTS);
         if (Strings.isNonBlank(unauthenticatedEndpoints)) {
@@ -125,6 +116,17 @@ public class BrooklynSecurityProviderFilterHelper {
                 }
             }
         }
+
+        final HttpSession preferredSession1 = preferredSessionWrapper==null ? null : preferredSessionWrapper.getPreferredSession();
+        
+        if (log.isTraceEnabled()) {
+            log.trace("{} checking {}", this, MultiSessionAttributeAdapter.info(webRequest));
+        }
+        if (provider.isAuthenticated(preferredSession1)) {
+            log.trace("{} already authenticated - {}", this, preferredSession1);
+            return;
+        }
+
 
         String user = null, pass = null;
         if (provider.requiresUserPass()) {


### PR DESCRIPTION
Previously we checked each call and if it was authenticated we did
returned without filtering.  As the logic for initialising some security
providers has changed this means that there can be a long delay before we
return data for calls that don't need to be authenticated.

Instead we now first check whether a resource needs authorisation before
authenticating.  This speeds up the response in the above case at the
cost of some calls taking slightly longer when the user is logged in.

NB This is the most misleading diff I've ever seen - should be viewed as lines 119 to 127 being moved up the file.