### PR TITLE
Better scope root evaluation

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/DslComponent.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.camp.brooklyn.spi.dsl.methods;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Set;
+import java.util.function.Function;
 import static org.apache.brooklyn.camp.brooklyn.spi.dsl.DslUtils.resolved;
 
 import java.util.Collection;
@@ -111,6 +112,20 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         } else {
             return new DslComponent(scope, (DeferredSupplier<?>)componentId);
         }
+    }
+
+    public static DslComponent newInstanceChangingScope(Scope scope, DslComponent old, Function<String,String> dslUpdateFn) {
+        DslComponent result;
+        if (old.componentIdSupplier!=null) result = new DslComponent(scope, old.componentIdSupplier);
+        else if (old.componentId!=null) result = new DslComponent(scope, old.componentId);
+        else result = new DslComponent(scope);
+
+        if (dslUpdateFn!=null && old.dsl instanceof String) {
+            result.dsl = dslUpdateFn.apply((String) old.dsl);
+        } else {
+            result.dsl = old.dsl;
+        }
+        return result;
     }
 
     /**
@@ -1028,7 +1043,8 @@ public class DslComponent extends BrooklynDslDeferredSupplier<Entity> implements
         DESCENDANT,
         ANCESTOR,
         ROOT,
-        /** highest ancestor where all items come from the same catalog item ID */
+        /** root node of blueprint where the the DSL is used; usually the depth in ancestor,
+         *  though specially treated in CampResolver to handle usage within blueprints */
         SCOPE_ROOT,
         THIS;
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ConfigParametersYamlTest.java
@@ -662,8 +662,11 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
                 "- type: wrapper-entity",
                 "  brooklyn.config:",
                 "    key4: $brooklyn:config(\"my.param.key\")",
-                "    key4.from.root: $brooklyn:scopeRoot().config(\"my.param.key\")");
-        
+                "    key4.from.root: $brooklyn:scopeRoot().config(\"my.other.key\")",
+                "    my.other.key: notUsed",
+                "brooklyn.config:",
+                "  my.other.key: otherDefaultValue");
+
         Entity app = createStartWaitAndLogApplication(yaml);
         final TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("my.param.key")), "myDefaultValInOuter");
@@ -671,7 +674,8 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key3")), "myDefaultValInOuter");
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key3.from.root")), "myDefaultValInOuter");
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4")), "myDefaultValInOuter");
-        assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4.from.root")), "myDefaultValInOuter");
+        // scopeRoot in this context now correctly goes to application root; previously (before 2021-08) it looked at the place where the wrapper-entity was defined
+        assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4.from.root")), "otherDefaultValue");
     }
     
     @Test
@@ -714,8 +718,11 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
                 "- type: wrapper-entity",
                 "  brooklyn.config:",
                 "    key4: $brooklyn:config(\"my.param.key\")",
-                "    key4.from.root: $brooklyn:scopeRoot().config(\"my.param.key\")");
-        
+                "    key4.from.root: $brooklyn:scopeRoot().config(\"my.other.key\")",
+                "    my.other.key: notUsed",
+                "brooklyn.config:",
+                "  my.other.key: otherDefaultValue");
+
         Entity app = createStartWaitAndLogApplication(yaml);
         final TestEntity entity = (TestEntity) Iterables.getOnlyElement(app.getChildren());
         LOG.info("Config keys declared on "+entity+": "+entity.config().findKeysDeclared(Predicates.alwaysTrue()));
@@ -728,7 +735,8 @@ public class ConfigParametersYamlTest extends AbstractYamlRebindTest {
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key3")), "myDefaultVal");
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key3.from.root")), "myDefaultVal");
         assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4")), "myDefaultVal");
-        assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4.from.root")), "myDefaultVal");
+        // scopeRoot in this context now correctly goes to application root; previously (before 2021-08) it looked at the place where the wrapper-entity was defined
+        assertEquals(entity.config().get(ConfigKeys.newStringConfigKey("key4.from.root")), "otherDefaultValue");
     }
     
     @Test

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -586,7 +586,8 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         Entity e2 = nextChild(e1);
         assertScopes(e2, "APP-grandchild", app, app);
         Entity e3 = nextChild(e2);
