### PR TITLE
Update to Minidev Accessors Smart 2.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,8 @@
         <log4j.version>1.2.17</log4j.version>
         <commons-logging.version>1.2</commons-logging.version>
         <jsonSmart.version>2.4.7</jsonSmart.version>
-        <minidev.accessors-smart.version>1.2</minidev.accessors-smart.version>
+        <!--JsonSmart requires minidev-asm (version>=2.4.0)(!(version>=3.0.0)))-->
+        <minidev.accessors-smart.version>2.4.7</minidev.accessors-smart.version>
 
         <ow2.asm.version.jsonpath>5.2</ow2.asm.version.jsonpath>
           <!-- json-path needs objectweb.asm version 5.2 (<6.0.0), and won't accept a bundleReplacement for a higher one; 


### PR DESCRIPTION
Updating Json Smart causes Apache Karaf to fail starting

```
Caused by: org.apache.felix.resolver.reason.ReasonException: Unable to resolve net.minidev.json-smart/2.4.7: missing requirement [net.minidev.json-smart/2.4.7] osgi.wiring.package; filter:="(&(osgi.wiring.package=net.minidev.asm)(version>=2.4.0)(!(version>=3.0.0)))"
...
```