### PR TITLE
Bump karaf to 434 staging

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
@@ -178,7 +178,7 @@ public class AsPropertyIfAmbiguous {
             }
         }
 
-        @Override
+//        @Override
         protected Object _deserializeTypedForId(JsonParser p, DeserializationContext ctxt,
                                                 TokenBuffer tb) throws IOException
         {

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/AsPropertyIfAmbiguous.java
@@ -178,7 +178,7 @@ public class AsPropertyIfAmbiguous {
             }
         }
 
-//        @Override
+        @Override
         protected Object _deserializeTypedForId(JsonParser p, DeserializationContext ctxt,
                                                 TokenBuffer tb) throws IOException
         {

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -140,7 +140,7 @@
             <version>0.12</version>
             <configuration>
                 <consoleOutput>true</consoleOutput>
-                <excludes combine.children="append">q
+                <excludes combine.children="append">
                     <!-- Exclude sandbox because not part of distribution: not in tgz, and not uploaded to maven-central -->
                     <exclude>sandbox/**</exclude>
                     <!-- Exclude release because not part of distribution: not in tgz, and not uploaded to maven-central -->

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -140,7 +140,7 @@
             <version>0.12</version>
             <configuration>
                 <consoleOutput>true</consoleOutput>
-                <excludes combine.children="append">
+                <excludes combine.children="append">q
                     <!-- Exclude sandbox because not part of distribution: not in tgz, and not uploaded to maven-central -->
                     <exclude>sandbox/**</exclude>
                     <!-- Exclude release because not part of distribution: not in tgz, and not uploaded to maven-central -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,12 @@
             </snapshots>
         </repository>
     </repositories>
-
+    <pluginRepositories>
+        <pluginRepository>
+            <id>testKaraf434-plugin</id>
+            <url>https://repository.apache.org/content/repositories/orgapachekaraf-1165/</url>
+        </pluginRepository>
+    </pluginRepositories>
     <properties>
         <brooklyn.version>1.1.0-SNAPSHOT</brooklyn.version>  <!-- BROOKLYN_VERSION -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@
         <activator.servicemix.version>2.9.0</activator.servicemix.version>
         <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.11.3</fasterxml.jackson.version>
-        <cxf.version>3.3.9</cxf.version>
+        <fasterxml.jackson.version>2.12.5</fasterxml.jackson.version>
+        <cxf.version>3.4.0</cxf.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version> <!-- To match cxf -->
         <!-- @deprecated since 0.11 -->
@@ -151,7 +151,7 @@
         <!-- Next version of swagger requires changes to how path mapping and scanner injection are done. -->
         <swagger.version>1.6.2</swagger.version>
         <mx4j.version>3.0.1</mx4j.version>
-        <bouncycastle.version>1.67</bouncycastle.version>  <!-- beyond this gives asn1 errors, needs a new dep probably -->
+        <bouncycastle.version>1.69</bouncycastle.version>  <!-- beyond this gives asn1 errors, needs a new dep probably -->
         <eddsa.version>0.2.0</eddsa.version>  <!-- eddsa 0.3.0 needs sun x509 -->
         <sshj.version>0.27.0</sshj.version>  <!-- jclouds 2.4 uses 0.27; 0.32 needs eddsa 0.3.0 -->
         <!-- jzlib osgi version is 1.1.3.2, but bundle is 1.1.3_2 ; JClouds 2.2.0 pulls in 1.0.7_1 but is happy with 1.1.3.2 -->
@@ -161,9 +161,9 @@
         <jetty-schemas.version>3.1.M0</jetty-schemas.version>
         <airline.version>0.7</airline.version>
         <freemarker.version>2.3.31</freemarker.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <jsonPath.version>2.4.0</jsonPath.version>
-        <commons-compress.version>1.20</commons-compress.version>
+        <commons-compress.version>1.21</commons-compress.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <geronimo-jms_1.1_spec.version>1.1.1</geronimo-jms_1.1_spec.version>
         <geronimo-jta_1.1_spec.version>1.1.1</geronimo-jta_1.1_spec.version>
@@ -195,14 +195,14 @@
         <!-- Dependencies shipped with vanilla karaf; update these when we update the karaf version -->
         <karaf.version>4.3.4</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
-        <jetty.version>9.4.39.v20210325</jetty.version> <!-- 9.4.31.v20200723 from Karaf 4.3.0 -->
+        <jetty.version>9.4.41.v20210516</jetty.version> <!-- 9.4.41.v20210516 from Karaf 4.3.4 -->
         <commons-collections.version>3.2.2</commons-collections.version>
-        <pax-web.version>7.3.9</pax-web.version>
+        <pax-web.version>7.3.17</pax-web.version>
         <spifly.version>1.3.2</spifly.version> <!-- 1.3.0 from kubernetes; 1.2.4 from pax-jetty; v1.3.2 from erstwhile jetty feature; but 1.3.2 fixes an NPE bug in 1.3.0 so use it -->
         <felix.framework.version>6.0.3</felix.framework.version>
 
         <!-- Transitive dependencies, declared explicitly to avoid version mismatch -->
-        <jna.version>4.1.0</jna.version>
+        <jna.version>5.9.0</jna.version>
         <objenesis.version>2.5</objenesis.version>
         <clojure.version>1.4.0</clojure.version>
         <clj-time.version>0.4.1</clj-time.version>
@@ -245,7 +245,7 @@
 
         <!-- Seemingly unused dependencies! -->
         <ivy.version>2.2.0</ivy.version>
-        <jline.version>2.12</jline.version>
+        <jline.version>3.21.0</jline.version>
         <jansi.version>1.2.1</jansi.version> <!-- Also shipped in vanilla karaf, v1.17.1 in karaf:4.1.6 -->
         <sleepycat-je.version>5.0.34</sleepycat-je.version>
         <jcommander.version>1.27</jcommander.version>
@@ -417,7 +417,7 @@
                 <version>${ow2.asm.version.jsonpath}</version>
             </dependency>
             <dependency>
-                <groupId>jline</groupId> <!-- when removing this, replace uses with org.jline -->
+                <groupId>org.jline</groupId> <!-- when removing this, replace uses with org.jline -->
                 <artifactId>jline</artifactId>
                 <version>${jline.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <activator.servicemix.version>2.9.0</activator.servicemix.version>
         <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <!-- double-check downstream projects before changing jackson version -->
-        <fasterxml.jackson.version>2.12.5</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.11.3</fasterxml.jackson.version>
         <cxf.version>3.4.0</cxf.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version> <!-- To match cxf-http-async -->
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version> <!-- To match cxf -->

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>testKaraf434</id>
+            <url>https://repository.apache.org/content/repositories/orgapachekaraf-1165/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <properties>
@@ -181,7 +188,7 @@
         <kubernetes-client.version>5.8.0</kubernetes-client.version>
 
         <!-- Dependencies shipped with vanilla karaf; update these when we update the karaf version -->
-        <karaf.version>4.3.0</karaf.version>
+        <karaf.version>4.3.4</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <jetty.version>9.4.39.v20210325</jetty.version> <!-- 9.4.31.v20200723 from Karaf 4.3.0 -->
         <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION
This bumps Karaf to a pre-release Karaf 4.3.4 which uses log4j 2.16.0 which avoids the CVE-2021-44228 vulnerability.

This uses the staging repo for that version of karaf.  When released we should remove the two references to the repo `orgapachekaraf-1165` as they will no longer be necessary and will eventually become unavailable.

The new version of Karaf appears to work fine, but two things should be checked:

* Newer version of bouncycastle used by this Karaf -- does SSH via jclouds still work?  Previously upgrading this version has been problematic.
* Older version of Jackson used -- less than what Karaf wants -- seems not to cause problems though there is a new `ERROR  BundleWiring is null for: javax.mail [3]` in the log; more testing is needed, or update Brooklyn code to work with the newer version of Jackson (the issue is that the jackson method overridden by our `AsPropertyIfAmbiguous._deserializeTypedForId` is no longer available, and deseriailzation requires this in some cases; there is a unit test which fails if this is not invoked)

We will merge this as the log4j bug is severe and @jcabrerizo has reviewed (actually he did most the work and I reviewed!) -- and we will do testing on the release.