### PR TITLE
Be stricter about java lambdas in data which is persisted

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/EntityManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/EntityManager.java
@@ -76,6 +76,8 @@ public interface EntityManager {
         default boolean isDryRun() { return false; }
         /** whether the item should have a specific identifier; may fail or return existing if it already exists */
         default String getRequiredUniqueId() { return null; }
+        /** whether to persist as part of creation (forces failure if creation fails, in the creating thread) */
+        default boolean persistAfterCreation() { return true; }
     }
 
     /**

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/PersistenceExceptionHandler.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/PersistenceExceptionHandler.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.api.mgmt.rebind;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Set;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.Memento;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
@@ -43,5 +45,10 @@ public interface PersistenceExceptionHandler {
     void onDeleteMementoFailed(String id, Exception e);
     
     void onUpdatePlaneIdFailed(String planeId, Exception e);
+
+    @Beta
+    void clearRecentErrors();
+    @Beta
+    Set<String> getRecentErrors();
 
 }

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindManager.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/RebindManager.java
@@ -64,6 +64,8 @@ public interface RebindManager {
     @VisibleForTesting
     public BrooklynMementoPersister getPersister();
 
+    public PersistenceExceptionHandler getPersisterExceptionHandler();
+
     /** Causes this management context to rebind, loading data from the given backing store.
      * use wisely, as this can cause local entities to be completely lost, or will throw in many other situations.
      * in general it may be invoked for a new node becoming {@link ManagementNodeState#MASTER} 

--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
@@ -95,10 +95,12 @@ public interface BrooklynMementoPersister {
       */
     BrooklynMemento loadMemento(@Nullable BrooklynMementoRawData mementoData, LookupContext lookupContext, RebindExceptionHandler exceptionHandler) throws IOException;
 
