### PR TITLE
removing extra subdir causing import issues

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -527,7 +527,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
             BrooklynPersistenceUtils.writeMemento(mgmt(), targetStore, preferredOrigin);
             
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), ((FileBasedObjectStore)targetStore).getBaseDir().getName()  + "/data" ).stream(baos);
+            ArchiveBuilder.zip().addDirContentsAt( ((FileBasedObjectStore)targetStore).getBaseDir(), "data" ).stream(baos);
             Os.deleteRecursively(dir);
             String filename = "brooklyn-state-"+label+".zip";
             return Response.ok(baos.toByteArray(), MediaType.APPLICATION_OCTET_STREAM_TYPE)


### PR DESCRIPTION
Export feature originally captured a zip 'brooklyn-state-id-timestamp' which also contained a subdir named 'web-persistence-id-timestamp' causing the data dir being unable to be found (as it was not in root but in web-persistence...').

Not straightforward to find the subdir name because of extra data like timestamp, but not really necessary for it to be there so removed.

Now, in the root of archive there is a data dir that has the persistence state data.