### PR TITLE
Fix rebind warnings

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/rebind/mementos/BrooklynMementoPersister.java
@@ -98,8 +98,8 @@ public interface BrooklynMementoPersister {
     Set<String> getLastErrors();
 
     /** applies a full checkpoint (write) of all state; returns true on success or false on error, with {@link #getLastErrors()} available to get the last errors */
-    boolean checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler);
-    /** applies a partial write of state delta; result and errors as per {@link #checkpoint(BrooklynMementoRawData, PersistenceExceptionHandler)} */
+    boolean checkpoint(BrooklynMementoRawData newMemento, PersistenceExceptionHandler exceptionHandler, String context, @Nullable RebindManager deltaDetails);
+    /** applies a partial write of state delta; result and errors as per {@link #checkpoint(BrooklynMementoRawData, PersistenceExceptionHandler, String, RebindManager)} */
     boolean delta(Delta delta, PersistenceExceptionHandler exceptionHandler);
     /** inserts an additional delta to be written on the next delta request */
     @Beta

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -116,9 +116,13 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
     /** Header on bundle indicating it is a wrapped BOM with no other resources */
     public static final String BROOKLYN_WRAPPED_BOM_BUNDLE = "Brooklyn-Wrapped-BOM";
+
     @VisibleForTesting
     public static final boolean AUTO_WRAP_CATALOG_YAML_AS_BUNDLE = true;
