### PR TITLE
fix for 406 http error on post request ha/state

### DIFF
--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -136,7 +136,7 @@ public interface ServerApi {
     @POST
     @Path("/ha/state")
     @ApiOperation(value = "Changes the HA state of this management node")
-    @Produces({MediaType.APPLICATION_FORM_URLENCODED})
+    @Consumes({MediaType.APPLICATION_FORM_URLENCODED})
     public ManagementNodeState setHighAvailabilityNodeState(
             @ApiParam(name = "mode", value = "The state to change to")
             @FormParam("mode") HighAvailabilityMode mode);


### PR DESCRIPTION
The API '/v1/server/ha/state' failed to work with HTTP error 406 - Not Acceptable.

Changing @produces to @consumes fixes the error.