### PR TITLE
Groups change policy

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
@@ -91,7 +91,7 @@ public class AddSensorInitializer<T> extends EntityInitializers.InitializerPatte
     private Duration period;
     private String type;
     private AttributeSensor<T> sensor;
-    private Object params;
+    private ConfigBag params;
     // introduced in 1.1 for legacy compatibility
     protected Object readResolve() {
         super.readResolve();

--- a/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/AddSensorInitializer.java
@@ -91,7 +91,7 @@ public class AddSensorInitializer<T> extends EntityInitializers.InitializerPatte
     private Duration period;
     private String type;
     private AttributeSensor<T> sensor;
-    private ConfigBag params;
+    private Object params;
     // introduced in 1.1 for legacy compatibility
     protected Object readResolve() {
         super.readResolve();

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BeanWithTypeUtils.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.annotations.Beta;
 import com.google.common.reflect.TypeToken;
+
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,7 @@ import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtil
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.guava.TypeTokens;
 import org.apache.brooklyn.util.javalang.Boxing;
@@ -120,14 +123,20 @@ public class BeanWithTypeUtils {
      * see in JsonDeserializerForCommonBrooklynThings.  See DslSerializationTest.
      */
 
+
     public static <T> T convert(ManagementContext mgmt, Object mapOrListToSerializeThenDeserialize, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {
         try {
             return convertDeeply(mgmt, mapOrListToSerializeThenDeserialize, type, allowRegisteredTypes, loader, allowJavaTypes);
 
         } catch (Exception e) {
-            return convertShallow(mgmt, mapOrListToSerializeThenDeserialize, type, allowRegisteredTypes, loader, allowJavaTypes);
+            try {
+                return convertShallow(mgmt, mapOrListToSerializeThenDeserialize, type, allowRegisteredTypes, loader, allowJavaTypes);
+            } catch (Exception e2) {
+                throw Exceptions.propagate(Arrays.asList(e, e2));
+            }
         }
     }
+
 
     @Beta
     public static <T> T convertShallow(ManagementContext mgmt, Object mapOrListToSerializeThenDeserialize, TypeToken<T> type, boolean allowRegisteredTypes, BrooklynClassLoadingContext loader, boolean allowJavaTypes) throws JsonProcessingException {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.group;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityInitializer;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.api.policy.Policy;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.api.sensor.Enricher;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.typereg.AbstractTypePlanTransformer;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
+import org.apache.brooklyn.core.typereg.RegisteredTypes;
+import org.apache.brooklyn.util.guava.Maybe;
+
+import java.util.List;
+import java.util.Map;
+
+public class GroupsChangePolicy extends AbstractMembershipTrackingPolicy {
+
+    public static final ConfigKey<List<Map<String, Object>>> POLICIES = ConfigKeys.builder(new TypeToken<List<Map<String, Object>>>(){})
+            .name("member.policies")
+            .defaultValue(ImmutableList.of())
+            .build();
+
+    public static final ConfigKey<List<Map<String, Object>>> INITIALIZERS = ConfigKeys.builder(new TypeToken<List<Map<String, Object>>>(){})
+            .name("member.initializers")
+            .defaultValue(ImmutableList.of())
+            .build();
+
+
+//    public static ConfigKey<Set<EntityInitializer>> INITIALIZERS = new SetConfigKey.Builder(EntityInitializer.class, "member.initializers").build();
+
+    ConfigKey<List<Map<String, Object>>> ENRICHERS = ConfigKeys.builder(new TypeToken<List<Map<String, Object>>>(){})
+            .name("member.enrichers")
+            .defaultValue(ImmutableList.of())
+            .build();
+
+    @Override
+    protected void onEntityAdded(Entity member) {
+        super.onEntityAdded(member);
+        ManagementContext mgmt = getManagementContext();
+
+        Maybe<Object> raw = config().getRaw(POLICIES);
+        List<Map<String, Object>> maps = raw.isPresent() ? (List<Map<String, Object>>) raw.get() : ImmutableList.of();
+        maps.forEach(
+                stringObjectMap -> {
+                    String type = (String) stringObjectMap.get("type");
+
+                    Maybe<RegisteredType> item = RegisteredTypes.tryValidate(mgmt.getTypeRegistry().get(type), RegisteredTypeLoadingContexts.spec(BrooklynObjectType.POLICY.getInterfaceType()));
+                    PolicySpec spec;
+                    Map<String, Object> brooklynConfig = (Map<String, Object>) stringObjectMap.get("brooklyn.config");
+
+                    if (!item.isNull()) {
+                        // throw error if absent for any reason other than null
+                        spec = mgmt.getTypeRegistry().createSpec(item.get(), null, (Class<PolicySpec<Policy>>) BrooklynObjectType.POLICY.getSpecType());
+                    } else {
+                        spec = PolicySpec.create(ImmutableMap.of(), (Class) new OsgiBrooklynClassLoadingContext(entity).tryLoadClass(type).get());
+                    }
+                    spec.configure(brooklynConfig);
+
+
+                    AbstractTypePlanTransformer.checkSecuritySensitiveFields(spec);
+                    member.policies().add(spec);
+                }
+        );
+
+//        config().get(INITIALIZERS).forEach(entityInitializer -> {
+//            entityInitializer.apply((EntityInternal)member);
+//        });
+
+
+        config().get(INITIALIZERS).forEach(
+                stringObjectMap -> {
+                    try {
+                        Maybe<EntityInitializer> entityInitializerMaybe = BeanWithTypeUtils.tryConvertOrAbsentUsingContext(Maybe.of(stringObjectMap), TypeToken.of(EntityInitializer.class));
+                        EntityInitializer initializer = entityInitializerMaybe.get();
+                        initializer.apply((EntityInternal) member);
+                    }catch(Throwable e){
+                        System.out.println(e);
+                    }
+                }
+        );
+
+        Maybe<Object> rawEnrichers = config().getRaw(ENRICHERS);
+        List<Map<String, Object>> enricherMaps = rawEnrichers.isPresent() ? (List<Map<String, Object>>) rawEnrichers.get() : ImmutableList.of();
+        enricherMaps.forEach(
+                stringObjectMap -> {
+                    String type = (String) stringObjectMap.get("type");
+                    Maybe<RegisteredType> item = RegisteredTypes.tryValidate(mgmt.getTypeRegistry().get(type), RegisteredTypeLoadingContexts.spec(BrooklynObjectType.ENRICHER.getInterfaceType()));
+                    EnricherSpec enricherSpec;
+                    Map<String, Object> brooklynConfig = (Map<String, Object>) stringObjectMap.get("brooklyn.config");
+
+                    if (!item.isNull()) {
+                        // throw error if absent for any reason other than null
+                        enricherSpec = mgmt.getTypeRegistry().createSpec(item.get(), null, (Class<EnricherSpec<Enricher>>) BrooklynObjectType.ENRICHER.getSpecType());
+                    } else {
+                        enricherSpec = EnricherSpec.create(ImmutableMap.of(), (Class) new OsgiBrooklynClassLoadingContext(entity).tryLoadClass(type).get());
+                    }
+                    enricherSpec.configure(brooklynConfig);
+
+
+                    AbstractTypePlanTransformer.checkSecuritySensitiveFields(enricherSpec);
+                    member.enrichers().add(enricherSpec);
+                }
+        );
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
@@ -44,6 +44,38 @@ import org.apache.brooklyn.util.guava.Maybe;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Policy for adding policies, enrichers, and initializers to entities as the join dynamic groups.
+ *
+ * Example usage:
+ *     - type: org.apache.brooklyn.entity.group.DynamicGroup
+ *       name: Empty Software Processes
+ *       brooklyn.policies:
+ *       - type: org.apache.brooklyn.entity.group.GroupsChangePolicy
+ *         brooklyn.config:
+ *           group: $brooklyn:self()
+ *           member.policies: kdjsldl
+ *           member.initializers:
+ *           - type: org.apache.brooklyn.core.sensor.StaticSensor
+ *             brooklyn.config:
+ *               name: testsensor
+ *               target.type: string
+ *               static.value: $brooklyn:formatString("%s%s","test","sensor")
+ *           member.enrichers:
+ *           - type: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
+ *             brooklyn.config:
+ *               latencyDetector.url: http://localost:8081
+ *               latencyDetector.period: 10s
+ *               latencyDetector.requireServiceUp: false
+ *
+ *       brooklyn.config:
+ *         dynamicgroup.entityfilter:
+ *           $brooklyn:object:
+ *             type: org.apache.brooklyn.core.entity.EntityPredicates
+ *             factoryMethod.name: displayNameEqualTo
+ *             factoryMethod.args:
+ *             - "Empty Software Process"
+ */
 public class GroupsChangePolicy extends AbstractMembershipTrackingPolicy {
 
     public static final ConfigKey<List<Map<String, Object>>> POLICIES = ConfigKeys.builder(new TypeToken<List<Map<String, Object>>>(){})

--- a/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/config/ConfigBag.java
@@ -28,6 +28,8 @@ import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.config.ConfigKey.HasConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
@@ -55,6 +57,7 @@ import com.google.common.collect.Sets;
  * <p>
  * @author alex
  */
+@JsonAutoDetect(fieldVisibility = Visibility.ANY, isGetterVisibility = Visibility.NONE, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE)
 public class ConfigBag {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigBag.class);

--- a/core/src/main/resources/catalog.bom
+++ b/core/src/main/resources/catalog.bom
@@ -166,4 +166,9 @@ brooklyn.catalog:
         type: org.apache.brooklyn.enricher.stock.reducer.Reducer
         name: Reducer
         description: Applies a transformation to a sensor
-        
+    - id: org.apache.brooklyn.entity.group.GroupsChangePolicy
+      itemType: policy
+      item:
+        type: org.apache.brooklyn.entity.group.GroupsChangePolicy
+        name: GroupsChangePolicy
+        description: Applies policies to entities as they are added to DynamicGroups

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
@@ -19,7 +19,9 @@
 package org.apache.brooklyn.core.resolve.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.sensor.StaticSensor;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
@@ -117,6 +119,14 @@ public class BrooklynRegisteredTypeJacksonSerializationTest extends BrooklynMgmt
 
         Object impl3 = deser("[3]", rt);
         Assert.assertEquals( ((ListExtended)impl3).size(), 1 );
+    }
+
+    @Test
+    public void testDeserializeEntityInitializer() throws Exception {
+        Object impl = deser("{\"type\":\""+ StaticSensor.class.getName()+"\""
+                +",\"brooklyn.config\":{\"name\":\"mytestsensor\"}"
+                +"}");
+        Asserts.assertInstanceOf(impl, EntityInitializer.class);
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerializationTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.resolve.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.StaticSensor;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.core.typereg.BasicBrooklynTypeRegistry;
@@ -29,6 +30,7 @@ import org.apache.brooklyn.core.typereg.JavaClassNameTypePlanTransformer;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -127,6 +129,23 @@ public class BrooklynRegisteredTypeJacksonSerializationTest extends BrooklynMgmt
                 +",\"brooklyn.config\":{\"name\":\"mytestsensor\"}"
                 +"}");
         Asserts.assertInstanceOf(impl, EntityInitializer.class);
+    }
+
+    @Test
+    public void testConfigBagSerialization() throws Exception {
+        ConfigBag bag = ConfigBag.newInstance();
+        bag.put(ConfigKeys.newConfigKey(String.class, "stringTypedKey"), "foo");
+        bag.putStringKey("stringUntypedKey", "bar");
+        bag.putStringKey("intUntypedKey", 2);
+        bag.getStringKey("stringUntypedKey");
+
+        String out = ser(bag);
+        Assert.assertEquals(out, "{\"type\":\"org.apache.brooklyn.util.core.config.ConfigBag\",\"config\":{\"stringTypedKey\":\"foo\",\"stringUntypedKey\":\"bar\",\"intUntypedKey\":2},\"unusedConfig\":{\"stringTypedKey\":\"foo\",\"intUntypedKey\":2},\"live\":false,\"sealed\":false}");
+
+        ConfigBag in = (ConfigBag) deser(out);
+        // used and unused is serialized
+        Asserts.assertSize(in.getUnusedConfig(), 2);
+        Asserts.assertEquals(in.getAllConfig(), bag.getAllConfig());
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/entity/group/GroupsChangePolicyTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/group/GroupsChangePolicyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.group;
+
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.sun.nio.sctp.SctpStandardSocketOptions;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.policy.Policy;
+import org.apache.brooklyn.api.policy.PolicySpec;
+import org.apache.brooklyn.api.sensor.EnricherSpec;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
+import org.apache.brooklyn.core.entity.EntityPredicates;
+import org.apache.brooklyn.core.location.LocationConfigKeys;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.sensor.StaticSensor;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.brooklyn.test.Asserts.assertEqualsIgnoringOrder;
+import static org.testng.Assert.*;
+
+public class GroupsChangePolicyTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testGroups() {
+
+        DynamicGroup dynamicGroup = app.addChild(EntitySpec.create(DynamicGroup.class));
+        PolicySpec<GroupsChangePolicy> policySpec =
+                PolicySpec.create(GroupsChangePolicy.class)
+                        .configure(GroupsChangePolicy.GROUP, dynamicGroup)
+                        .configure(GroupsChangePolicy.INITIALIZERS,
+                                ImmutableList.of(
+                                        ImmutableMap.of(
+                                                "type", "org.apache.brooklyn.core.sensor.StaticSensor",
+                                                "brooklyn.config", ImmutableMap.of(
+                                                        "name", "mytestsensor",
+                                                        "target.type", "string",
+                                                        "static.value",  "$brooklyn:formatString(\"%s%s\",\"test\",\"sensor\")")
+)));
+        TestEntity myTestEntity = app.addChild(EntitySpec.create(TestEntity.class).configure(LocationConfigKeys.DISPLAY_NAME, "mytestentity"));
+        dynamicGroup.policies().add(policySpec);
+        dynamicGroup.setEntityFilter(EntityPredicates.idEqualTo(myTestEntity.getId()));
+
+        assertEqualsIgnoringOrder(dynamicGroup.getMembers(), ImmutableList.of(myTestEntity));
+        Asserts.eventually(new Supplier<String>() {
+            @Override
+            public String get() {
+                return myTestEntity.getAttribute(Sensors.newStringSensor("mytestsensor"));
+            }
+        }, Predicates.<String> equalTo("testsensor"));
+    }
+}


### PR DESCRIPTION
This should now be working.

I've been testing this code with this yaml
```   

    location: localhost
    name: Brooklyn Deployment
    services:
    - type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
      brooklyn.config:
        example: "dfdfsdfsfs"
        displayName: "MyEntity"
      brooklyn.initializers:
      - type: org.apache.brooklyn.core.sensor.StaticSensor
        brooklyn.config:
          name: tf.resource.type
          static.value: aws_instance

    - type: org.apache.brooklyn.entity.group.DynamicGroup
      name: EC2 instances
      brooklyn.policies:
      - type: org.apache.brooklyn.entity.group.GroupsChangePolicy
        brooklyn.config:
          group: $brooklyn:self()
          member.policies: kdjsldl
          member.initializers:
          - type: org.apache.brooklyn.core.sensor.StaticSensor
            brooklyn.config:
              name: testsensor
              target.type: string
              static.value: $brooklyn:formatString("%s%s","test","sensor")
          member.enrichers:
          - type: org.apache.brooklyn.policy.enricher.HttpLatencyDetector
            brooklyn.config:
              latencyDetector.url: http://localost:8081
              latencyDetector.period: 10s
              latencyDetector.requireServiceUp: false

      brooklyn.config:
        dynamicgroup.entityfilter:
          $brooklyn:object:
            type: org.apache.brooklyn.core.entity.EntityPredicates
            factoryMethod.name: displayNameEqualTo
            factoryMethod.args:
            - "Empty Software Process"



```