### PR TITLE
Configurable sanitizing

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynComponentTemplateResolver.java
@@ -63,6 +63,7 @@ import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
 import org.apache.brooklyn.core.mgmt.ManagementContextInjectable;
 import org.apache.brooklyn.core.mgmt.classloading.JavaBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.resolve.entity.EntitySpecResolver;
+import org.apache.brooklyn.core.typereg.AbstractTypePlanTransformer;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -283,6 +284,13 @@ public class BrooklynComponentTemplateResolver {
         new BrooklynEntityDecorationResolver.TagsResolver(yamlLoader).decorate(spec, attrs, encounteredRegisteredTypeIds);
 
         configureEntityConfig(spec, encounteredRegisteredTypeIds);
+
+        // check security. we probably used the catalog resolver which will have delegated to the transformer;
+        // but if we used the java resolver or one of the others, then:
+        // - we won't have all the right source tags, but that's okay
+        // - depth will come from the containing transformer and so be ignored here (which is fine, none of them should have children)
+        // - secure fields won't be scanned - need to fix that; just check again here on the spec, and above on the spec decorations
+        AbstractTypePlanTransformer.checkSecuritySensitiveFields(spec);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/BrooklynEntityDecorationResolver.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.objs.BasicSpecParameter;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.typereg.AbstractTypePlanTransformer;
 import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -148,6 +149,9 @@ public abstract class BrooklynEntityDecorationResolver<DT> {
                 spec = classFactory.apply((Class<DTInterface>)type).parameters(BasicSpecParameter.fromClass(mgmt, type));
             }
             spec.configure(decoLoader.getConfigMap());
+
+            AbstractTypePlanTransformer.checkSecuritySensitiveFields(spec);
+
             return spec;
         }
 

--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampTypePlanTransformer.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/creation/CampTypePlanTransformer.java
@@ -109,10 +109,7 @@ public class CampTypePlanTransformer extends AbstractTypePlanTransformer {
     @Override
     protected AbstractBrooklynObjectSpec<?, ?> createSpec(RegisteredType type, RegisteredTypeLoadingContext context) throws Exception {
         try {
-            return decorateWithCommonTags(
-                    checkSecuritySensitiveFields(
-                            new CampResolver(mgmt, type, context).createSpec()
-                    ),
+            return decorateWithCommonTags(new CampResolver(mgmt, type, context).createSpec(),
                     type, null, null, prevHeadSpecSummary -> "Based on "+prevHeadSpecSummary);
 
         } catch (Exception e) {
@@ -138,35 +135,6 @@ public class CampTypePlanTransformer extends AbstractTypePlanTransformer {
                 throw e;
             }
         }
-    }
-
-    @Beta
-    public static AbstractBrooklynObjectSpec<?,?> checkSecuritySensitiveFields(AbstractBrooklynObjectSpec<?,?> spec) {
-        if (Sanitizer.isSensitiveFieldsPlaintextBlocked()) {
-            // if blocking plaintext values, check them before instantiating
-            Predicate<Object> predicate = Sanitizer.IS_SECRET_PREDICATE;
-            spec.getConfig().forEach( (key,val) -> failOnInsecureValueForSensitiveNamedField(predicate, key.getName(), val) );
-            spec.getFlags().forEach( (key,val) -> failOnInsecureValueForSensitiveNamedField(predicate, key, val) );
-        }
-        return spec;
-    }
-
-    public static void failOnInsecureValueForSensitiveNamedField(Predicate<Object> tokens, String key, Object val) {
-        if (val instanceof BrooklynDslDeferredSupplier || val==null) {
-            // value allowed; key is irrelevant
-            return;
-        }
-        if (!tokens.apply(key)) {
-            // not a sensitive named key
-            return;
-        }
-
-        // sensitive named key
-        if (val instanceof String || Boxing.isPrimitiveOrBoxedClass(val.getClass()) || val instanceof Number) {
-            // value
-            throw new IllegalStateException("Insecure value supplied for '"+key+"'; external suppliers must be used here");
-        }
-        // complex values allowed
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -53,6 +53,7 @@ import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.core.catalog.CatalogPredicates;
 import org.apache.brooklyn.core.catalog.internal.CatalogClasspathDo.CatalogScanningModes;
 import org.apache.brooklyn.core.config.ConfigUtils;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
 import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
 import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
@@ -1736,7 +1737,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         }
 
         // often in tests we don't have osgi and so it acts as follows
-        log.debug("Catalog load, adding registered types to "+mgmt+": "+catalogYaml);
+        log.debug("Catalog load, adding registered types to "+mgmt+": "+ Sanitizer.sanitizeMultilineString(catalogYaml));
         if (result==null) result = MutableMap.of();
         collectCatalogItemsFromCatalogBomRoot("unbundled catalog definition", catalogYaml, null, null, result, false, MutableMap.of(), 0, forceUpdate, true);
 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -563,7 +563,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
         }
         Map<?,?> catalogMetadata = getFirstAsMap(itemDef, "brooklyn.catalog").orNull();
         if (catalogMetadata==null)
-            log.warn("No `brooklyn.catalog` supplied in catalog request; using legacy mode for "+itemDef);
+            log.warn("No `brooklyn.catalog` supplied in catalog request; using legacy mode for "+Sanitizer.sanitize(itemDef));
         catalogMetadata = MutableMap.copyOf(catalogMetadata);
 
         collectCatalogItemsFromItemMetadataBlock(Yamls.getTextOfYamlAtPath(yaml, "brooklyn.catalog").getMatchedYamlTextOrWarn(), 
@@ -813,7 +813,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 // TODO we should let the plan transformer give us this
                 symbolicName = setFromItemIfUnset(symbolicName, itemAsMap, "template_name");
                 if (Strings.isBlank(symbolicName)) {
-                    log.error("Can't infer catalog item symbolicName from the following plan:\n" + sourceYaml);
+                    log.error("Can't infer catalog item symbolicName from the following plan:\n" + Sanitizer.sanitizeJsonTypes(sourceYaml));
                     throw new IllegalStateException("Can't infer catalog item symbolicName from catalog item metadata");
                 }
             }
@@ -871,7 +871,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
                 if (Strings.isNonBlank(symbolicName)) {
                     id = symbolicName;
                 } else {
-                    log.error("Can't infer catalog item id from the following plan:\n" + sourceYaml);
+                    log.error("Can't infer catalog item id from the following plan:\n" + Sanitizer.sanitizeJsonTypes(sourceYaml));
                     throw new IllegalStateException("Can't infer catalog item id from catalog item metadata");
                 }
             }
