### PR TITLE
Deprecate AggregationJob.java

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
+++ b/core/src/main/java/org/apache/brooklyn/enricher/stock/aggregator/AggregationJob.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.annotations.Beta;
@@ -32,6 +33,8 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 
 @Beta
+@Deprecated
+/** @Deprecated since 1.0.0 No planed replacement */
 public final class AggregationJob implements Runnable {
 
     public static BasicAttributeSensorAndConfigKey<Map<String, String>> DASHBOARD_COST_PER_MONTH = new BasicAttributeSensorAndConfigKey(Map.class,


### PR DESCRIPTION
This was an experimental feature but nothing is using it. The logic is also very primitive and not fully baked in hence the deprecation