-        assertScopes(e3, "APP-greatgrandchild=RP", app, e2, app);
+        // see logic in CampResolver which ensures scopeRoot in a nested blueprint refer to the root of that nested blueprint
+        assertScopes(e3, "APP-greatgrandchild=RP", app, e3, app);
         Entity e4 = nextChild(e3);
         assertScopes(e4, "RP-child", app, e3);
         Entity e5 = nextChild(e4);
@@ -622,14 +623,7 @@ public class EntitiesYamlTest extends AbstractYamlTest {
     private static void assertScopes(Entity entity, String name, Entity root, Entity scopeRoot, Entity scopeRoot2) {
         if (name!=null) assertEquals(entity.getDisplayName(), name);
         assertEquals(entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_ROOT), root);
-
-        Entity actualScopeRoot = entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_SCOPE_ROOT);
-        if (!actualScopeRoot.equals(scopeRoot) && !actualScopeRoot.equals(scopeRoot2)) {
-            Assert.fail("Wrong scope root; should be either "+scopeRoot+" or "+scopeRoot2+"; but is actually "+actualScopeRoot);
-        }
-        // TODO would be nice if we can capture which blueprint scopeRoot is used in - but this requires introspecting the DSL
-        // currently it will always equal scopeRoot2; if we could convert it to "self()" when the definition is loaded, that would solve it
-
+        assertEquals(entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_SCOPE_ROOT), scopeRoot);
         assertEquals(entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_SCOPE_ROOT2), scopeRoot2);
     }
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -536,59 +536,69 @@ public class EntitiesYamlTest extends AbstractYamlTest {
                 "  - id: ref_child",
                 "    item:",
                 "      type: " + ReferencingYamlTestEntity.class.getName(),
+                "      name: RC",
                 "      test.reference.root: $brooklyn:root()",
                 "      test.reference.scope_root: $brooklyn:scopeRoot()",
                 "      brooklyn.children:",
                 "      - type: " + ReferencingYamlTestEntity.class.getName(),
+                "        name: RC-child",
                 "        test.reference.root: $brooklyn:root()",
                 "        test.reference.scope_root: $brooklyn:scopeRoot()",
 
                 "  - id: ref_parent",
                 "    item:",
                 "      type: " + ReferencingYamlTestEntity.class.getName(),
+                "      name: RP",
                 "      test.reference.root: $brooklyn:root()",
                 "      test.reference.scope_root: $brooklyn:scopeRoot()",
                 "      brooklyn.children:",
                 "      - type: " + ReferencingYamlTestEntity.class.getName(),
+                "        name: RP-child",
                 "        test.reference.root: $brooklyn:root()",
                 "        test.reference.scope_root: $brooklyn:scopeRoot()",
                 "        brooklyn.children:",
-                "        - type: ref_child");
+                "        - type: ref_child",
+                "          name: RP-grandchild=RC");
         
         Entity app = createAndStartApplication(
                 "brooklyn.config:",
                 "  test.reference.root: $brooklyn:root()",
                 "  test.reference.scope_root: $brooklyn:scopeRoot()",
+                "name: APP",
                 "services:",
                 "- type: " + ReferencingYamlTestEntity.class.getName(),
+                "  name: APP-child",
                 "  test.reference.root: $brooklyn:root()",
                 "  test.reference.scope_root: $brooklyn:scopeRoot()",
                 "  brooklyn.children:",
                 "  - type: " + ReferencingYamlTestEntity.class.getName(),
+                "    name: APP-grandchild",
                 "    test.reference.root: $brooklyn:root()",
                 "    test.reference.scope_root: $brooklyn:scopeRoot()",
                 "    brooklyn.children:",
-                "    - type: ref_parent");
+                "    - type: ref_parent",
+                "      name: APP-greatgrandchild=RP");
         
-        assertScopes(app, app, app);
+        assertScopes(app, "APP", app, app);
         Entity e1 = nextChild(app);
-        assertScopes(e1, app, app);
+        assertScopes(e1, "APP-child", app, app);
         Entity e2 = nextChild(e1);
