### PR TITLE
Fix logbook query by EntityId or TaskId

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
@@ -41,7 +41,11 @@ public class LogBookQueryParams {
     private String dateTimeTo;
 
     /** The search phrase to look log items with */
-    private List<String> searchPhrases;
+    private String searchPhrase;
+
+    private String taskId;
+
+    private String entityId;
 
     public Integer getNumberOfItems() {
         return numberOfItems;
@@ -83,11 +87,27 @@ public class LogBookQueryParams {
         this.dateTimeTo = dateTimeTo;
     }
 
-    public List<String> getSearchPhrases() {
-        return searchPhrases;
+    public String getSearchPhrase() {
+        return searchPhrase;
     }
 
-    public void setSearchPhrases(List<String> searchPhrases) {
-        this.searchPhrases = searchPhrases;
+    public void setSearchPhrase(String searchPhrase) {
+        this.searchPhrase = searchPhrase;
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
@@ -105,8 +105,6 @@ public class FileLogStore implements LogStore {
 
             Date dateTimeFrom = Strings.isNonBlank(params.getDateTimeFrom()) ? Time.parseDate(params.getDateTimeFrom()) : null;
             Date dateTimeTo = Strings.isNonBlank(params.getDateTimeTo()) ? Time.parseDate(params.getDateTimeTo()) : null;
-            boolean isSearchPhrasesPresent = !Objects.isNull(params.getSearchPhrases()) && !params.getSearchPhrases().isEmpty();
-
             Predicate<BrooklynLogEntry> filter = brooklynLogEntry -> {
 
                 // Excludes unrecognized items or items without a date, typically they are multiline log messages.
@@ -120,6 +118,8 @@ public class FileLogStore implements LogStore {
                 boolean isDateTimeFromMatch = true;
                 boolean isDateTimeToMatch = true;
                 boolean isSearchPhraseMatch = true;
+                boolean isSearchTaskIdMatch = true;
+                boolean isSearchEntityIdMatch = true;
                 // Re-evaluate conditions if requested in the query.
 
                 // Check log levels.
@@ -141,12 +141,37 @@ public class FileLogStore implements LogStore {
                     }
                 }
 
-                // Check search phrases.
-                if (isSearchPhrasesPresent && Strings.isNonBlank(brooklynLogEntry.getMessage())) {
-                    isSearchPhraseMatch = containsSearchPhrases(brooklynLogEntry.getMessage(), params.getSearchPhrases());
+                // Check search entityId as field or part of the message.
+                if (Strings.isNonBlank(params.getEntityId()) &&
+                        (Strings.isNonBlank(brooklynLogEntry.getEntityIds()) || Strings.isNonBlank(brooklynLogEntry.getMessage())))
+                {
+                    isSearchEntityIdMatch =
+                            (Strings.isNonBlank(brooklynLogEntry.getEntityIds()) && brooklynLogEntry.getEntityIds().contains(params.getEntityId())) ||
+                                    (Strings.isNonBlank(brooklynLogEntry.getMessage()) && brooklynLogEntry.getMessage().contains(params.getEntityId()))
+                    ;
                 }
 
-                return isLogLevelMatch && isDateTimeFromMatch && isDateTimeToMatch && isSearchPhraseMatch;
+                // Check search taskId as field or part of the message.
+                if (Strings.isNonBlank(params.getTaskId()) &&
+                        (Strings.isNonBlank(brooklynLogEntry.getTaskId()) || Strings.isNonBlank(brooklynLogEntry.getMessage())))
+                {
+                    isSearchTaskIdMatch =
+                            params.getTaskId().equals(brooklynLogEntry.getTaskId()) ||
+                                    (Strings.isNonBlank(brooklynLogEntry.getMessage()) && brooklynLogEntry.getMessage().contains(params.getTaskId()));
+                }
+
+                // Check search phrases.
+                if (Strings.isNonBlank(params.getSearchPhrase()) && Strings.isNonBlank(brooklynLogEntry.getMessage())) {
+                    isSearchPhraseMatch = brooklynLogEntry.getMessage().contains(params.getSearchPhrase());
+                }
+
+
+                return isLogLevelMatch
+                        && isDateTimeFromMatch
+                        && isDateTimeToMatch
+                        && isSearchPhraseMatch
+                        && isSearchTaskIdMatch
+                        && isSearchEntityIdMatch;
             };
 
             // Use line count to supply identification of go lines.
@@ -200,16 +225,5 @@ public class FileLogStore implements LogStore {
             entry.setLineId(String.valueOf(lineCount.incrementAndGet()));
         }
         return entry;
-    }
-
-    public static boolean containsSearchPhrases(String logMessage, List<String> searchPhrases) {
-        boolean found = true;
-        for (String searchPhrase : searchPhrases) {
-            if (!logMessage.contains(searchPhrase)) {
-                found = false;
-                break;
-            }
-        }
-        return found;
     }
 }

--- a/core/src/test/java/org/apache/brooklyn/util/core/logbook/file/FileLogStoreTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/logbook/file/FileLogStoreTest.java
@@ -232,10 +232,10 @@ public class FileLogStoreTest extends TestCase {
 
         // Test with log levels only. There are 5 records in total in the normal order: DEBUG, ERROR, INFO, INFO, WARN.
         // Expect 4 last items starting with ERROR.
-        assertEquals("ERROR", brooklynLogEntries.get(0).getLevel());
+        assertEquals("INFO", brooklynLogEntries.get(0).getLevel());
         assertEquals("INFO", brooklynLogEntries.get(1).getLevel());
-        assertEquals("INFO", brooklynLogEntries.get(2).getLevel());
-        assertEquals("WARN", brooklynLogEntries.get(3).getLevel());
+        assertEquals("WARN", brooklynLogEntries.get(2).getLevel());
+        assertEquals("INFO", brooklynLogEntries.get(3).getLevel());
     }
 
     @Test
@@ -247,7 +247,7 @@ public class FileLogStoreTest extends TestCase {
         logBookQueryParams.setNumberOfItems(2); // Request first two only.
         logBookQueryParams.setTail(false);
         logBookQueryParams.setLevels(ImmutableList.of());
-        logBookQueryParams.setSearchPhrases(ImmutableList.of("Cannot register component")); // Request search phrase.
+        logBookQueryParams.setSearchPhrase("Cannot register component"); // Request search phrase.
         FileLogStore fileLogStore = new FileLogStore(mgmt);
         List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
         assertEquals(1, brooklynLogEntries.size());
@@ -267,7 +267,23 @@ public class FileLogStoreTest extends TestCase {
     }
 
     @Test
-    public void testQueryLogSampleWithSearchMultiplePhrases() {
+    public void testQueryLogSampleWithTaskId() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        ManagementContextInternal mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(5); // Request first five only, only three expected.
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setTaskId("CMeSRJNF");
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+        assertEquals(2, brooklynLogEntries.size());
+        assertEquals("INFO", brooklynLogEntries.get(1).getLevel());
+    }
+
+    @Test
+    public void testQueryLogSampleWithTaskIdAndPhase() {
         File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
         ManagementContextInternal mgmt = LocalManagementContextForTests.newInstance();
         mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
@@ -275,22 +291,62 @@ public class FileLogStoreTest extends TestCase {
         logBookQueryParams.setNumberOfItems(2); // Request first two only.
         logBookQueryParams.setTail(false);
         logBookQueryParams.setLevels(ImmutableList.of());
-        logBookQueryParams.setSearchPhrases(ImmutableList.of("bundle")); // Request search phrase.
+        logBookQueryParams.setTaskId("CMeSRJNF");
+        logBookQueryParams.setSearchPhrase("testing");
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+        assertEquals(1, brooklynLogEntries.size());
+        assertEquals("INFO", brooklynLogEntries.get(0).getLevel());
+    }
+
+    @Test
+    public void testQueryLogSampleWithEntityId() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        ManagementContextInternal mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(10); // Request first two only.
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setEntityId("l8442kq0zu");
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+        assertEquals(4, brooklynLogEntries.size());
+        assertEquals("INFO", brooklynLogEntries.get(0).getLevel());
+    }
+
+    @Test
+    public void testQueryLogSampleWithEntityIdAndPhase() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        ManagementContextInternal mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(2); // Request first two only.
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setEntityId("l8442kq0zu");
+        logBookQueryParams.setSearchPhrase("testing");
         FileLogStore fileLogStore = new FileLogStore(mgmt);
         List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
         assertEquals(2, brooklynLogEntries.size());
+        assertEquals("INFO", brooklynLogEntries.get(0).getLevel());
+    }
 
-        // Search phrase appears in ERROR and WARN log lines.
+    @Test
+    public void testQueryLogSampleWithEntityIdInMessageAndPhase() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        ManagementContextInternal mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(2); // Request first two only.
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setEntityId("iffj68b370");
+        logBookQueryParams.setSearchPhrase("testing");
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+        assertEquals(2, brooklynLogEntries.size());
         assertEquals("ERROR", brooklynLogEntries.get(0).getLevel());
-        assertEquals("WARN", brooklynLogEntries.get(1).getLevel());
-
-        // Now request multiple search phrases
-        logBookQueryParams.setSearchPhrases(ImmutableList.of("bundle", "is waiting for dependencies"));
-        brooklynLogEntries = fileLogStore.query(logBookQueryParams);
-        assertEquals(1, brooklynLogEntries.size());
-
-        // 2 phrases appear in WARN log line only
-        assertEquals("WARN", brooklynLogEntries.get(0).getLevel());
     }
 
     @Test
@@ -325,7 +381,7 @@ public class FileLogStoreTest extends TestCase {
         // Check first log line,
         BrooklynLogEntry firstBrooklynLogEntry = brooklynLogEntries.get(0);
         assertEquals("INFO", firstBrooklynLogEntry.getLevel());
-        assertEquals("  org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT", firstBrooklynLogEntry.getMessage());
+        assertEquals("  org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT in entity l8442kq0zu", firstBrooklynLogEntry.getMessage());
 
         // Check second log line.
         BrooklynLogEntry secondBrooklynLogEntry = brooklynLogEntries.get(1);
@@ -345,8 +401,8 @@ public class FileLogStoreTest extends TestCase {
         FileLogStore fileLogStore = new FileLogStore(mgmt);
         List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
 
-        // There is one DEBUG log line and two INFO lines.
-        assertEquals(3, brooklynLogEntries.size());
+        // There is one DEBUG log line and five INFO lines.
+        assertEquals(6, brooklynLogEntries.size());
 
         // Check appearance of log levels
         assertEquals("DEBUG", brooklynLogEntries.get(0).getLevel());

--- a/core/src/test/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStoreTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStoreTest.java
@@ -130,20 +130,58 @@ public class OpenSearchLogStoreTest {
         p.setNumberOfItems(10);
         p.setTail(false);
         p.setLevels(ImmutableList.of());
-        p.setSearchPhrases(ImmutableList.of("some phrase"));
+        p.setSearchPhrase("some phrase");
         String query = cut.getJSONQuery(p);
         assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"match_phrase\":{\"message\":\"some phrase\"}}]}}}");
     }
 
     @Test
-    public void queryWithSearchMultiplePhrases() {
+    public void queryWithEntityId() {
         OpenSearchLogStore cut = new OpenSearchLogStore();
         LogBookQueryParams p = new LogBookQueryParams();
         p.setNumberOfItems(10);
         p.setTail(false);
         p.setLevels(ImmutableList.of());
-        p.setSearchPhrases(ImmutableList.of("some phrase", "another phrase"));
+        p.setEntityId("entityIdxx");
         String query = cut.getJSONQuery(p);
-        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"match_phrase\":{\"message\":\"some phrase\"}},{\"match_phrase\":{\"message\":\"another phrase\"}}]}}}");
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match_phrase\":{\"entityIds\":\"entityIdxx\"}},{\"match_phrase\":{\"message\":\"entityIdxx\"}}]}}]}}}");
+    }
+
+    @Test
+    public void queryWithTaskId() {
+        OpenSearchLogStore cut = new OpenSearchLogStore();
+        LogBookQueryParams p = new LogBookQueryParams();
+        p.setNumberOfItems(10);
+        p.setTail(false);
+        p.setLevels(ImmutableList.of());
+        p.setTaskId("taskIdxxxx");
+        String query = cut.getJSONQuery(p);
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match_phrase\":{\"taskId\":\"taskIdxxxx\"}},{\"match_phrase\":{\"message\":\"taskIdxxxx\"}}]}}]}}}");
+    }
+
+    @Test
+    public void queryWithEntityIdAndPhrase() {
+        OpenSearchLogStore cut = new OpenSearchLogStore();
+        LogBookQueryParams p = new LogBookQueryParams();
+        p.setNumberOfItems(10);
+        p.setTail(false);
+        p.setLevels(ImmutableList.of());
+        p.setEntityId("entityIdxx");
+        p.setSearchPhrase("some phrase");
+        String query = cut.getJSONQuery(p);
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match_phrase\":{\"entityIds\":\"entityIdxx\"}},{\"match_phrase\":{\"message\":\"entityIdxx\"}}]}},{\"match_phrase\":{\"message\":\"some phrase\"}}]}}}");
+    }
+
+    @Test
+    public void queryWithTaskIdAndPhrase() {
+        OpenSearchLogStore cut = new OpenSearchLogStore();
+        LogBookQueryParams p = new LogBookQueryParams();
+        p.setNumberOfItems(10);
+        p.setTail(false);
+        p.setLevels(ImmutableList.of());
+        p.setTaskId("taskIdxxxx");
+        p.setSearchPhrase("some phrase");
+        String query = cut.getJSONQuery(p);
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match_phrase\":{\"taskId\":\"taskIdxxxx\"}},{\"match_phrase\":{\"message\":\"taskIdxxxx\"}}]}},{\"match_phrase\":{\"message\":\"some phrase\"}}]}}}");
     }
 }