@@ -1687,7 +1687,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
     @Override
     public List<? extends CatalogItem<?,?>> addItems(String yaml, ManagedBundle bundle, boolean forceUpdate) {
-        log.debug("Adding catalog item to "+mgmt+": "+yaml);
+        log.debug("Adding catalog item to "+mgmt+": "+Sanitizer.sanitizeJsonTypes(yaml));
         checkNotNull(yaml, "yaml");
         List<CatalogItemDtoAbstract<?, ?>> result = MutableList.of();
         collectCatalogItemsFromCatalogBomRoot("caller-supplied YAML", yaml, bundle, result, null, true, ImmutableMap.of(), 0, forceUpdate, true);
@@ -1718,7 +1718,7 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
     
     @Override @Beta
     public void addTypesFromBundleBom(String yaml, ManagedBundle bundle, boolean forceUpdate, Map<RegisteredType, RegisteredType> result) {
-        log.debug("Catalog load, adding registered types to "+mgmt+" for bundle "+bundle+": "+yaml);
+        log.debug("Catalog load, adding registered types to "+mgmt+" for bundle "+bundle+": "+Sanitizer.sanitizeJsonTypes(yaml));
         checkNotNull(yaml, "yaml");
         if (result==null) result = MutableMap.of();
         collectCatalogItemsFromCatalogBomRoot("bundle BOM in "+bundle, yaml, bundle, null, result, false, MutableMap.of(), 0, forceUpdate, false);

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -18,33 +18,27 @@
  */
 package org.apache.brooklyn.core.config;
 
-import com.google.common.reflect.TypeToken;
-import java.io.ByteArrayInputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import java.util.stream.Collectors;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.server.BrooklynServerConfig;
-import org.apache.brooklyn.util.core.config.ConfigBag;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.server.BrooklynServerConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.osgi.Osgis;
-import org.apache.brooklyn.util.internal.BrooklynSystemProperties;
 import org.apache.brooklyn.util.internal.StringSystemProperty;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.StringEscapes.BashStringEscapes;
 import org.apache.brooklyn.util.text.Strings;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.ServiceReference;
 
 public final class Sanitizer {
 
@@ -145,7 +139,8 @@ public final class Sanitizer {
     }
 
     public static String suppress(Object value) {
-        String md5Checksum = Streams.getMd5Checksum(new ByteArrayInputStream(("" + value).getBytes()));
+        // only include the first few chars so that malicious observers can't uniquely brute-force discover the source
+        String md5Checksum = Strings.maxlen(Streams.getMd5Checksum(new ByteArrayInputStream(("" + value).getBytes())), 8);
         return "<suppressed> (MD5 hash: " + md5Checksum + ")";
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -269,6 +269,8 @@ public final class Sanitizer {
             return (K) applySet((Set) input, visited);
         } else if (input instanceof String) {
             return (K) sanitizeMultilineString((String) input);
+        } else if (input instanceof ConfigBag) {
+            return (K) ConfigBag.newInstance( applyMap( ((ConfigBag)input).getAllConfig(), visited) );
         } else {
             return (K) input;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -68,7 +68,8 @@ public final class Sanitizer {
     private static long LAST_SENSITIVE_FIELDS_CACHE_MILLIS = 60*1000;
 
     private static final void refreshProperties(Boolean refresh) {
-        if (Boolean.FALSE.equals(refresh) || LAST_SENSITIVE_FIELDS_LOAD_TIME + LAST_SENSITIVE_FIELDS_CACHE_MILLIS > System.currentTimeMillis()) {
+        if (Boolean.FALSE.equals(refresh) ||
+                (refresh==null && (LAST_SENSITIVE_FIELDS_LOAD_TIME + LAST_SENSITIVE_FIELDS_CACHE_MILLIS > System.currentTimeMillis()))) {
             return;
         }
         synchronized (Sanitizer.class) {
@@ -98,7 +99,7 @@ public final class Sanitizer {
                 }
 
                 if (plaintextBlocked==null) {
-                    StringSystemProperty plaintextSP = new StringSystemProperty(SENSITIVE_FIELDS_TOKENS.getName());
+                    StringSystemProperty plaintextSP = new StringSystemProperty(SENSITIVE_FIELDS_PLAINTEXT_BLOCKED.getName());
                     if (plaintextSP.isNonEmpty()) {
                         plaintextBlocked = TypeCoercions.coerce(plaintextSP.getValue(), SENSITIVE_FIELDS_PLAINTEXT_BLOCKED.getTypeToken());
                     }

--- a/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/server/BrooklynServerConfig.java
@@ -170,5 +170,10 @@ public class BrooklynServerConfig {
     public static Maybe<URI> getBrooklynWebUri(ManagementContext mgmt) {
         return mgmt.getManagementNodeUri();
     }
-    
+
+    public static final ConfigKey<List<String>> SENSITIVE_FIELDS_TOKENS = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {}, "brooklyn.security.sensitive.fields.tokens",
+            "List of tokens which get treated as sensitive-named fields and suppressed in many places");
+    public static final ConfigKey<Boolean> SENSITIVE_FIELDS_PLAINTEXT_BLOCKED = ConfigKeys.newBooleanConfigKey("brooklyn.security.sensitive.fields.plaintext.blocked",
+            "Whether plaintext values for sensitive-named fields are blocked");
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/TypePlanTransformers.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.api.typereg.RegisteredTypeLoadingContext;
 import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
@@ -159,7 +160,7 @@ public class TypePlanTransformers {
             String prefix = Strings.isBlank(type.getPlan().getPlanFormat()) ? "Invalid plan" : "Invalid '"+type.getPlan().getPlanFormat()+"' plan";
             if (transformers.isEmpty()) {
                 result = new UnsupportedTypePlanException(prefix + "; format could not be recognized, none of the available transformers "+all(mgmt)+" support "+
-                    (type.getId()!=null ? type.getId() : "plan:\n"+type.getPlan().getPlanData()));
+                    (type.getId()!=null ? type.getId() : "plan:\n"+ Sanitizer.sanitizeJsonTypes(type.getPlan().getPlanData())));
             } else {
                 result = new UnsupportedTypePlanException(prefix + "; potentially applicable transformers "+transformers+" do not support it, and other available transformers "+
 //                    // the removeAll call below won't work until "all" caches it

--- a/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/osgi/Osgis.java
@@ -18,6 +18,11 @@
  */
 package org.apache.brooklyn.util.core.osgi;
 
+import com.google.common.annotations.Beta;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +33,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
-
 import org.apache.brooklyn.api.catalog.CatalogItem.CatalogBundle;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -45,17 +50,12 @@ import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.text.VersionComparator;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.Version;
 import org.osgi.framework.VersionRange;
 import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.Beta;
-import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 
 /** 
  * utilities for working with osgi.
@@ -407,4 +407,13 @@ public class Osgis {
         Bundle bundle = org.osgi.framework.FrameworkUtil.getBundle(clazz);
         return Optional.fromNullable(bundle);
     }
+
+    public static ManagementContext getManagementContext() {
+        Bundle bundle = Osgis.getBundleOf(Osgis.class).orNull();
+        if (bundle == null) return null;
+        ServiceReference<ManagementContext> svc = bundle.getBundleContext().getServiceReference(ManagementContext.class);
+        if (svc == null) return null;
+        return bundle.getBundleContext().getService(svc);
+    }
+
 }

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -18,20 +18,16 @@
  */
 package org.apache.brooklyn.core.config;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import java.io.ByteArrayInputStream;
+import java.util.Map;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import static org.testng.Assert.assertEquals;
-
-import java.util.Map;
-
-import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Functions;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 public class SanitizerTest {
 

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -84,7 +84,7 @@ public class SanitizerTest {
                 "  allowedOnNewLine"
             )), Strings.lines(
                 "public: password",
-                "private: <suppressed> (MD5 hash: " + hashPassword2 + ")",
+                "private: <suppressed> (MD5 hash: " + hashPassword2.substring(0, 8) + ")",
                 "private: ",
                 "  allowedOnNewLine"
             ));

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -49,7 +49,7 @@ public class SanitizerTest {
                 .put("mykey", "myval")
                 .build();
         Map<String, Object> expected = MutableMap.<String, Object>builder()
-                .putAll(Maps.transformValues(map, Functions.constant("xxxxxxxx")))
+                .putAll(Maps.transformValues(map, Sanitizer::suppress))
                 .put("mykey", "myval")
                 .build();
         

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.brooklyn.core.config;
 
+import java.io.ByteArrayInputStream;
+import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.text.Strings;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Map;
@@ -69,5 +72,22 @@ public class SanitizerTest {
         assertEquals(Sanitizer.sanitize((ConfigBag)null), null);
         assertEquals(Sanitizer.sanitize((Map<?,?>)null), null);
         assertEquals(Sanitizer.newInstance().apply((Map<?,?>)null), null);
+    }
+
+    @Test
+    public void testSanitizeMultiline() throws Exception {
+        String hashPassword2 = "6CB75F652A9B52798EB6CF2201057C73";
+        assertEquals(Sanitizer.sanitizeMultilineString(Strings.lines(
+                "public: password",
+                "private: password2",
+                "private: ",
+                "  allowedOnNewLine"
+            )), Strings.lines(
+                "public: password",
+                "private: <suppressed> (MD5 hash: " + hashPassword2 + ")",
+                "private: ",
+                "  allowedOnNewLine"
+            ));
+        assertEquals(hashPassword2, Streams.getMd5Checksum(new ByteArrayInputStream(("password2").getBytes())));
     }
 }

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/ServerApi.java
@@ -108,7 +108,8 @@ public interface ServerApi {
     @GET
     @Path("/up/extended")
     @ApiOperation(value = "Returns extended server-up information, a map including up (/up), shuttingDown (/shuttingDown), healthy (/healthy), and ha (/ha/states) (qv)"
-        + "; also forces a session, so a useful general-purpose call for a UI client to do when starting")
+            + " as well as selected settings such as sensitive field treatment"
+            + "; also forces a session, so a useful general-purpose call for a UI client to do when starting")
     public Map<String,Object> getUpExtended();
 
     @GET

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ApplicationResource.java
@@ -23,6 +23,7 @@ import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.config.Sanitizer;
 import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceAbsoluteUriBuilder;
 
 import java.net.URI;
@@ -444,7 +445,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
             }
         }
 
-        log.debug("Creating app from yaml:\n{}", yaml);
+        log.debug("Creating app from yaml:\n{}", Sanitizer.sanitizeMultilineString(yaml));
 
         EntitySpec<? extends Application> spec;
         try {
@@ -498,7 +499,7 @@ public class ApplicationResource extends AbstractBrooklynRestResource implements
             CreationResult<Application,Void> result = EntityManagementUtils.start(app);
             waitForStart(app, Duration.millis(100));
 
-            log.info("Launched from plan: " + planForReference + " -> " + app + " (" + result.task() + ")");
+            log.info("Launched from plan: " + Sanitizer.sanitizeMultilineString(planForReference) + " -> " + app + " (" + result.task() + ")");
 
             URI ref = serviceAbsoluteUriBuilder(ui.getBaseUriBuilder(), ApplicationApi.class, "get").build(app.getApplicationId());
             ResponseBuilder response = created(ref);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -48,6 +48,7 @@ import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoRawData;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.BrooklynVersion;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.StartableApplication;
@@ -395,7 +396,12 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
             "up", isUp(),
             "shuttingDown", isShuttingDown(),
             "healthy", isHealthy(),
-            "ha", getHighAvailabilityPlaneStates());
+            "ha", getHighAvailabilityPlaneStates(),
+            "brooklyn.security.sensitive.fields",
+                MutableMap.of(
+                        "tokens", Sanitizer.getSensitiveFieldsTokens(),
+                        "plaintext.blocked", Sanitizer.isSensitiveFieldsPlaintextBlocked()
+                ));
     }
 
     @Override

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorUtilsRestTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EffectorUtilsRestTest.java
@@ -89,7 +89,7 @@ public class EffectorUtilsRestTest extends BrooklynAppUnitTestSupport {
         assertEquals(
                 summary.getDescription(),
                 "Invoking effector resetPassword on "+TestEntityWithEffectors.class.getSimpleName()+":"+entity.getId().substring(0,4)
-                    +" with parameters {"+sensitiveField1+"=xxxxxxxx, "+sensitiveField2+"=xxxxxxxx}",
+                    +" with parameters {"+sensitiveField1+"=<suppressed> (MD5 hash: 5E70B271), "+sensitiveField2+"=<suppressed> (MD5 hash: 81DC9BDB)}",
                 "Task summary must hide sensitive parameters");
     }
 

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EntityConfigResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/EntityConfigResourceTest.java
@@ -150,7 +150,7 @@ public class EntityConfigResourceTest extends BrooklynRestResourceTest {
                         .get(String.class);
 
         assertEquals(getSecretWithQueryParams.apply(""), JavaStringEscapes.wrapJavaString("hello-world"));
-        assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true"), JavaStringEscapes.wrapJavaString("<suppressed> (MD5 hash: 2095312189753DE6AD47DFE20CBE97EC)"));
+        assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true"), JavaStringEscapes.wrapJavaString("<suppressed> (MD5 hash: 20953121)"));
         assertEquals(getSecretWithQueryParams.apply("skipResolution=true"), JavaStringEscapes.wrapJavaString(HELLO_WORLD_DSL));
         assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true&skipResolution=true"), JavaStringEscapes.wrapJavaString(HELLO_WORLD_DSL));
     }
@@ -165,7 +165,7 @@ public class EntityConfigResourceTest extends BrooklynRestResourceTest {
                     .get(String.class);
 
         assertEquals(getSecretWithQueryParams.apply(""), "hello-world");
-        assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true"), "<suppressed> (MD5 hash: 2095312189753DE6AD47DFE20CBE97EC)");
+        assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true"), "<suppressed> (MD5 hash: 20953121)");
         assertEquals(getSecretWithQueryParams.apply("skipResolution=true"), HELLO_WORLD_DSL);
         assertEquals(getSecretWithQueryParams.apply("suppressSecrets=true&skipResolution=true"), HELLO_WORLD_DSL);
     }

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/VanillaSoftwareProcessStreamsTest.java
@@ -71,7 +71,7 @@ public class VanillaSoftwareProcessStreamsTest extends AbstractSoftwareProcessSt
         // Prepare expected environment variables, secret names are keys with values that should be masked in env stream
         Map<String, String> expectedEnv = new ImmutableMap.Builder<String, String>()
                 .put("KEY1", "VAL1")
-                .putAll(Sanitizer.SECRET_NAMES.stream().collect(Collectors.toMap(item -> item, item -> item)))
+                .putAll(Sanitizer.DEFAULT_SENSITIVE_FIELDS_TOKENS.stream().collect(Collectors.toMap(item -> item, item -> item)))
                 .build();
 
         // Create configuration
@@ -115,9 +115,9 @@ public class VanillaSoftwareProcessStreamsTest extends AbstractSoftwareProcessSt
         // Calculate MD5 hash for all keys that are expected to be masked and verify them displayed masked in env stream
         Map<String, String> expectedMaskedEnv = new ImmutableMap.Builder<String, String>()
                 .put("KEY1", "VAL1") // this key must appear unmasked, it is not in the list of SECRET NAMES to mask
-                .putAll(Sanitizer.SECRET_NAMES.stream().collect(Collectors.toMap(
+                .putAll(Sanitizer.DEFAULT_SENSITIVE_FIELDS_TOKENS.stream().collect(Collectors.toMap(
                         item -> item, // key and expected masked (suppressed) value for a SECRET NAME with MD5 hash
-                        item -> "<suppressed> (MD5 hash: " + Streams.getMd5Checksum(new ByteArrayInputStream(item.getBytes())) + ")")))
+                        Sanitizer::suppress)))
                 .build();
         assertEnvStream(entity, expectedMaskedEnv);
     }


### PR DESCRIPTION
This allows the set of tokens used to determine potentially sensitive names to be configured, and allows a configuration to block deployment and some catalog additions of blueprints where such config keys are in plaintext.  Makes these settings available via API to the UI.  Suppresses potentially sensitive data in logs in many places.