### PR TITLE
Introduce entity adjunct proxy, fix deserialization edge case

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/enricher/AbstractEnricher.java
+++ b/core/src/main/java/org/apache/brooklyn/core/enricher/AbstractEnricher.java
@@ -31,6 +31,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.rebind.BasicEnricherRebindSupport;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
@@ -44,7 +45,7 @@ import com.google.common.collect.Maps;
 /**
 * Base {@link Enricher} implementation; all enrichers should extend this or its children
 */
-public abstract class AbstractEnricher extends AbstractEntityAdjunct implements Enricher {
+public abstract class AbstractEnricher extends AbstractEntityAdjunct implements Enricher, EntityAdjuncts.EntityAdjunctProxyable {
 
     public static final ConfigKey<Boolean> SUPPRESS_DUPLICATES = ConfigKeys.newBooleanConfigKey(
             "enricher.suppressDuplicates",

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAdjuncts.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAdjuncts.java
@@ -30,12 +30,15 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ComputeServiceIndicatorsFromChildrenAndMembers;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ComputeServiceState;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
+import org.apache.brooklyn.core.objs.proxy.EntityAdjunctProxyImpl;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
 
 /**
  * Convenience methods for working with entity adjunts.
@@ -91,6 +94,18 @@ public class EntityAdjuncts {
         // Enricher doesn't support suspend so if not running or destroyed then
         // it is just created
         return Lifecycle.CREATED;
+    }
+
+    public static <T extends EntityAdjunct> T createProxy(Class<T> adjunctType, @Nullable T delegate) {
+        return (T) java.lang.reflect.Proxy.newProxyInstance(
+                /** must have sight of all interfaces */ EntityAdjuncts.class.getClassLoader(),
+                new Class[] { adjunctType, EntityAdjuncts.EntityAdjunctProxyable.class},
+
+                new EntityAdjunctProxyImpl(delegate));
+    }
+
+    public interface EntityAdjunctProxyable {
+        Entity getEntity();
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/AbstractFeed.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.sensor.Sensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.rebind.BasicFeedRebindSupport;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
@@ -42,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * These generally poll or subscribe to get sensor values for an entity.
  * They make it easy to poll over http, jmx, etc.
  */
-public abstract class AbstractFeed extends AbstractEntityAdjunct implements Feed {
+public abstract class AbstractFeed extends AbstractEntityAdjunct implements Feed, EntityAdjuncts.EntityAdjunctProxyable {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractFeed.class);
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/XmlMementoSerializer.java
@@ -218,6 +218,10 @@ public class XmlMementoSerializer<T> extends XmlSerializer<T> implements Memento
         MapperWrapper mapper = super.wrapMapperForNormalUsage(next);
         mapper = new CustomMapper(mapper, Entity.class, "entityProxy");
         mapper = new CustomMapper(mapper, Location.class, "locationProxy");
+
+        mapper = new CustomMapper(mapper, Policy.class, "policyRef");
+        mapper = new CustomMapper(mapper, Enricher.class, "enricherRef");
+
         mapper = new UnwantedStateLoggingMapper(mapper);
         return mapper;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindExceptionHandlerImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindExceptionHandlerImpl.java
@@ -18,12 +18,10 @@
  */
 package org.apache.brooklyn.core.mgmt.rebind;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.brooklyn.api.catalog.CatalogItem;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
@@ -35,6 +33,7 @@ import org.apache.brooklyn.api.mgmt.rebind.RebindManager.RebindFailureMode;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.EntityMemento;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
@@ -49,9 +48,12 @@ import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /** Stateful handler, meant for a single rebind pass */
 public class RebindExceptionHandlerImpl implements RebindExceptionHandler {
@@ -224,11 +226,20 @@ public class RebindExceptionHandlerImpl implements RebindExceptionHandler {
         }
     }
 
+    BiFunction<Class<? extends EntityAdjunct>, String, EntityAdjunct> createAdjunctProxy;
+
+    @Beta
+    public void setAdjunctProxyCreator(BiFunction<Class<? extends EntityAdjunct>,String,EntityAdjunct> createAdjunctProxy) {
+        this.createAdjunctProxy = createAdjunctProxy;
+    }
+
     @Override
     public Policy onDanglingPolicyRef(String id) {
         if (Thread.currentThread().isInterrupted()) {
             throw new RuntimeInterruptedException("Interruption discovered when recording dangling policy "+id);
         }
+
+        if (createAdjunctProxy!=null) return (Policy) createAdjunctProxy.apply(Policy.class, id);
 
         missingPolicies.add(id);
         if (danglingRefFailureMode == RebindManager.RebindFailureMode.FAIL_FAST) {
@@ -244,6 +255,8 @@ public class RebindExceptionHandlerImpl implements RebindExceptionHandler {
         if (Thread.currentThread().isInterrupted()) {
             throw new RuntimeInterruptedException("Interruption discovered when recording dangling enricher "+id);
         }
+
+        if (createAdjunctProxy!=null) return (Enricher) createAdjunctProxy.apply(Enricher.class, id);
 
         missingEnrichers.add(id);
         if (danglingRefFailureMode == RebindManager.RebindFailureMode.FAIL_FAST) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/RebindIteration.java
@@ -63,6 +63,7 @@ import org.apache.brooklyn.api.mgmt.rebind.mementos.PolicyMemento;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.TreeNode;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
@@ -78,6 +79,7 @@ import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
 import org.apache.brooklyn.core.enricher.AbstractEnricher;
 import org.apache.brooklyn.core.entity.AbstractApplication;
 import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.feed.AbstractFeed;
 import org.apache.brooklyn.core.location.AbstractLocation;
@@ -97,10 +99,7 @@ import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.RebindTracker;
 import org.apache.brooklyn.core.objs.AbstractBrooklynObject;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
-import org.apache.brooklyn.core.objs.proxy.InternalEntityFactory;
-import org.apache.brooklyn.core.objs.proxy.InternalFactory;
-import org.apache.brooklyn.core.objs.proxy.InternalLocationFactory;
-import org.apache.brooklyn.core.objs.proxy.InternalPolicyFactory;
+import org.apache.brooklyn.core.objs.proxy.*;
 import org.apache.brooklyn.core.policy.AbstractPolicy;
 import org.apache.brooklyn.core.typereg.BasicManagedBundle;
 import org.apache.brooklyn.core.typereg.BundleUpgradeParser.CatalogUpgrades;
@@ -484,11 +483,23 @@ public abstract class RebindIteration {
         }
     }
 
+    protected Map<String,EntityAdjunct> adjunctProxies = MutableMap.of();
+    protected <T extends EntityAdjunct> T createAdjunctProxy(Class<T> adjunctType, String id) {
+        return (T) adjunctProxies.computeIfAbsent(id, (id2) -> EntityAdjuncts.createProxy(adjunctType, null) );
+    }
+
     protected void instantiateMementos() throws IOException {
 
         checkEnteringPhase(4);
 
+        if (!adjunctProxies.isEmpty()) {
+            LOG.warn("Had stale adjunct information when rebinding; ignoring: "+adjunctProxies);
+        }
+        adjunctProxies.clear();
+
+        ((RebindExceptionHandlerImpl)exceptionHandler).setAdjunctProxyCreator(this::createAdjunctProxy);
         memento = persistenceStoreAccess.loadMemento(mementoRawData, rebindContext.lookup(), exceptionHandler);
+        ((RebindExceptionHandlerImpl)exceptionHandler).setAdjunctProxyCreator(null);
     }
 
     protected void initPlaneId() {
@@ -518,6 +529,9 @@ public abstract class RebindIteration {
 
                 try {
                     Policy policy = instantiator.newPolicy(policyMemento);
+
+                    EntityAdjunctProxyImpl.resetDelegate( adjunctProxies.remove(policy.getId()) , policy);
+
                     rebindContext.registerPolicy(policyMemento.getId(), policy);
                 } catch (Exception e) {
                     exceptionHandler.onCreateFailed(BrooklynObjectType.POLICY, policyMemento.getId(), policyMemento.getType(), e);
@@ -535,6 +549,7 @@ public abstract class RebindIteration {
 
                 try {
                     Enricher enricher = instantiator.newEnricher(enricherMemento);
+                    EntityAdjunctProxyImpl.resetDelegate( adjunctProxies.remove(enricher.getId()) , enricher);
                     rebindContext.registerEnricher(enricherMemento.getId(), enricher);
                 } catch (Exception e) {
                     exceptionHandler.onCreateFailed(BrooklynObjectType.ENRICHER, enricherMemento.getId(), enricherMemento.getType(), e);
@@ -542,6 +557,18 @@ public abstract class RebindIteration {
             }
         } else {
             logRebindingDebug("Not rebinding enrichers; feature disabled: {}", memento.getEnricherIds());
+        }
+
+        if (!adjunctProxies.isEmpty()) {
+            adjunctProxies.entrySet().forEach(entry -> {
+                if (entry.getValue() instanceof Policy) exceptionHandler.onDanglingPolicyRef(entry.getKey());
+                else if (entry.getValue() instanceof Enricher) exceptionHandler.onDanglingEnricherRef(entry.getKey());
+                else {
+                    LOG.warn("Adjunct proxy for "+entry.getKey()+" is of unexpected type; "+entry.getValue()+"; reporting as dangling of unknown type");
+                    exceptionHandler.onDanglingUntypedItemRef(entry.getKey());
+                }
+            });
+            adjunctProxies.clear();
         }
 
         // Instantiate feeds

--- a/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/AbstractEntityAdjunct.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.core.objs;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
 import java.util.concurrent.ConcurrentHashMap;
 import static org.apache.brooklyn.util.JavaGroovyEquivalents.groovyTruth;
 
@@ -52,6 +54,7 @@ import org.apache.brooklyn.core.config.internal.AbstractConfigMapImpl;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.internal.ConfigUtilsInternal;
 import org.apache.brooklyn.core.mgmt.internal.SubscriptionTracker;
+import org.apache.brooklyn.core.objs.proxy.EntityAdjunctProxyImpl;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
@@ -584,4 +587,18 @@ public abstract class AbstractEntityAdjunct extends AbstractBrooklynObject imple
                 .add("id", getId())
                 .toString();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o==null) return false;
+        if (Proxy.isProxyClass(o.getClass())) {
+            InvocationHandler ph = Proxy.getInvocationHandler(o);
+            if (ph!=null && ph instanceof EntityAdjunctProxyImpl) return ((EntityAdjunctProxyImpl)ph).equals(this);
+            return false;
+        }
+
+        return super.equals(o);
+    }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/AbstractBrooklynObjectProxyImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/AbstractBrooklynObjectProxyImpl.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs.proxy;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.collect.Sets;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.objs.BrooklynObject;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
+import org.apache.brooklyn.core.mgmt.internal.ManagementTransitionMode;
+import org.apache.brooklyn.core.mgmt.rebind.RebindManagerImpl.RebindTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * Methods lifted from EntityProxyImpl to support an AdjunctProxyImpl
+ */
+public abstract class AbstractBrooklynObjectProxyImpl<T extends BrooklynObject> implements java.lang.reflect.InvocationHandler {
+
+    // TODO Currently the proxy references the real entity and invokes methods on it directly.
+    // As we work on remoting/distribution, this will be replaced by RPC.
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBrooklynObjectProxyImpl.class);
+
+    protected T delegate;
+    protected Boolean isMaster;
+
+    private WeakHashMap<T,Void> temporaryProxies = new WeakHashMap<T, Void>();
+
+    private static final Set<MethodSignature> OBJECT_METHODS = Sets.newLinkedHashSet();
+    static {
+        for (Method m : Object.class.getMethods()) {
+            OBJECT_METHODS.add(new MethodSignature(m));
+        }
+    }
+
+    protected AbstractBrooklynObjectProxyImpl(T delegate) {
+        this.delegate = delegate;
+    }
+
+    protected abstract T getProxy(T instance, boolean requireNonProxy);
+    protected abstract void resetProxy(T instance, T preferredProxy);
+
+    /** invoked to specify that a different underlying delegate should be used, 
+     * e.g. because we are switching copy impls or switching primary/copy*/
+    public synchronized void resetDelegate(T thisProxy, T preferredProxy, T newDelegate) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("updating "+Integer.toHexString(System.identityHashCode(thisProxy))
+                +" to be the same as "+Integer.toHexString(System.identityHashCode(preferredProxy))
+                +" pointing at "+Integer.toHexString(System.identityHashCode(newDelegate)) 
+                +" ("+temporaryProxies.size()+" temporary proxies)");
+        }
+
+        T oldDelegate = delegate;
+        this.delegate = newDelegate;
+        this.isMaster = null;
+        
+        if (newDelegate==oldDelegate)
+            return;
+        
+        /* we have to make sure that any newly created proxy of the newDelegate 
+         * which have leaked (eg by being set as a child) also get repointed to this new delegate */
+        if (oldDelegate!=null) {
+            T temporaryProxy = getProxy(oldDelegate, true);
+            if (temporaryProxy!=null) temporaryProxies.put(temporaryProxy, null);
+            resetProxy(oldDelegate, preferredProxy);
+        }
+        if (newDelegate!=null) {   
+            T temporaryProxy = getProxy(newDelegate, true);
+            if (temporaryProxy!=null) temporaryProxies.put(temporaryProxy, null);
+            resetProxy(newDelegate, preferredProxy);
+        }
+        
+        // update any proxies which might be in use
+        for (T tp: temporaryProxies.keySet()) {
+            if (tp==thisProxy || tp==preferredProxy) continue;
+            ((AbstractBrooklynObjectProxyImpl)(Proxy.getInvocationHandler(tp))).resetDelegate(tp, preferredProxy, newDelegate);
+        }
+    }
+    
+    @Override
+    public String toString() {
+        return delegate==null ? getClass().getName()+"[null]" : delegate.toString();
+    }
+    
+    protected boolean isMaster() {
+        if (isMaster!=null) return isMaster;
+        if (delegate==null) return false;
+        
+        ManagementContext mgmt = ((EntityInternal)delegate).getManagementContext();
+        ManagementTransitionMode mode = ((EntityManagerInternal)mgmt.getEntityManager()).getLastManagementTransitionMode(delegate.getId());
+        Boolean ro = ((EntityInternal)delegate).getManagementSupport().isReadOnlyRaw();
+        
+        if (mode==null || ro==null) {
+            // not configured yet
+            return false;
+        }
+        boolean isMasterX = !mode.isReadOnly();
+        if (isMasterX != !ro) {
+            LOG.warn("Inconsistent read-only state for "+delegate+" (possibly rebinding); "
+                + "management thinks "+isMasterX+" but entity thinks "+!ro);
+            return false;
+        }
+        isMaster = isMasterX;
+        return isMasterX;
+    }
+
+    /** calls permitted even when in RO / non-master mode */
+    protected abstract boolean isPermittedReadOnlyMethod(MethodSignature sig);
+
+    @Override
+    public Object invoke(Object proxy, final Method m, final Object[] args) throws Throwable {
+        if (proxy == null) {
+            throw new IllegalArgumentException("Static methods not supported via proxy on entity "+delegate);
+        }
+        
+        MethodSignature sig = new MethodSignature(m);
+
+        Object result;
+        if (delegate==null) {
+            // allow access to toString (mainly for logging of errors during serialization)
+            if ("toString".equals(sig.name)) return toString();
+            throw new NullPointerException("Access to proxy before initialized, method "+m);
+        } else if (OBJECT_METHODS.contains(sig)) {
+            result = m.invoke(delegate, args);
+        } else if (isPermittedReadOnlyMethod(sig)) {
+            result = m.invoke(delegate, args);
+        } else {
+            if (!isMaster()) {
+                if (isMaster==null || RebindTracker.isRebinding()) {
+                    // rebinding or caller manipulating before management; permit all access
+                    // (as of this writing, things seem to work fine without the isRebinding check;
+                    // but including in it may allow us to tighten the methods in EntityTransientCopyInternal) 
+                    result = m.invoke(delegate, args);
+                } else {
+                    throw new UnsupportedOperationException("Call to '"+sig+"' not permitted on read-only entity "+delegate);
+                }
+            } else {
+                result = invokeOther(m, args);
+            }
+        }
+        
+        return result == delegate ? getProxy(delegate, false) : result;
+    }
+
+    protected Object invokeOther(Method m, Object[] args) throws IllegalAccessException, InvocationTargetException {
+        return m.invoke(delegate, args);
+    }
+
+    static class MethodSignature {
+        private final String name;
+        private final Class<?>[] parameterTypes;
+        
+        MethodSignature(Method m) {
+            name = m.getName();
+            parameterTypes = m.getParameterTypes();
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(name, Arrays.hashCode(parameterTypes));
+        }
+        
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof MethodSignature)) return false;
+            MethodSignature o = (MethodSignature) obj;
+            return name.equals(o.name) && Arrays.equals(parameterTypes, o.parameterTypes);
+        }
+        
+        @Override
+        public String toString() {
+            return name+Arrays.toString(parameterTypes);
+        }
+    }
+    
+    @VisibleForTesting
+    public T getDelegate() {
+        return delegate;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        return Objects.equal(delegate, obj);
+    }
+    
+    @Override
+    public int hashCode() {
+        return delegate==null ? 0 : delegate.hashCode();
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/EntityAdjunctProxyImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/EntityAdjunctProxyImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.objs.proxy;
+
+import org.apache.brooklyn.api.objs.EntityAdjunct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Proxy;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * As EntityProxyImpl, but for policies etc.
+ * Not as widely used as the entity proxy; only used where needed eg when rebinding an entity with a reference to a policy
+ * which hasn't yet been rebinded.
+ */
+public class EntityAdjunctProxyImpl extends AbstractBrooklynObjectProxyImpl<EntityAdjunct> implements java.lang.reflect.InvocationHandler {
+
+    // TODO Currently the proxy references the real entity and invokes methods on it directly.
+    // As we work on remoting/distribution, this will be replaced by RPC.
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntityAdjunctProxyImpl.class);
+
+    /** These are allowed to be null, assuming they are replaced later during rebind. */
+    public EntityAdjunctProxyImpl(@Nullable EntityAdjunct adjunct) {
+        super(adjunct);
+    }
+
+    public static void resetDelegate(EntityAdjunct proxy, EntityAdjunct preferredDelegate) {
+        if (proxy==null) return;
+        if (!Proxy.isProxyClass(proxy.getClass())) return;
+        ((EntityAdjunctProxyImpl) Proxy.getInvocationHandler(proxy)).resetDelegate(proxy, proxy, preferredDelegate);
+    }
+
+    public static EntityAdjunct deproxy(EntityAdjunct proxy) {
+        if (proxy==null) return proxy;
+        if (!Proxy.isProxyClass(proxy.getClass())) return proxy;
+        return deproxy( ((EntityAdjunctProxyImpl) Proxy.getInvocationHandler(proxy)).delegate );
+    }
+
+    @Override
+    protected EntityAdjunct getProxy(EntityAdjunct instance, boolean requireNonProxy) {
+        if (!requireNonProxy) return instance;
+        return null;
+    }
+
+    @Override
+    protected void resetProxy(EntityAdjunct instance, EntityAdjunct preferredProxy) {
+        // no action needed (adjunct doesn't store proxy)
+    }
+
+    @Override
+    protected boolean isPermittedReadOnlyMethod(MethodSignature sig) {
+        // we could restrict by name as we do for entities; but for adjuncts that seems less important;
+        // anything which needs a task is likely to fail in any case.
+        // previously (before introducting proxy) we had full instances unmanaged so allowed such things there.
+        return true;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/core/policy/AbstractPolicy.java
@@ -27,6 +27,7 @@ import org.apache.brooklyn.api.mgmt.rebind.mementos.PolicyMemento;
 import org.apache.brooklyn.api.objs.Configurable;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.policy.PolicyType;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.mgmt.rebind.BasicPolicyRebindSupport;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 import org.slf4j.Logger;
@@ -37,7 +38,7 @@ import com.google.common.base.MoreObjects;
 /**
  * Base {@link Policy} implementation; all policies should extend this or its children
  */
-public abstract class AbstractPolicy extends AbstractEntityAdjunct implements Policy, Configurable {
+public abstract class AbstractPolicy extends AbstractEntityAdjunct implements Policy, Configurable, EntityAdjuncts.EntityAdjunctProxyable {
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(AbstractPolicy.class);
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/BidiSerialization.java
@@ -30,6 +30,7 @@ import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 
@@ -190,6 +191,10 @@ public class BidiSerialization {
             return getInstanceFromId(entity, id);
         }
         protected Optional<String> getEntityId(T value) {
+            if (value instanceof EntityAdjuncts.EntityAdjunctProxyable) {
+                Entity entity = ((EntityAdjuncts.EntityAdjunctProxyable)value).getEntity();
+                return Optional.fromNullable(entity == null ? null : entity.getId());
+            }
             if (value instanceof AbstractEntityAdjunct) {
                 Entity entity = ((AbstractEntityAdjunct)value).getEntity();
                 return Optional.fromNullable(entity == null ? null : entity.getId());


### PR DESCRIPTION
If one BrooklynObject refers to another in an unusual place (eg in a map, not simply policies on entities or vice versa) and the referrer is deserialized before the referent, Apache Brooklyn would give an error.  With this PR, in these cases we introduce an EntityAdjunctProxy, similar to the EntityProxy (long since used for the much more common case of entities referring to other entities).
