### PR TITLE
Fix persistence deletion race

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
@@ -18,6 +18,8 @@
  */
 package org.apache.brooklyn.api.objs;
 
+import org.apache.brooklyn.api.entity.Entity;
+
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -48,7 +50,7 @@ public interface EntityAdjunct extends BrooklynObject {
      * This is used to prevent multiple instances with the same purpose from being created,
      * and to access and customize adjuncts so created.
      * <p>
-     * This will be included in the call to {@link #getTags()}.
+     * This will be included in the call to {@link BrooklynObject#tags()}.
      */
     @Nullable String getUniqueTag();
 

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
@@ -36,7 +36,12 @@ import org.testng.annotations.Test;
 @Test
 public class DynamicMultiGroupYamlRebindTest extends AbstractYamlRebindTest {
 
-   @Test(invocationCount = 100)
+   @Test(invocationCount = 100, groups="Integration")
+   public void testDynamicMultiGroupWithCluster_DeleteBeforeRebind_ManyTimes() throws Exception {
+      testDynamicMultiGroupWithCluster_DeleteBeforeRebind();
+   }
+
+   @Test
    public void testDynamicMultiGroupWithCluster_DeleteBeforeRebind() throws Exception {
       try {
          // Create test app first.

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 @Test
 public class DynamicMultiGroupYamlRebindTest extends AbstractYamlRebindTest {
 
-   @Test(groups="Broken")  // bug we are fixing
+   @Test(invocationCount = 100)
    public void testDynamicMultiGroupWithCluster_DeleteBeforeRebind() throws Exception {
       try {
          // Create test app first.
@@ -46,7 +46,7 @@ public class DynamicMultiGroupYamlRebindTest extends AbstractYamlRebindTest {
          BrooklynMementoRawData state = BrooklynPersistenceUtils.newStateMemento(mgmt(), MementoCopyMode.LOCAL);
          Assert.assertEquals(state.getEntities().size(), 10);
 
-         Dumper.dumpInfo(app);
+//         Dumper.dumpInfo(app);
 
          // Destroy application before first rebind.
          Entities.destroy(app);

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/DynamicMultiGroupYamlRebindTest.java
@@ -22,6 +22,7 @@ import com.google.common.io.Files;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ha.MementoCopyMode;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoRawData;
+import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.core.entity.Dumper;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
@@ -47,9 +48,13 @@ public class DynamicMultiGroupYamlRebindTest extends AbstractYamlRebindTest {
          Assert.assertEquals(state.getEntities().size(), 10);
 
 //         Dumper.dumpInfo(app);
+         Enricher enricher1 = app.enrichers().iterator().next();
 
          // Destroy application before first rebind.
          Entities.destroy(app);
+
+         // check that a subsequent change doesn't cause it to re-create
+         mgmt().getRebindManager().getChangeListener().onChanged(enricher1);
 
          // Rebind, expect no apps.
          Entity appRebind = rebind(RebindOptions.create().terminateOrigManagementContext(true));

--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -630,7 +630,10 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
                 if (Entities.isAncestor(this, child)) throw new IllegalStateException("loop detected trying to add child "+child+" to "+this+"; it is already an ancestor");
                 child.setParent(getProxyIfAvailable());
                 boolean changed = children.add(child);
-                
+                if (Entities.isUnmanagingOrNoLongerManaged(this)) {
+                    throw new IllegalStateException("Cannot add " + child + " as child of " + this + " because the latter is unmanaging or no longer managed");
+                }
+
                 getManagementSupport().getEntityChangeListener().onChildrenChanged();
                 if (changed) {
                     sensors().emit(AbstractEntity.CHILD_ADDED, child);
@@ -674,7 +677,8 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
                     getManagementSupport().getEntityChangeListener().onChildrenChanged();
                 }
             
-                if (changed) {
+                if (changed && Entities.isManagedActiveOrComingUp(this)) {
+                    // don't publish when tearing down
                     sensors().emit(AbstractEntity.CHILD_REMOVED, child);
                 }
                 return changed;

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -816,6 +816,14 @@ public class Entities {
         return ((EntityInternal)e).getManagementSupport().isNoLongerManaged();
     }
 
+    public static boolean isUnmanaging(Entity e) {
+        return ((EntityInternal)e).getManagementSupport().isUnmanaging();
+    }
+
+    public static boolean isUnmanagingOrNoLongerManaged(Entity e) {
+        return isNoLongerManaged(e) || isUnmanaging(e);
+    }
+
     /** if entity is managed, but in a read-only state */
     public static boolean isReadOnly(Entity e) {
         return Boolean.TRUE.equals( ((EntityInternal)e).getManagementSupport().isReadOnlyRaw() );

--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.core.entity;
 
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.core.mgmt.BrooklynTags;
+import org.apache.brooklyn.core.mgmt.internal.*;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
 import static org.apache.brooklyn.util.guava.Functionals.isSatisfied;
 
@@ -38,6 +39,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Application;
@@ -68,12 +70,6 @@ import org.apache.brooklyn.core.entity.trait.StartableMethods;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
-import org.apache.brooklyn.core.mgmt.internal.BrooklynShutdownHooks;
-import org.apache.brooklyn.core.mgmt.internal.EffectorUtils;
-import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
-import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
-import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
-import org.apache.brooklyn.core.mgmt.internal.NonDeploymentManagementContext;
 import org.apache.brooklyn.core.objs.proxy.EntityProxyImpl;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -876,6 +872,7 @@ public class Entities {
         }
         
         log.warn("Deprecated use of Entities.manage(Entity), for unmanaged entity "+e);
+
         Entity o = e.getParent();
         Entity eum = e; // Highest unmanaged ancestor
         if (o==null) throw new IllegalArgumentException("Can't manage "+e+" because it is an orphan");
@@ -884,7 +881,9 @@ public class Entities {
             o = o.getParent();
         }
         if (isManaged(o)) {
-            ((EntityInternal)o).getManagementContext().getEntityManager().manage(eum);
+            ManagementContextInternal mgmt = (ManagementContextInternal) ((EntityInternal) o).getManagementContext();
+            premanageRecursively(mgmt, eum);
+            mgmt.getEntityManager().manage(eum);
             return true;
         }
         if (!(o instanceof Application)) {
@@ -956,8 +955,20 @@ public class Entities {
             }
         }
 
+        premanageRecursively((ManagementContextInternal)mgmt, app);
+
         mgmt.getEntityManager().manage(app);
         return mgmt;
+    }
+
+    private static void premanageRecursively(ManagementContextInternal mgmt, Entity e) {
+        if (Entities.isUnmanagingOrNoLongerManaged(e) || Entities.isManagedActive(e)) {
+            log.warn("Skipping premanagement for "+e+", as it has some form of known management");
+            // skip for active and unmanaged entities
+            return;
+        }
+        mgmt.prePreManage(e);
+        e.getChildren().forEach(e2 -> premanageRecursively(mgmt, e2));
     }
 
     /**

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityAdjuncts.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityAdjuncts.java
@@ -21,7 +21,10 @@ package org.apache.brooklyn.core.entity;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
@@ -30,6 +33,7 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ComputeServiceIndicatorsFromChildrenAndMembers;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ComputeServiceState;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic.ServiceNotUpLogic;
+import org.apache.brooklyn.core.objs.AbstractEntityAdjunct;
 import org.apache.brooklyn.core.objs.proxy.EntityAdjunctProxyImpl;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -113,7 +117,26 @@ public class EntityAdjuncts {
                 new EntityAdjunctProxyImpl(id));
     }
 
-    public interface EntityAdjunctProxyable {
+    /** all real EntityAdjunct items support getEntity, but via two different paths, depending whether it is proxied or not */
+    public static <T extends EntityAdjunct> Maybe<Entity> getEntity(T value, boolean treatDefinitelyMissingAsAbsent) {
+        final Function<Maybe<Entity>,Maybe<Entity>> handleNull = mv -> {
+            if (!treatDefinitelyMissingAsAbsent || mv.isAbsent() || mv.isPresentAndNonNull()) return mv;
+            return Maybe.absentNull("entity definitely not set on adjunct");
+        };
+        if (value instanceof EntityAdjuncts.EntityAdjunctProxyable) {
+            // works for proxies and almost all real instances
+            return handleNull.apply(Maybe.ofAllowingNull( ((EntityAdjuncts.EntityAdjunctProxyable)value).getEntity() ));
+        }
+        if (value instanceof AbstractEntityAdjunct) {
+            // needed for items that don't extend the standard Abstracts, eg something that implements Enricher but don't extend AbstractEnricher
+            // (we might be able to get rid of those; and maybe move getEntity to the EntityAdjunct interface, but that is for another day)
+            return handleNull.apply(Maybe.ofAllowingNull( ((AbstractEntityAdjunct)value).getEntity() ));
+        }
+        return Maybe.absent("adjunct does not supply way to detect if entity set");
+    }
+
+    /** supported by nearly all EntityAdjuncts, but a few in the wild might that don't extend the standard AbstractEntityAdjunct might not implement this; see {@link #getEntity()} */
+    public interface EntityAdjunctProxyable extends EntityAdjunct {
         Entity getEntity();
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/CollectionChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/CollectionChangeListener.java
@@ -18,7 +18,13 @@
  */
 package org.apache.brooklyn.core.mgmt.internal;
 
+import org.apache.brooklyn.api.entity.Entity;
+
 public interface CollectionChangeListener<Item> {
     void onItemAdded(Item item);
     void onItemRemoved(Item item);
+
+    public interface ListenerWithErrorHandler<Item> extends CollectionChangeListener<Item> {
+        void onError(String error, Throwable trace);
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -309,6 +309,7 @@ public class EntityManagementSupport {
     
     @SuppressWarnings("deprecation")
     public void onManagementStopping(ManagementTransitionInfo info, boolean wasDryRun) {
+log.info("XXX mgmt stopping "+entity);
         synchronized (this) {
             currentlyStopping.set(true);
             if (!wasDryRun) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -384,7 +384,12 @@ log.info("XXX mgmt stopping "+entity);
                     return;
                 }
                 if (managementContext != info.getManagementContext()) {
-                    throw new IllegalStateException("Has different management context: " + managementContext + "; expected " + info.getManagementContext());
+                    if (managementContext == null && nonDeploymentManagementContext.getMode() == NonDeploymentManagementContextMode.PRE_MANAGEMENT) {
+                        log.info("Stopping management of "+entity+" during pre-management phase; likely concurrent creation/deletion");
+                        // proceed to below, without error
+                    } else {
+                        throw new IllegalStateException(entity + " has different management context: " + managementContext + "; expected " + info.getManagementContext());
+                    }
                 }
             }
             getSubscriptionContext().unsubscribeAll();

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -309,7 +309,6 @@ public class EntityManagementSupport {
     
     @SuppressWarnings("deprecation")
     public void onManagementStopping(ManagementTransitionInfo info, boolean wasDryRun) {
-log.info("XXX mgmt stopping "+entity);
         synchronized (this) {
             currentlyStopping.set(true);
             if (!wasDryRun) {

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -313,7 +313,6 @@ public class LocalEntityManager implements EntityManagerInternal {
     }
     
     void prePreManage(Entity entity) {
-log.info("XXX prePreManage "+entity);
         if (isPreRegistered(entity)) {
             log.warn(""+this+" redundant call to pre-pre-manage entity "+entity+"; skipping", 
                     new Exception("source of duplicate pre-pre-manage of "+entity));
@@ -619,7 +618,6 @@ log.info("XXX prePreManage "+entity);
                 for (EntityInternal it : allEntities) {
                     it.getManagementSupport().onManagementStopped(info, false);
                     managementContext.getRebindManager().getChangeListener().onUnmanaged(it);
-                    log.info("XXX told persister to unmanage " + it);
                     if (managementContext.getGarbageCollector() != null)
                         managementContext.getGarbageCollector().onUnmanaged(e);
                 }
@@ -901,7 +899,6 @@ log.info("XXX prePreManage "+entity);
      * Returns true if the entity has been removed from management; false if it is not known or pre-pre-managed (anything else throws exception)
      */
     private boolean unmanageNonRecursive(Entity e) {
-log.info("XXX unmanaging NR "+e);
         /*
          * When method is synchronized, hit deadlock: 
          * 1. thread called unmanage() on a member of a group, so we got the lock and called group.removeMember;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -195,7 +195,8 @@ public class LocalEntityManager implements EntityManagerInternal {
             }
 
         } catch (Throwable e) {
-            log.warn("Failed to create entity using spec "+spec+" (rethrowing)", e);
+            // this may be expected, eg if parent is being unmanaged; rely on catcher to handle
+            log.debug("Failed to create entity using spec "+spec+" (rethrowing)", e);
             throw Exceptions.propagate(e);
         }
     }
@@ -533,7 +534,7 @@ public class LocalEntityManager implements EntityManagerInternal {
     private void unmanage(final Entity e, ManagementTransitionMode mode, boolean hasBeenReplaced) {
         if (shouldSkipUnmanagement(e, hasBeenReplaced)) return;
         final ManagementTransitionInfo info = new ManagementTransitionInfo(managementContext, mode);
-        
+log.info("XXX unmanaging "+e);
         if (hasBeenReplaced) {
             // we are unmanaging an old instance after having replaced it
             // don't unmanage or even clear its fields, because there might be references to it

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/LocalEntityManager.java
@@ -534,7 +534,6 @@ public class LocalEntityManager implements EntityManagerInternal {
     private void unmanage(final Entity e, ManagementTransitionMode mode, boolean hasBeenReplaced) {
         if (shouldSkipUnmanagement(e, hasBeenReplaced)) return;
         final ManagementTransitionInfo info = new ManagementTransitionInfo(managementContext, mode);
-log.info("XXX unmanaging "+e);
         if (hasBeenReplaced) {
             // we are unmanaging an old instance after having replaced it
             // don't unmanage or even clear its fields, because there might be references to it
@@ -603,6 +602,7 @@ log.info("XXX unmanaging "+e);
             for (EntityInternal it : allEntities) {
                 it.getManagementSupport().onManagementStopped(info, false);
                 managementContext.getRebindManager().getChangeListener().onUnmanaged(it);
+log.info("XXX told persister to unmanage "+it);
                 if (managementContext.getGarbageCollector() != null) managementContext.getGarbageCollector().onUnmanaged(e);
             }
             
@@ -853,6 +853,7 @@ log.info("XXX unmanaging "+e);
      * Returns true if the entity has been removed from management; if it was not previously managed (anything else throws exception) 
      */
     private boolean unmanageNonRecursive(Entity e) {
+log.info("XXX unmanaging NR "+e);
         /*
          * When method is synchronized, hit deadlock: 
          * 1. thread called unmanage() on a member of a group, so we got the lock and called group.removeMember;

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/persist/BrooklynMementoPersisterToObjectStore.java
@@ -895,7 +895,11 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
                 if (me == null) me = Maybe.ofAllowingNull(mgmt.lookup(memento.getId()));
                 if (me.isPresentAndNonNull() && isKnownNotManagedActive(me.get())) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("Persistence dependency incomplete with " + memento.getType() + " " + memento.getId() + "; "+me.get()+" is being unmanaged, and dependency " + id + "(" + bo + ") is not known; likely the former will be deleted shortly also but persisting it for now as requested");
+                        LOG.debug("Persistence dependency incomplete with " + memento.getType() + " " + memento.getId() + "; "+me.get()+" is being unmanaged, and dependency " + id + "(" + bo + ") is not known; likely the former will be unpersisted shortly also but persisting it for now as requested");
+                    }
+                } else if (me.get()==null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Persistence dependency incomplete with " + memento.getType() + " " + memento.getId() + "; "+me.get()+" is not known to mgmt context, and dependency " + id + "(" + bo + ") is not known; likely the former will be unpersisted shortly also but persisting it for now as requested");
                     }
                 } else {
                     // almost definitely a problem, as the descendants should be unmanaged by the time the parent is removed altogether from lookup tables
@@ -906,7 +910,7 @@ public class BrooklynMementoPersisterToObjectStore implements BrooklynMementoPer
             if (isKnownNotManagedActive(bo)) {
                 // common to do partial persistence when deleting a tree, so this is not worrisome
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("Persistence dependency incomplete with " + memento.getType() + " " + memento.getId() + "; dependency " + id + "(" + bo + ") is being unmanaged; likely the former will be unmanaged and deleted shortly but persisting it for now as requested");
+                    LOG.debug("Persistence dependency incomplete with " + memento.getType() + " " + memento.getId() + "; dependency " + id + "(" + bo + ") is being unmanaged; likely the former will be unmanaged and unpersisted shortly but persisting it for now as requested");
                 }
             }
         }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -600,7 +600,6 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
         }
     }
     
-
     @Override
     public synchronized void onUnmanaged(BrooklynObject instance) {
         if (LOG.isTraceEnabled()) LOG.trace("onUnmanaged: {}", instance);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -498,7 +498,6 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                             prevDeltaCollector.entities.size(), prevDeltaCollector.locations.size(), prevDeltaCollector.policies.size(), prevDeltaCollector.enrichers.size(), prevDeltaCollector.catalogItems.size(), prevDeltaCollector.bundles.size(),
                             prevDeltaCollector.removedEntityIds.size(), prevDeltaCollector.removedLocationIds.size(), prevDeltaCollector.removedPolicyIds.size(), prevDeltaCollector.removedEnricherIds.size(), prevDeltaCollector.removedCatalogItemIds.size(), prevDeltaCollector.removedBundleIds.size()});
             }
-LOG.info("XXX persistence cycle");
             // Generate mementos for everything that has changed in this time period
             if (prevDeltaCollector.isEmpty()) {
                 if (LOG.isTraceEnabled()) LOG.trace("No changes to persist since last delta");
@@ -539,7 +538,6 @@ LOG.info("XXX persistence cycle");
                 }
 
                 for (BrooklynObjectType type: BrooklynPersistenceUtils.STANDARD_BROOKLYN_OBJECT_TYPE_PERSISTENCE_ORDER) {
-if (!prevDeltaCollector.getRemovedIdsOfType(type).isEmpty()) LOG.info("XXX persistence removing "+prevDeltaCollector.getRemovedIdsOfType(type));
                     persisterDelta.removed(type, prevDeltaCollector.getRemovedIdsOfType(type));
                 }
 

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/PeriodicDeltaChangeListener.java
@@ -39,12 +39,16 @@ import org.apache.brooklyn.api.mgmt.rebind.RebindManager;
 import org.apache.brooklyn.api.mgmt.rebind.mementos.BrooklynMementoPersister;
 import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.BrooklynObjectType;
+import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.api.policy.Policy;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.api.sensor.Feed;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.core.BrooklynFeatureEnablement;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.mgmt.persist.BrooklynPersistenceUtils;
 import org.apache.brooklyn.core.mgmt.persist.PersistenceActivityMetrics;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal;
@@ -54,6 +58,7 @@ import org.apache.brooklyn.util.core.task.ScheduledTask;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.exceptions.RuntimeInterruptedException;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.CountdownTimer;
 import org.apache.brooklyn.util.time.Duration;
@@ -493,7 +498,7 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                             prevDeltaCollector.entities.size(), prevDeltaCollector.locations.size(), prevDeltaCollector.policies.size(), prevDeltaCollector.enrichers.size(), prevDeltaCollector.catalogItems.size(), prevDeltaCollector.bundles.size(),
                             prevDeltaCollector.removedEntityIds.size(), prevDeltaCollector.removedLocationIds.size(), prevDeltaCollector.removedPolicyIds.size(), prevDeltaCollector.removedEnricherIds.size(), prevDeltaCollector.removedCatalogItemIds.size(), prevDeltaCollector.removedBundleIds.size()});
             }
-
+LOG.info("XXX persistence cycle");
             // Generate mementos for everything that has changed in this time period
             if (prevDeltaCollector.isEmpty()) {
                 if (LOG.isTraceEnabled()) LOG.trace("No changes to persist since last delta");
@@ -506,13 +511,35 @@ public class PeriodicDeltaChangeListener implements ChangeListener {
                 for (BrooklynObjectType type: BrooklynPersistenceUtils.STANDARD_BROOKLYN_OBJECT_TYPE_PERSISTENCE_ORDER) {
                     for (BrooklynObject instance: prevDeltaCollector.getCollectionOfType(type)) {
                         try {
-                            persisterDelta.add(type, ((BrooklynObjectInternal)instance).getRebindSupport().getMemento());
+                            String skip = null;
+                            if (instance instanceof Entity) {
+                                if (Entities.isUnmanagingOrNoLongerManaged((Entity)instance)) skip = "unmanaging or no longer managed";
+                            } else if (instance instanceof Location) {
+                                if (!Locations.isManaged((Location)instance)) skip = "not managed";
+                            } else if (instance instanceof EntityAdjunct) {
+                                Maybe<Entity> entity = EntityAdjuncts.getEntity((EntityAdjunct) instance, false);
+                                if (entity.isAbsent()) skip = "not assigned to any entity";
+                                // if null, means adjunct doesn't tell us, which is weird, but don't skip
+                                else if (entity.isPresentAndNonNull()) {
+                                    if (Entities.isUnmanagingOrNoLongerManaged(entity.get())) skip = "associated entity is unmanaging or no longer managed";
+                                }
+                            }
+                            if (skip!=null) {
+                                // not uncommon if deleting lots of things
+                                LOG.debug("Persistence skipping change to "+instance+" because "+skip+"; expect this to be unpersisted soon");
+                                continue;
+
+                            } else {
+                                persisterDelta.add(type, ((BrooklynObjectInternal) instance).getRebindSupport().getMemento());
+                            }
                         } catch (Exception e) {
                             exceptionHandler.onGenerateMementoFailed(type, instance, e);
                         }
                     }
                 }
+
                 for (BrooklynObjectType type: BrooklynPersistenceUtils.STANDARD_BROOKLYN_OBJECT_TYPE_PERSISTENCE_ORDER) {
+if (!prevDeltaCollector.getRemovedIdsOfType(type).isEmpty()) LOG.info("XXX persistence removing "+prevDeltaCollector.getRemovedIdsOfType(type));
                     persisterDelta.removed(type, prevDeltaCollector.getRemovedIdsOfType(type));
                 }
 

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -319,7 +319,7 @@ public class InternalEntityFactory extends InternalFactory {
                 Entity parent = spec.getParent();
                 if (parent != null) {
                     parent = (parent instanceof AbstractEntity) ? ((AbstractEntity) parent).getProxyIfAvailable() : parent;
-log.info("XXX creating " + entity + " child of " + parent);
+log.info("XXX creating " + entity + " child of " + parent +" - unmanaging? "+Entities.isUnmanagingOrNoLongerManaged(parent));
                     if (Entities.isUnmanagingOrNoLongerManaged(parent))
                         throw new IllegalStateException("Cannot create " + entity + " as child of " + parent + " because the latter is unmanaging or no longer managed");
                     entity.setParent(parent);

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -266,6 +266,8 @@ public class InternalEntityFactory extends InternalFactory {
                 }
                 childSpec.parent(entity);
                 Entity child = createEntityAndDescendantsUninitialized(depth+1, childSpec, options, entitiesByEntityId, specsByEntityId);
+                if (Entities.isUnmanagingOrNoLongerManaged(entity))
+                    throw new IllegalStateException("Cannot create "+child+" as child of "+entity+" because the latter is unmanaging or no longer managed");
                 entity.addChild(child);
             }
 
@@ -317,6 +319,9 @@ public class InternalEntityFactory extends InternalFactory {
                 Entity parent = spec.getParent();
                 if (parent != null) {
                     parent = (parent instanceof AbstractEntity) ? ((AbstractEntity) parent).getProxyIfAvailable() : parent;
+log.info("XXX creating " + entity + " child of " + parent);
+                    if (Entities.isUnmanagingOrNoLongerManaged(parent))
+                        throw new IllegalStateException("Cannot create " + entity + " as child of " + parent + " because the latter is unmanaging or no longer managed");
                     entity.setParent(parent);
                 }
                 return entity;

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -319,10 +319,9 @@ public class InternalEntityFactory extends InternalFactory {
                 Entity parent = spec.getParent();
                 if (parent != null) {
                     parent = (parent instanceof AbstractEntity) ? ((AbstractEntity) parent).getProxyIfAvailable() : parent;
-log.info("XXX creating " + entity + " child of " + parent +" - unmanaging? "+Entities.isUnmanagingOrNoLongerManaged(parent));
-                    if (Entities.isUnmanagingOrNoLongerManaged(parent))
-                        throw new IllegalStateException("Cannot create " + entity + " as child of " + parent + " because the latter is unmanaging or no longer managed");
+                    // below will throw if parent is unmanaging, _after_ adding
                     entity.setParent(parent);
+log.info("XXX created " + entity + " child of " + parent +" - unmanaging? "+Entities.isUnmanagingOrNoLongerManaged(parent));
                 }
                 return entity;
             });

--- a/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
+++ b/core/src/main/java/org/apache/brooklyn/core/objs/proxy/InternalEntityFactory.java
@@ -321,7 +321,6 @@ public class InternalEntityFactory extends InternalFactory {
                     parent = (parent instanceof AbstractEntity) ? ((AbstractEntity) parent).getProxyIfAvailable() : parent;
                     // below will throw if parent is unmanaging, _after_ adding
                     entity.setParent(parent);
-log.info("XXX created " + entity + " child of " + parent +" - unmanaging? "+Entities.isUnmanagingOrNoLongerManaged(parent));
                 }
                 return entity;
             });

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroupImpl.java
@@ -144,11 +144,19 @@ public class DynamicGroupImpl extends AbstractGroupImpl implements DynamicGroup 
         }
     }
 
-    private class MyEntitySetChangeListener implements CollectionChangeListener<Entity> {
+    private class MyEntitySetChangeListener implements CollectionChangeListener.ListenerWithErrorHandler<Entity> {
         @Override
         public void onItemAdded(Entity item) { onEntityAdded(item); }
         @Override
         public void onItemRemoved(Entity item) { onEntityRemoved(item); }
+
+        @Override
+        public void onError(String msg, Throwable trace) {
+            // log debug if shutting down
+            BrooklynLogging.log(log, Entities.isManagedActive(DynamicGroupImpl.this) ? BrooklynLogging.LoggingLevel.WARN : BrooklynLogging.LoggingLevel.DEBUG,
+                    msg, trace);
+            throw Exceptions.propagate(trace);
+        }
     }
 
     @Override


### PR DESCRIPTION
Build on #1307, fixing the races that could cause persistence files for unmanaged items.  Expands test to cover enrichers also.  Several routes identified and fixed, plus better warnings, per the individual commits.