### PR TITLE
Calling unmanage on a removed child that causes the corresponding dyn…

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -672,10 +672,8 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
                 
                 if (changed) {
                     getManagementSupport().getEntityChangeListener().onChildrenChanged();
-                }
-            
-                if (changed) {
                     sensors().emit(AbstractEntity.CHILD_REMOVED, child);
+                    Entities.unmanage(child);
                 }
                 return changed;
             }


### PR DESCRIPTION
…amicgroup item to be removed

As above. When removing children that have corresponding items in a group (e.g. DynamicGroup), the corresponding item in the group was not removed. Calling the unmanage() method when removing the child causes necessary event to be triggered, essentially removing the item from the group as required.