### PR TITLE
Feature/persisted state archive export on change

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/HighAvailabilityManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/ha/HighAvailabilityManager.java
@@ -115,6 +115,11 @@ public interface HighAvailabilityManager {
     @Beta
     void publishClearNonMaster();
 
+     /** deletes non-master node records; active nodes (including this) will republish,
+      * so this provides a simple way to clean out the cache of dead brooklyn nodes */
+     @Beta
+     void setNodeIdToRemove(String nodeId);
+
     /**
      * Returns a snapshot of the management-plane's current / most-recently-known status,
      * as last read from {@link #loadManagementPlaneSyncRecord(boolean)}, or null if none read.

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -700,6 +700,10 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }
         @Override
+        public void setNodeIdToRemove(String nodeId) {
+            throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
+        }
+        @Override
         public long getLastStateChange() {
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -893,4 +893,6 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
     public String getBackingStoreDescription() {
         return getObjectStore().getSummaryName();
     }
+
+    public ManagementContext getManagementContext() { return this.mgmt;}
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.mgmt.persist;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.util.List;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
@@ -52,7 +54,10 @@ import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServerPaths;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.file.ArchiveBuilder;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -262,7 +267,6 @@ public class BrooklynPersistenceUtils {
                 } else {
                     log.debug("Back-up of (empty) persisted state created on "+mode+", in "+destinationObjectStore.getSummaryName());
                 }
-                
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);
                 PersistenceObjectStore failedStore = destinationObjectStore;
@@ -285,5 +289,40 @@ public class BrooklynPersistenceUtils {
             Exceptions.propagateIfFatal(e);
             log.warn("Unable to backup management plane sync state on "+mode+" (ignoring): "+e, e);
         }
+    }
+
+    public static void createStateExport (ManagementContext managementContext, File persistenceBaseDir){
+        try {
+            File dir = null;
+
+            BrooklynMementoRawData memento = null;
+            ManagementPlaneSyncRecord planeState = null;
+
+            MementoCopyMode source = (managementContext.getHighAvailabilityManager().getNodeState()==ManagementNodeState.MASTER ? MementoCopyMode.LOCAL : MementoCopyMode.REMOTE);
+
+            memento = newStateMemento(managementContext, source);
+            try {
+                planeState = newManagerMemento(managementContext, source);
+            } catch (Exception e) {
+                Exceptions.propagateIfFatal(e);
+            }
+
+            PersistenceObjectStore targetStore = BrooklynPersistenceUtils.newPersistenceObjectStore(managementContext, null,
+                    "tmp/persistence-state-export");
+            dir = ((FileBasedObjectStore)targetStore).getBaseDir();
+            // only register the parent dir because that will prevent leaks for the random ID
+            Os.deleteOnExitEmptyParentsUpTo(dir.getParentFile(), dir.getParentFile());
+            BrooklynPersistenceUtils.writeMemento(managementContext, memento, targetStore);
+            BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, targetStore);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName() ).stream(baos);
+            ArchiveBuilder.zip().create(persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip");
+            Os.deleteRecursively(dir);
+
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+        }
+
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -44,7 +44,9 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
+import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -516,6 +518,13 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
 
                 // Tell the persister to persist it
                 persister.delta(persisterDelta, exceptionHandler);
+
+                // save export zip of persistence state, only for file based
+                if ((persister instanceof BrooklynMementoPersisterToObjectStore) && (((BrooklynMementoPersisterToObjectStore) persister).getObjectStore() instanceof FileBasedObjectStore)){
+                    BrooklynPersistenceUtils.createStateExport(((BrooklynMementoPersisterToObjectStore) persister).getManagementContext(), ((FileBasedObjectStore) ((BrooklynMementoPersisterToObjectStore) persister).getObjectStore()).getBaseDir());
+                }
+
+
             }
         } catch (Exception e) {
             if (isActive()) {

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -149,6 +149,13 @@ public interface ServerApi {
     @Path("/ha/states/clear")
     @ApiOperation(value = "Clears HA node information for non-master nodes; active nodes will repopulate and other records will be erased")
     public Response clearHighAvailabilityPlaneStates();
+
+    @POST
+    @Path("/ha/states/clear/node")
+    @ApiOperation(value = "Clears HA node information for a particular non-master node; other nodes will repopulate and selected node will be erased")
+    public Response clearHighAvailabilityPlaneStates(
+            @ApiParam(name = "nodeId", value = "ID of node to be removed")
+            @FormParam("nodeId") String nodeId);
     
     @GET
     @Path("/ha/priority")

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/HighAvailabilitySummary.java
@@ -38,18 +38,21 @@ public class HighAvailabilitySummary implements Serializable {
         private final String status;
         private final Long localTimestamp;
         private final Long remoteTimestamp;
+        private final Long priority;
 
         public HaNodeSummary(
                 @JsonProperty("nodeId") String nodeId,
                 @JsonProperty("nodeUri") URI nodeUri,
                 @JsonProperty("status") String status,
                 @JsonProperty("localTimestamp") Long localTimestamp,
-                @JsonProperty("remoteTimestamp") Long remoteTimestamp) {
+                @JsonProperty("remoteTimestamp") Long remoteTimestamp,
+                @JsonProperty("priority") Long priority) {
             this.nodeId = nodeId;
             this.nodeUri = nodeUri;
             this.status = status;
             this.localTimestamp = localTimestamp;
             this.remoteTimestamp = remoteTimestamp;
+            this.priority = priority;
         }
 
         public String getNodeId() {
@@ -71,6 +74,8 @@ public class HighAvailabilitySummary implements Serializable {
         public Long getRemoteTimestamp() {
             return remoteTimestamp;
         }
+
+        public Long getPriority() { return priority; }
 
         @Override
         public boolean equals(Object o) {
@@ -97,6 +102,7 @@ public class HighAvailabilitySummary implements Serializable {
                     ", status='" + status + '\'' +
                     ", localTimestamp=" + localTimestamp +
                     ", remoteTimestamp=" + remoteTimestamp +
+                    ", priority= " + priority +
                     '}';
         }
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -477,6 +477,16 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
     }
 
     @Override
+    public Response clearHighAvailabilityPlaneStates(String nodeId) {
+        if (!Entitlements.isEntitled(mgmt().getEntitlementManager(), Entitlements.SYSTEM_ADMIN, null))
+            throw WebResourceUtils.forbidden("User '%s' is not authorized to perform this operation", Entitlements.getEntitlementContext().user());
+        HighAvailabilityManager haMan = mgmt().getHighAvailabilityManager();
+        haMan.setNodeIdToRemove(nodeId);
+        haMan.publishClearNonMaster();
+        return Response.ok().build();
+    }
+
+    @Override
     public String getUser() {
         // force creation of session to help ui, ensure continuity of user info
         MultiSessionAttributeAdapter.of(request);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -465,6 +465,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
         if (memento.getMasterNodeId() == null) {
             memento = mgmt().getHighAvailabilityManager().loadManagementPlaneSyncRecord(true);
         }
+
         return HighAvailabilityTransformer.highAvailabilitySummary(mgmt().getManagementNodeId(), memento);
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/HighAvailabilityTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/HighAvailabilityTransformer.java
@@ -45,6 +45,6 @@ public class HighAvailabilityTransformer {
 
     public static HaNodeSummary haNodeSummary(ManagementNodeSyncRecord memento) {
         String status = memento.getStatus() == null ? null : memento.getStatus().toString();
-        return new HaNodeSummary(memento.getNodeId(), memento.getUri(), status, memento.getLocalTimestamp(), memento.getRemoteTimestamp());
+        return new HaNodeSummary(memento.getNodeId(), memento.getUri(), status, memento.getLocalTimestamp(), memento.getRemoteTimestamp(), memento.getPriority());
     }
 }


### PR DESCRIPTION
WIP

Automated capture of persisted state into an archive saved in the root persistence directory - invoked on persistence change.

Archive is of hardcoded name 'persistence-state-export.zip' and is saved in the root or persistence directory. In case a new one is generated, old one is removed so we keep only the most up to date version of the export.

This is applicable only to file based persistence stores