### PR TITLE
Fix path to tomcat icons on apache.org

### DIFF
--- a/test-framework/src/test/resources/test-framework-examples/example-catalog-test.bom
+++ b/test-framework/src/test/resources/test-framework-examples/example-catalog-test.bom
@@ -20,7 +20,7 @@ brooklyn.catalog:
   id: simple-tomcat-test
   version: 1.0
   itemType: template
-  iconUrl: http://tomcat.apache.org/images/tomcat.png
+  iconUrl: http://tomcat.apache.org/res/images/tomcat.png
   name: Simple Tomcat Test
   license: Apache-2.0
   item:

--- a/test-framework/src/test/resources/test-framework-examples/example-catalog.bom
+++ b/test-framework/src/test/resources/test-framework-examples/example-catalog.bom
@@ -20,7 +20,7 @@ brooklyn.catalog:
   id: simple-tomcat
   version: 1.0
   itemType: template
-  iconUrl: http://tomcat.apache.org/images/tomcat.png
+  iconUrl: http://tomcat.apache.org/res/images/tomcat.png
   name: Simple Tomcat
   license: Apache-2.0
   item:


### PR DESCRIPTION
Set correct path for `tomcat.png` icon URL on the Apache server.