### PR TITLE
Dynamic group ancestor

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/AbstractEntity.java
@@ -1198,6 +1198,7 @@ public abstract class AbstractEntity extends AbstractBrooklynObject implements E
     // TODO can this be replaced with config().set ?
     // seems only used for configure(Map) -- where validation might want to be skipped;
     // and also in a couple places where i don't think it matters
+    // (difference is that this one skips the onChanging and onChanged calls)
     @SuppressWarnings("unchecked")
     public <T> T setConfigEvenIfOwned(ConfigKey<T> key, T val) {
         return (T) configsInternal.setConfig(key, val);

--- a/core/src/main/java/org/apache/brooklyn/core/entity/EntityPredicates.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/EntityPredicates.java
@@ -415,6 +415,30 @@ public class EntityPredicates {
         };
     }
 
+    /**
+     * Returns a predicate that determines if a given entity is a descendant of (or equal to) this {@code ancestor}.
+     */
+    public static Predicate<Entity> isDescendantOf(final Entity ancestor) {
+        return new IsDescendantOf(ancestor);
+    }
+
+    protected static class IsDescendantOf implements SerializablePredicate<Entity> {
+        protected final Entity ancestor;
+        protected IsDescendantOf(Entity ancestor) {
+            this.ancestor = ancestor;
+        }
+        @Override
+        public boolean apply(@Nullable Entity input) {
+            if (input==null) return false;
+            if (Objects.equal(input, ancestor)) return true;
+            return apply(input.getParent());
+        }
+        @Override
+        public String toString() {
+            return "isDescendantOf("+ancestor+")";
+        }
+    }
+
     // ---------------------------
     
     public static Predicate<Entity> isMemberOf(final Group group) {

--- a/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroup.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/DynamicGroup.java
@@ -46,6 +46,10 @@ public interface DynamicGroup extends AbstractGroup {
             "dynamicgroup.entityfilter", 
             "Filter for entities which will automatically be in the group");
 
+    ConfigKey<Entity> ANCESTOR = ConfigKeys.newConfigKey(Entity.class,
+            "dynamicgroup.ancestor",
+            "Ancestor (or application) under which to search, or null to use containing application");
+
     AttributeSensor<Boolean> RUNNING = Sensors.newBooleanSensor(
             "dynamicgroup.running", "Whether the entity is running, and will automatically update group membership");
 


### PR DESCRIPTION
All `dynamicgroup.ancestor` to point to an entity (or a different application) to restrict what entities are permitted to join the group.

Tested with `brooklyn-terraform` to restrict discovery in our group to a specific terraform configuration `efs-tier-tf`, as follows:

```
  - id: efs-tier-tf
    item:
        type: terraform
        name: EFS+VM (TF)
        location: localhost
        brooklyn.config:
          tf.configuration.url: classpath://updating-web-with-efs-efs-volume.zip
          tf_var.name: amp-alex-2
          tf_var.ami: ami-0fe9b2de9ff3caeb2   # 2021-10
          # tf_var.ami: ami-0852b274a4f812259 # 2022-04
        brooklyn.initializers:
          - type: terraform-drift-compliance-check
            brooklyn.config:
              terraform.resources-drift.enabled: true

  - id: efs-tier
    iconUrl: classpath://efs.png
    item:
      name: Shared Storage (EFS)
      services:
      - type: efs-tier-tf
        id: efs-tier-tf
      - type: org.apache.brooklyn.entity.group.DynamicGroup
        name: EFS Server
        brooklyn.config:
          dynamicgroup.ancestor: $brooklyn:entity("efs-tier-tf")
          dynamicgroup.entityfilter:
            config: tf.resource.type
            equals: aws_instance
      - type: efs-tier-tf
        brooklyn.config:
          tf_var.name: amp-alex-3-excluded
```