### PR TITLE
allow lookup of an icon url with respect to an entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ brooklyn*.log.*
 *brooklyn-persisted-state/
 
 ignored
+.java-version

--- a/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/TypeApi.java
+++ b/rest/rest-api/src/main/java/org/apache/brooklyn/rest/api/TypeApi.java
@@ -84,17 +84,20 @@ public interface TypeApi {
         @ApiParam(name = "version", value = "Version to query", required = true)
         @PathParam("version")
         String version);
-    
+
     @Path("/{symbolicName}/{version}/icon")
     @GET
     @ApiOperation(value = "Returns the icon image registered for this item")
     @Produces("application/image")
     public Response icon(
-        @ApiParam(name = "symbolicName", value = "Type name to query", required = true)
-        @PathParam("symbolicName")
-        String symbolicName,
-        @ApiParam(name = "version", value = "Version to query", required = true)
-        @PathParam("version")
-        String version);
+            @ApiParam(name = "symbolicName", value = "Type name to query", required = true)
+            @PathParam("symbolicName")
+                    String symbolicName,
+            @ApiParam(name = "version", value = "Version to query (or 'latest')", required = true)
+            @PathParam("version")
+                    String version,
+            @ApiParam(name = "iconUrl", value = "URL or path to icon to load with respect to this entity", required = false)
+            @QueryParam("iconUrl")
+            String iconUrl);
     
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/TypeResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/TypeResource.java
@@ -160,14 +160,22 @@ public class TypeResource extends AbstractBrooklynRestResource implements TypeAp
         return item;
     }
 
-    @Override
+    @Deprecated /** @deprecated since 1.1, include iconUrl */
     public Response icon(String symbolicName, String version) {
+        return icon(symbolicName, version, null);
+    }
+
+    @Override
+    public Response icon(String symbolicName, String version, String iconUrl) {
         RegisteredType item = lookup(symbolicName, version);
-        return produceIcon(mgmt(), brooklyn(), item);
+        return produceIcon(mgmt(), brooklyn(), item, iconUrl);
     }
 
     static Response produceIcon(ManagementContext mgmt, BrooklynRestResourceUtils brooklyn, RegisteredType result) {
-        String url = result.getIconUrl();
+        return produceIcon(mgmt, brooklyn, result, null);
+    }
+    static Response produceIcon(ManagementContext mgmt, BrooklynRestResourceUtils brooklyn, RegisteredType result, String url) {
+        if (Strings.isBlank(url)) url = result.getIconUrl();
         if (url==null) {
             log.debug("No icon available for "+result+"; returning "+Status.NO_CONTENT);
             return Response.status(Status.NO_CONTENT).build();


### PR DESCRIPTION
adds an optional iconUrl query parameter, if an alternate icon is specified in the context of an entity
useful in the composer to show custom icons on entities