-    
+
+    /** key within brooklyn.catalog containing a map of items used to generate headers if an OSGi bundle is being produced by wrapping the YAML */
+    public static final String CATALOG_OSGI_WRAP_HEADERS = "catalog.osgi.wrap.headers";
+
     private static final Logger log = LoggerFactory.getLogger(BasicBrooklynCatalog.class);
 
     public static class BrooklynLoaderTracker {

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -559,7 +559,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
             if (b.getBundle().getState() >= Bundle.INSTALLED && b.getBundle().getState() < Bundle.STARTING) {
                 // we installed it, catalog did not start it, so let's uninstall it
                 OsgiBundleInstallationResult result = getManagementContext().getOsgiManager().get().uninstallUploadedBundle(b.getMetadata());
-                log.debug("Result of uninstalling "+b+" due to due to catalog upgrade metadata instructions: "+result);
+                log.debug("Result of uninstalling "+b+" due to catalog upgrade metadata instructions: "+result);
             }
         });
 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -663,7 +663,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
         for (Map.Entry<VersionedName, InstallableManagedBundle> entry : persistedState.getBundles().entrySet()) {
             if (catalogUpgrades.isBundleRemoved(entry.getKey())) {
                 rebindLogger.debug("Filtering out persisted bundle "+entry.getKey());
-                getManagementContext().getRebindManager().getChangeListener().onUnmanaged(entry.getValue().getManagedBundle());
+                // will skip persistence while not yet installed, and will remove when uninstalled
             } else {
                 bundles.put(entry.getKey(), entry.getValue());
             }
@@ -673,7 +673,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
         for (CatalogItem<?, ?> legacyCatalogItem : persistedState.getLegacyCatalogItems()) {
             if (catalogUpgrades.isLegacyItemRemoved(legacyCatalogItem)) {
                 rebindLogger.debug("Filtering out persisted legacy catalog item "+legacyCatalogItem.getId());
-                getManagementContext().getRebindManager().getChangeListener().onUnmanaged(legacyCatalogItem);
+                // will skip persistence while not yet installed, and will remove when uninstalled
             } else {
                 legacyCatalogItems.add(legacyCatalogItem);
             }

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogInitialization.java
@@ -663,6 +663,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
         for (Map.Entry<VersionedName, InstallableManagedBundle> entry : persistedState.getBundles().entrySet()) {
             if (catalogUpgrades.isBundleRemoved(entry.getKey())) {
                 rebindLogger.debug("Filtering out persisted bundle "+entry.getKey());
+                getManagementContext().getRebindManager().getChangeListener().onUnmanaged(entry.getValue().getManagedBundle());
             } else {
                 bundles.put(entry.getKey(), entry.getValue());
             }
@@ -672,6 +673,7 @@ public class CatalogInitialization implements ManagementContextInjectable {
         for (CatalogItem<?, ?> legacyCatalogItem : persistedState.getLegacyCatalogItems()) {
             if (catalogUpgrades.isLegacyItemRemoved(legacyCatalogItem)) {
                 rebindLogger.debug("Filtering out persisted legacy catalog item "+legacyCatalogItem.getId());
+                getManagementContext().getRebindManager().getChangeListener().onUnmanaged(legacyCatalogItem);
             } else {
                 legacyCatalogItems.add(legacyCatalogItem);
             }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -385,6 +385,10 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
     boolean isStopped() {
         return state == ListenerState.STOPPING || state == ListenerState.STOPPED || executionContext.isShutdown();
     }
+
+    boolean isBundleIdUnmanaged(String id) {
+        return deltaCollector.removedBundleIds.contains(id);
+    }
     
     /**
      * @deprecated since 1.0.0; its use is enabled via BrooklynFeatureEnablement.FEATURE_REFERENCED_OBJECTS_PERSISTENCE_PROPERTY,

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -1068,25 +1068,25 @@ public abstract class RebindIteration {
             if (searchPath != null && !searchPath.isEmpty()) {
                 for (String searchItemId : searchPath) {
                     String fixedSearchItemId = null;
+                    VersionedName searchItemVersionedName = VersionedName.fromString(searchItemId);
+
                     OsgiManager osgi = managementContext.getOsgiManager().orNull();
 
-                    VersionedName bundleVN = VersionedName.fromString(searchItemId);
                     String bundleUpgraded = CatalogUpgrades.getBundleUpgradedIfNecessary(managementContext, searchItemId);
                     if (bundleUpgraded!=null && !bundleUpgraded.equals(searchItemId)) {
                         logRebindingDebug("Upgrading search path entry of " + bType.getSimpleName().toLowerCase() + " " + contextSuchAsId + " from " + searchItemId + " to bundle " + bundleUpgraded);
-                        bundleVN = VersionedName.fromString(bundleUpgraded);
+                        searchItemVersionedName = VersionedName.fromString(bundleUpgraded);
                     }
 
                     if (osgi != null) {
-                        ManagedBundle bundle = osgi.getManagedBundle(bundleVN);
+                        ManagedBundle bundle = osgi.getManagedBundle(searchItemVersionedName);
                         if (bundle != null) {
                             // found as bundle
-                            reboundSearchPath.add(searchItemId);
+                            fixedSearchItemId = searchItemVersionedName.toOsgiString();
+                            reboundSearchPath.add(fixedSearchItemId);
                             continue;
                         }
                     }
-
-
 
                     // look for as a type now
                     RegisteredType t1 = managementContext.getTypeRegistry().get(searchItemId);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindManagerImpl.java
@@ -555,6 +555,10 @@ public class RebindManagerImpl implements RebindManager {
         return persistenceRealChangeListener.hasPending() || persistenceStoreAccess.isWriting();
     }
 
+    public boolean isBundleIdUnmanaged(String id) {
+        return persistenceRealChangeListener.isBundleIdUnmanaged(id);
+    }
+
     @Override
     @VisibleForTesting
     public void forcePersistNow(boolean full, PersistenceExceptionHandler exceptionHandler) {
@@ -567,7 +571,7 @@ public class RebindManagerImpl implements RebindManager {
             if (exceptionHandler == null) {
                 exceptionHandler = persistenceRealChangeListener.getExceptionHandler();
             }
-            persistenceStoreAccess.checkpoint(memento, exceptionHandler);
+            persistenceStoreAccess.checkpoint(memento, exceptionHandler, "manual forced persistence", null);
         } else {
             if (!persistenceRealChangeListener.persistNowSafely()) {
                 throw new IllegalStateException("Forced persistence failed; see logs for more detail");

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BrooklynBomYamlCatalogBundleResolver.java
@@ -107,6 +107,15 @@ public class BrooklynBomYamlCatalogBundleResolver extends AbstractCatalogBundleR
         mf.getMainAttributes().putValue(Attributes.Name.MANIFEST_VERSION.toString(), BasicBrooklynCatalog.OSGI_MANIFEST_VERSION_VALUE);
         mf.getMainAttributes().putValue(BasicBrooklynCatalog.BROOKLYN_WRAPPED_BOM_BUNDLE, Boolean.TRUE.toString());
 
+        Object impliedHeaders = cm.get(BasicBrooklynCatalog.CATALOG_OSGI_WRAP_HEADERS);
+        if (impliedHeaders instanceof Map) {
+            ((Map<?, ?>) impliedHeaders).forEach((k,v)->{
+                mf.getMainAttributes().putValue(Strings.toString(k), Strings.toString(v));
+            });
+        } else if (impliedHeaders!=null) {
+            throw new IllegalStateException("Must contain map of OSGi headers to insert in "+BasicBrooklynCatalog.CATALOG_OSGI_WRAP_HEADERS);
+        }
+
         BundleMaker bm = new BundleMaker(mgmt);
         File bf = bm.createTempBundle(vn.getSymbolicName(), mf, MutableMap.of(
                 new ZipEntry(BasicBrooklynCatalog.CATALOG_BOM), (InputStream) new ByteArrayInputStream(yaml.getBytes())));

--- a/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties
+++ b/core/src/main/resources/org/apache/brooklyn/core/mgmt/persist/deserializingClassRenames.properties
@@ -1462,4 +1462,5 @@ org.apache.brooklyn.software-cm-salt\:org.apache.brooklyn.entity.cm.salt.impl.Sa
 # code-grant of new UI
 io.cloudsoft.amp.ui.common.enricher.AmpExternalUiModuleEnricher                  : org.apache.brooklyn.ui.modularity.enricher.BrooklynExternalUiModuleEnricher
 
+com.google.guava\:com.google.common.collect.EmptyImmutableBiMap                  : org.apache.brooklyn.util.guava.EmptyImmutableBiMap
 com.google.common.collect.EmptyImmutableBiMap                                    : org.apache.brooklyn.util.guava.EmptyImmutableBiMap

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterTestFixture.java
@@ -164,7 +164,7 @@ public abstract class BrooklynMementoPersisterTestFixture {
             
             // And test persisting
             PersistenceExceptionHandler exceptionHandler = PersistenceExceptionHandlerImpl.builder().build();
-            ((BrooklynMementoPersisterToObjectStore) persister).checkpoint(rawMemento, exceptionHandler);
+            ((BrooklynMementoPersisterToObjectStore) persister).checkpoint(rawMemento, exceptionHandler, "test", null);
         } else {
             throw new SkipException("Persister "+persister+" not a "+BrooklynMementoPersisterToObjectStore.class.getSimpleName());
         }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/transformer/CompoundTransformerTest.java
@@ -455,7 +455,7 @@ public class CompoundTransformerTest extends RebindTestFixtureWithApp {
         persister.enableWriteAccess();
 
         PersistenceExceptionHandler exceptionHandler = PersistenceExceptionHandlerImpl.builder().build();
-        persister.checkpoint(rawData, exceptionHandler);
+        persister.checkpoint(rawData, exceptionHandler, "test", null);
         
         LOG.info("Test "+getClass()+" persisted raw data to "+newMementoDir);
         return newMementoDir;

--- a/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
+++ b/launcher-common/src/main/java/org/apache/brooklyn/launcher/common/BasicLauncher.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.launcher.common;
 
+import com.google.common.annotations.VisibleForTesting;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
@@ -333,7 +334,7 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
             LOG.info("Copying persisted state to "+destinationDir+(destinationLocationSpec!=null ? " @ "+destinationLocationSpec : ""));
             PersistenceObjectStore destinationObjectStore = BrooklynPersistenceUtils.newPersistenceObjectStore(
                 managementContext, destinationLocationSpec, destinationDir);
-            BrooklynPersistenceUtils.writeMemento(managementContext, memento, destinationObjectStore);
+            BrooklynPersistenceUtils.writeMemento(managementContext, memento, destinationObjectStore, "copy on launch");
             BrooklynPersistenceUtils.writeManagerMemento(managementContext, planeState, destinationObjectStore);
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
@@ -364,11 +365,12 @@ public class BasicLauncher<T extends BasicLauncher<T>> {
      */
     // Make private after deprecation
     @Deprecated
+    @VisibleForTesting
     public void persistState(BrooklynMementoRawData memento, String destinationDir, @Nullable String destinationLocationSpec) {
         initManagementContext();
         PersistenceObjectStore destinationObjectStore = BrooklynPersistenceUtils.newPersistenceObjectStore(
             managementContext, destinationLocationSpec, destinationDir);
-        BrooklynPersistenceUtils.writeMemento(managementContext, memento, destinationObjectStore);
+        BrooklynPersistenceUtils.writeMemento(managementContext, memento, destinationObjectStore, "persist on launch (for testing only)");
     }
 
     /**

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/ServerResource.java
@@ -648,7 +648,7 @@ public class ServerResource extends AbstractBrooklynRestResource implements Serv
             result.catalogItems(newMementoRawData.getCatalogItems());
 
             PersistenceObjectStore currentPersistenceStore = ((BrooklynMementoPersisterToObjectStore) mgmt().getRebindManager().getPersister()).getObjectStore();
-            BrooklynPersistenceUtils.writeMemento(mgmt(),result.build(),currentPersistenceStore);
+            BrooklynPersistenceUtils.writeMemento(mgmt(),result.build(),currentPersistenceStore, "persist for REST call");
 
             mgmt().getRebindManager().rebind(mgmt().getCatalogClassLoader(),null, mgmt().getHighAvailabilityManager().getNodeState());
 


### PR DESCRIPTION
fix four warnings discovered when rebinding old state (it succeeds without this, but clean it up!)

(A) default catalog does not cleanly replace previous default catalog

```
2021-12-06T11:41:20,996Z ZRsSuuDG- WARN  207 o.a.b.c.m.r.RebindExceptionHandlerImpl [tures-3-thread-1] No catalog item found with id ThreeTierApp:6.0.0; dangling reference on rebind (subsequent log messages will indicate context)
```

(B) search path not upgraded

```
2021-12-06T11:41:21,020Z ZRsSuuDG- WARN  207 o.a.b.c.c.i.CatalogUtils [tures-3-thread-1] Can't find catalog item org.apache.brooklyn.core:1.1.0.20210922_1514 when searching; a search path may be incomplete and other errors may follo
```

(C) redundant warning about removed bundles

```
2021-12-06T11:41:21,639Z - WARN  207 o.a.b.c.m.p.BrooklynMementoPersisterToObjectStore [tures-3-thread-1] Cannot find managed bundle for added bundle qjmej14cyn; ignoring (probably uninstalled or reinstalled with another OSGi ID; see debug log for contents)
```

(D) guava update renames should include osgi metadata, to avoid

```
2021-12-06T11:41:21,103Z ZRsSuuDG- WARN  207 o.a.b.u.c.ClassLoaderUtils [ooklyn-persister] No class 'com.google.common.collect.EmptyImmutableBiMap' in bundle 'com.google.guava' (using spec 'com.google.guava:com.google.common.collect.EmptyImmutableBiMap'); found using deprecated no-bundle syntax, but this behaviour is deprecated and likely to be unsupported in future. Change so invalid bundle is not supplied.
```

