### PR TITLE
Feature/working peristence import api

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -174,7 +174,7 @@ public interface ServerApi {
     // TODO would be nice to allow setting, as a means to recover / control more easily than messing with persistent stores
     @POST
     @Path("/ha/persist/import")
-    @ApiOperation(value = "Imports persistence")
+    @ApiOperation(value = "Imports a persistence export to a file-based store, moving catalog items, locations and managed applications.")
     public Response importPersistenceData(
         @ApiParam(name = "persistenceExportLocation", value = "location of perisstence to import", required = true)
         @FormParam("persistenceExportLocation") String persistenceExportLocation);

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -174,9 +174,9 @@ public interface ServerApi {
     // TODO would be nice to allow setting, as a means to recover / control more easily than messing with persistent stores
     @POST
     @Path("/ha/persist/import")
-    @ApiOperation(value = "Imports a persistence export to a file-based store, moving catalog items, locations and managed applications.")
+    @ApiOperation(value = "Imports a persistence export to a file-based store, moving catalog items, locations and managed applications (merged with the current persistence).")
     public Response importPersistenceData(
-        @ApiParam(name = "persistenceExportLocation", value = "location of perisstence to import", required = true)
+        @ApiParam(name = "persistenceExportLocation", value = "location of persistence to import", required = true)
         @FormParam("persistenceExportLocation") String persistenceExportLocation);
 
 

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.rest.api;
 
+import java.io.InputStream;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
@@ -181,10 +182,10 @@ public interface ServerApi {
 
     @POST
     @Path("/ha/persist/import")
+    @Consumes
     @ApiOperation(value = "Imports a persistence export to a file-based store, moving catalog items, locations and managed applications (merged with the current persistence).")
     public Response importPersistenceData(
-        @ApiParam(name = "persistenceStateData", value = "Archived data", required = true)
-        @FormParam("persistenceStateData") byte[] persistenceStateData);
+        @ApiParam(name = "persistenceData", value = "Archived data", required = true) byte[] persistenceData);
 
 
     // TODO /ha/persist/backup set of endpoints, to list and retrieve specific backups

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -171,13 +171,13 @@ public interface ServerApi {
                 + "using LOCAL as master and REMOTE for other notes")
         @QueryParam("origin") @DefaultValue("AUTO") String origin);
 
-    // TODO would be nice to allow setting, as a means to recover / control more easily than messing with persistent stores
+
     @POST
     @Path("/ha/persist/import")
     @ApiOperation(value = "Imports a persistence export to a file-based store, moving catalog items, locations and managed applications (merged with the current persistence).")
     public Response importPersistenceData(
-        @ApiParam(name = "persistenceExportLocation", value = "location of persistence to import", required = true)
-        @FormParam("persistenceExportLocation") String persistenceExportLocation);
+        @ApiParam(name = "persistenceStateData", value = "Archived data", required = true)
+        @FormParam("persistenceStateData") byte[] persistenceStateData);
 
 
     // TODO /ha/persist/backup set of endpoints, to list and retrieve specific backups

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -172,18 +172,13 @@ public interface ServerApi {
         @QueryParam("origin") @DefaultValue("AUTO") String origin);
 
     // TODO would be nice to allow setting, as a means to recover / control more easily than messing with persistent stores
-//    @POST
-//    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
-//    @Path("/ha/persist/import")
-//    @ApiOperation(value = "Causes the supplied persistence data (tgz) to be imported and added "
-//        + "(fails if the node is not master), optionally removing any items not referenced")
-//    public Response importPersistenceData(
-//          // question: do we want the MementoCopyMode, cf export above?
-//        @ApiParam(name = "clearOthers", value = "Whether to clear all existing items before adding these", required = false, defaultValue = "false")
-//        @FormParam("clearOthers") Boolean clearOthers,
-//        @ApiParam(name = "data",
-//        value = "TGZ contents of a persistent directory to be imported", required = true)
-//    @Valid String dataTgz);
+    @POST
+    @Path("/ha/persist/import")
+    @ApiOperation(value = "Imports persistence")
+    public Response importPersistenceData(
+        @ApiParam(name = "persistenceExportLocation", value = "location of perisstence to import", required = true)
+        @FormParam("persistenceExportLocation") String persistenceExportLocation);
+
 
     // TODO /ha/persist/backup set of endpoints, to list and retrieve specific backups
 


### PR DESCRIPTION
Introducing an API for persistence import feature.
This is intended for file based persistence stores and as a parameter, it takes the location of root of the persistence store to be imported.

Invoking the operation will merge the new data to the currently existing store. The process is as follows:
- new temporary management context is created with the persistence store to be imported
- memento of that persistence store is captured
- bundles from the persistence store are installed in the active management context - this deals with bundles/types in the catalog and locations
- contents of relevant directories (policies, enrichers, etc). are written to the active management context. These are used for the deployed applications
- rebind method adds the deployed applications to the active management context without having to reset the full management context/restart the server

Note: For the edge case when directory passed to the API is not a valid persistence, it uses prepareForSharedUse() method with REBIND parameter. As per documentation, persistMode = REBIND will rebind to the existing state, or fail if no state available. This uses methods checkPersistenceDirPlausible() and checkPersistenceDirNonEmpty() but these are not very robust checks. If we pass a dir which has a single empty file (and therefore is not a valid persistence), it will still pass those checks and eventually create a new persistence store in that location - this is a bug and will need to be fixed.