### PR TITLE
Fixes race where multiple RestApiResourceScanner created

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/ScannerInjectHelper.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/ScannerInjectHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Apache Software Foundation.
+ * Copyright 2015-2021 The Apache Software Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,11 @@
  */
 package org.apache.brooklyn.rest.util;
 
-import io.swagger.jaxrs.config.SwaggerContextService;
-import io.swagger.jaxrs.config.SwaggerScannerLocator;
 import org.apache.brooklyn.rest.apidoc.RestApiResourceScanner;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 
-import io.swagger.config.ScannerFactory;
-
 public class ScannerInjectHelper {
     public void setServer(JAXRSServerFactoryBean server) {
-        RestApiResourceScanner scanner = new RestApiResourceScanner(server.getResourceClasses());
-        ScannerFactory.setScanner(scanner);
-        // Above method broken in Swagger 1.6.2:
-        // In Swagger 1.6.2 the method SwaggerContextService.getScanner calls to ScannerFactory.getScanner() only
-        // when SwaggerScannerLocator.getInstance().getScanner(scannerIdKey) == null, but seeing its implementations,
-        // it's impossible to get a null value, so we need to use SwaggerScannerLocator instead.
-        SwaggerScannerLocator.getInstance().putScanner(SwaggerContextService.SCANNER_ID_DEFAULT, scanner);
+        RestApiResourceScanner.install(server.getResourceClasses());
     }
 }


### PR DESCRIPTION
Always call the `install(Collection<Class>)` method, since this has the logic to determine whether we need to create a new scanner. Makes the constructors `private` to prevent this recurring, implements the caveats mentioned in `ScannerInjectHelper` here instead, and make the method `synchronized`.

Signed-off-by: Andrew Donald Kennedy <andrew.international@gmail.com>