### PR TITLE
Fix s3 wiring

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -374,7 +374,8 @@
         <bundle>mvn:org.apache.jclouds/jclouds-loadbalancer/${jclouds.version}</bundle>
         <bundle>mvn:org.apache.jclouds/jclouds-scriptbuilder/${jclouds.version}</bundle>
         <bundle>mvn:org.apache.jclouds.provider/aws-ec2/${jclouds.version}</bundle>
-        <bundle>mvn:org.apache.jclouds.provider/aws-s3/${jclouds.version}</bundle>
+        <!-- <bundle>mvn:org.apache.jclouds.provider/aws-s3/${jclouds.version}</bundle> add visibility to options so guice can resolve, below -->
+        <bundle>wrap:mvn:org.apache.jclouds.provider/aws-s3/${jclouds.version}$overwrite=merge&amp;Import-Package=org.jclouds.http.options,*</bundle>
         <bundle>mvn:org.apache.jclouds.provider/azureblob/${jclouds.version}</bundle>
         <bundle>mvn:org.apache.jclouds.provider/azurecompute-arm/${jclouds.version}</bundle>
         <bundle>mvn:org.apache.jclouds.provider/b2/${jclouds.version}</bundle>

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/BlobStoreTest.java
@@ -65,7 +65,7 @@ public class BlobStoreTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setup() {
-        testContainerName = CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(8);
+        testContainerName = (CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(8)).toLowerCase();
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
         location = (JcloudsLocation) mgmt.getLocationRegistry().getLocationManaged(locationSpec);
         context = BlobStoreContextFactoryImpl.INSTANCE.newBlobStoreContext(location);
@@ -82,7 +82,7 @@ public class BlobStoreTest {
         PageSet<? extends StorageMetadata> ps = context.getBlobStore().list();
         assertHasItemNamed(ps, testContainerName);
         
-        Blob b = context.getBlobStore().blobBuilder("my-blob-1").payload(Streams.newInputStreamWithContents("hello world")).build();
+        Blob b = context.getBlobStore().blobBuilder("my-blob-1").payload("hello world").build();
         context.getBlobStore().putBlob(testContainerName, b);
         
         Blob b2 = context.getBlobStore().getBlob(testContainerName, "my-blob-1");

--- a/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStoreTest.java
+++ b/locations/jclouds/src/test/java/org/apache/brooklyn/core/mgmt/persist/jclouds/JcloudsBlobStoreBasedObjectStoreTest.java
@@ -82,14 +82,14 @@ public class JcloudsBlobStoreBasedObjectStoreTest {
     
     @Test(groups={"Live", "Live-sanity"})
     public void testJclouds() throws Exception {
-        doTestWithStore( newObjectStore(BlobStoreTest.PERSIST_TO_OBJECT_STORE_FOR_TEST_SPEC, 
-            BlobStoreTest.CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(4)) );
+        doTestWithStore( newObjectStore(BlobStoreTest.PERSIST_TO_OBJECT_STORE_FOR_TEST_SPEC,
+                (BlobStoreTest.CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(4)).toLowerCase()) );
     }
     
     @Test(groups={"Live", "Live-sanity"})
     public void testJcloudsWithSubPathInContainerName() throws Exception {
         doTestWithStore( newObjectStore(BlobStoreTest.PERSIST_TO_OBJECT_STORE_FOR_TEST_SPEC, 
-            BlobStoreTest.CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(4)+"/subpath1/subpath2") );
+            BlobStoreTest.CONTAINER_PREFIX+"-"+Identifiers.makeRandomId(4).toLowerCase()+"/subpath1/subpath2") );
     }
     
     protected void doTestWithStore(PersistenceObjectStore objectStore) {


### PR DESCRIPTION
the `wrap` is needed to avoid the following error at runtime when trying to instantiate aws-s3 using guice

```
1) Error in custom provider, java.lang.NoClassDefFoundError: org.jclouds.http.options.GetOptions not found by aws-s3 [134]
  at org.jclouds.aws.s3.config.AWSS3HttpApiModule.provide(AWSS3HttpApiModule.java:67)
  while locating org.jclouds.s3.S3Client
    for the 2nd parameter of org.jclouds.s3.config.S3HttpApiModule.provideBucketToRegion(S3HttpApiModule.java:88)
  at org.jclouds.s3.config.S3HttpApiModule.provideBucketToRegion(S3HttpApiModule.java:88)
  while locating com.google.common.cache.CacheLoader<java.lang.String, com.google.common.base.Optional<java.lang.String>> annotated with @org.jclouds.s3.Bucket()
    for the 1st parameter of org.jclouds.s3.config.S3HttpApiModule.bucketToRegion(S3HttpApiModule.java:145)
  at org.jclouds.s3.config.S3HttpApiModule.bucketToRegion(S3HttpApiModule.java:145)
  while locating com.google.common.cache.LoadingCache<java.lang.String, com.google.common.base.Optional<java.lang.String>> annotated with @org.jclouds.s3.Bucket()
    for the 1st parameter of org.jclouds.s3.functions.GetRegionForBucket.<init>(GetRegionForBucket.java:42)
  at org.jclouds.s3.functions.GetRegionForBucket.class(GetRegionForBucket.java:34)
  while locating org.jclouds.s3.functions.GetRegionForBucket
  while locating com.google.common.base.Function<java.lang.String, com.google.common.base.Optional<java.lang.String>> annotated with interface org.jclouds.s3.Bucket
Caused by: java.lang.NoClassDefFoundError: org.jclouds.http.options.GetOptions not found by aws-s3 [134]
        at com.sun.proxy.$Proxy168.<clinit>(Unknown Source)
```
