### PR TITLE
Adding new attribute to control save the user groups origin

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/entitlement/WebEntitlementContext.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class WebEntitlementContext implements EntitlementContext {
 
     public static final String USER_GROUPS = "brooklyn.entitlements.user.groups";
-
+    public static final String USER_GROUPS_ORIGIN = "brooklyn.entitlements.user.groups.origin";
 
     final String user;
     final String sourceIp;

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/EntitlementContextFilter.java
@@ -75,7 +75,9 @@ public class EntitlementContextFilter implements ContainerRequestFilter, Contain
                     remoteAddr,
                     uri,
                     uid,
-                    MutableMap.<String, Object>of().addIfNotNull(WebEntitlementContext.USER_GROUPS, getAttributeFromSession(WebEntitlementContext.USER_GROUPS)));
+                    MutableMap.<String, Object>of()
+                            .addIfNotNull(WebEntitlementContext.USER_GROUPS, getAttributeFromSession(WebEntitlementContext.USER_GROUPS))
+                            .addIfNotNull(WebEntitlementContext.USER_GROUPS_ORIGIN, getAttributeFromSession(WebEntitlementContext.USER_GROUPS_ORIGIN)));
             Entitlements.setEntitlementContext(entitlementContext);
         }
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_GROUPS;
+import static org.apache.brooklyn.core.mgmt.entitlement.WebEntitlementContext.USER_GROUPS_ORIGIN;
 
 /**
  * A {@link SecurityProvider} implementation that relies on LDAP to authenticate.
@@ -69,6 +70,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
     public static final Logger LOG = LoggerFactory.getLogger(LdapSecurityProvider.class);
 
     public static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    public static final String LDAP_USER_GROUPS_ORIGIN = "brooklyn.entitlements.user.groups.origin.LdapSecurityProvider";
     private final String ldapUrl;
     private final String defaultLdapRealm;
     private final String organizationUnit;
@@ -131,6 +133,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
 
             DirContext ctx = new InitialDirContext(env);// will throw if password is invalid
             if (fetchUserGroups) {
+                sessionSupplierOnSuccess.get().setAttribute(USER_GROUPS_ORIGIN, LDAP_USER_GROUPS_ORIGIN);
                 List<String> userGroups = getUserGroups(user, ctx);
                 if (userGroups.isEmpty()) {
                     addToInfoLog("Unsuccessful for " + user);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -70,7 +70,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
     public static final Logger LOG = LoggerFactory.getLogger(LdapSecurityProvider.class);
 
     public static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
-    public static final String LDAP_USER_GROUPS_ORIGIN = "brooklyn.entitlements.user.groups.origin.LdapSecurityProvider";
+    public static final String LDAP_USER_GROUPS_ORIGIN = LdapSecurityProvider.class.getName();
     private final String ldapUrl;
     private final String defaultLdapRealm;
     private final String organizationUnit;


### PR DESCRIPTION
Adds a new attribute in the WebEntitlementContext sincronized with the user session to keep the origin of the user groups