### PR TITLE
Updated to Apache Karaf 4.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <kubernetes-client.version>5.8.0</kubernetes-client.version>
 
         <!-- Dependencies shipped with vanilla karaf; update these when we update the karaf version -->
-        <karaf.version>4.3.5</karaf.version>
+        <karaf.version>4.3.6</karaf.version>
         <karaf.plugin.version>${karaf.version}</karaf.plugin.version>
         <pax-web.version>7.3.23</pax-web.version> <!-- karaf 4.3 -->
         <jetty.version>9.4.43.v20210629</jetty.version> <!-- pax 7.3.23 from karaf 4.3 -->


### PR DESCRIPTION
Karaf updates:

> This release is an important release on the Karaf 4.3.x series containing:
> - upgrade to Pax Logging 2.0.14 with log4j 2.17.1 (fixing CVE-2021-44832)
> - prepare JDK 18 support
> - fix deployment issue by upgrading to Apache Felix FileInstall 3.7.4
> - and much more!
> The Release Notes are available here: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12351123