### PR TITLE
better "interesting task" analysis for API when working with limits

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/BrooklynGarbageCollector.java
@@ -266,7 +266,7 @@ public class BrooklynGarbageCollector {
             executionManager.getNumActiveTasks()+" active, "+
             executionManager.getNumIncompleteTasks()+" unfinished; "+
             executionManager.getNumInMemoryTasks()+" remembered, "+
-            executionManager.getTotalTasksSubmitted()+" total submitted)";
+            executionManager.getTotalTasksSubmitted()+" total submitted";
     }
     
     public void shutdownNow() {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
@@ -185,6 +185,8 @@ public class EntityResource extends AbstractBrooklynRestResource implements Enti
                 return !o1.isBegun() ? -1 : 1;
             }
 
+            // we no longer do this analysis, but instead we first take at least one of each task with a distinct name
+
 //            if (!o1.isDone()) {
 //                // among active items, scheduled ones
 //                if (!Objects.equal(o1 instanceof ScheduledTask, o2 instanceof ScheduledTask)) {


### PR DESCRIPTION
take at least 1 task with each unique name, and the "best" / most recent -- this will ensure 'start' shows up if it is still in memory (unless there are 200+ tasks of different names, which is unusual), instead of showing 20+ other tasks with the same name