### PR TITLE
in REST API, apply suppression logic to fields in maps wherever we re…

### DIFF
--- a/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
+++ b/camp/camp-brooklyn/src/main/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/methods/BrooklynDslCommon.java
@@ -70,6 +70,7 @@ import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.json.BrooklynObjectsJsonMapper;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
 import org.apache.brooklyn.util.core.task.ImmediateSupplier;
 import org.apache.brooklyn.util.core.task.Tasks;
@@ -111,6 +112,7 @@ public class BrooklynDslCommon {
     public static synchronized void registerSerializationHooks(boolean forceReinitialization) {
         if (INITIALIZED && !forceReinitialization) return;
         BrooklynJacksonSerializationUtils.JsonDeserializerForCommonBrooklynThings.BROOKLYN_PARSE_DSL_FUNCTION = DslUtils::parseBrooklynDsl;
+        BrooklynObjectsJsonMapper.DslToStringSerialization.BROOKLYN_DSL_INTERFACE = BrooklynDslDeferredSupplier.class;
         registerSpecCoercionAdapter();
         INITIALIZED = true;
     }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityConfigResource.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.internal.EntityConfigMap;
@@ -160,14 +161,21 @@ public class EntityConfigResource extends AbstractBrooklynRestResource implement
     public String getPlain(String application, String entityToken, String configKeyName,
                            Boolean useDisplayHints, Boolean skipResolution, Boolean suppressSecrets,
                            @Deprecated Boolean raw) {
-        return Strings.toString(get(false, application, entityToken, configKeyName,
+        return (String) get(false, application, entityToken, configKeyName,
                 useDisplayHints, skipResolution, suppressSecrets,
-                raw));
+                raw, true);
     }
 
     public Object get(boolean preferJson, String application, String entityToken, String configKeyName,
                       Boolean useDisplayHints, Boolean skipResolution, Boolean suppressSecrets,
                       @Deprecated Boolean raw) {
+        return get(preferJson, application, entityToken, configKeyName, useDisplayHints, skipResolution, suppressSecrets, raw, false);
+    }
+
+    public Object get(boolean preferJson, String application, String entityToken, String configKeyName,
+                      Boolean useDisplayHints, Boolean skipResolution, Boolean suppressSecrets,
+                      @Deprecated Boolean raw, boolean plain) {
+
         Entity entity = brooklyn().getEntity(application, entityToken);
         ConfigKey<?> ck = findConfig(entity, configKeyName);
         

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/util/json/BrooklynJacksonJsonProvider.java
@@ -29,6 +29,8 @@ import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.BrooklynDslDeferredSupplier;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.server.BrooklynServiceAttributes;
@@ -110,7 +112,7 @@ public class BrooklynJacksonJsonProvider extends JacksonJsonProvider implements
     }
 
     /**
-     * Like {@link #findSharedObjectMapper(ServletContext, ManagementContext)} but will create a private
+     * Like {@link #findSharedObjectMapper(ManagementContext)} but will create a private
      * ObjectMapper if it can, from the servlet context and/or the management context, or else fail
      */
     public static ObjectMapper findAnyObjectMapper(ManagementContext mgmt) {
@@ -129,7 +131,8 @@ public class BrooklynJacksonJsonProvider extends JacksonJsonProvider implements
             throw new IllegalStateException("No management context available for creating ObjectMapper");
         }
 
-        return BrooklynObjectsJsonMapper.newMapper(mgmt);
+        BrooklynDslCommon.registerSerializationHooks();
+        return BrooklynObjectsJsonMapper.newDslToStringSerializingMapper(mgmt);
     }
 
 }


### PR DESCRIPTION
…solve things

esp for config keys; so if a non-sensitive config key is a complex object or map with a `password` field, that password field will be suppressed as part of the JSON serialization

two other minor subtle tweaks:
* previously when we suppressed complex objects we showed the hash code for the toString; now we show the hash code for the json (with minimal whitespace)
* if an API caller requests PLAIN_TEXT we run toString on the internal java objects; now if secret suppression is desired, we check that toString (which is often a value), and if it has any sensitive token indicators, it is suppressed; this could hide a value we want to see, but realy PLAIN_TEXT is rarely used AFAIK esp with compex objects, the meaning of plaintext here is not formally specified, and if secrets need to be suppressed this seems the right balance.