### PR TITLE
Fix catalog deletion bundles and transient

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/ManagedBundleMemento.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/ManagedBundleMemento.java
@@ -37,4 +37,8 @@ public interface ManagedBundleMemento extends Memento {
     ByteSource getJarContent();
     void setJarContent(ByteSource byteSource);
 
+    @Nullable
+    /** whether the bundle is known to be able to be permanently deleteable (eg it was installed by a user) */
+    Boolean getDeleteable();
+
 }

--- a/api/src/main/java/org/apache/brooklyn/api/typereg/OsgiBundleWithUrl.java
+++ b/api/src/main/java/org/apache/brooklyn/api/typereg/OsgiBundleWithUrl.java
@@ -44,6 +44,10 @@ public interface OsgiBundleWithUrl {
     /** @return true if we have a name and version for this bundle;
      * false if not, e.g. if we only know the URL and we haven't loaded it yet */
     public boolean isNameResolved();
+
+    /** @return whether this is known to be deleteable (eg installed by user) or known not to be (eg installed at boot and will be reinstalled)
+     * or unknown (null, probably installed at boot or before this info was kept) */
+    public Boolean getDeleteable();
     
     /** @return the {@link VersionedName} for this bundle, or null if not available */
     public VersionedName getVersionedName();

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/AbstractYamlTest.java
@@ -269,7 +269,7 @@ public abstract class AbstractYamlTest {
             File bf = bundleMaker.createTempZip("test", MutableMap.of(
                 new ZipEntry(BasicBrooklynCatalog.CATALOG_BOM), new ByteArrayInputStream(catalogYaml.getBytes())));
             ReferenceWithError<OsgiBundleInstallationResult> b = ((ManagementContextInternal)mgmt).getOsgiManager().get().installDeferredStart(
-                new BasicManagedBundle(bundleName.getSymbolicName(), bundleName.getVersionString(), null, null, null, null),
+                new BasicManagedBundle(bundleName.getSymbolicName(), bundleName.getVersionString(), null, null, null, null, true),
                 InputStreamSource.of("tests:"+bundleName+":"+bf, bf),
                 false);
             

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampYamlLiteTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/test/lite/CampYamlLiteTest.java
@@ -213,7 +213,7 @@ public class CampYamlLiteTest {
         // install bundle for class access but without loading its catalog.bom, 
         // since we only have mock matchers here
         // (if we don't do this, the default routines install it and try to process the catalog.bom, failing)
-        ((ManagementContextInternal)mgmt).getOsgiManager().get().installDeferredStart(new BasicManagedBundle(null, null, bundleUrl, null, null, null), null, false).get();
+        ((ManagementContextInternal)mgmt).getOsgiManager().get().installDeferredStart(new BasicManagedBundle(null, null, bundleUrl, null, null, null, true), null, false).get();
     }
 
     private void assertMgmtHasSampleMyCatalogApp(String symbolicName, String bundleUrl) {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleDto.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleDto.java
@@ -39,14 +39,20 @@ public class CatalogBundleDto implements CatalogBundle {
     private String version;
     private String url;
     private Credentials credential;
+    private Boolean deleteable;
 
     public CatalogBundleDto() {}
 
+    @Deprecated /** @deprecated since 1.1 use larger constructor */
     public CatalogBundleDto(String name, String version, String url) {
         this(name, version, url, null);
     }
 
+    @Deprecated /** @deprecated since 1.1 use larger constructor */
     public CatalogBundleDto(String name, String version, String url, @Nullable Credentials credential) {
+        this(name, version, url, credential, null);
+    }
+    public CatalogBundleDto(String name, String version, String url, @Nullable Credentials credential, @Nullable Boolean deleteable) {
         if (name == null && version == null) {
             Preconditions.checkNotNull(url, "url to an OSGi bundle is required");
         } else {
@@ -58,6 +64,7 @@ public class CatalogBundleDto implements CatalogBundle {
         this.version = version==null ? null : BrooklynVersionSyntax.toValidOsgiVersion(version);
         this.url = url;
         this.credential = credential;
+        this.deleteable = deleteable;
     }
 
     @Override
@@ -97,6 +104,11 @@ public class CatalogBundleDto implements CatalogBundle {
     }
 
     @Override
+    public Boolean getDeleteable() {
+        return deleteable;
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("symbolicName", symbolicName)
@@ -128,7 +140,7 @@ public class CatalogBundleDto implements CatalogBundle {
         if (osgi==null) return Maybe.absent("No OSGi manager");
         Maybe<Bundle> b2 = osgi.findBundle(b);
         if (b2.isAbsent()) return Maybe.absent("Nothing installed for "+b);
-        return Maybe.of(new CatalogBundleDto(b2.get().getSymbolicName(), b2.get().getVersion().toString(), b.getUrl()));
+        return Maybe.of(new CatalogBundleDto(b2.get().getSymbolicName(), b2.get().getVersion().toString(), b.getUrl(), b.getUrlCredential(), b.getDeleteable()));
     }
     
 }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDtoAbstract.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogItemDtoAbstract.java
@@ -441,7 +441,8 @@ public abstract class CatalogItemDtoAbstract<T, SpecT> extends AbstractBrooklynO
                         bwu.getSymbolicName(),
                         bwu.getSuppliedVersionString(),
                         bwu.getUrl(),
-                        bwu.getUrlCredential()));
+                        bwu.getUrlCredential(),
+                        bwu.getDeleteable()));
             } else if (object instanceof VersionedName) {
                 dto.add(new CatalogBundleDto(((VersionedName) object).getSymbolicName(), ((VersionedName) object).getVersionString(), null));
             } else {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/ha/OsgiManager.java
@@ -443,10 +443,15 @@ public class OsgiManager {
         return BrooklynCatalogBundleResolvers.install(getManagementContext(), zipIn, options);
     }
 
+    @Deprecated /** @deprecated since 1.1 use larger variant of method */
     public ReferenceWithError<OsgiBundleInstallationResult> install(Supplier<InputStream> input, String format, boolean force) {
+        return install(input, format, force, null);
+    }
+    public ReferenceWithError<OsgiBundleInstallationResult> install(Supplier<InputStream> input, String format, boolean force, Boolean deleteable) {
         BundleInstallationOptions options = new BundleInstallationOptions();
         options.setFormat(format);
         options.setForceUpdateOfNonSnapshots(force);
+        options.setDeleteable(deleteable);
         return BrooklynCatalogBundleResolvers.install(getManagementContext(), input, options);
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -1379,7 +1379,7 @@ public abstract class RebindIteration {
 
         protected ManagedBundle newManagedBundle(ManagedBundleMemento memento) {
             ManagedBundle result = new BasicManagedBundle(memento.getSymbolicName(), memento.getVersion(), memento.getUrl(),
-                    memento.getFormat(), null, memento.getChecksum());
+                    memento.getFormat(), null, memento.getChecksum(), memento.getDeleteable());
             FlagUtils.setFieldsFromFlags(ImmutableMap.of("id", memento.getId()), result);
             return result;
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -504,15 +504,7 @@ public class RebindManagerImpl implements RebindManager {
         // failure at various points should leave proxies in a sensible state,
         // either pointing at old or at new, though this is relatively untested,
         // and some things e.g. policies might not be properly started
-        final RebindExceptionHandler exceptionHandler = 
-            RebindExceptionHandlerImpl.builder()
-                .danglingRefFailureMode(danglingRefFailureMode)
-                .danglingRefQuorumRequiredHealthy(danglingRefsQuorumRequiredHealthy)
-                .rebindFailureMode(rebindFailureMode)
-                .addConfigFailureMode(addConfigFailureMode)
-                .addPolicyFailureMode(addPolicyFailureMode)
-                .loadPolicyFailureMode(loadPolicyFailureMode)
-                .build();
+        final RebindExceptionHandler exceptionHandler = newExceptionHandler();
         final ManagementNodeState mode = getRebindMode();
 
         ActivePartialRebindIteration iteration = new ActivePartialRebindIteration(this, mode, classLoader, exceptionHandler,
@@ -597,14 +589,7 @@ public class RebindManagerImpl implements RebindManager {
         final ClassLoader classLoader = classLoaderO!=null ? classLoaderO :
             managementContext.getCatalogClassLoader();
         final RebindExceptionHandler exceptionHandler = exceptionHandlerO!=null ? exceptionHandlerO :
-            RebindExceptionHandlerImpl.builder()
-                .danglingRefFailureMode(danglingRefFailureMode)
-                .danglingRefQuorumRequiredHealthy(danglingRefsQuorumRequiredHealthy)
-                .rebindFailureMode(rebindFailureMode)
-                .addConfigFailureMode(addConfigFailureMode)
-                .addPolicyFailureMode(addPolicyFailureMode)
-                .loadPolicyFailureMode(loadPolicyFailureMode)
-                .build();
+                newExceptionHandler();
         final ManagementNodeState mode = modeO!=null ? modeO : getRebindMode();
         
         if (mode!=ManagementNodeState.MASTER && mode!=ManagementNodeState.HOT_STANDBY && mode!=ManagementNodeState.HOT_BACKUP)
@@ -619,7 +604,19 @@ public class RebindManagerImpl implements RebindManager {
             return rebindImpl(classLoader, exceptionHandler, mode);
         }
     }
-    
+
+    @Beta
+    public RebindExceptionHandler newExceptionHandler() {
+        return RebindExceptionHandlerImpl.builder()
+                .danglingRefFailureMode(danglingRefFailureMode)
+                .danglingRefQuorumRequiredHealthy(danglingRefsQuorumRequiredHealthy)
+                .rebindFailureMode(rebindFailureMode)
+                .addConfigFailureMode(addConfigFailureMode)
+                .addPolicyFailureMode(addPolicyFailureMode)
+                .loadPolicyFailureMode(loadPolicyFailureMode)
+                .build();
+    }
+
     @Override
     public BrooklynMementoRawData retrieveMementoRawData() {
         RebindExceptionHandler exceptionHandler = RebindExceptionHandlerImpl.builder()

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicManagedBundleMemento.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/BasicManagedBundleMemento.java
@@ -44,7 +44,8 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
         protected String format;
         protected String url;
         protected String checksum;
-        
+        protected Boolean deleteable;
+
         public Builder symbolicName(String symbolicName) {
             this.symbolicName = symbolicName;
             return self();
@@ -70,6 +71,11 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
             return self();
         }
 
+        public Builder deleteable(Boolean deleteable) {
+            this.deleteable = deleteable;
+            return self();
+        }
+
         public Builder from(ManagedBundleMemento other) {
             super.from(other);
             symbolicName = other.getSymbolicName();
@@ -77,6 +83,7 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
             format = other.getFormat();
             url = other.getUrl();
             checksum = other.getChecksum();
+            deleteable = other.getDeleteable();
             return self();
         }
 
@@ -90,6 +97,7 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
     private String format;
     private String url;
     private String checksum;
+    private Boolean deleteable;
     transient private ByteSource jarContent;
 
     @SuppressWarnings("unused") // For deserialisation
@@ -102,6 +110,7 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
         this.format = builder.format;
         this.url = builder.url;
         this.checksum = builder.checksum;
+        this.deleteable = builder.deleteable;
     }
 
     @Override
@@ -130,10 +139,13 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
     }
 
     @Override
+    public Boolean getDeleteable() { return deleteable; }
+
+    @Override
     public ByteSource getJarContent() {
         return jarContent;
     }
-    
+
     @Override
     public void setJarContent(ByteSource byteSource) {
         this.jarContent = byteSource;
@@ -159,7 +171,8 @@ public class BasicManagedBundleMemento extends AbstractMemento implements Manage
                 .add("version", getVersion())
                 .add("format", getFormat())
                 .add("url", getUrl())
-                .add("checksum", getChecksum());
+                .add("checksum", getChecksum())
+                .add("deleteable", getDeleteable());
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementosGenerators.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/dto/MementosGenerators.java
@@ -355,6 +355,8 @@ public class MementosGenerators {
         builder.url(bundle.getUrl())
             .symbolicName(bundle.getSymbolicName())
             .version(bundle.getSuppliedVersionString())
+            .checksum(bundle.getChecksum())
+            .deleteable(bundle.getDeleteable())
             .format(bundle.getFormat());
         return builder.build();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -515,7 +515,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         // if not osgi, everything is treated as a wrapper bundle
         if (osgi.isAbsent()) return true;
         VersionedName vn = VersionedName.fromString(bundleNameVersion);
-        Maybe<Bundle> b = osgi.get().findBundle(new BasicOsgiBundleWithUrl(vn.getSymbolicName(), vn.getOsgiVersionString(), null));
+        Maybe<Bundle> b = osgi.get().findBundle(new BasicOsgiBundleWithUrl(vn.getSymbolicName(), vn.getOsgiVersionString(), null, null, null));
         // if bundle not found it is an error or a race; we don't fail, but we shouldn't treat it as a wrapper
         if (b.isAbsent()) return false;
         

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicOsgiBundleWithUrl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicOsgiBundleWithUrl.java
@@ -34,17 +34,23 @@ public class BasicOsgiBundleWithUrl implements CatalogBundle, OsgiBundleWithUrl 
     private String symbolicName;
     private String version;
     private String url;
+    private Boolean deleteable;
     private Credentials credential;
 
     // for deserializing (not sure if needed?)
     @SuppressWarnings("unused")
     private BasicOsgiBundleWithUrl() {}
 
+    @Deprecated /** @deprecated since 1.1 use larger constructor */
     public BasicOsgiBundleWithUrl(String name, String version, String url) {
         this(name, version, url, null);
     }
-
+    @Deprecated /** @deprecated since 1.1 use larger constructor */
     public BasicOsgiBundleWithUrl(String name, String version, String url, @Nullable Credentials cred) {
+        this(name, version, url, cred, null);
+    }
+
+    public BasicOsgiBundleWithUrl(String name, String version, String url, @Nullable Credentials cred, @Nullable Boolean deleteable) {
         if (name == null && version == null) {
             Preconditions.checkNotNull(url, "Either a URL or both name and version are required");
         } else {
@@ -56,10 +62,11 @@ public class BasicOsgiBundleWithUrl implements CatalogBundle, OsgiBundleWithUrl 
         this.version = version;
         this.url = url;
         this.credential = cred;
+        this.deleteable = deleteable;
     }
     
     public BasicOsgiBundleWithUrl(OsgiBundleWithUrl b) {
-        this(b.getSymbolicName(), b.getSuppliedVersionString(), b.getUrl());
+        this(b.getSymbolicName(), b.getSuppliedVersionString(), b.getUrl(), b.getUrlCredential(), b.getDeleteable());
     }
 
     @Override
@@ -96,6 +103,11 @@ public class BasicOsgiBundleWithUrl implements CatalogBundle, OsgiBundleWithUrl 
     @Override
     public Credentials getUrlCredential() {
         return credential;
+    }
+
+    @Override
+    public Boolean getDeleteable() {
+        return deleteable;
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
@@ -31,9 +31,7 @@ import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.osgi.BundleMaker;
-import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.ReferenceWithError;
-import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.osgi.VersionedName;
 import org.apache.brooklyn.util.stream.InputStreamSource;
 import org.apache.brooklyn.util.stream.Streams;
@@ -118,7 +116,7 @@ public class BrooklynBomYamlCatalogBundleResolver extends AbstractCatalogBundleR
 
             BasicManagedBundle basicManagedBundle = new BasicManagedBundle(vn.getSymbolicName(), vn.getVersionString(),
                     null, BrooklynBomBundleCatalogBundleResolver.FORMAT,
-                    null, null);
+                    null, null, options.getDeleteable());
             // if the submitted blueprint contains tags, we set them on the bundle, so they can be picked up and used to tag the plan.
             if( cm.containsKey("tags") && cm.get("tags") instanceof Iterable) {
                 basicManagedBundle.tags().addTags((Iterable<?>)cm.get("tags"));

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynCatalogBundleResolver.java
@@ -99,6 +99,7 @@ public interface BrooklynCatalogBundleResolver extends ManagementContextInjectab
         protected boolean deferredStart = false;
         protected boolean start = true;
         protected boolean loadCatalogBom = true;
+        protected Boolean deleteable = null;
         protected ManagedBundle knownBundleMetadata = null;
 
         public void setFormat(String format) {
@@ -155,6 +156,12 @@ public interface BrooklynCatalogBundleResolver extends ManagementContextInjectab
 
         public boolean isValidateTypes() {
             return validateTypes;
+        }
+
+        public Boolean getDeleteable() { return deleteable; }
+
+        public void setDeleteable(Boolean deleteable) {
+            this.deleteable = deleteable;
         }
     }
 

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/BundleSummary.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/domain/BundleSummary.java
@@ -49,7 +49,10 @@ public class BundleSummary implements Comparable<BundleSummary> {
 
     @JsonInclude(value=Include.ALWAYS)
     private final List<TypeSummary> types = MutableList.of();
-    
+
+    @JsonInclude(value=Include.NON_NULL)
+    private final Boolean deleteable;
+
     // not exported directly, but used to provide other top-level json fields
     // for specific types
     @JsonIgnore
@@ -59,11 +62,13 @@ public class BundleSummary implements Comparable<BundleSummary> {
     BundleSummary() {
         symbolicName = null;
         version = null;
+        deleteable = null;
     }
     
     public BundleSummary(OsgiBundleWithUrl bundle) {
         symbolicName = bundle.getSymbolicName();
         version = bundle.getSuppliedVersionString();
+        deleteable = bundle.getDeleteable();
     }
     
     /** Mutable map of other top-level metadata included on this DTO (eg listing config keys or effectors) */ 
@@ -98,7 +103,9 @@ public class BundleSummary implements Comparable<BundleSummary> {
     public List<TypeSummary> getTypes() {
         return types;
     }
-    
+
+    public Boolean getDeleteable() { return deleteable; }
+
     @Override
     public String toString() {
         return JavaClassNames.cleanSimpleClassName(this)+"["+symbolicName+":"+version+"]";

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/BundleResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/BundleResource.java
@@ -222,7 +222,7 @@ public class BundleResource extends AbstractBrooklynRestResource implements Bund
         if (force==null) force = false;
 
         ReferenceWithError<OsgiBundleInstallationResult> result = ((ManagementContextInternal)mgmt()).getOsgiManager().get()
-                .install(source, format, force);
+                .install(source, format, force, true);
 
         if (result.hasError()) {
             // (rollback already done as part of install, if necessary)

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -153,7 +153,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
         }
 
         ReferenceWithError<OsgiBundleInstallationResult> result = ((ManagementContextInternal)mgmt()).getOsgiManager().get()
-                .install(source, format, forceUpdate);
+                .install(source, format, forceUpdate, true);
 
         if (result.hasError()) {
             // (rollback already done as part of install, if necessary)

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements.StringAndArgument;
@@ -208,6 +209,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.preconditionFailed("Item with id '%s:%s' not an entity", symbolicName, version);
         } else {
             brooklyn().getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
+            ((BasicBrooklynCatalog)brooklyn().getCatalog()).uninstallEmptyWrapperBundles();
         }
     }
 
@@ -228,6 +230,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.preconditionFailed("Item with id '%s:%s' not a policy", policyId, version);
         } else {
             brooklyn().getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
+            ((BasicBrooklynCatalog)brooklyn().getCatalog()).uninstallEmptyWrapperBundles();
         }
     }
 
@@ -248,6 +251,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.preconditionFailed("Item with id '%s:%s' not a location", locationId, version);
         } else {
             brooklyn().getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
+            ((BasicBrooklynCatalog)brooklyn().getCatalog()).uninstallEmptyWrapperBundles();
         }
     }
 
@@ -449,6 +453,7 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             throw WebResourceUtils.preconditionFailed("Item with id '%s:%s' not an enricher", enricherId, version);
         } else {
             brooklyn().getCatalog().deleteCatalogItem(item.getSymbolicName(), item.getVersion());
+            ((BasicBrooklynCatalog)brooklyn().getCatalog()).uninstallEmptyWrapperBundles();
         }
     }
 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LocationResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/LocationResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.rest.resources;
 
+import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
 import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceAbsoluteUriBuilder;
 
 import java.net.URI;
@@ -192,6 +193,8 @@ public class LocationResource extends AbstractBrooklynRestResource implements Lo
 
         // TODO make all locations be part of the catalog, then flip the JS GUI to use catalog api
         if (deleteAllVersions(locationId)>0) return;
+        ((BasicBrooklynCatalog)brooklyn().getCatalog()).uninstallEmptyWrapperBundles();
+
         throw WebResourceUtils.notFound("No catalog item location matching %s; only catalog item locations can be deleted", locationId);
     }
     


### PR DESCRIPTION
First commit fixes a problem where if a location is deleted and the bundle was a dedicated BOM for that location, the bundle wasn't deleted.  Now the "delete-empty-bom-bundles" check is done on all type deletions.  (This caused weirdness where if you then try to add the bundle again, it says it is already installed (which was true, though it shouldn't be), and the uninstall triggers the delete-empty-bom-bundles check so at _this_ point the original bundle is also deleted, so if you then try to add the bundle yet again, it works.)

Second commit extends the metadata on bundles to record those added via the REST API and which are thus deleteable, for use in a UI update to follow.