### PR TITLE
Add user name regex for LDAP authentication

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
@@ -78,7 +78,10 @@ public class BrooklynWebConfig {
     public final static ConfigKey<String> SHA256_FOR_USER(String user) {
         return ConfigKeys.newStringConfigKey(BASE_NAME_SECURITY + ".user." + user + ".sha256");
     }
-    
+
+    public final static ConfigKey<String> LDAP_USERNAME_REGEX = ConfigKeys.newStringConfigKey(
+            BASE_NAME_SECURITY+".ldap.user_name_regex");
+
     public final static ConfigKey<String> LDAP_URL = ConfigKeys.newStringConfigKey(
             BASE_NAME_SECURITY+".ldap.url");
 


### PR DESCRIPTION
New ConfigKey for set up a regex pattern to be matched by the user names before checking credentials in the LDAP server, avoiding unnecessary request

eg. for  `domain\user` pattern:

```
brooklyn.webconsole.security.ldap.user_name_regex=.*\\.*
```