-    /** applies a full checkpoint (write) of all state */  
-    void checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler);
-    /** applies a partial write of state delta */  
-    void delta(Delta delta, PersistenceExceptionHandler exceptionHandler);
+    Set<String> getLastErrors();
+
+    /** applies a full checkpoint (write) of all state; returns true on success or false on error, with {@link #getLastErrors()} available to get the last errors */
+    boolean checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler);
+    /** applies a partial write of state delta; result and errors as per {@link #checkpoint(BrooklynMementoRawData, PersistenceExceptionHandler)} */
+    boolean delta(Delta delta, PersistenceExceptionHandler exceptionHandler);
     /** inserts an additional delta to be written on the next delta request */
     @Beta
     void queueDelta(Delta delta);

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/CatalogPredicates.java
@@ -40,6 +40,7 @@ import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.core.mgmt.rebind.dto.MementosGenerators;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.slf4j.Logger;
@@ -290,9 +291,9 @@ public class CatalogPredicates {
         public boolean apply(@Nullable CatalogItem<T,SpecT> item) {
             try {
                 Memento memento = MementosGenerators.newBasicMemento(item);
-                XmlMementoSerializer<CatalogItem<?,?>> serializer = new XmlMementoSerializer<CatalogItem<?,?>>(
-                        CatalogPredicates.class.getClassLoader(), 
-                        ImmutableMap.<String,String>of());
+                XmlMementoSerializer<CatalogItem<?,?>> serializer = XmlMementoSerializerBuilder.<CatalogItem<?,?>>empty()
+                        .withDeserializingClassRenames(null)
+                        .withClassLoader( CatalogPredicates.class.getClassLoader() ).build();
                 StringWriter writer = new StringWriter();
                 serializer.serialize(memento, writer);
                 return filter.apply(writer.toString());

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/ManagementPlaneSyncRecordPersisterToObjectStore.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.core.mgmt.persist.RetryingMementoSerializer;
 import org.apache.brooklyn.core.mgmt.persist.StoreObjectAccessorLocking;
 import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore.StoreObjectAccessorWithLock;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
@@ -126,7 +127,9 @@ public class ManagementPlaneSyncRecordPersisterToObjectStore implements Manageme
         this.mgmt = mgmt;
         this.objectStore = checkNotNull(objectStore, "objectStore");
 
-        MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(checkNotNull(classLoader, "classLoader"));
+        MementoSerializer<Object> rawSerializer = XmlMementoSerializerBuilder.from(mgmt)
+                .withBrooklynDeserializingClassRenames()
+                .withClassLoader(checkNotNull(classLoader, "classLoader")).build();
         this.serializer = new RetryingMementoSerializer<Object>(rawSerializer, MAX_SERIALIZATION_ATTEMPTS);
 
         objectStore.createSubPath(NODES_SUB_PATH);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/NonDeploymentManagementContext.java
@@ -568,6 +568,11 @@ public class NonDeploymentManagementContext implements ManagementContextInternal
         }
 
         @Override
+        public PersistenceExceptionHandler getPersisterExceptionHandler() {
+            throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
+        }
+
+        @Override
         public List<Application> rebind(ClassLoader classLoader, RebindExceptionHandler exceptionHandler, ManagementNodeState mode) {
             throw new IllegalStateException("Non-deployment context "+NonDeploymentManagementContext.this+" is not valid for this operation.");
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -60,6 +60,7 @@ import org.apache.brooklyn.core.mgmt.classloading.ClassLoaderFromBrooklynClassLo
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore.StoreObjectAccessor;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceObjectStore.StoreObjectAccessorWithLock;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.core.mgmt.rebind.PeriodicDeltaChangeListener;
 import org.apache.brooklyn.core.mgmt.rebind.dto.BrooklynMementoImpl;
 import org.apache.brooklyn.core.mgmt.rebind.dto.BrooklynMementoManifestImpl;
@@ -147,7 +148,9 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
         this.brooklynProperties = brooklynProperties;
         
         int maxSerializationAttempts = brooklynProperties.getConfig(PERSISTER_MAX_SERIALIZATION_ATTEMPTS);
-        MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(classLoader);
+        MementoSerializer<Object> rawSerializer = XmlMementoSerializerBuilder.from(brooklynProperties)
+                .withBrooklynDeserializingClassRenames()
+                .withClassLoader(classLoader).build();
         this.serializerWithStandardClassLoader = new RetryingMementoSerializer<Object>(rawSerializer, maxSerializationAttempts);
 
         int maxThreadPoolSize = brooklynProperties.getConfig(PERSISTER_MAX_THREAD_POOL_SIZE);
@@ -185,7 +188,9 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
     
     protected MementoSerializer<Object> getSerializerWithCustomClassLoader(LookupContext lookupContext, ClassLoader classLoader) {
         int maxSerializationAttempts = brooklynProperties.getConfig(PERSISTER_MAX_SERIALIZATION_ATTEMPTS);
-        MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(classLoader);
+        MementoSerializer<Object> rawSerializer = XmlMementoSerializerBuilder.from(brooklynProperties)
+                .withBrooklynDeserializingClassRenames()
+                .withClassLoader(classLoader).build();
         MementoSerializer<Object> result = new RetryingMementoSerializer<Object>(rawSerializer, maxSerializationAttempts);
         result.setLookupContext(lookupContext);
         return result;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -131,6 +131,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
      * for any concurrent call to complete.
      */
     private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
+    private Set<String> lastErrors = MutableSet.of();
 
     public BrooklynMementoPersisterToObjectStore(PersistenceObjectStore objectStore, ManagementContext mgmt) {
         this(objectStore, mgmt, mgmt.getCatalogClassLoader());
@@ -587,11 +588,16 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
             throw new IllegalStateException("Writes not allowed in "+this);
         }
     }
-    
+
+    @Override
+    public Set<String> getLastErrors() {
+        return lastErrors;
+    }
+
     /** See {@link BrooklynPersistenceUtils} for conveniences for using this method. */
     @Override
     @Beta
-    public void checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler) {
+    public boolean checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler) {
         checkWritesAllowed();
         try {
             lock.writeLock().lockInterruptibly();
@@ -600,6 +606,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
         }
         
         try {
+            exceptionHandler.clearRecentErrors();
             objectStore.prepareForMasterUse();
             
             Stopwatch stopwatch = Stopwatch.createStarted();
@@ -623,31 +630,40 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
             }
             if (LOG.isDebugEnabled()) LOG.debug("Checkpointed entire memento in {}", Time.makeTimeStringRounded(stopwatch));
         } finally {
+            lastErrors = exceptionHandler.getRecentErrors();
             lock.writeLock().unlock();
         }
+        return lastErrors.isEmpty();
     }
 
     @Override
-    public void delta(Delta delta, PersistenceExceptionHandler exceptionHandler) {
+    public boolean delta(Delta delta, PersistenceExceptionHandler exceptionHandler) {
         checkWritesAllowed();
+        Set<String> theseErrors = MutableSet.of();
 
         while (!queuedDeltas.isEmpty()) {
             Delta extraDelta = queuedDeltas.remove(0);
-            doDelta(extraDelta, exceptionHandler, true);
+            theseErrors.addAll( doDelta(extraDelta, exceptionHandler, true) );
         }
 
-        doDelta(delta, exceptionHandler, false);
+        theseErrors.addAll( doDelta(delta, exceptionHandler, false) );
+        lastErrors = theseErrors;
+        return theseErrors.isEmpty();
     }
     
-    protected void doDelta(Delta delta, PersistenceExceptionHandler exceptionHandler, boolean previouslyQueued) {
-        Stopwatch stopwatch = deltaImpl(delta, exceptionHandler);
+    protected Set<String> doDelta(Delta delta, PersistenceExceptionHandler exceptionHandler, boolean previouslyQueued) {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        Set<String> theseLastErrors = deltaImpl(delta, exceptionHandler);
         
         if (LOG.isDebugEnabled()) LOG.debug("Checkpointed "+(previouslyQueued ? "previously queued " : "")+"delta of memento in {}: "
                 + "updated {} entities, {} locations, {} policies, {} enrichers, {} catalog items, {} bundles; "
-                + "removed {} entities, {} locations, {} policies, {} enrichers, {} catalog items, {} bundles",
+                + "removed {} entities, {} locations, {} policies, {} enrichers, {} catalog items, {} bundles"
+                + (theseLastErrors.isEmpty() ? "" : "; "+theseLastErrors.size()+" errors: "+theseLastErrors),
                     new Object[] {Time.makeTimeStringRounded(stopwatch),
                         delta.entities().size(), delta.locations().size(), delta.policies().size(), delta.enrichers().size(), delta.catalogItems().size(), delta.bundles().size(),
                         delta.removedEntityIds().size(), delta.removedLocationIds().size(), delta.removedPolicyIds().size(), delta.removedEnricherIds().size(), delta.removedCatalogItemIds().size(), delta.removedBundleIds().size()});
+
+        return theseLastErrors;
     }
     
     @Override
@@ -662,16 +678,16 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
      * TODO Longer term, if we care more about concurrent calls we could merge the queued deltas so that we
      * don't do unnecessary repeated writes of an entity.
      */
-    private Stopwatch deltaImpl(Delta delta, PersistenceExceptionHandler exceptionHandler) {
+    private Set<String> deltaImpl(Delta delta, PersistenceExceptionHandler exceptionHandler) {
         try {
             lock.writeLock().lockInterruptibly();
         } catch (InterruptedException e) {
             throw Exceptions.propagate(e);
         }
         try {
+            exceptionHandler.clearRecentErrors();
             objectStore.prepareForMasterUse();
-            
-            Stopwatch stopwatch = Stopwatch.createStarted();
+
             List<ListenableFuture<?>> futures = Lists.newArrayList();
             
             Set<String> deletedIds = MutableSet.of();
@@ -708,10 +724,11 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
                 throw Exceptions.propagate(e);
             }
             
-            return stopwatch;
         } finally {
+            lastErrors = exceptionHandler.getRecentErrors();
             lock.writeLock().unlock();
         }
+        return lastErrors;
     }
 
     private void addPersistContentIfManagedBundle(final BrooklynObjectType type, final String id, List<ListenableFuture<?>> futures, final PersistenceExceptionHandler exceptionHandler) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynPersistenceUtils.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.core.mgmt.ha.ManagementPlaneSyncRecordPersisterToObje
 import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.LocalLocationManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.core.mgmt.rebind.PersistenceExceptionHandlerImpl;
 import org.apache.brooklyn.core.mgmt.rebind.transformer.CompoundTransformer;
 import org.apache.brooklyn.core.mgmt.rebind.transformer.CompoundTransformerLoader;
@@ -170,7 +171,9 @@ public class BrooklynPersistenceUtils {
 
     private static BrooklynMementoRawData newStateMementoFromLocal(ManagementContext mgmt) {
         BrooklynMementoRawData.Builder result = BrooklynMementoRawData.builder();
-        MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(mgmt.getClass().getClassLoader());
+        MementoSerializer<Object> rawSerializer = XmlMementoSerializerBuilder.from(mgmt)
+                .withBrooklynDeserializingClassRenames()
+                .build();
         RetryingMementoSerializer<Object> serializer = new RetryingMementoSerializer<Object>(rawSerializer, 1);
         
         result.planeId(mgmt.getManagementPlaneIdMaybe().orNull());

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.core.mgmt.persist;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Method;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
 
+import java.util.function.Function;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
@@ -42,6 +44,7 @@ import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.config.StringConfigMap;
 import org.apache.brooklyn.core.catalog.internal.CatalogBundleDto;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.config.BasicConfigKey;
@@ -50,6 +53,7 @@ import org.apache.brooklyn.core.effector.EffectorAndBody;
 import org.apache.brooklyn.core.effector.EffectorTasks.EffectorBodyTaskFactory;
 import org.apache.brooklyn.core.effector.EffectorTasks.EffectorTaskFactory;
 import org.apache.brooklyn.core.mgmt.classloading.ClassLoaderFromStackOfBrooklynClassLoadingContext;
+import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.rebind.dto.BasicCatalogItemMemento;
 import org.apache.brooklyn.core.mgmt.rebind.dto.BasicEnricherMemento;
 import org.apache.brooklyn.core.mgmt.rebind.dto.BasicEntityMemento;
@@ -60,6 +64,9 @@ import org.apache.brooklyn.core.mgmt.rebind.dto.BasicPolicyMemento;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableSet.Builder;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.xstream.LambdaPreventionMapper;
 import org.apache.brooklyn.util.core.xstream.XmlSerializer;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Strings;
@@ -90,13 +97,75 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
 
     private final ClassLoaderFromStackOfBrooklynClassLoadingContext delegatingClassLoader;
     private LookupContext lookupContext;
-    
+
+
+    public static class XmlMementoSerializerBuilder<T> {
+        public static <T> XmlMementoSerializerBuilder<T> empty() {
+            return new XmlMementoSerializerBuilder<>();
+        }
+
+        public static <T> XmlMementoSerializerBuilder<T> from(ManagementContext mgmt) {
+            return XmlMementoSerializerBuilder.<T>empty()
+                    .withClassLoader(mgmt.getClass().getClassLoader())
+                    .withConfig( ((ManagementContextInternal)mgmt).getBrooklynProperties());
+        }
+
+        public static <T> XmlMementoSerializerBuilder<T> from(StringConfigMap cfg) {
+            return XmlMementoSerializerBuilder.<T>empty().withConfig(cfg);
+        }
+
+        public static <T> XmlMementoSerializerBuilder<T> from(ConfigBag cfg) {
+            return XmlMementoSerializerBuilder.<T>empty().withConfig(cfg);
+        }
+
+        ClassLoader classLoader = null;
+        Map<String, String> deserializingClassRenames = null;
+        Function<MapperWrapper,MapperWrapper> mapperCustomizer = null;
+
+        public XmlMementoSerializer<T> build() {
+            return new XmlMementoSerializer<T>(classLoader, deserializingClassRenames, mapperCustomizer);
+        }
+
+        public XmlMementoSerializerBuilder<T> withConfig(StringConfigMap cfg) {
+            return withConfig(ConfigBag.newInstance().putAll(cfg.getAllConfigLocalRaw()));
+        }
+        public XmlMementoSerializerBuilder<T> withConfig(ConfigBag cfg) {
+            return withMapperCustomizer(LambdaPreventionMapper.factory(cfg));
+        }
+
+        public XmlMementoSerializerBuilder<T> withClassLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+            return this;
+        }
+
+        public XmlMementoSerializerBuilder<T> withBrooklynDeserializingClassRenames() {
+            return withDeserializingClassRenames(DeserializingClassRenamesProvider.INSTANCE.loadDeserializingMapping());
+        }
+
+        public XmlMementoSerializerBuilder<T> withDeserializingClassRenames(Map<String, String> deserializingClassRenames) {
+            // only injected in tests; the default one works great
+            this.deserializingClassRenames = deserializingClassRenames==null ? ImmutableMap.of() : deserializingClassRenames;
+            return this;
+        }
+
+        public XmlMementoSerializerBuilder<T> withMapperCustomizer(Function<MapperWrapper, MapperWrapper> mapperCustomizer) {
+            this.mapperCustomizer = mapperCustomizer;
+            return this;
+        }
+    }
+
+    @Deprecated /** @deprecated since 1.1, use {@link XmlMementoSerializerBuilder} */
     public XmlMementoSerializer(ClassLoader classLoader) {
         this(classLoader, DeserializingClassRenamesProvider.INSTANCE.loadDeserializingMapping());
     }
-    
+
+    @Deprecated /** @deprecated since 1.1, use {@link XmlMementoSerializerBuilder} */
     public XmlMementoSerializer(ClassLoader classLoader, Map<String, String> deserializingClassRenames) {
-        super(new ClassLoaderFromStackOfBrooklynClassLoadingContext(classLoader), deserializingClassRenames);
+        this(classLoader, deserializingClassRenames, null);
+    }
+
+    protected XmlMementoSerializer(ClassLoader classLoader, Map<String, String> deserializingClassRenames, Function<MapperWrapper,MapperWrapper> mapperCustomizer) {
+        super(new ClassLoaderFromStackOfBrooklynClassLoadingContext(classLoader), deserializingClassRenames, mapperCustomizer);
         this.delegatingClassLoader = (ClassLoaderFromStackOfBrooklynClassLoadingContext) xstream.getClassLoader();
         
         xstream.alias("entity", BasicEntityMemento.class);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindContextImpl.java
@@ -40,6 +40,7 @@ import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.osgi.VersionedName;
 import org.osgi.framework.BundleException;
 
 import com.google.common.collect.Maps;
@@ -90,6 +91,10 @@ public class RebindContextImpl implements RebindContext {
     
     public void registerCatalogItem(String id, CatalogItem<?, ?> catalogItem) {
         catalogItems.put(id, catalogItem);
+    }
+
+    public void registerBundle(String versionedName, ManagedBundle bundle) {
+        bundles.put(versionedName, bundle);
     }
 
     /** install the bundles into brooklyn and osgi, but do not start nor validate;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -378,6 +378,7 @@ public abstract class RebindIteration {
             for (ManagedBundleMemento bundleMemento : mementoManifest.getBundles().values()) {
                 ManagedBundle managedBundle = instantiator.newManagedBundle(bundleMemento);
                 bundles.put(managedBundle.getVersionedName(), new InstallableManagedBundleImpl(bundleMemento, managedBundle));
+                rebindContext.registerBundle(bundleMemento.getId(), managedBundle);
             }
         } else {
             logRebindingDebug("Not rebinding bundles; feature disabled: {}", mementoManifest.getBundleIds());

--- a/core/src/main/java/org/apache/brooklyn/util/core/xstream/LambdaPreventionMapper.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/xstream/LambdaPreventionMapper.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.core.xstream;
+
+import com.thoughtworks.xstream.core.util.Types;
+import com.thoughtworks.xstream.mapper.Mapper;
+import com.thoughtworks.xstream.mapper.MapperWrapper;
+import java.io.Serializable;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Not to be confused with {@link com.thoughtworks.xstream.mapper.LambdaMapper} which actually makes an effort,
+ * this simply fails or warns once, depending on configuration.
+ */
+public class LambdaPreventionMapper extends MapperWrapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LambdaPreventionMapper.class);
+
+    enum LambdaPersistenceMode { ACCEPT, WARN, FAIL };
+
+    public static final ConfigKey<LambdaPersistenceMode> LAMBDA_PERSISTENCE = ConfigKeys.newConfigKey(LambdaPersistenceMode.class, "brooklyn.persistence.advanced.lambdas",
+            "How to handle attempts to persist data (entities, esp effectors; feeds; etc) containing lambdas; default since Apache Brooklyn 1.1 is to 'FAIL' on lambdas that don't implement Serializable and 'WARN' on those which do, " +
+                    "because the former is guaranteed not to work and the latter is JVM-specific, and in all cases a concrete class is preferable. " +
+                    "This setting can be used to restore previous behavior where required, where Brooklyn will silently 'ACCEPT' them even though it often won't restore on de-serialization, " +
+                    "or a halfway house of 'WARN' (once only per type). Note the lambdas which implement Serializable may work in some JVMs but then break if deserialized to a different VM," +
+                    "and lambdas that do not implement Serializable will always serialize then restore as null. The default FAIL will flag these errors on creation. " +
+                    "The two cases 'if_serializale' and 'if_non_serializable' can be customized using sub-keys.", LambdaPersistenceMode.FAIL);
+    public static final ConfigKey<LambdaPersistenceMode> LAMBDA_PERSISTENCE_SERIALIZABLE = ConfigKeys.newConfigKey(LambdaPersistenceMode.class, "brooklyn.persistence.advanced.lambdas.if_serializable", null, LambdaPersistenceMode.WARN);
+    public static final ConfigKey<LambdaPersistenceMode> LAMBDA_PERSISTENCE_NON_SERIALIZABLE = ConfigKeys.newConfigKey(LambdaPersistenceMode.class, "brooklyn.persistence.advanced.lambdas.if_non_serializable", null, LambdaPersistenceMode.FAIL);
+
+
+    static Set<String> warnedTypes = MutableSet.of();
+
+    private final LambdaPersistenceMode persistenceMode;
+    private final LambdaPersistenceMode persistenceModeIfSerializable;
+    private final LambdaPersistenceMode persistenceModeIfNonSerializable;
+
+    public static Function<MapperWrapper,MapperWrapper> factory(ConfigBag properties) {
+        return factory(
+                properties.getFirst(LAMBDA_PERSISTENCE),
+                properties.getFirst(LAMBDA_PERSISTENCE_SERIALIZABLE, LAMBDA_PERSISTENCE),
+                properties.getFirst(LAMBDA_PERSISTENCE_NON_SERIALIZABLE, LAMBDA_PERSISTENCE) );
+    }
+
+    public static Function<MapperWrapper,MapperWrapper> factory(@Nonnull LambdaPersistenceMode persistenceMode, @Nullable LambdaPersistenceMode persistenceModeIfSerializable, @Nullable LambdaPersistenceMode persistenceModeIfNonSerializable) {
+        return wrapper -> new LambdaPreventionMapper(wrapper, persistenceMode, persistenceModeIfSerializable, persistenceModeIfNonSerializable);
+    }
+
+    public LambdaPreventionMapper(Mapper wrapped, @Nonnull LambdaPersistenceMode persistenceMode, @Nullable LambdaPersistenceMode persistenceModeIfSerializable, @Nullable LambdaPersistenceMode persistenceModeIfNonSerializable) {
+        super(wrapped);
+        this.persistenceMode = persistenceMode;
+        this.persistenceModeIfSerializable = persistenceModeIfSerializable;
+        this.persistenceModeIfNonSerializable = persistenceModeIfNonSerializable;
+    }
+
+    public String serializedClass(Class type) {
+        if (Types.isLambdaType(type)) {
+            LambdaPersistenceMode mode = null;
+            if (Serializable.class.isAssignableFrom(type)) {
+                mode = persistenceModeIfSerializable;
+            } else {
+                mode = persistenceModeIfNonSerializable;
+            }
+            if (mode==null) {
+                mode = persistenceMode;
+            }
+            if (mode==null) {
+                mode = LAMBDA_PERSISTENCE.getDefaultValue();
+            }
+            switch (mode) {
+                case ACCEPT:
+                    break;
+                case FAIL:
+                    throw new IllegalStateException("Attempt to XML serialize lambda: " + type + "; forbidden by configuration");
+                case WARN:
+                    if (warnedTypes.add(type.toString())) {
+                        LOG.warn("Attempt to XML serialize lambda: " + type + "; allowed, but may cause problems on de-serialization");
+                    }
+                    break;
+            }
+        }
+
+        return super.serializedClass(type);
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/entity/EntitySpecTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import java.util.Collection;
+import java.util.function.Supplier;
+import org.apache.brooklyn.util.collections.MutableList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerPerformanceTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerPerformanceTest.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.core.mgmt.rebind.dto.MementosGenerators;
 import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.sensor.Sensors;
@@ -55,7 +56,9 @@ public class XmlMementoSerializerPerformanceTest extends AbstractPerformanceTest
     public void setUp() throws Exception {
         super.setUp();
 
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerPerformanceTest.class.getClassLoader());
+        serializer = XmlMementoSerializerBuilder.empty()
+                .withBrooklynDeserializingClassRenames()
+                .withClassLoader(XmlMementoSerializerPerformanceTest.class.getClassLoader()).build();
     }
 
     protected int numIterations() {

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.mgmt.persist;
 
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import static org.testng.Assert.assertEquals;
 
 import java.net.InetAddress;
@@ -113,7 +114,9 @@ public class XmlMementoSerializerTest {
     
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerTest.class.getClassLoader());
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(XmlMementoSerializerTest.class.getClassLoader())
+                .withBrooklynDeserializingClassRenames()
+                .build();
     }
 
     @AfterMethod(alwaysRun=true)
@@ -126,8 +129,8 @@ public class XmlMementoSerializerTest {
     
     @Test
     public void testRenamedClass() throws Exception {
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerTest.class.getClassLoader(),
-                ImmutableMap.of("old.package.name.UserAndHostAndPort", UserAndHostAndPort.class.getName()));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(XmlMementoSerializerTest.class.getClassLoader()).
+                withDeserializingClassRenames(ImmutableMap.of("old.package.name.UserAndHostAndPort", UserAndHostAndPort.class.getName())).build();
         
         String serializedForm = Joiner.on("\n").join(
                 "<org.apache.brooklyn.util.net.UserAndHostAndPort>",
@@ -145,8 +148,8 @@ public class XmlMementoSerializerTest {
 
     @Test
     public void testRenamedStaticInner() throws Exception {
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerTest.class.getClassLoader(),
-                ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName()));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(XmlMementoSerializerTest.class.getClassLoader()).
+                withDeserializingClassRenames(ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName())).build();
         
         String serializedForm = Joiner.on("\n").join(
                 "<org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializerTest_-MyStaticInner>",
@@ -159,8 +162,8 @@ public class XmlMementoSerializerTest {
 
     @Test
     public void testRenamedNonStaticInner() throws Exception {
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerTest.class.getClassLoader(),
-                ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName()));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(XmlMementoSerializerTest.class.getClassLoader()).
+                withDeserializingClassRenames(ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName())).build();
         
         String serializedForm = Joiner.on("\n").join(
                 "<org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializerTest_-MyStaticInner_-MyNonStaticInner>",
@@ -177,8 +180,8 @@ public class XmlMementoSerializerTest {
 
     @Test
     public void testRenamedAnonymousInner() throws Exception {
-        serializer = new XmlMementoSerializer<Object>(XmlMementoSerializerTest.class.getClassLoader(),
-                ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName()));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(XmlMementoSerializerTest.class.getClassLoader()).
+                withDeserializingClassRenames(ImmutableMap.of("old.package.name.XmlMementoSerializerTest", XmlMementoSerializerTest.class.getName())).build();
         
         String serializedForm = Joiner.on("\n").join(
                 "<org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializerTest_-MySuper_-1>",
@@ -457,8 +460,9 @@ public class XmlMementoSerializerTest {
         Class<?> osgiObjectClazz = bundle.loadClass(classname);
         Object obj = Reflections.invokeConstructorFromArgs(osgiObjectClazz, "myval").get();
 
-        serializer = new XmlMementoSerializer<Object>(mgmt.getCatalogClassLoader(),
-                ImmutableMap.<String,String>of());
+        serializer = XmlMementoSerializerBuilder.empty()
+                .withDeserializingClassRenames(null)
+                .withClassLoader(mgmt.getCatalogClassLoader()).build();
         
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
 
@@ -487,8 +491,9 @@ public class XmlMementoSerializerTest {
         Class<?> osgiObjectClazz = bundle.loadClass(classname);
         Object obj = Reflections.invokeConstructorFromArgs(osgiObjectClazz, "myval").get();
 
-        serializer = new XmlMementoSerializer<Object>(mgmt.getCatalogClassLoader(),
-                ImmutableMap.of(oldBundlePrefix + ":" + classname, bundlePrefix + ":" + classname));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(mgmt.getCatalogClassLoader())
+                .withDeserializingClassRenames(ImmutableMap.of(oldBundlePrefix + ":" + classname, bundlePrefix + ":" + classname))
+                .build();
         
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
 
@@ -518,8 +523,9 @@ public class XmlMementoSerializerTest {
         Class<?> osgiObjectClazz = bundle.loadClass(classname);
         Object obj = Reflections.invokeConstructorFromArgs(osgiObjectClazz, "myval").get();
 
-        serializer = new XmlMementoSerializer<Object>(mgmt.getCatalogClassLoader(),
-                ImmutableMap.of(oldClassname, classname));
+        serializer = XmlMementoSerializerBuilder.empty().withClassLoader(mgmt.getCatalogClassLoader())
+                .withDeserializingClassRenames( ImmutableMap.of(oldClassname, classname) )
+                .build();
         serializer.setLookupContext(newEmptyLookupManagementContext(mgmt, true));
 
         // i.e. prepended with bundle name

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -62,6 +62,7 @@ import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.mgmt.persist.*;
+import org.apache.brooklyn.core.mgmt.persist.XmlMementoSerializer.XmlMementoSerializerBuilder;
 import org.apache.brooklyn.core.mgmt.rebind.PersistenceExceptionHandlerImpl;
 import org.apache.brooklyn.rest.api.ServerApi;
 import org.apache.brooklyn.rest.domain.ApiError;
@@ -593,7 +594,9 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
 
             // write persisted items and rebind to load applications
             BrooklynMementoRawData.Builder result = BrooklynMementoRawData.builder();
-            MementoSerializer<Object> rawSerializer = new XmlMementoSerializer<Object>(mgmt().getClass().getClassLoader());
+            MementoSerializer<Object> rawSerializer = XmlMementoSerializerBuilder.from(mgmt())
+                    .withBrooklynDeserializingClassRenames()
+                    .build();
             RetryingMementoSerializer<Object> serializer = new RetryingMementoSerializer<Object>(rawSerializer, 1);
 
             result.planeId(mgmt().getManagementPlaneIdMaybe().orNull());

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -1092,13 +1092,18 @@ public class Asserts {
     }
 
     public static void assertFailsWith(Runnable r, Predicate<? super Throwable> exceptionChecker) {
-        assertFailsWith(toCallable(r), exceptionChecker);
+        assertFailsWith(toCallable(r), exceptionChecker, false);
     }
     
     public static void assertFailsWith(Callable<?> c, Predicate<? super Throwable> exceptionChecker) {
+        assertFailsWith(c, exceptionChecker, true);
+    }
+
+    private static void assertFailsWith(Callable<?> c, Predicate<? super Throwable> exceptionChecker, boolean showResult) {
         boolean failed = false;
+        Object result = null;
         try {
-            c.call();
+            result = c.call();
         } catch (Throwable e) {
             failed = true;
             try {
@@ -1112,7 +1117,8 @@ public class Asserts {
                 throw Exceptions.propagate(e2);
             }
         }
-        if (!failed) fail("Test code should have thrown exception but did not");
+        if (!failed) fail("Test code should have thrown exception but did not" +
+                (showResult ? "; returned: "+result : ""));
     }
 
     public static void assertReturnsEventually(final Runnable r, Duration timeout) throws InterruptedException, ExecutionException, TimeoutException {


### PR DESCRIPTION
It has always been a bad idea but previously we have allowed it.  This causes obscure but horrible problems in many cases:

* lambdas which don't implement Serializable are written by xstream as `null`, and read back as null, with no warning
* lambdas which do implement Serializable might be okay written by xstream but might not, and can be read differently or not at all by different JVMs, and are even more brittle than inner classes

This PR causes us to be stricter about persisting lambdas e.g. within a config key or part of an effector so that we fail fast.

Default is to FAIL if we attempt to write one which will be treated as null, and WARN otherwise.  This can be configured in brooklyn.cfg using the keys in LambdaPreventionMapper.

In addition this adds a delta-persistence synchronously as part of application/entity creation, so if a problem is detected the creation will fail.  Things are unmanaged now if creation fails.

Internally there is more work done and more API methods to get access to failures during persistence.