### PR TITLE
Exclude 'logbook.log.sample' license to be checked

### DIFF
--- a/rest/rest-resources/pom.xml
+++ b/rest/rest-resources/pom.xml
@@ -244,6 +244,15 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>src/test/resources/logbook.log.sample</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This fix the build exception due to the lack of license on the file