--- a/core/src/test/resources/brooklyn/util/core/logbook/file/log-sample.txt
+++ b/core/src/test/resources/brooklyn/util/core/logbook/file/log-sample.txt
@@ -20,6 +20,12 @@
 org.osgi.service.component.ComponentException: The component name 'org.apache.brooklyn.ui.external.module' has already been registered by Bundle 293 (org.apache.brooklyn.ui.modularity.brooklyn-ui-external-modules) as Component of Class org.apache.brooklyn.ui.modularity.ExternalUiModule
 	at org.apache.felix.scr.impl.ComponentRegistry.checkComponentName(ComponentRegistry.java:240) ~[?:?]
 	at org.apache.felix.scr.impl.BundleComponentActivator.validateAndRegister(BundleComponentActivator.java:443) ~[?:?]
-2021-07-05T12:38:10,355Z - INFO   18 o.a.k.f.i.s.FeaturesServiceImpl [tures-3-thread-1]   org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT
+2021-07-05T12:38:10,355Z - INFO   18 o.a.k.f.i.s.FeaturesServiceImpl [tures-3-thread-1]   org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT in entity l8442kq0zu
 2021-07-05T12:38:11,382Z - INFO  178 o.o.p.w.s.j.i.HttpServiceContext [ender-3-thread-2] registering JasperInitializer
 2021-07-05T12:38:12,369Z - WARN   48 o.a.a.b.c.BlueprintContainerImpl [tures-3-thread-1] Blueprint bundle org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT is waiting for dependencies [(objectClass=org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal), (objectClass=org.apache.brooklyn.core.mgmt.ShutdownHandler)]