-        assertScopes(e2, app, app);
+        assertScopes(e2, "APP-grandchild", app, app);
         Entity e3 = nextChild(e2);
-        assertScopes(e3, app, e3);
+        assertScopes(e3, "APP-greatgrandchild=RP", app, e3);
         Entity e4 = nextChild(e3);
-        assertScopes(e4, app, e3);
+        assertScopes(e4, "RP-child", app, e3);
         Entity e5 = nextChild(e4);
-        assertScopes(e5, app, e5);
+        assertScopes(e5, "RP-grandchild=RC", app, e5);
         Entity e6 = nextChild(e5);
-        assertScopes(e6, app, e5);
+        assertScopes(e6, "RC-child", app, e5);
     }
     
     private static Entity nextChild(Entity entity) {
         return Iterables.getOnlyElement(entity.getChildren());
     }
-    private static void assertScopes(Entity entity, Entity root, Entity scopeRoot) {
+    private static void assertScopes(Entity entity, String name, Entity root, Entity scopeRoot) {
+        if (name!=null) assertEquals(entity.getDisplayName(), name);
         assertEquals(entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_ROOT), root);
         assertEquals(entity.config().get(ReferencingYamlTestEntity.TEST_REFERENCE_SCOPE_ROOT), scopeRoot);
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/EntitiesYamlTest.java
@@ -526,59 +526,58 @@ public class EntitiesYamlTest extends AbstractYamlTest {
             }
         }
     }
