### PR TITLE
Default path for logbook using FileLogStore relative

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
@@ -60,7 +60,7 @@ public class FileLogStore implements LogStore {
     */
     public final static String BASE_NAME_FILE_LOG_STORE = BASE_NAME_LOGBOOK + ".fileLogStore";
     public final static ConfigKey<String> LOGBOOK_LOG_STORE_PATH = ConfigKeys.newStringConfigKey(
-            BASE_NAME_FILE_LOG_STORE + ".path", "Log file path", "/var/log/brooklyn/brooklyn.debug.log");
+            BASE_NAME_FILE_LOG_STORE + ".path", "Log file path", "data/log/brooklyn.debug.log");
 
     public final static ConfigKey<String> LOGBOOK_LOG_STORE_REGEX = ConfigKeys.newStringConfigKey(
             BASE_NAME_FILE_LOG_STORE + ".regexPattern",


### PR DESCRIPTION
Makes the Logbook work out of the box with the default log configuration using the relative path instead of the absolute based on the RPM installation.

Path can be overwrite modifying the brooklyn.cfg file with the next config-key to match the one in `etc/org.ops4j.pax.logging.cfg` in case it's changed: 
```
brooklyn.logbook.fileLogStore.path=<alternative path>
```