### PR TITLE
Bump gson from 2.5 to 2.8.9 due to discovered vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <snakeyaml.version>1.27</snakeyaml.version> <!-- 1.27 matches cxf-jackson 3.3.9 -->
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.6.2</swagger.version>
-        <gson.version>2.5</gson.version>
+        <gson.version>2.8.9</gson.version>
         <mx4j.version>3.0.1</mx4j.version>
         <bouncycastle.version>1.67</bouncycastle.version>
         <!-- JClouds 2.2.0 imports eddsa 0.1.0 -->


### PR DESCRIPTION
Bumping gson after snyk identified it as vulnerable: 
https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327