-    
-    @Test
-    public void testScopeReferences() throws Exception {
+
+    private void doTestScopeReferences(String reference) throws Exception {
         addCatalogItems(
                 "brooklyn.catalog:",
                 "  itemType: entity",
                 "  items:",
                 "  - id: ref_child",
                 "    item:",
-                "      type: " + ReferencingYamlTestEntity.class.getName(),
+                "      type: " + reference,
                 "      name: RC",
                 "      test.reference.root: $brooklyn:root()",
                 "      test.reference.scope_root: $brooklyn:scopeRoot()",
                 "      brooklyn.children:",
-                "      - type: " + ReferencingYamlTestEntity.class.getName(),
+                "      - type: " + reference,
                 "        name: RC-child",
                 "        test.reference.root: $brooklyn:root()",
                 "        test.reference.scope_root: $brooklyn:scopeRoot()",
 
                 "  - id: ref_parent",
                 "    item:",
-                "      type: " + ReferencingYamlTestEntity.class.getName(),
+                "      type: " + reference,
                 "      name: RP",
                 "      test.reference.root: $brooklyn:root()",
                 "      test.reference.scope_root: $brooklyn:scopeRoot()",
                 "      brooklyn.children:",
-                "      - type: " + ReferencingYamlTestEntity.class.getName(),
+                "      - type: " + reference,
                 "        name: RP-child",
                 "        test.reference.root: $brooklyn:root()",
                 "        test.reference.scope_root: $brooklyn:scopeRoot()",
                 "        brooklyn.children:",
                 "        - type: ref_child",
                 "          name: RP-grandchild=RC");
-        
+
         Entity app = createAndStartApplication(
                 "brooklyn.config:",
                 "  test.reference.root: $brooklyn:root()",
                 "  test.reference.scope_root: $brooklyn:scopeRoot()",
                 "name: APP",
                 "services:",
-                "- type: " + ReferencingYamlTestEntity.class.getName(),
+                "- type: " + reference,
                 "  name: APP-child",
                 "  test.reference.root: $brooklyn:root()",
                 "  test.reference.scope_root: $brooklyn:scopeRoot()",
                 "  brooklyn.children:",
-                "  - type: " + ReferencingYamlTestEntity.class.getName(),
+                "  - type: " + reference,
                 "    name: APP-grandchild",
                 "    test.reference.root: $brooklyn:root()",
                 "    test.reference.scope_root: $brooklyn:scopeRoot()",
                 "    brooklyn.children:",
                 "    - type: ref_parent",
                 "      name: APP-greatgrandchild=RP");
-        
+
         assertScopes(app, "APP", app, app);
         Entity e1 = nextChild(app);
         assertScopes(e1, "APP-child", app, app);
@@ -592,6 +591,23 @@ public class EntitiesYamlTest extends AbstractYamlTest {
         assertScopes(e5, "RP-grandchild=RC", app, e5);
         Entity e6 = nextChild(e5);
         assertScopes(e6, "RC-child", app, e5);
+    }
+    @Test
+    public void testScopeReferences() throws Exception {
+        doTestScopeReferences(ReferencingYamlTestEntity.class.getName());
+    }
+
+    @Test(groups="WIP")
+    public void testScopeReferencesComplex() throws Exception {
+        addCatalogItems(
+                "brooklyn.catalog:",
+                "  itemType: entity",
+                "  items:",
+                "  - id: ref_entity",
+                "    item:",
+                "      type: " + ReferencingYamlTestEntity.class.getName(),
+                "      name: RE");
+        doTestScopeReferences("ref_entity");
     }
     
     private static Entity nextChild(Entity entity) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencingYamlTestEntity.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/ReferencingYamlTestEntity.java
@@ -20,7 +20,9 @@ package org.apache.brooklyn.camp.brooklyn;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigInheritance;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.BasicConfigInheritance;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 
 import com.google.common.reflect.TypeToken;
@@ -34,6 +36,10 @@ public interface ReferencingYamlTestEntity extends Entity {
     @SuppressWarnings("serial")
     public static final ConfigKey<Entity> TEST_REFERENCE_SCOPE_ROOT = BasicConfigKey.builder(new TypeToken<Entity>(){})
             .name("test.reference.scope_root")
+            .build();
+    public static final ConfigKey<Entity> TEST_REFERENCE_SCOPE_ROOT2 = BasicConfigKey.builder(new TypeToken<Entity>(){})
+            .name("test.reference.scope_root2")
+            .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
             .build();
     @SuppressWarnings("serial")
     public static final ConfigKey<Entity> TEST_REFERENCE_APP = BasicConfigKey.builder(new TypeToken<Entity>(){})

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslYamlTest.java
@@ -260,18 +260,13 @@ public class DslYamlTest extends AbstractYamlTest {
                 "  - type: wrapping-simple");
         Entity child1 = Iterables.get(app.getChildren(), 0);
         Entity child2 = Iterables.get(app.getChildren(), 1);
-        assertScopeRoot(child1, false);
-        // TODO Not the result I'd expect - in both cases the entity argument should the the scopeRoot element, not its child
-        assertScopeRoot(child2, true);
+        assertChildScopeRootReferenceIs(child1);
+        assertChildScopeRootReferenceIs(child2);
     }
 
-    private void assertScopeRoot(Entity entity, boolean isScopeBugged) throws Exception {
+    private void assertChildScopeRootReferenceIs(Entity entity) throws Exception {
         Entity child = Iterables.getOnlyElement(entity.getChildren());
-        if (!isScopeBugged) {
-            assertEquals(getConfigEventually(child, DEST), entity);
-        } else {
-            assertEquals(getConfigEventually(child, DEST), child);
-        }
+        assertEquals(getConfigEventually(child, DEST), entity);
     }
 
     @Test

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.entity;
 
+import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import static org.apache.brooklyn.util.guava.Functionals.isSatisfied;
 
 import java.io.Closeable;
@@ -1149,6 +1150,16 @@ public class Entities {
 
     public static Entity catalogItemScopeRoot(Entity entity) {
         Entity root = entity;
+
+        Integer depth = BrooklynTags.getDepthInAncestorTag(root.tags().getTags());
+        if (depth!=null && depth>0) {
+            while (depth>0) {
+                root = root.getParent();
+                depth--;
+            }
+            return root;
+        }
+
         while (root.getParent() != null &&
                 root != root.getParent() &&
                 Objects.equal(root.getParent().getCatalogItemId(), root.getCatalogItemId())) {


### PR DESCRIPTION
scopeRoot logic was too simplistic where catalog types are used extensively.

this fixes it by using the DEPTH_IN_ANCESTOR tag to identify the right blueprint better.

it also has some special logic for root nodes to ensure scopeRoot when used in an ancestor type blueprint refers to the ancestor type, whereas when used on the same entity but in a referencing blueprint it refers to the root of the blueprint which refers to it