### PR TITLE
ensuring the server is not terminated after persistence import

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -619,7 +619,6 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
             rebindManager.stop();
             persister.stop(true);
             tempPersistenceStore.close();
-            tempMgmt.terminate();
 
         } catch (Exception e){
             Exceptions.propagateIfFatal(e);


### PR DESCRIPTION
Calling the terminate on the temporary management context causes closure of OSGI which results in terminating AMP server after this operation. The removal of the termination call fixes the issue. 
It's fine as the temp management context is garbage collected.