### PR TITLE
Adds recursive LogBook query feature

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
@@ -31,6 +31,9 @@ public class LogBookQueryParams {
     /** The indicator whether to return last number of items (tail) or not */
     private Boolean tail;
 
+    /** The indicator whether to list sub-task items (recursively) or not */
+    private Boolean recursive;
+
     /** The log levels: INFO, FATAL, ERROR, DEBUG or WARNING */
     private List<String> levels;
 
@@ -61,6 +64,14 @@ public class LogBookQueryParams {
 
     public void setTail(Boolean tail) {
         this.tail = tail;
+    }
+
+    public Boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(Boolean recursive) {
+        this.recursive = recursive;
     }
 
     public List<String> getLevels() {

--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
@@ -32,7 +32,7 @@ public class LogBookQueryParams {
     private Boolean tail;
 
     /** The indicator whether to list sub-task items (recursively) or not */
-    private Boolean recursive = false;
+    private Boolean recursive = false; // for backward compatibility
 
     /** The log levels: INFO, FATAL, ERROR, DEBUG or WARNING */
     private List<String> levels;

--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogBookQueryParams.java
@@ -32,7 +32,7 @@ public class LogBookQueryParams {
     private Boolean tail;
 
     /** The indicator whether to list sub-task items (recursively) or not */
-    private Boolean recursive;
+    private Boolean recursive = false;
 
     /** The log levels: INFO, FATAL, ERROR, DEBUG or WARNING */
     private List<String> levels;

--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogbookConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/LogbookConfig.java
@@ -24,10 +24,16 @@ import org.apache.brooklyn.core.config.ConfigKeys;
 public class LogbookConfig {
     public final static String BASE_NAME_LOGBOOK = "brooklyn.logbook";
 
-    public final static ConfigKey<String> LOGBOOK_LOG_STORE_CLASSNAME = ConfigKeys.newStringConfigKey(
-            BASE_NAME_LOGBOOK + ".logStore", "Log store implementation class name","org.apache.brooklyn.util.core.logbook.file.FileLogStore");
-
-    public final static ConfigKey<LogStore> LOGBOOK_LOG_STORE_INSTANCE = ConfigKeys.newConfigKey(LogStore.class,
-            LOGBOOK_LOG_STORE_CLASSNAME.getName() + ".internal.instance", "instance of a pre-configured log store");
+    public final static ConfigKey<String> LOGBOOK_LOG_STORE_CLASSNAME = ConfigKeys.builder(String.class, BASE_NAME_LOGBOOK + ".logStore")
+            .description("Log store implementation class name")
+            .defaultValue("org.apache.brooklyn.util.core.logbook.file.FileLogStore")
+            .build();
+    public final static ConfigKey<LogStore> LOGBOOK_LOG_STORE_INSTANCE = ConfigKeys.builder(LogStore.class, LOGBOOK_LOG_STORE_CLASSNAME.getName() + ".internal.instance")
+            .description("Instance of a pre-configured log store")
+            .build();
+    public final static ConfigKey<Integer> LOGBOOK_MAX_RECURSIVE_TASKS = ConfigKeys.builder(Integer.class, BASE_NAME_LOGBOOK + ".maxTasks")
+            .description("Maximum number of recursive tasks")
+            .defaultValue(100)
+            .build();
 
 }


### PR DESCRIPTION
Adds recursive task query for logbook using limited breadth-first search of child tasks.

Uses https://github.com/apache/brooklyn-server/pull/1316 for UI component.

Signed-off-by: Andrew Donald Kennedy <andrew.international@gmail.com>