### PR TITLE
Add info and security definition to the swagger doc

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -135,6 +135,7 @@ public interface ServerApi {
     @POST
     @Path("/ha/state")
     @ApiOperation(value = "Changes the HA state of this management node")
+    @Produces({MediaType.APPLICATION_FORM_URLENCODED})
     public ManagementNodeState setHighAvailabilityNodeState(
             @ApiParam(name = "mode", value = "The state to change to")
             @FormParam("mode") HighAvailabilityMode mode);
@@ -158,6 +159,7 @@ public interface ServerApi {
     @POST
     @Path("/ha/priority")
     @ApiOperation(value = "Sets the HA node priority for MASTER failover")
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     public long setHighAvailabilityPriority(
             @ApiParam(name = "priority", value = "The priority to be set")
             @FormParam("priority") long priority);

--- a/utils/rest-swagger/src/main/java/org/apache/brooklyn/rest/apidoc/RestApiResourceScanner.java
+++ b/utils/rest-swagger/src/main/java/org/apache/brooklyn/rest/apidoc/RestApiResourceScanner.java
@@ -27,7 +27,12 @@ import io.swagger.annotations.Api;
 import io.swagger.config.SwaggerConfig;
 import io.swagger.jaxrs.config.AbstractScanner;
 import io.swagger.jaxrs.config.JaxrsScanner;
+import io.swagger.models.Info;
+import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
+import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.models.auth.In;
 
 
 /**
@@ -109,7 +114,29 @@ public class RestApiResourceScanner extends AbstractScanner implements JaxrsScan
     @Override
     public Swagger configure(Swagger swagger) {
         swagger.setBasePath("/v1");
+        swagger.setSchemes(Arrays.asList(new Scheme[]{Scheme.HTTPS, Scheme.HTTP}));
+
+        swagger.info(getSwaggerInfo());
+
+        ApiKeyAuthDefinition security = new ApiKeyAuthDefinition();
+        String apiKeyName = "JWT";
+        security.setName(apiKeyName);
+        security.setIn(In.HEADER);
+        security.setType("apiKey");
+        swagger.addSecurityDefinition(apiKeyName, security);
+
+        BasicAuthDefinition basicAuthDefinition = new BasicAuthDefinition();
+        swagger.addSecurityDefinition("Basic authentication", basicAuthDefinition);
+
         return swagger;
+    }
+
+    private Info getSwaggerInfo() {
+        Info info = new Info();
+        info.setTitle("Apache Brooklyn API");
+        info.setVersion(this.getClass().getPackage()!=null?this.getClass().getPackage().getImplementationVersion():"");
+        info.setDescription("API specification for Apache Brooklyn");
+        return info;
     }
 
     @Override


### PR DESCRIPTION
This adds a couple of extra fields in the swagger document: info, showing the current build version, the available schemas, and also the possible authentication mechanism

![image](https://user-images.githubusercontent.com/17095501/124782337-10557580-df3c-11eb-8c5f-ebc74c150712.png)
