### PR TITLE
Adding a feature to automatically capture a persistence export archiv…

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -893,4 +893,6 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
     public String getBackingStoreDescription() {
         return getObjectStore().getSummaryName();
     }
+
+    public ManagementContext getManagementContext() { return this.mgmt;}
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -292,24 +292,21 @@ public class BrooklynPersistenceUtils {
 
     public static void createStateExport (ManagementContext managementContext, File persistenceBaseDir){
         try {
-            File dir = null;
-            BrooklynMementoRawData memento = null;
-            ManagementPlaneSyncRecord planeState = null;
             MementoCopyMode source = (managementContext.getHighAvailabilityManager().getNodeState()==ManagementNodeState.MASTER ? MementoCopyMode.LOCAL : MementoCopyMode.REMOTE);
 
-            memento = newStateMemento(managementContext, source);
-            planeState = newManagerMemento(managementContext, source);
+            BrooklynMementoRawData memento = newStateMemento(managementContext, source);
+            ManagementPlaneSyncRecord planeState = newManagerMemento(managementContext, source);
 
             PersistenceObjectStore targetStore = BrooklynPersistenceUtils.newPersistenceObjectStore(managementContext, null,
                     "tmp/persistence-state-export");
-            dir = ((FileBasedObjectStore)targetStore).getBaseDir();
+            File dir = ((FileBasedObjectStore)targetStore).getBaseDir();
             Os.deleteOnExitEmptyParentsUpTo(dir.getParentFile(), dir.getParentFile());
 
             BrooklynPersistenceUtils.writeMemento(managementContext, memento, targetStore);
             BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, targetStore);
 
-            ArchiveBuilder.zip().addDirContentsAt(((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName())
-                    .create((persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip"));
+            ArchiveBuilder.zip().addDirContentsAt(dir, dir.getName())
+                    .create((persistenceBaseDir + File.separator + "../backups" + File.separator + "persistence-state-export.zip"));
             Os.deleteRecursively(dir);
 
         } catch (Exception e) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.mgmt.persist;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.util.List;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
@@ -52,7 +54,10 @@ import org.apache.brooklyn.core.server.BrooklynServerConfig;
 import org.apache.brooklyn.core.server.BrooklynServerPaths;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.core.file.ArchiveBuilder;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -262,7 +267,6 @@ public class BrooklynPersistenceUtils {
                 } else {
                     log.debug("Back-up of (empty) persisted state created on "+mode+", in "+destinationObjectStore.getSummaryName());
                 }
-                
             } catch (Exception e) {
                 Exceptions.propagateIfFatal(e);
                 PersistenceObjectStore failedStore = destinationObjectStore;
@@ -285,5 +289,40 @@ public class BrooklynPersistenceUtils {
             Exceptions.propagateIfFatal(e);
             log.warn("Unable to backup management plane sync state on "+mode+" (ignoring): "+e, e);
         }
+    }
+
+    public static void createStateExport (ManagementContext managementContext, File persistenceBaseDir){
+        try {
+            File dir = null;
+
+            BrooklynMementoRawData memento = null;
+            ManagementPlaneSyncRecord planeState = null;
+
+            MementoCopyMode source = (managementContext.getHighAvailabilityManager().getNodeState()==ManagementNodeState.MASTER ? MementoCopyMode.LOCAL : MementoCopyMode.REMOTE);
+
+            memento = newStateMemento(managementContext, source);
+            try {
+                planeState = newManagerMemento(managementContext, source);
+            } catch (Exception e) {
+                Exceptions.propagateIfFatal(e);
+            }
+
+            PersistenceObjectStore targetStore = BrooklynPersistenceUtils.newPersistenceObjectStore(managementContext, null,
+                    "tmp/persistence-state-export");
+            dir = ((FileBasedObjectStore)targetStore).getBaseDir();
+            // only register the parent dir because that will prevent leaks for the random ID
+            Os.deleteOnExitEmptyParentsUpTo(dir.getParentFile(), dir.getParentFile());
+            BrooklynPersistenceUtils.writeMemento(managementContext, memento, targetStore);
+            BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, targetStore);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName() ).stream(baos);
+            ArchiveBuilder.zip().create(persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip");
+            Os.deleteRecursively(dir);
+
+        } catch (Exception e) {
+            Exceptions.propagateIfFatal(e);
+        }
+
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -294,30 +294,24 @@ public class BrooklynPersistenceUtils {
     public static void createStateExport (ManagementContext managementContext, File persistenceBaseDir){
         try {
             File dir = null;
-
             BrooklynMementoRawData memento = null;
             ManagementPlaneSyncRecord planeState = null;
-
             MementoCopyMode source = (managementContext.getHighAvailabilityManager().getNodeState()==ManagementNodeState.MASTER ? MementoCopyMode.LOCAL : MementoCopyMode.REMOTE);
 
             memento = newStateMemento(managementContext, source);
-            try {
-                planeState = newManagerMemento(managementContext, source);
-            } catch (Exception e) {
-                Exceptions.propagateIfFatal(e);
-            }
+            planeState = newManagerMemento(managementContext, source);
 
             PersistenceObjectStore targetStore = BrooklynPersistenceUtils.newPersistenceObjectStore(managementContext, null,
                     "tmp/persistence-state-export");
             dir = ((FileBasedObjectStore)targetStore).getBaseDir();
-            // only register the parent dir because that will prevent leaks for the random ID
             Os.deleteOnExitEmptyParentsUpTo(dir.getParentFile(), dir.getParentFile());
+
             BrooklynPersistenceUtils.writeMemento(managementContext, memento, targetStore);
             BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, targetStore);
 
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName() ).stream(baos);
-            ArchiveBuilder.zip().create(persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip");
+            //ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName() ).create((persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip"));
+            //ArchiveBuilder.zip().create(persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip");
             Os.deleteRecursively(dir);
 
         } catch (Exception e) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.core.mgmt.persist;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.List;
 
@@ -309,9 +308,8 @@ public class BrooklynPersistenceUtils {
             BrooklynPersistenceUtils.writeMemento(managementContext, memento, targetStore);
             BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, targetStore);
 
-            //ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName() ).create((persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip"));
-            //ArchiveBuilder.zip().create(persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip");
+            ArchiveBuilder.zip().addDirContentsAt(((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName())
+                    .create((persistenceBaseDir + File.separator + ".." + File.separator + "persistence-state-export.zip"));
             Os.deleteRecursively(dir);
 
         } catch (Exception e) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -44,7 +44,9 @@ import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.persist.BrooklynMementoPersisterToObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
+import org.apache.brooklyn.core.mgmt.persist.FileBasedObjectStore;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -516,6 +518,13 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
 
                 // Tell the persister to persist it
                 persister.delta(persisterDelta, exceptionHandler);
+
+                // save export zip of persistence state, only for file based
+                if ((persister instanceof BrooklynMementoPersisterToObjectStore) && (((BrooklynMementoPersisterToObjectStore) persister).getObjectStore() instanceof FileBasedObjectStore)){
+                    BrooklynPersistenceUtils.createStateExport(((BrooklynMementoPersisterToObjectStore) persister).getManagementContext(), ((FileBasedObjectStore) ((BrooklynMementoPersisterToObjectStore) persister).getObjectStore()).getBaseDir());
+                }
+
+
             }
         } catch (Exception e) {
             if (isActive()) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -519,7 +519,7 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                 // Tell the persister to persist it
                 persister.delta(persisterDelta, exceptionHandler);
 
-                // save export zip of persistence state, only for file based
+                // save export zip of persistence state, only for file based persistence stores
                 if ((persister instanceof BrooklynMementoPersisterToObjectStore) && (((BrooklynMementoPersisterToObjectStore) persister).getObjectStore() instanceof FileBasedObjectStore)){
                     BrooklynPersistenceUtils.createStateExport(((BrooklynMementoPersisterToObjectStore) persister).getManagementContext(), ((FileBasedObjectStore) ((BrooklynMementoPersisterToObjectStore) persister).getObjectStore()).getBaseDir());
                 }


### PR DESCRIPTION
WIP

Automated capture of persisted state into an archive saved in the root persistence directory - invoked on persistence change.

Archive is of hardcoded name 'persistence-state-export.zip' and is saved in the root or persistence directory. In case a new one is generated, old one is removed so we keep only the most up to date version of the export.

This is applicable only to file based persistence stores