### PR TITLE
Bump xstream to 1.4.18 due to high level vulnerabilities

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlSerializer.java
@@ -18,16 +18,11 @@
  */
 package org.apache.brooklyn.util.core.xstream;
 
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
+import java.io.*;
+import java.util.*;
 
 import java.util.function.Function;
+
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
@@ -71,10 +66,7 @@ public class XmlSerializer<T> {
             }
         };
 
-        XStream.setupDefaultSecurity(xstream);
-        xstream.allowTypesByWildcard(new String[] {
-               "**"
-        });
+        allowAllTypes(xstream);
 
         if (loader!=null) {
             xstream.setClassLoader(loader);
@@ -105,11 +97,17 @@ public class XmlSerializer<T> {
 
         xstream.registerConverter(new EnumCaseForgivingConverter());
         xstream.registerConverter(new Inet4AddressConverter());
-        
+
         // See ObjectWithDefaultStringImplConverter (and its usage) for why we want to auto-detect 
         // annotations (usages of this is in the camp project, so we can't just list it statically
         // here unfortunately).
         xstream.autodetectAnnotations(true);
+    }
+
+    public static void allowAllTypes(final XStream xstream) {
+        xstream.allowTypesByWildcard(new String[] {
+                "**"
+        });
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/xstream/XmlSerializer.java
@@ -18,11 +18,16 @@
  */
 package org.apache.brooklyn.util.core.xstream;
 
-import java.io.*;
-import java.util.*;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 import java.util.function.Function;
-
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;

--- a/core/src/test/java/org/apache/brooklyn/util/core/xstream/CompilerCompatibilityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/xstream/CompilerCompatibilityTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertTrue;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 
-import org.apache.brooklyn.util.core.xstream.CompilerIndependentOuterClassFieldMapper;
 import org.apache.brooklyn.util.core.xstream.CompilerCompatibilityTest.EnclosingClass.DynamicClass;
 import org.apache.brooklyn.util.core.xstream.CompilerCompatibilityTest.EnclosingClass.DynamicExtendingClass;
 import org.apache.brooklyn.util.core.xstream.CompilerCompatibilityTest.EnclosingClass.EnclosingDynamicClass;
@@ -124,7 +123,7 @@ public class CompilerCompatibilityTest {
                 return new CompilerIndependentOuterClassFieldMapper(super.wrapMapper(next));
             }
         };
-
+        XmlSerializer.allowAllTypes(xstream);
         InputStream in = this.getClass().getResourceAsStream(inputUrl);
         try {
             Object obj = xstream.fromXML(in);

--- a/core/src/test/java/org/apache/brooklyn/util/core/xstream/ConverterTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/xstream/ConverterTestFixture.java
@@ -26,6 +26,7 @@ public class ConverterTestFixture {
 
     protected Object assertX(Object obj, String fmt) {
         XStream xstream = new XStream();
+        XmlSerializer.allowAllTypes(xstream);
         registerConverters(xstream);
         String s1 = xstream.toXML(obj);
         Assert.assertEquals(s1, fmt);

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <failureaccess.version>1.0.1</failureaccess.version>
 
         <!-- xstream -->
-        <xstream.version>1.4.17</xstream.version>
+        <xstream.version>1.4.18</xstream.version>
 
         <xpp3.servicemix.version>1.1.4c_7</xpp3.servicemix.version>
         <kxml2.servicemix.version>2.3.0_3</kxml2.servicemix.version>


### PR DESCRIPTION
Snyk detected the next vulnerabilities on prev version:
```
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569176] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569177] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569178] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569179] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569180] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569181] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569182] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Remote Code Execution (RCE) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569183] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569185] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569186] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Arbitrary Code Execution [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569187] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Server-Side Request Forgery (SSRF) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569190] in com.thoughtworks.xstream:xstream@1.4.17
  ✗ Server-Side Request Forgery (SSRF) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1569191] in com.thoughtworks.xstream:xstream@1.4.17
```

xstream 1.4.18 has deprecated the method `XStream.setupDefaultSecurity(xstream);`