### PR TITLE
Fix partial login when ldap user in no groups

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -109,8 +109,12 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
 
             DirContext ctx = new InitialDirContext(env);// will throw if password is invalid
             if (fetchUserGroups) {
-                // adds user groups ot eh session
-                sessionSupplierOnSuccess.get().setAttribute(USER_GROUPS, getUserGroups(user, ctx));
+                List<String> userGroups = getUserGroups(user, ctx);
+                if (userGroups.isEmpty()) {
+                    return false;
+                }
+                // adds user groups to the session
+                sessionSupplierOnSuccess.get().setAttribute(USER_GROUPS, userGroups);
             }
             return allow(sessionSupplierOnSuccess.get(), user);
         } catch (NamingException e) {


### PR DESCRIPTION
If ldap user is a member of no groups then they will fail to login but
will have a user associated with the session that cannot easily be
logged out or login as another user.

Fixed by not allowing authentication of a user in no groups.