### PR TITLE
Adding Kubectl Task factory, Docker effector  and Docker Sensor

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
@@ -19,10 +19,14 @@
 package org.apache.brooklyn.tasks.kubectl;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings({ "rawtypes"})
 public interface ContainerCommons {
@@ -33,6 +37,10 @@ public interface ContainerCommons {
 
     ConfigKey<List> COMMANDS = ConfigKeys.newConfigKey(List.class,"commands", "Commands to execute for container", Lists.newArrayList());
     ConfigKey<List> ARGUMENTS = ConfigKeys.newConfigKey(List.class,"args", "Arguments to execute for container", Lists.newArrayList());
+
+    ConfigKey<String> WORKING_DIR = ConfigKeys.newStringConfigKey("workingDir", "Location where the container commands are executed");
+    ConfigKey<List<Map<String,String>>> VOLUME_MOUNTS = ConfigKeys.newConfigKey("volumeMounts", "Configuration to  mount a volume  into a container.", Lists.newArrayList());
+    ConfigKey<List<Map<String, Object>>> VOLUMES = ConfigKeys.newConfigKey("volumes", "List of directories with data that is accessible across multiple containers", Lists.newArrayList());
 
     String NAMESPACE_CREATE_CMD = "kubectl create namespace brooklyn-%s"; // namespace name
     String NAMESPACE_SET_CMD = "kubectl config set-context --current --namespace=brooklyn-%s"; // namespace name

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
@@ -28,7 +28,7 @@ import java.util.List;
 public interface ContainerCommons {
     ConfigKey<String> CONTAINER_IMAGE = ConfigKeys.newStringConfigKey("image", "Container image");
     ConfigKey<String> CONTAINER_NAME = ConfigKeys.newStringConfigKey("containerName", "Container name");
-    ConfigKey<Boolean> DEV_MODE = ConfigKeys.newBooleanConfigKey("devMode", "When set to true, the namespace" +
+    ConfigKey<Boolean> KEEP_CONTAINER_FOR_DEBUGGING = ConfigKeys.newBooleanConfigKey("keepContainerForDebugging", "When set to true, the namespace" +
             " and associated resources and services are not destroyed after execution. Defaults value is 'false'.", Boolean.FALSE);
 
     ConfigKey<List> COMMANDS = ConfigKeys.newConfigKey(List.class,"commands", "Commands to execute for container", Lists.newArrayList());

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerCommons.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.Lists;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+
+import java.util.List;
+
+@SuppressWarnings({ "rawtypes"})
+public interface ContainerCommons {
+    ConfigKey<String> CONTAINER_IMAGE = ConfigKeys.newStringConfigKey("image", "Container image");
+    ConfigKey<String> CONTAINER_NAME = ConfigKeys.newStringConfigKey("containerName", "Container name");
+    ConfigKey<Boolean> DEV_MODE = ConfigKeys.newBooleanConfigKey("devMode", "When set to true, the namespace" +
+            " and associated resources and services are not destroyed after execution. Defaults value is 'false'.", Boolean.FALSE);
+
+    ConfigKey<List> COMMANDS = ConfigKeys.newConfigKey(List.class,"commands", "Commands to execute for container", Lists.newArrayList());
+    ConfigKey<List> ARGUMENTS = ConfigKeys.newConfigKey(List.class,"args", "Arguments to execute for container", Lists.newArrayList());
+
+    String NAMESPACE_CREATE_CMD = "kubectl create namespace brooklyn-%s"; // namespace name
+    String NAMESPACE_SET_CMD = "kubectl config set-context --current --namespace=brooklyn-%s"; // namespace name
+    String JOBS_CREATE_CMD = "kubectl apply -f %s"; // deployment.yaml absolute path
+    String JOBS_FEED_CMD = "kubectl wait --for=condition=complete job/%s"; // containerName
+    String JOBS_LOGS_CMD = "kubectl logs jobs/%s"; // containerName
+    String NAMESPACE_DELETE_CMD = "kubectl delete namespace brooklyn-%s"; // namespace name
+
+}

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
@@ -52,7 +52,7 @@ public class ContainerTaskFactory<T extends ContainerTaskFactory<T,RET>,RET>  im
         List<String> argumentsCfg =  EntityInitializers.resolve(configBag, ARGUMENTS);
         String containerImage = EntityInitializers.resolve(configBag, CONTAINER_IMAGE);
         String containerNameFromCfg = EntityInitializers.resolve(configBag, CONTAINER_NAME);
-        Boolean devMode = EntityInitializers.resolve(configBag, DEV_MODE);
+        Boolean devMode = EntityInitializers.resolve(configBag, KEEP_CONTAINER_FOR_DEBUGGING);
 
         if(Strings.isBlank(containerImage)) {
             throw new IllegalStateException("You must specify containerImage when using " + this.getClass().getSimpleName());

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
@@ -54,6 +54,10 @@ public class ContainerTaskFactory<T extends ContainerTaskFactory<T,RET>,RET>  im
         String containerNameFromCfg = EntityInitializers.resolve(configBag, CONTAINER_NAME);
         Boolean devMode = EntityInitializers.resolve(configBag, KEEP_CONTAINER_FOR_DEBUGGING);
 
+        String workingDir = EntityInitializers.resolve(configBag, WORKING_DIR);
+        List<Map<String,String>> volumeMounts = EntityInitializers.resolve(configBag, VOLUME_MOUNTS);
+        List<Map<String, Object>> volumes = EntityInitializers.resolve(configBag, VOLUMES);
+
         if(Strings.isBlank(containerImage)) {
             throw new IllegalStateException("You must specify containerImage when using " + this.getClass().getSimpleName());
         }
@@ -69,6 +73,8 @@ public class ContainerTaskFactory<T extends ContainerTaskFactory<T,RET>,RET>  im
                 .withArgs(argumentsCfg)
                 .withEnv(EntityInitializers.resolve(configBag, BrooklynConfigKeys.SHELL_ENVIRONMENT))
                 .withCommands(Lists.newArrayList(commandsCfg))
+                .withVolumeMounts(volumeMounts)
+                .withVolumes(volumes)
                 .build();
 
 

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.Lists;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.mgmt.TaskFactory;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.TaskBuilder;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskStub;
+import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
+import org.apache.brooklyn.util.core.task.system.internal.SystemProcessTaskFactory;
+import org.apache.brooklyn.util.text.Strings;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.brooklyn.tasks.kubectl.ContainerCommons.*;
+
+public class ContainerTaskFactory<T extends ContainerTaskFactory<T,RET>,RET>  implements TaskFactory<Task<RET>> {
+
+    protected String summary;
+    protected String tag = "";
+    protected final ConfigBag config = ConfigBag.newInstance();
+
+    @Override
+    public Task<RET> newTask() {
+        ConfigBag configBag = this.config;
+
+        List<String> commandsCfg =  EntityInitializers.resolve(configBag, COMMANDS);
+        List<String> argumentsCfg =  EntityInitializers.resolve(configBag, ARGUMENTS);
+        String containerImage = EntityInitializers.resolve(configBag, CONTAINER_IMAGE);
+        String containerNameFromCfg = EntityInitializers.resolve(configBag, CONTAINER_NAME);
+        Boolean devMode = EntityInitializers.resolve(configBag, DEV_MODE);
+
+        if(Strings.isBlank(containerImage)) {
+            throw new IllegalStateException("You must specify containerImage when using " + this.getClass().getSimpleName());
+        }
+
+
+        final String containerName = (Strings.isBlank(containerNameFromCfg)
+                ? ( (Strings.isNonBlank(this.tag) ? this.tag + "-" : "").concat(containerImage).concat("-").concat(Strings.makeRandomId(10)))
+                : containerNameFromCfg).replace(" ", "-").replace("/", "-").toLowerCase();
+
+        final String jobYamlLocation =  new JobBuilder()
+                .withImage(containerImage)
+                .withName(containerName)
+                .withArgs(argumentsCfg)
+                .withEnv(EntityInitializers.resolve(configBag, BrooklynConfigKeys.SHELL_ENVIRONMENT))
+                .withCommands(Lists.newArrayList(commandsCfg))
+                .build();
+
+
+        Task<String> runCommandsTask = buildKubeTask(configBag, "Submit job", String.format(JOBS_CREATE_CMD,jobYamlLocation)).asTask();
+        Task<String> waitTask =  buildKubeTask(configBag, "Wait For Completion", String.format(JOBS_FEED_CMD,containerName)).asTask();
+        if(!devMode) {
+            BrooklynTaskTags.addTagDynamically(waitTask, BrooklynTaskTags.INESSENTIAL_TASK);
+        }
+
+        TaskBuilder<RET> taskBuilder = Tasks.<RET>builder()
+                .displayName(this.summary)
+                .add(buildKubeTask(configBag, "Set Up and Run",
+                        String.format(NAMESPACE_CREATE_CMD,containerName),
+                        String.format(NAMESPACE_SET_CMD,containerName)))
+                .add(runCommandsTask)
+                .add(waitTask)
+                .add(buildKubeTask(configBag, "Retrieve Output", String.format(JOBS_LOGS_CMD,containerName)));
+
+        if(!devMode) {
+            taskBuilder.add(buildKubeTask(configBag, "Tear Down", String.format(NAMESPACE_DELETE_CMD,containerName)));
+        }
+        return taskBuilder.build();
+    }
+
+    public T summary(String summary) {
+        this.summary = summary;
+        return self();
+    }
+
+    public T tag(String tag) {
+        this.tag = tag;
+        return self();
+    }
+
+    protected T self() { return (T)this; }
+
+    public T configure(Map<?, ?> flags) {
+        if (flags!=null)
+            config.putAll(flags);
+        return self();
+    }
+
+    public static ProcessTaskWrapper<String> buildKubeTask(final ConfigBag configBag, final String taskSummary, final String... kubeCommands) {
+        Map<String, Object> env = EntityInitializers.resolve(configBag, BrooklynConfigKeys.SHELL_ENVIRONMENT);
+        Map<String, String> envVars = MutableMap.of();
+        if(env != null && env.size() > 0) {
+            env.forEach((k,v) -> envVars.put(k, v.toString()));
+        }
+        return new SystemProcessTaskFactory.ConcreteSystemProcessTaskFactory<String>(kubeCommands)
+                .summary(taskSummary)
+                .configure(configBag.getAllConfig())
+                .environmentVariables(envVars) // needed to be shown in the UI ;)
+                .<String>returning(ProcessTaskStub.ScriptReturnType.STDOUT_STRING)
+                .requiringExitCodeZero().newTask();
+    }
+
+    public static class ConcreteContainerTaskFactory<RET> extends ContainerTaskFactory<ConcreteContainerTaskFactory<RET>, RET> {
+        public ConcreteContainerTaskFactory() {
+            super();
+        }
+    }
+}

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/DockerEffector.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/DockerEffector.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import org.apache.brooklyn.api.effector.Effector;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.effector.AddEffectorInitializerAbstract;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.brooklyn.core.mgmt.BrooklynTaskTags.EFFECTOR_TAG;
+
+public class DockerEffector extends AddEffectorInitializerAbstract implements  ContainerCommons {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DockerEffector.class);
+
+    public DockerEffector() {
+    }
+
+    public DockerEffector(ConfigBag configBag) {
+        super(configBag);
+    }
+
+    @Override
+    protected  Effectors.EffectorBuilder<String> newEffectorBuilder() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating container effector {}", initParam(EFFECTOR_NAME));
+        }
+        Effectors.EffectorBuilder<String> eff = newAbstractEffectorBuilder(String.class);
+        eff.impl(new Body(eff.buildAbstract(), initParams()));
+        return eff;
+    }
+
+    protected static class Body extends EffectorBody<String> {
+        private final Effector<String> effector;
+        private final ConfigBag params;
+
+        public Body(Effector<String> eff, final ConfigBag params) {
+            this.effector = eff;
+            checkNotNull(params.getAllConfigRaw().get(CONTAINER_IMAGE.getName()), "container image must be supplied when defining this effector");
+            this.params = params;
+        }
+
+        @Override
+        public String call(ConfigBag parameters) {
+            ConfigBag configBag = ConfigBag.newInstanceCopying(this.params).putAll(parameters);
+            Task<String> dockerTask = new ContainerTaskFactory.ConcreteContainerTaskFactory<String>()
+                    .summary("Executing Docker Image: " + EntityInitializers.resolve(configBag, CONTAINER_IMAGE))
+                    .tag(entity().getId() + "-" + EFFECTOR_TAG)
+                    .configure(configBag.getAllConfig())
+                    .newTask();
+            DynamicTasks.queueIfPossible(dockerTask).orSubmitAsync(entity());
+            Object result = dockerTask.getUnchecked(Duration.of(5, TimeUnit.MINUTES));
+            return result.toString();
+        }
+    }
+}

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/DockerSensor.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/DockerSensor.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.EntityInitializers;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.sensor.AbstractAddSensorFeed;
+import org.apache.brooklyn.core.sensor.ssh.SshCommandSensor;
+import org.apache.brooklyn.feed.function.FunctionFeed;
+import org.apache.brooklyn.feed.function.FunctionPollConfig;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.brooklyn.core.mgmt.BrooklynTaskTags.SENSOR_TAG;
+
+@SuppressWarnings({"UnstableApiUsage", "deprecation", "unchecked"})
+public class DockerSensor<T> extends AbstractAddSensorFeed<T> implements ContainerCommons {
+
+    public static final ConfigKey<String> FORMAT = SshCommandSensor.FORMAT;
+    public static final ConfigKey<Boolean> LAST_YAML_DOCUMENT = SshCommandSensor.LAST_YAML_DOCUMENT;
+
+    private static final Logger LOG = LoggerFactory.getLogger(DockerSensor.class);
+
+    public DockerSensor() {
+    }
+
+    public DockerSensor(final ConfigBag parameters) {
+        super(parameters);
+    }
+
+    @Override
+    public void apply(final EntityLocal entity) {
+        AttributeSensor<String> sensor = (AttributeSensor<String>) addSensor(entity);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding container sensor {} to {}", initParam(SENSOR_NAME), entity);
+        }
+
+        ConfigBag configBag = ConfigBag.newInstanceCopying(initParams());
+
+        final Boolean suppressDuplicates = EntityInitializers.resolve(configBag, SUPPRESS_DUPLICATES);
+        final Duration logWarningGraceTimeOnStartup = EntityInitializers.resolve(configBag, LOG_WARNING_GRACE_TIME_ON_STARTUP);
+        final Duration logWarningGraceTime = EntityInitializers.resolve(configBag, LOG_WARNING_GRACE_TIME);
+
+        ((EntityInternal)entity).feeds().add(FunctionFeed.builder()
+                .entity(entity)
+                .period(initParam(SENSOR_PERIOD))
+                .onlyIfServiceUp()
+                .poll(new FunctionPollConfig<>(sensor)
+                        .callable(new Callable<Object>() {
+                            @Override
+                            public Object call() throws Exception {
+                                Task<String> dockerTask = new ContainerTaskFactory.ConcreteContainerTaskFactory<String>()
+                                        .summary("Running " + EntityInitializers.resolve(configBag, SENSOR_NAME))
+                                        .tag(entity.getId() + "-" + SENSOR_TAG)
+                                        .configure(configBag.getAllConfig())
+                                        .newTask();
+                                DynamicTasks.queueIfPossible(dockerTask).orSubmitAsync(entity);
+                                Object result = dockerTask.getUnchecked(Duration.of(5, TimeUnit.MINUTES));
+                                List<String> res = (List<String>) result;
+                                while(!res.isEmpty() && Iterables.getLast(res).matches("namespace .* deleted\\s*")) res = res.subList(0, res.size()-1);
+
+                                String res2 = res.isEmpty() ? null : Iterables.getLast(res);
+                                return (new SshCommandSensor.CoerceOutputFunction<>(sensor.getTypeToken(), initParam(FORMAT), initParam(LAST_YAML_DOCUMENT))).apply(res2);
+                            }
+                        })
+                        .suppressDuplicates(Boolean.TRUE.equals(suppressDuplicates))
+                        .logWarningGraceTimeOnStartup(logWarningGraceTimeOnStartup)
+                        .logWarningGraceTime(logWarningGraceTime))
+                .build());
+    }
+
+
+}
+

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/JobBuilder.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/JobBuilder.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.tasks.kubectl;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;
@@ -42,6 +43,8 @@ public class JobBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(JobBuilder.class);
     String jobName;
     String imageName;
+
+    String workingDir;
 
     String prefix = "brooklyn-job";
 
@@ -84,6 +87,11 @@ public class JobBuilder {
         return this;
     }
 
+    public JobBuilder withWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+        return this;
+    }
+
     public JobBuilder withPrefix(final String prefixArg){
         this.prefix = prefixArg;
         return this;
@@ -99,6 +107,9 @@ public class JobBuilder {
 
         ContainerSpec containerSpec = jobTemplate.getSpec().get("template").getContainerSpec(0);
 
+        if(Strings.isNonBlank(workingDir)) {
+            containerSpec.setWorkingDir(workingDir);
+        }
         containerSpec.setImage(imageName);
         if (!env.isEmpty()) {
             List<Map<String,String>> envList = env.entrySet().stream().map (e ->  {

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/JobBuilder.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/JobBuilder.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * This was needed to ensure our Kubernetes Yaml Job configurations are valid.
+ */
+public class JobBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(JobBuilder.class);
+    String jobName;
+    String imageName;
+
+    String prefix = "brooklyn-job";
+
+    List<String> commands = Lists.newArrayList();
+    List<String> args = Lists.newArrayList();
+
+    Map<String, Object> env = Maps.newHashMap();
+
+    List<Map<String,String>> volumeMounts = Lists.newArrayList();
+
+    List<Map<String, Object>> volumes = Lists.newArrayList();
+
+    public JobBuilder withName(final String name) {
+        this.jobName = name;
+        return this;
+    }
+
+    public JobBuilder withImage(final String image){
+        this.imageName = image;
+        return this;
+    }
+
+    public JobBuilder withCommands(final List<String> commandsArg){
+        this.commands.addAll(commandsArg);
+        return this;
+    }
+
+    public JobBuilder withArgs(final List<String> args){
+        this.args.addAll(args);
+        return this;
+    }
+
+    public JobBuilder withVolumeMounts(final List<Map<String,String>> volumeMounts) {
+        this.volumeMounts.addAll(volumeMounts);
+        return this;
+    }
+
+    public JobBuilder withVolumes(final List<Map<String, Object>> volumes) {
+        this.volumes.addAll(volumes);
+        return this;
+    }
+
+    public JobBuilder withPrefix(final String prefixArg){
+        this.prefix = prefixArg;
+        return this;
+    }
+
+    public JobBuilder withEnv(final Map<String,Object> env){
+        this.env.putAll(env);
+        return this;
+    }
+
+    public String build(){
+        JobTemplate jobTemplate = new JobTemplate(jobName);
+
+        ContainerSpec containerSpec = jobTemplate.getSpec().get("template").getContainerSpec(0);
+
+        containerSpec.setImage(imageName);
+        if (!env.isEmpty()) {
+            List<Map<String,String>> envList = env.entrySet().stream().map (e ->  {
+                    Map<String,String> envItem = new HashMap<>();
+                    envItem.put("name", e.getKey());
+                    envItem.put("value", e.getValue().toString());
+                    return envItem;
+                }).collect(Collectors.toList());
+            containerSpec.setEnv(envList);
+        }
+        if (!commands.isEmpty()) {
+            containerSpec.setCommand(this.commands);
+        }
+        if (!args.isEmpty()) {
+            containerSpec.setArgs(this.args);
+        }
+
+        final Set<String> volumeNames = new HashSet<>();
+        if (!volumes.isEmpty()) {
+            jobTemplate.getSpec().get("template").getSpec().setVolumes(volumes);
+            volumes.stream().map(volumeSpec -> (String)volumeSpec.get("name")).forEach(volumeNames::add);
+        }
+
+        if (!volumeMounts.isEmpty()) {
+            List<VolumeMount> vms = Lists.newArrayList();
+            volumeMounts.forEach(vmMap -> {
+                VolumeMount vm = new VolumeMount();
+                vm.setName(vmMap.get("name"));
+                if(!volumeNames.contains(vm.getName())) {
+                   throw new IllegalArgumentException("The Job "  + this.jobName + "is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found:\"" + vm.getName() + "\"");
+                }
+                vm.setMountPath(vmMap.get("mountPath"));
+                vms.add(vm);
+            });
+            containerSpec.setVolumeMounts(vms);
+        }
+        return serializeAndWriteToTempFile(jobTemplate);
+    }
+
+    private String serializeAndWriteToTempFile(JobTemplate jobTemplate) {
+        DumperOptions options = new DumperOptions();
+        options.setIndent(2);
+        options.setPrettyFlow(true);
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        Representer representer = new Representer(){
+            @Override
+            protected NodeTuple representJavaBeanProperty(Object javaBean, Property property, Object propertyValue, Tag customTag) {
+                // if value of property is null, ignore it.
+                if (propertyValue == null) {
+                    return null;
+                }
+                else {
+                    return super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
+                }
+            }
+        };
+        representer.addClassTag(JobTemplate.class, Tag.MAP);
+
+        try {
+            File jobBodyPath = File.createTempFile(prefix, ".yaml");
+            jobBodyPath.deleteOnExit();  // We should have already deleted it, but just in case
+
+            PrintWriter sw = new PrintWriter(jobBodyPath);
+            Yaml yaml = new Yaml(representer, options);
+            yaml.dump(jobTemplate, sw);
+            LOG.info("Job body dumped at: {}" , jobBodyPath.getAbsolutePath());
+            return jobBodyPath.getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp file for container", e);
+        }
+    }
+}
+
+class JobTemplate {
+    String kind = "Job";
+    String apiVersion = "batch/v1";
+    Map<String, String> metadata;
+    Map<String, JobSpec> spec;
+
+    public JobTemplate() {
+    }
+
+    public JobTemplate(String name) {
+        metadata = Maps.newHashMap();
+        metadata.put("name", name);
+        spec = new HashMap<>();
+        spec.put("template", new JobSpec());
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    // Do not explicitly call this
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    // Do not explicitly call this
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
+
+    public Map<String, JobSpec> getSpec() {
+        return spec;
+    }
+
+    public void setSpec(Map<String, JobSpec> spec) {
+        this.spec = spec;
+    }
+
+}
+
+class JobSpec {
+    ContainerSpecs spec;
+
+    public JobSpec() {
+        this.spec = new ContainerSpecs();
+    }
+
+    public ContainerSpecs getSpec() {
+        return spec;
+    }
+
+    public void setSpec(ContainerSpecs spec) {
+        this.spec = spec;
+    }
+
+    public ContainerSpec getContainerSpec(int index) {
+        if(this.spec.containers.size() > 0) {
+            return this.spec.containers.get(index);
+        }
+        return null;
+    }
+}
+
+
+class ContainerSpecs {
+    List<ContainerSpec> containers;
+
+    List<Map<String, Object>> volumes;
+
+    Boolean automountServiceAccountToken = false;
+    String restartPolicy = "Never";
+
+    public ContainerSpecs() {
+        this.containers = Lists.newArrayList();
+        this.containers.add(new ContainerSpec());}
+
+    public List<ContainerSpec> getContainers() {
+        return containers;
+    }
+
+    public void setContainers(List<ContainerSpec> containers) {
+        this.containers = containers;
+    }
+
+    public String getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    public void setRestartPolicy(String restartPolicy) {
+        this.restartPolicy = restartPolicy;
+    }
+
+    public Boolean getAutomountServiceAccountToken() {
+        return automountServiceAccountToken;
+    }
+
+    public void setAutomountServiceAccountToken(Boolean automountServiceAccountToken) {
+        this.automountServiceAccountToken = automountServiceAccountToken;
+    }
+
+    public List<Map<String, Object>> getVolumes() {
+        return volumes;
+    }
+
+    public void setVolumes(List<Map<String, Object>> volumes) {
+        this.volumes = volumes;
+    }
+}
+
+class ContainerSpec {
+    String name = "test";
+    String image = "defaultImage";
+
+    String workingDir = null; // default is /
+
+    List<String> command = null;
+    List<String> args = null;
+
+    List<VolumeMount>  volumeMounts = null;
+
+    List<Map<String, String>> env = null;
+
+    public ContainerSpec() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    // Do not explicitly call this
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public List<String> getCommand() {
+        return command;
+    }
+
+    public void setCommand(List<String> command) {
+        this.command = command;
+    }
+
+    public List<String> getArgs() {
+        return args;
+    }
+
+    public void setArgs(List<String> args) {
+        this.args = args;
+    }
+
+    public List<Map<String, String>> getEnv() {
+        return env;
+    }
+
+    public void setEnv(List<Map<String, String>> env) {
+        this.env = env;
+    }
+    public void setVolumeMounts(List<VolumeMount> volumeMounts) {
+        this.volumeMounts = volumeMounts;
+    }
+
+    public List<VolumeMount> getVolumeMounts() {
+        return volumeMounts;
+    }
+
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+    }
+}
+
+class VolumeMount {
+    String name;
+    String mountPath;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getMountPath() {
+        return mountPath;
+    }
+
+    public void setMountPath(String mountPath) {
+        this.mountPath = mountPath;
+    }
+}
+

--- a/software/base/src/main/resources/catalog.bom
+++ b/software/base/src/main/resources/catalog.bom
@@ -79,3 +79,20 @@ brooklyn.catalog:
         type: org.apache.brooklyn.entity.machine.pool.ServerPool
         name: Server Pool
         description: Creates a pre-allocated server pool, which other applications can deploy to
+
+      #-----------------------------------------kubectl effector & sensor-------------------------------------------------------
+    - id: org.apache.brooklyn.tasks.kubectl.DockerSensor
+      format: java-type-name
+      itemType: bean
+      item:
+        type: org.apache.brooklyn.tasks.kubectl.DockerSensor
+        name: Docker Sensor
+        description: A sensor that exposes a value produced by a Kubectl Job
+
+    - id: org.apache.brooklyn.tasks.kubectl.DockerEffector
+      format: java-type-name
+      itemType: bean
+      item:
+        type: org.apache.brooklyn.tasks.kubectl.DockerEffector
+        name: Docker Effector
+        description: An effector that runs a Kubectl Job

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/DockerEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/DockerEffectorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.brooklyn.util.time.Duration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings( "UnstableApiUsage")
+@Test(groups = {"Live"})
+public class DockerEffectorTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testEchoPerlCommand() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                DockerEffector.EFFECTOR_NAME, "test-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "perl",
+                ContainerCommons.COMMANDS, ImmutableList.of("/bin/bash", "-c", "echo " + message),
+                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of("HELLO", "WORLD")));
+
+        DockerEffector initializer = new DockerEffector(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains(message));
+    }
+
+    @Test
+    public void testEchoBashCommand() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                DockerEffector.EFFECTOR_NAME, "test-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "bash",
+                ContainerCommons.ARGUMENTS, ImmutableList.of( "-c", "echo " + message),
+                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of("HELLO", "WORLD")));
+
+        DockerEffector initializer = new DockerEffector(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains(message));
+    }
+
+    @Test
+    public void testEchoVarBashCommand() {
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                DockerEffector.EFFECTOR_NAME, "test-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "bash",
+                ContainerCommons.ARGUMENTS, ImmutableList.of( "-c", "echo $HELLO"),
+                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of("HELLO", "WORLD")));
+
+        DockerEffector initializer = new DockerEffector(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains("WORLD"));
+    }
+
+    @Test
+    public void testEchoMultiBashCommand() {
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                DockerEffector.EFFECTOR_NAME, "test-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "bash",
+                ContainerCommons.ARGUMENTS, ImmutableList.of( "-c", "date; echo $HELLO"),
+                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of("HELLO", "WORLD")));
+
+        DockerEffector initializer = new DockerEffector(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains("WORLD"));
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/DockerSensorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/DockerSensorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.Test;
+
+@SuppressWarnings( "UnstableApiUsage")
+@Test(groups = {"Live"})
+public class DockerSensorTest extends BrooklynAppUnitTestSupport {
+
+    @Test
+    public void testEchoPerlCommand() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerCommons.CONTAINER_IMAGE, "perl",
+                ContainerCommons.COMMANDS, ImmutableList.of("/bin/bash", "-c","echo " + message) ,
+                DockerSensor.SENSOR_PERIOD, "1s",
+                DockerSensor.SENSOR_NAME, "test-echo-sensor"));
+
+        DockerSensor<String> initializer = new DockerSensor<>(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventually(parentEntity, Sensors.newStringSensor("test-echo-sensor"), s -> s.contains(message));
+    }
+
+    @Test
+    public void testEchoPerlCommandAndArgs() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerCommons.CONTAINER_IMAGE, "perl",
+                ContainerCommons.COMMANDS, ImmutableList.of("/bin/bash") ,
+                ContainerCommons.ARGUMENTS, ImmutableList.of("-c", "echo " + message) ,
+                DockerSensor.SENSOR_PERIOD, "1s",
+                DockerSensor.SENSOR_NAME, "test-echo-sensor"));
+
+        DockerSensor<String> initializer = new DockerSensor<>(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventually(parentEntity, Sensors.newStringSensor("test-echo-sensor"), s -> s.contains(message));
+    }
+
+    @Test
+    public void testEchoPerlArgs() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerCommons.CONTAINER_IMAGE, "perl",
+                ContainerCommons.ARGUMENTS, ImmutableList.of("echo", message) ,
+                DockerSensor.SENSOR_PERIOD, "1s",
+                DockerSensor.SENSOR_NAME, "test-echo-sensor"));
+
+        DockerSensor<String> initializer = new DockerSensor<>(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventually(parentEntity, Sensors.newStringSensor("test-echo-sensor"), s -> s.contains(message));
+    }
+
+    @Test
+    public void testEchoBashArgs() {
+        final String message = ("hello " + Strings.makeRandomId(10)).toLowerCase();
+
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerCommons.CONTAINER_IMAGE, "bash",
+                ContainerCommons.ARGUMENTS, ImmutableList.of("-c", "echo " + message) ,
+                DockerSensor.SENSOR_PERIOD, "1s",
+                DockerSensor.SENSOR_NAME, "test-echo-sensor"));
+
+        DockerSensor<String> initializer = new DockerSensor<>(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventually(parentEntity, Sensors.newStringSensor("test-echo-sensor"), s -> s.contains(message));
+    }
+
+    @Test
+    public void testTfVersionSensor() {
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerCommons.CONTAINER_IMAGE, "hashicorp/terraform",
+                ContainerCommons.COMMANDS, ImmutableList.of("terraform", "version" ),
+                DockerSensor.SENSOR_PERIOD, "1s",
+                DockerSensor.SENSOR_NAME, "tf-version-sensor"));
+
+        DockerSensor<String> initializer = new DockerSensor<>(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventually(parentEntity, Sensors.newStringSensor("tf-version-sensor"), s -> s.contains("Terraform"));
+    }
+}

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/JobBuilderTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/JobBuilderTest.java
@@ -126,8 +126,9 @@ public class JobBuilderTest {
                 new JobBuilder().withImage("hashicorp/terraform").withName("tf-version")
                         .withVolumes(Lists.newArrayList(volumes))
                         .withVolumeMounts(Lists.newArrayList(Maps.newHashMap("name", "tf-ws", "mountPath", "/tfws")))
-                        .withCommands(Lists.newArrayList("terraform", "version")
-                        ).build();
+                        .withCommands(Lists.newArrayList("terraform", "version"))
+                        .withWorkingDir("/tfws/app1")
+                        .build();
         assertNotNull(yamlJobLocation);
         String actual = String.join("\n", Files.readAllLines(Paths.get(yamlJobLocation)));
         String expected = "apiVersion: batch/v1\n" +
@@ -147,6 +148,7 @@ public class JobBuilderTest {
                 "        volumeMounts:\n" +
                 "        - mountPath: /tfws\n" +
                 "          name: tf-ws\n" +
+                "        workingDir: /tfws/app1\n" +
                 "      restartPolicy: Never\n" +
                 "      volumes:\n" +
                 "      - name: tf-ws\n" +

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/JobBuilderTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/JobBuilderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.tasks.kubectl;
+
+import com.beust.jcommander.internal.Maps;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class JobBuilderTest {
+    private static final Logger LOG = LoggerFactory.getLogger(JobBuilderTest.class);
+
+    @Test
+    public void testPerlWithArgs() throws  Exception{
+        String yamlJobLocation =
+                new JobBuilder().withImage("perl").withName("perl-args-test")
+                        .withArgs(Lists.newArrayList( "echo", "aaa"))
+                        .build();
+        assertNotNull(yamlJobLocation);
+        String actual = String.join("\n", Files.readAllLines(Paths.get(yamlJobLocation)));
+        String expected = "apiVersion: batch/v1\n" +
+                "kind: Job\n" +
+                "metadata:\n" +
+                "  name: perl-args-test\n" +
+                "spec:\n" +
+                "  template:\n" +
+                "    spec:\n" +
+                "      automountServiceAccountToken: false\n" +
+                "      containers:\n" +
+                "      - args:\n" +
+                "        - echo\n" +
+                "        - aaa\n" +
+                "        image: perl\n" +
+                "        name: test\n" +
+                "      restartPolicy: Never";
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    public void testPerlWithArgsAndCommand() throws  Exception{
+        String yamlJobLocation =
+                new JobBuilder().withImage("perl").withName("perl-args-and-command-test")
+                        .withCommands(Lists.newArrayList("/bin/bash"))
+                        .withArgs(Lists.newArrayList("-c", "echo aaa"))
+                        .build();
+        assertNotNull(yamlJobLocation);
+        String actual = String.join("\n", Files.readAllLines(Paths.get(yamlJobLocation)));
+        String expected = "apiVersion: batch/v1\n" +
+                "kind: Job\n" +
+                "metadata:\n" +
+                "  name: perl-args-and-command-test\n" +
+                "spec:\n" +
+                "  template:\n" +
+                "    spec:\n" +
+                "      automountServiceAccountToken: false\n" +
+                "      containers:\n" +
+                "      - args:\n" +
+                "        - -c\n" +
+                "        - echo aaa\n" +
+                "        command:\n" +
+                "        - /bin/bash\n" +
+                "        image: perl\n" +
+                "        name: test\n" +
+                "      restartPolicy: Never";
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    public void testPerlCommand() throws  Exception{
+        String yamlJobLocation =
+                new JobBuilder().withImage("perl").withName("perl-command-test")
+                        .withCommands(Lists.newArrayList("/bin/bash", "-c", "echo aaa"))
+                        .build();
+        assertNotNull(yamlJobLocation);
+        String actual = String.join("\n", Files.readAllLines(Paths.get(yamlJobLocation)));
+        String expected = "apiVersion: batch/v1\n" +
+                "kind: Job\n" +
+                "metadata:\n" +
+                "  name: perl-command-test\n" +
+                "spec:\n" +
+                "  template:\n" +
+                "    spec:\n" +
+                "      automountServiceAccountToken: false\n" +
+                "      containers:\n" +
+                "      - command:\n" +
+                "        - /bin/bash\n" +
+                "        - -c\n" +
+                "        - echo aaa\n" +
+                "        image: perl\n" +
+                "        name: test\n" +
+                "      restartPolicy: Never";
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    public void testTerraformWithVolumeJobBuilder() throws  Exception{
+        Map<String,Object> volumes = Maps.newHashMap();
+        volumes.put("name", "tf-ws");
+        volumes.put("hostPath", Maps.newHashMap("path", "/tfws"));
+        String yamlJobLocation =
+                new JobBuilder().withImage("hashicorp/terraform").withName("tf-version")
+                        .withVolumes(Lists.newArrayList(volumes))
+                        .withVolumeMounts(Lists.newArrayList(Maps.newHashMap("name", "tf-ws", "mountPath", "/tfws")))
+                        .withCommands(Lists.newArrayList("terraform", "version")
+                        ).build();
+        assertNotNull(yamlJobLocation);
+        String actual = String.join("\n", Files.readAllLines(Paths.get(yamlJobLocation)));
+        String expected = "apiVersion: batch/v1\n" +
+                "kind: Job\n" +
+                "metadata:\n" +
+                "  name: tf-version\n" +
+                "spec:\n" +
+                "  template:\n" +
+                "    spec:\n" +
+                "      automountServiceAccountToken: false\n" +
+                "      containers:\n" +
+                "      - command:\n" +
+                "        - terraform\n" +
+                "        - version\n" +
+                "        image: hashicorp/terraform\n" +
+                "        name: test\n" +
+                "        volumeMounts:\n" +
+                "        - mountPath: /tfws\n" +
+                "          name: tf-ws\n" +
+                "      restartPolicy: Never\n" +
+                "      volumes:\n" +
+                "      - name: tf-ws\n" +
+                "        hostPath:\n" +
+                "          path: /tfws";
+        assertEquals(expected,actual);
+    }
+}

--- a/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-both.yaml
+++ b/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-both.yaml
@@ -1,0 +1,38 @@
+[#ftl]
+  # Licensed to the Apache Software Foundation (ASF) under one
+  # or more contributor license agreements.  See the NOTICE file
+  # distributed with this work for additional information
+  # regarding copyright ownership.  The ASF licenses this file
+  # to you under the Apache License, Version 2.0 (the
+  # "License"); you may not use this file except in compliance
+  # with the License.  You may obtain a copy of the License at
+  #
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing,
+  # software distributed under the License is distributed on an
+  # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  # KIND, either express or implied.  See the License for the
+  # specific language governing permissions and limitations
+  # under the License.
+name: container-both
+services:
+  - type: 'org.apache.brooklyn.entity.stock.BasicStartable:1.1.0-SNAPSHOT'
+    brooklyn.initializers:
+      - type: org.apache.brooklyn.tasks.kubectl.DockerEffector
+        brooklyn.config:
+          shell.env:
+            hello: hello-amp-docker-effector
+          image: bash
+          args:
+          - -c
+          - HELLO=$(ls -la) ; sleep 5 ; echo $HELLO ; echo $hello
+          name: docker-effector
+      - type: org.apache.brooklyn.tasks.kubectl.DockerSensor
+        brooklyn.config:
+          image: perl
+          args:
+            - echo
+            - hello
+          name: test-sensor
+          period: 20s

--- a/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector-dev.yaml
+++ b/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector-dev.yaml
@@ -1,0 +1,34 @@
+[#ftl]
+  # Licensed to the Apache Software Foundation (ASF) under one
+  # or more contributor license agreements.  See the NOTICE file
+  # distributed with this work for additional information
+  # regarding copyright ownership.  The ASF licenses this file
+  # to you under the Apache License, Version 2.0 (the
+  # "License"); you may not use this file except in compliance
+  # with the License.  You may obtain a copy of the License at
+  #
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing,
+  # software distributed under the License is distributed on an
+  # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  # KIND, either express or implied.  See the License for the
+  # specific language governing permissions and limitations
+  # under the License.
+name: container-effector-dev
+services:
+  - type: 'org.apache.brooklyn.entity.stock.BasicStartable:1.1.0-SNAPSHOT'
+    brooklyn.initializers:
+      - type: org.apache.brooklyn.tasks.kubectl.DockerEffector
+        brooklyn.config:
+          name: docker-effector
+          description: Very simple Docker effector
+          shell.env:
+            hello: world-amp
+            # hello: $brooklyn:external("hello", "hello")
+          devMode: true  # makes the activity fail and does not delete namespace allowing debug
+          image: perl
+          commands:
+            - /bin/bash
+            - -c
+            - HELLO=$(ls -la) ; echo $HELLO ; date ; echo $hello ; exit 1

--- a/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector-dev.yaml
+++ b/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector-dev.yaml
@@ -26,7 +26,7 @@ services:
           shell.env:
             hello: world-amp
             # hello: $brooklyn:external("hello", "hello")
-          devMode: true  # makes the activity fail and does not delete namespace allowing debug
+          keepContainerForDebugging: true  # makes the activity fail and does not delete namespace allowing debug
           image: perl
           commands:
             - /bin/bash

--- a/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector.yaml
+++ b/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-effector.yaml
@@ -1,0 +1,32 @@
+[#ftl]
+  # Licensed to the Apache Software Foundation (ASF) under one
+  # or more contributor license agreements.  See the NOTICE file
+  # distributed with this work for additional information
+  # regarding copyright ownership.  The ASF licenses this file
+  # to you under the Apache License, Version 2.0 (the
+  # "License"); you may not use this file except in compliance
+  # with the License.  You may obtain a copy of the License at
+  #
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing,
+  # software distributed under the License is distributed on an
+  # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  # KIND, either express or implied.  See the License for the
+  # specific language governing permissions and limitations
+  # under the License.
+name: container-effector
+services:
+  - type: 'org.apache.brooklyn.entity.stock.BasicStartable:1.1.0-SNAPSHOT'
+    brooklyn.initializers:
+      - type: org.apache.brooklyn.tasks.kubectl.DockerEffector
+        brooklyn.config:
+          name: docker-effector
+          description: Very simple Docker effector
+          shell.env:
+            hello: world-amp
+          image: perl
+          commands:
+          - /bin/bash
+          - -c
+          - HELLO=$(ls -la) ; echo $HELLO; date ; echo $hello

--- a/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-sensor.yaml
+++ b/software/base/src/test/resources/org/apache/brooklyn/kubectl/sample-sensor.yaml
@@ -1,0 +1,30 @@
+[#ftl]
+  # Licensed to the Apache Software Foundation (ASF) under one
+  # or more contributor license agreements.  See the NOTICE file
+  # distributed with this work for additional information
+  # regarding copyright ownership.  The ASF licenses this file
+  # to you under the Apache License, Version 2.0 (the
+  # "License"); you may not use this file except in compliance
+  # with the License.  You may obtain a copy of the License at
+  #
+  #  http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing,
+  # software distributed under the License is distributed on an
+  # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  # KIND, either express or implied.  See the License for the
+  # specific language governing permissions and limitations
+  # under the License.
+name: container-sensor
+services:
+  - type: 'org.apache.brooklyn.entity.stock.BasicStartable:1.1.0-SNAPSHOT'
+    brooklyn.initializers:
+      - type: org.apache.brooklyn.tasks.kubectl.DockerSensor
+        brooklyn.config:
+          image: perl
+          commands:
+            - /bin/bash
+            - -c
+            - echo $((1 + $RANDOM % 10))
+          name: test-sensor
+          period: 20s


### PR DESCRIPTION
**What**

`kubectl` task factory that allows blueprint designers to externalize effectors and sensors  to containers run on a Kubernetes cluster.

**Why**
Because it is practical and higly customizable. 

**Testing**
Sample blueprints are provided. Also tests for sensor, effector and task factory.