### PR TITLE
Add support setup default initializers for all deployment

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddDeploySensorsInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddDeploySensorsInitializer.java
@@ -18,9 +18,8 @@
  */
 package org.apache.brooklyn.core.effector;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
@@ -28,6 +27,8 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.sensor.Sensors;
+
+import java.util.Map;
 
 public class AddDeploySensorsInitializer implements EntityInitializer {
     @Override
@@ -37,18 +38,15 @@ public class AddDeploySensorsInitializer implements EntityInitializer {
             return;
         }
         EntitlementContext entitlementContext = Entitlements.getEntitlementContext();
-        AttributeSensor<String> sensor = Sensors.newSensor(
-                String.class,
+        AttributeSensor<Map<String, Object>> sensor = Sensors.newSensor(
+                new TypeToken<Map<String, Object>>() {},
                 "deployment.metadata",
-                "Metadata information about this particular deployment. Contains at least who triggered it and when.");
+                "A map of metadata information about this particular deployment. Contains at least who triggered it and when.");
         ((EntityInternal) entity).getMutableEntityType().addSensor(sensor);
-        try {
-            entity.sensors().set(sensor, new ObjectMapper().writeValueAsString(ImmutableMap.of(
-                    "user", entitlementContext != null ? entitlementContext.user() : "Unknown",
-                    "deploy_time", System.currentTimeMillis()
-            )));
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException(e);
-        }
+        entity.sensors().set(sensor, ImmutableMap.of(
+                "user", entitlementContext != null ? entitlementContext.user() : "Unknown",
+                "deploy_time", System.currentTimeMillis()
+        ));
+
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddDeploySensorsInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddDeploySensorsInitializer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.effector;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.sensor.Sensors;
+
+public class AddDeploySensorsInitializer implements EntityInitializer {
+    @Override
+    public void apply(EntityLocal entity) {
+        // We want to set the metadata only on the root node of an application
+        if (entity.getParent() != null) {
+            return;
+        }
+        EntitlementContext entitlementContext = Entitlements.getEntitlementContext();
+        AttributeSensor<String> sensor = Sensors.newSensor(
+                String.class,
+                "deployment.metadata",
+                "Metadata information about this particular deployment. Contains at least who triggered it and when.");
+        ((EntityInternal) entity).getMutableEntityType().addSensor(sensor);
+        try {
+            entity.sensors().set(sensor, new ObjectMapper().writeValueAsString(ImmutableMap.of(
+                    "user", entitlementContext != null ? entitlementContext.user() : "Unknown",
+                    "deploy_time", System.currentTimeMillis()
+            )));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -385,13 +385,9 @@ public class InternalEntityFactory extends InternalFactory {
                 }
                 ((AbstractEntity)entity).addLocations(spec.getLocations());
 
-                List<EntityInitializer> initializers = Stream.concat(spec.getInitializers().stream(), getDefaultInitializers().stream())
+                List<EntityInitializer> initializers = Stream.concat(getDefaultInitializers().stream(), spec.getInitializers().stream())
                         .collect(Collectors.toList());
                 for (EntityInitializer initializer: initializers) {
-                    initializer.apply((EntityInternal)entity);
-                }
-
-                for (EntityInitializer initializer: spec.getInitializers()) {
                     initializer.apply((EntityInternal)entity);
                 }
 


### PR DESCRIPTION
This looks up a new configuration options called `brooklyn.deployment.initializers` (comma separated list). If specified on a Brooklyn instance, all deployments will load and execute these initializers. Theses classes are expected to be `EntityInitializer`, if an error occur (either cast or anything else) then the deployment will fail.

The code will try to:
1. load the class from the default class loader.
2. if (1) fails, it will try to load the class from the `TypeRegistry`. This is to allow execution of custom initializers that might be installed in the catalog later on.
3. if (1) and (2) fails, then the deployment is aborted.

This PR contains a new initializer that give more information about the deployment (who and when currently) but it is not set by default (see https://github.com/apache/brooklyn-dist/pull/174)