### PR TITLE
Updated to json-smart 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <log4j.version>1.2.17</log4j.version>
         <commons-logging.version>1.2</commons-logging.version>
-        <jsonSmart.version>2.3</jsonSmart.version>
+        <jsonSmart.version>2.4.7</jsonSmart.version>
         <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
 
         <ow2.asm.version.jsonpath>5.2</ow2.asm.version.jsonpath>


### PR DESCRIPTION
Mitigates [CVE-2021-27568 ](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-27568) cataloged by [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-1078499) as **Critical**