+2021-08-30T11:28:24,764Z - ERROR   18 o.a.k.f.i.s.FeaturesServiceImpl [tures-3-thread-1]   org.apache.brooklyn.ui.modularity.brooklyn-ui-module-registry/1.1.0.SNAPSHOT in entity iffj68b370 and testing
+2021-08-30T11:28:25,764Z CMeSRJNF-[l8442kq0zu,iffj68b370] WARN  237 i.c.b.t.c.AbstractToscaYamlConverter [ger-rhkc5jtA-351] key 'brooklyn.locations' not supported
+2021-08-30T11:28:26,764Z CMeSRJNF-[l8442kq0zu,iffj68b370] INFO  237 i.c.b.t.c.AbstractToscaYamlConverter [ger-rhkc5jtA-351] for testing
+2021-08-30T11:28:27,764Z CMeSRJNX-[l8442kq0zu,iffj68b370] INFO  237 i.c.b.t.c.AbstractToscaYamlConverter [ger-rhkc5jtA-351] for testing
+2021-08-30T11:28:28,764Z CMeSRJNX-[l8442kq0zx,iffj68b370] WARN  237 i.c.b.t.c.AbstractToscaYamlConverter [ger-rhkc5jtA-351] key 'brooklyn.locations' not supported
+2021-08-30T11:28:54,466Z THGMmYiu-[l8442kq0zx,iffj68b370] INFO  282 o.a.b.e.s.b.l.MachineLifecycleEffectorTasks [ger-rhkc5jtA-360] Starting ToscaComputeNodeEntityImpl{id=iffj68b370} on machine SshMachineLocation[cloudsoft-ubuntu:cloudsoft@135.181.244.108/135.181.244.108:22(id=dr6f7lah7i)]


### PR DESCRIPTION
It try to find the Ids in the fields and the message for both, `FileLogStore` and `OpenSearchLogStore`,  instead of only search for it on the message as before.

Requires changes in the UI for sending the Ids as independent fields in the query parameters: 
https://github.com/apache/brooklyn-ui/pull/275