### PR TITLE
Separate logic for domain name and user name regex

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/BrooklynWebConfig.java
@@ -79,8 +79,11 @@ public class BrooklynWebConfig {
         return ConfigKeys.newStringConfigKey(BASE_NAME_SECURITY + ".user." + user + ".sha256");
     }
 
+    public final static ConfigKey<String> LDAP_DOMAIN_REGEX = ConfigKeys.newStringConfigKey(
+            BASE_NAME_SECURITY+".ldap.domain_name_regex","Regex pattern for the domain","");
+
     public final static ConfigKey<String> LDAP_USERNAME_REGEX = ConfigKeys.newStringConfigKey(
-            BASE_NAME_SECURITY+".ldap.user_name_regex");
+            BASE_NAME_SECURITY+".ldap.user_name_regex","Regex pattern for the username","");
 
     public final static ConfigKey<String> LDAP_URL = ConfigKeys.newStringConfigKey(
             BASE_NAME_SECURITY+".ldap.url");

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/LdapSecurityProvider.java
@@ -75,6 +75,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
     private final String defaultLdapRealm;
     private final String organizationUnit;
     private final String userNameRegex;
+    private final String domainRegex;
     private boolean logUserLoginAttempt;
     private boolean fetchUserGroups = false;
     private List<String> validGroups;
@@ -85,6 +86,7 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
         Strings.checkNonEmpty(ldapUrl, "LDAP security provider configuration missing required property " + BrooklynWebConfig.LDAP_URL);
         fetchUserGroups = properties.getConfig(BrooklynWebConfig.LDAP_FETCH_USER_GROUPS);
         logUserLoginAttempt = properties.getConfig(BrooklynWebConfig.LDAP_LOGIN_INFO_LOG);
+        domainRegex = properties.getConfig(BrooklynWebConfig.LDAP_DOMAIN_REGEX);
         userNameRegex = properties.getConfig(BrooklynWebConfig.LDAP_USERNAME_REGEX);
         List ldapGroupsPrefixes = properties.getConfig(BrooklynWebConfig.GROUP_CONFIG_KEY_NAME);
         if (fetchUserGroups && !ldapGroupsPrefixes.isEmpty()) {
@@ -113,14 +115,16 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
         this.defaultLdapRealm = ldapRealm;
         this.organizationUnit = organizationUnit;
         this.userNameRegex = "";
+        this.domainRegex = "";
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
         if (user == null) return false;
-        if(Strings.isNonEmpty(userNameRegex) && !user.matches(userNameRegex)){
-            LOG.debug("Rejecting authenticating attempt for user `{}` due to userNameRegex configuration: {}", user, userNameRegex);
+        String ldapRegex = getLdapRegexPattern();
+        if(Strings.isNonEmpty(ldapRegex) && !user.matches(ldapRegex)){
+            LOG.debug("Rejecting authenticating attempt for user `{}` due to userNameRegex configuration: {}", user, ldapRegex);
             return false;
         }
         checkCanLoad();
@@ -158,6 +162,15 @@ public class LdapSecurityProvider extends AbstractSecurityProvider implements Se
             addToInfoLog("Unsuccessful for " + user);
             return false;
         }
+    }
+
+    private String getLdapRegexPattern() {
+        if(Strings.isBlank(domainRegex) && Strings.isBlank(userNameRegex)) return "";
+        if(Strings.isBlank(domainRegex)) return userNameRegex;
+        return Strings.join(new String[]{
+                        domainRegex,
+                        Strings.isNonBlank(userNameRegex) ? userNameRegex : ".*"}
+                , "\\\\");
     }
 
     private List<String> getConfiguredGroups(StringConfigMap properties, List<String> prefixes) {


### PR DESCRIPTION
Two properties for handle a _domain_ name and _username_ regex before validating credentials on the LDAP server:
eg:

```
brooklyn.webconsole.security.ldap.user_name_regex=.*
brooklyn.webconsole.security.ldap.domain_name_regex=DOMAIN
```
will try to validate only usernames with the format `DOMAIN\<user>`