### PR TITLE
Adds an attributes map on WebEntitlementContext to handle user roles

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
@@ -19,7 +19,11 @@
 package org.apache.brooklyn.core.mgmt.entitlement;
 
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Indicates an authenticated web request as the entitlements context;
@@ -27,9 +31,15 @@ import org.apache.brooklyn.util.javalang.JavaClassNames;
  */
 public class WebEntitlementContext implements EntitlementContext {
 
+    public static final String ENTITLEMENTS_ATTRIBUTES = "brooklyn.entitlements.attributes";
+
+    public static final String USER_ROLES = "brooklyn.entitlements.user.roles";
+
+
     final String user;
     final String sourceIp;
     final String requestUri;
+    final Map<String, Object> attributes;
     
     /**
      * A mostly-unique identifier for the inbound request, to distinguish
@@ -38,16 +48,25 @@ public class WebEntitlementContext implements EntitlementContext {
     final String requestUniqueIdentifier;
     
     public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier) {
+        this(user, sourceIp, requestUri, requestUniqueIdentifier, new HashMap<>());
+    }
+
+    public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier, Map attributes) {
         this.user = user;
         this.sourceIp = sourceIp;
         this.requestUri = requestUri;
         this.requestUniqueIdentifier = requestUniqueIdentifier;
+        if(attributes!=null)
+            this.attributes = attributes;
+        else
+            this.attributes = MutableMap.of();
     }
-    
+
     @Override public String user() { return user; }
     public String sourceIp() { return sourceIp; }
     public String requestUri() { return requestUri; }
     public String requestUniqueIdentifier() { return requestUniqueIdentifier; }
+    public Map<String, Object> attributes() { return attributes; }
 
     @Override
     public String toString() {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
@@ -19,7 +19,6 @@
 package org.apache.brooklyn.core.mgmt.entitlement;
 
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 
 import java.util.HashMap;
@@ -51,7 +50,7 @@ public class WebEntitlementContext implements EntitlementContext {
         this(user, sourceIp, requestUri, requestUniqueIdentifier, new HashMap<>());
     }
 
-    public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier, Map attributes) {
+    public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier, Map<String, Object> attributes) {
         this.user = user;
         this.sourceIp = sourceIp;
         this.requestUri = requestUri;
@@ -59,7 +58,7 @@ public class WebEntitlementContext implements EntitlementContext {
         if(attributes!=null)
             this.attributes = attributes;
         else
-            this.attributes = MutableMap.of();
+            this.attributes = new HashMap<>();
     }
 
     @Override public String user() { return user; }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.mgmt.entitlement;
 
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 
 import java.util.HashMap;
@@ -38,7 +39,7 @@ public class WebEntitlementContext implements EntitlementContext {
     final String user;
     final String sourceIp;
     final String requestUri;
-    final Map<String, Object> attributes;
+    final Map<String, Object> attributes = MutableMap.of();
     
     /**
      * A mostly-unique identifier for the inbound request, to distinguish
@@ -47,7 +48,7 @@ public class WebEntitlementContext implements EntitlementContext {
     final String requestUniqueIdentifier;
     
     public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier) {
-        this(user, sourceIp, requestUri, requestUniqueIdentifier, new HashMap<>());
+        this(user, sourceIp, requestUri, requestUniqueIdentifier, null);
     }
 
     public WebEntitlementContext(String user, String sourceIp, String requestUri, String requestUniqueIdentifier, Map<String, Object> attributes) {
@@ -56,9 +57,7 @@ public class WebEntitlementContext implements EntitlementContext {
         this.requestUri = requestUri;
         this.requestUniqueIdentifier = requestUniqueIdentifier;
         if(attributes!=null)
-            this.attributes = attributes;
-        else
-            this.attributes = new HashMap<>();
+            this.attributes.putAll(attributes) ;
     }
 
     @Override public String user() { return user; }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
@@ -22,7 +22,6 @@ import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -31,9 +30,7 @@ import java.util.Map;
  */
 public class WebEntitlementContext implements EntitlementContext {
 
-    public static final String ENTITLEMENTS_ATTRIBUTES = "brooklyn.entitlements.attributes";
-
-    public static final String USER_ROLES = "brooklyn.entitlements.user.roles";
+    public static final String USER_GROUPS = "brooklyn.entitlements.user.groups";
 
 
     final String user;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
@@ -83,6 +83,11 @@ public class BrooklynWebConfig {
     public final static ConfigKey<String> LDAP_OU = ConfigKeys.newStringConfigKey(
             BASE_NAME_SECURITY+".ldap.ou");
 
+    public final static ConfigKey<Boolean> LDAP_FETCH_USER_GROUPS = ConfigKeys.newBooleanConfigKey(
+            BASE_NAME_SECURITY+".ldap.fetch_user_group",
+            "Whether if user groups should be fetch from LDAP server",
+            false);
+
     public final static ConfigKey<Boolean> HTTPS_REQUIRED = ConfigKeys.newBooleanConfigKey(
             BASE_NAME+".security.https.required",
             "Whether HTTPS is required; false here can be overridden by CLI option", false); 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
@@ -85,7 +85,7 @@ public class BrooklynWebConfig {
 
     public final static ConfigKey<Boolean> LDAP_FETCH_USER_GROUPS = ConfigKeys.newBooleanConfigKey(
             BASE_NAME_SECURITY+".ldap.fetch_user_group",
-            "Whether if user groups should be fetch from LDAP server",
+            "Whether user groups should be fetched from the LDAP server",
             false);
 
     public final static ConfigKey<Boolean> HTTPS_REQUIRED = ConfigKeys.newBooleanConfigKey(

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -20,8 +20,6 @@ package org.apache.brooklyn.rest.filter;
 
 import java.io.IOException;
 import java.security.Principal;
-import java.util.List;
-import java.util.Map;
 
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
@@ -33,11 +31,11 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
 import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Strings;;
 
 @Provider
@@ -71,17 +69,13 @@ public class EntitlementContextFilter implements ContainerRequestFilter, Contain
             String remoteAddr = request.getRemoteAddr();
 
             String uid = RequestTaggingRsFilter.getTag();
-            List<String> userRoles = (List<String>) getAttributeFromSession(WebEntitlementContext.USER_ROLES);
-            Map<String, Object> entitlementAttributes = null;
-            if (userRoles != null) {
-                entitlementAttributes = ImmutableMap.of(
-                        WebEntitlementContext.ENTITLEMENTS_ATTRIBUTES,
-                        ImmutableMap.of(
-                                WebEntitlementContext.USER_ROLES,
-                                userRoles));
-            }
 
-            WebEntitlementContext entitlementContext = new WebEntitlementContext(userName, remoteAddr, uri, uid, entitlementAttributes);
+            WebEntitlementContext entitlementContext = new WebEntitlementContext(
+                    userName,
+                    remoteAddr,
+                    uri,
+                    uid,
+                    MutableMap.<String, Object>of().addIfNotNull(WebEntitlementContext.USER_GROUPS, getAttributeFromSession(WebEntitlementContext.USER_GROUPS)));
             Entitlements.setEntitlementContext(entitlementContext);
         }
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -18,12 +18,10 @@
  */
 package org.apache.brooklyn.rest.filter;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
-import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
-import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
-import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
-import org.apache.brooklyn.util.text.Strings;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Priority;
 import javax.servlet.http.HttpServletRequest;
@@ -34,10 +32,13 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
-import java.io.IOException;
-import java.security.Principal;
-import java.util.List;
-import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.mgmt.entitlement.EntitlementContext;
+import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
+import org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext;
+import org.apache.brooklyn.rest.util.MultiSessionAttributeAdapter;
+import org.apache.brooklyn.util.text.Strings;;
 
 @Provider
 @Priority(400)

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -44,7 +44,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_ROLES;
+import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_GROUPS;
 
 /**
  * A {@link SecurityProvider} implementation that relies on LDAP to authenticate.
@@ -110,7 +110,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
             DirContext ctx = new InitialDirContext(env);// will throw if password is invalid
             if (fetchUserGroups) {
                 // adds user groups ot eh session
-                sessionSupplierOnSuccess.get().setAttribute(USER_ROLES, getUserGroups(user, ctx));
+                sessionSupplierOnSuccess.get().setAttribute(USER_GROUPS, getUserGroups(user, ctx));
             }
             return allow(sessionSupplierOnSuccess.get(), user);
         } catch (NamingException e) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -131,9 +131,13 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
         while (answer.hasMore()) {
             SearchResult rslt = (SearchResult) answer.next();
             Attributes attrs = rslt.getAttributes();
-            NamingEnumeration<?> memberOf = attrs.get("memberOf").getAll();
-            while (memberOf.hasMore()) {
-                groupsListBuilder.add(getGroupName(memberOf.next().toString()));
+
+            Attribute memberOf = attrs.get("memberOf");
+            if(memberOf != null){
+                NamingEnumeration<?> groups = memberOf.getAll();
+                while (groups.hasMore()) {
+                    groupsListBuilder.add(getGroupName(groups.next().toString()));
+                }
             }
         }
         return groupsListBuilder.build();

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -23,6 +23,18 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
@@ -31,19 +43,6 @@ import org.apache.brooklyn.util.text.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.naming.Context;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
-import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_ROLES;
 
@@ -113,7 +112,6 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
                 // adds user groups ot eh session
                 sessionSupplierOnSuccess.get().setAttribute(USER_ROLES, getUserGroups(user, ctx));
             }
-            ctx.close();
             return allow(sessionSupplierOnSuccess.get(), user);
         } catch (NamingException e) {
             return false;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -21,23 +21,31 @@ package org.apache.brooklyn.rest.security.provider;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import java.util.Arrays;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.function.Supplier;
-import javax.naming.Context;
-import javax.naming.NamingException;
-import javax.naming.directory.InitialDirContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.rest.BrooklynWebConfig;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_ROLES;
 
 /**
  * A {@link SecurityProvider} implementation that relies on LDAP to authenticate.
@@ -49,15 +57,16 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
     public static final Logger LOG = LoggerFactory.getLogger(LdapSecurityProvider.class);
 
     public static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
-
     private final String ldapUrl;
     private final String defaultLdapRealm;
     private final String organizationUnit;
+    private boolean fetchUserGroups = false;
 
     public LdapSecurityProvider(ManagementContext mgmt) {
         StringConfigMap properties = mgmt.getConfig();
         ldapUrl = properties.getConfig(BrooklynWebConfig.LDAP_URL);
-        Strings.checkNonEmpty(ldapUrl, "LDAP security provider configuration missing required property "+BrooklynWebConfig.LDAP_URL);
+        Strings.checkNonEmpty(ldapUrl, "LDAP security provider configuration missing required property " + BrooklynWebConfig.LDAP_URL);
+        fetchUserGroups = properties.getConfig(BrooklynWebConfig.LDAP_FETCH_USER_GROUPS);
 
         String realmConfig = properties.getConfig(BrooklynWebConfig.LDAP_REALM);
         if (Strings.isNonBlank(realmConfig)) {
@@ -66,7 +75,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
             defaultLdapRealm = "";
         }
 
-        if(Strings.isBlank(properties.getConfig(BrooklynWebConfig.LDAP_OU))) {
+        if (Strings.isBlank(properties.getConfig(BrooklynWebConfig.LDAP_OU))) {
             LOG.info("Setting LDAP ou attribute to: Users");
             organizationUnit = "Users";
         } else {
@@ -80,10 +89,10 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
         this.organizationUnit = organizationUnit;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
-        if (user==null) return false;
+        if (user == null) return false;
         checkCanLoad();
 
         if (Strings.isBlank(pass)) {
@@ -99,11 +108,70 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
             env.put(Context.SECURITY_PRINCIPAL, getSecurityPrincipal(user));
             env.put(Context.SECURITY_CREDENTIALS, pass);
 
-            new InitialDirContext(env);  // will throw if password is invalid
+            DirContext ctx = new InitialDirContext(env);// will throw if password is invalid
+            if (fetchUserGroups) {
+                // adds user groups ot eh session
+                sessionSupplierOnSuccess.get().setAttribute(USER_ROLES, getUserGroups(user, ctx));
+            }
+            ctx.close();
             return allow(sessionSupplierOnSuccess.get(), user);
         } catch (NamingException e) {
             return false;
         }
+    }
+
+    private List<String> getUserGroups(String user, DirContext ctx) throws NamingException {
+        ImmutableList.Builder<String> groupsListBuilder = ImmutableList.builder();
+
+        SearchControls ctls = new SearchControls();
+        ctls.setReturningAttributes(new String[]{"memberOf"});
+
+        NamingEnumeration<?> answer = ctx.search(buildUserContainer(), "(&(objectclass=user)(sAMAccountName=" + getAccountName(user) + "))", ctls);
+
+        while (answer.hasMore()) {
+            SearchResult rslt = (SearchResult) answer.next();
+            Attributes attrs = rslt.getAttributes();
+            NamingEnumeration<?> memberOf = attrs.get("memberOf").getAll();
+            while (memberOf.hasMore()) {
+                groupsListBuilder.add(getGroupName(memberOf.next().toString()));
+            }
+        }
+        return groupsListBuilder.build();
+    }
+
+    private String buildUserContainer() {
+        StringBuilder userContainerBuilder = new StringBuilder();
+        for (String s : organizationUnit.split("\\.")) {
+            userContainerBuilder.append("OU=").append(s).append(",");
+        }
+        for (String s : defaultLdapRealm.split("\\.")) {
+            userContainerBuilder.append("DC=").append(s).append(",");
+        }
+        return StringUtils.chop(userContainerBuilder.toString());
+    }
+
+    private String getAccountName(String user) {
+        if (user.contains("\\")) {
+            String[] split = user.split("\\\\");
+            return split[split.length - 1];
+        }
+        return user;
+    }
+
+    /**
+     * Returns the name of deepest name of the group ignoring upper levels of nesting
+     *
+     * @param groupAttribute
+     * @return
+     */
+    private String getGroupName(String groupAttribute) {
+        // CN=groupName,OU=OuGroups,OU=Users,DC=dc,DC=example,DC=com
+        Pattern groupNamePatter = Pattern.compile("^CN=(?<groupName>[a-zA-Z0-9_-]+),*");
+        Matcher m = groupNamePatter.matcher(groupAttribute);
+        if (m.find()) {
+            return m.group(1);
+        }
+        throw new IllegalStateException("Not valid group found in " + groupAttribute);
     }
 
     /**


### PR DESCRIPTION
Adds an attributes map to WebEntitlementContext and use EntitlementContextFilter to sync the user LDAP groups from the session.

LDAP groups can only be resolved at login time, using the user password. For exposing them when checking the entitlements is necessary to add them to the `EntitlementContext`. This PR adds a map of attributes in the `WebEntitlementContext` and put there the groups when the new config key `LDAP_FETCH_USER_GROUPS` is true