### PR TITLE
Predicates & feeds improvements

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
+++ b/api/src/main/java/org/apache/brooklyn/api/objs/EntityAdjunct.java
@@ -55,4 +55,10 @@ public interface EntityAdjunct extends BrooklynObject {
     @Nullable String getUniqueTag();
 
     Map<String, HighlightTuple> getHighlights();
+
+    interface AutoStartEntityAdjunct extends EntityAdjunct {
+        /** for things that should start when the entity is managed, including on rebind;
+         *  replaces logic which started things during creation time */
+        public void start();
+    }
 }

--- a/api/src/main/java/org/apache/brooklyn/api/sensor/Feed.java
+++ b/api/src/main/java/org/apache/brooklyn/api/sensor/Feed.java
@@ -39,7 +39,7 @@ import com.google.common.annotations.Beta;
  *   </ul>
  */
 @Beta
-public interface Feed extends EntityAdjunct, Rebindable {
+public interface Feed extends EntityAdjunct, EntityAdjunct.AutoStartEntityAdjunct, Rebindable {
 
     /** 
      * True if everything has been _started_ (or it is starting) but not stopped,

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslPredicateYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/spi/dsl/DslPredicateYamlTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.brooklyn.camp.brooklyn.spi.dsl;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslTestObjects.DslTestCallable;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslTestObjects.DslTestSupplierWrapper;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslTestObjects.TestDslSupplier;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.DslTestObjects.TestDslSupplierValue;
+import org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.custom.UserSuppliedPackageType;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.entity.group.DynamicCluster;
+import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.entity.stock.BasicStartable;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.predicates.DslPredicates;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.Assert.assertEquals;
+
+public class DslPredicateYamlTest extends AbstractYamlTest {
+
+    @Test
+    public void testDslConfigSimple() throws Exception {
+        final Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicApplication.class.getName(),
+                "  brooklyn.config:",
+                "    "+TestEntity.CONF_STRING.getName()+": x",
+                "    test.confPredicate:",
+                "      config: "+TestEntity.CONF_STRING.getName(),
+                "      equals: y");
+        DslPredicates.DslPredicate predicate = app.config().get(TestEntity.CONF_PREDICATE);
+        Asserts.assertFalse( predicate.apply(app) );
+        app.config().set(TestEntity.CONF_STRING, "y");
+        Asserts.assertTrue( predicate.apply(app) );
+    }
+
+    @Test
+    public void testDslTags() throws Exception {
+        final Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicApplication.class.getName(),
+                "  brooklyn.tags:",
+                "  - tag1",
+                "  - color: blue");
+
+        DslPredicates.DslPredicate predicate = TypeCoercions.coerce(MutableMap.of("tag", "tag1"), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue( predicate.apply(app) );
+
+        predicate = TypeCoercions.coerce(MutableMap.of("tag", "tag2"), DslPredicates.DslPredicate.class);
+        Asserts.assertFalse( predicate.apply(app) );
+
+        predicate = TypeCoercions.coerce(MutableMap.of("tag", MutableMap.of("key", "color", "equals", "blue")), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue( predicate.apply(app) );
+
+        predicate = TypeCoercions.coerce(MutableMap.of("tag", MutableMap.of("key", "color", "equals", "red")), DslPredicates.DslPredicate.class);
+        Asserts.assertFalse( predicate.apply(app) );
+    }
+
+    @Test
+    public void testDslConfigContainingDsl() throws Exception {
+        final Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicApplication.class.getName(),
+                "  brooklyn.config:",
+                "    "+TestEntity.CONF_STRING.getName()+": x",
+                "    expected: x",
+                "    test.confPredicate:",
+                "      config: "+TestEntity.CONF_STRING.getName(),
+                "      equals: $brooklyn:config(\"expected\")");
+        DslPredicates.DslPredicate predicate = app.config().get(TestEntity.CONF_PREDICATE);
+        Asserts.assertTrue( predicate.apply(app) );
+
+        app.config().set(TestEntity.CONF_STRING, "y");
+        Asserts.assertFalse( predicate.apply(app) );
+
+        // nested DSL is resolved when predicate is _retrieved_, not when predicate is applied
+        // this is simpler and more efficient, although it might be surprising
+        app.config().set(ConfigKeys.newStringConfigKey("expected"), "y");
+        Asserts.assertFalse( predicate.apply(app) );
+
+        // per above, if we re-retrieve the predicate it should work fine
+        predicate = app.config().get(TestEntity.CONF_PREDICATE);
+        Asserts.assertTrue( predicate.apply(app) );
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/feed/PollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/PollConfig.java
@@ -21,9 +21,11 @@ package org.apache.brooklyn.core.feed;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.core.predicates.DslPredicates;
 import org.apache.brooklyn.util.time.Duration;
 
 /**
@@ -36,6 +38,7 @@ public class PollConfig<V, T, F extends PollConfig<V, T, F>> extends FeedConfig<
     private long period = -1;
     private Object otherTriggers;
     private String description;
+    private Supplier<DslPredicates.DslPredicate> condition;
 
     public PollConfig(AttributeSensor<T> sensor) {
         super(sensor);
@@ -45,6 +48,7 @@ public class PollConfig<V, T, F extends PollConfig<V, T, F>> extends FeedConfig<
         super(other);
         this.period = other.period;
         this.otherTriggers = other.otherTriggers;
+        this.condition = other.condition;
         this.description = other.description;
     }
 
@@ -80,6 +84,15 @@ public class PollConfig<V, T, F extends PollConfig<V, T, F>> extends FeedConfig<
 
     public Object getOtherTriggers() {
         return otherTriggers;
+    }
+
+    public F condition(Supplier<DslPredicates.DslPredicate> condition) {
+        this.condition = condition;
+        return self();
+    }
+
+    public Supplier<DslPredicates.DslPredicate> getCondition() {
+        return condition;
     }
 
     public String getDescription() {

--- a/core/src/main/java/org/apache/brooklyn/core/feed/PollConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/feed/PollConfig.java
@@ -101,7 +101,7 @@ public class PollConfig<V, T, F extends PollConfig<V, T, F>> extends FeedConfig<
     
     @Override protected MutableList<Object> toStringOtherFields() {
         MutableList<Object> result = super.toStringOtherFields().appendIfNotNull(description);
-        if (period>0 && period <= Duration.PRACTICALLY_FOREVER.toMilliseconds()) result.append("period: "+Duration.of(period));
+        if (period>0 && period < Duration.PRACTICALLY_FOREVER.toMilliseconds()) result.append("period: "+Duration.of(period));
         if (otherTriggers!=null) result.append("triggers: "+otherTriggers);
         return result;
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/internal/EntityManagementSupport.java
@@ -210,7 +210,7 @@ public class EntityManagementSupport {
             }
             
             /*
-             * TODO framework starting events - phase 1, including rebind
+             * framework starting events - phase 1, including rebind
              *  - establish hierarchy (child, groups, etc; construction if necessary on rebind)
              *  - set location
              *  - set local config values
@@ -223,6 +223,11 @@ public class EntityManagementSupport {
             
             if (!isReadOnly()) {
                 entity.onManagementStarting();
+
+                // start those policies etc which are labelled as auto-start
+                entity.policies().forEach(adj -> { if (adj instanceof EntityAdjunct.AutoStartEntityAdjunct) ((EntityAdjunct.AutoStartEntityAdjunct)adj).start(); });
+                entity.enrichers().forEach(adj -> { if (adj instanceof EntityAdjunct.AutoStartEntityAdjunct) ((EntityAdjunct.AutoStartEntityAdjunct)adj).start(); });
+                entity.feeds().forEach(f -> { if (!f.isActivated()) f.start(); });
             }
         } catch (Throwable t) {
             managementFailed.set(true);

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicEntityRebindSupport.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/rebind/BasicEntityRebindSupport.java
@@ -159,14 +159,6 @@ public class BasicEntityRebindSupport extends AbstractBrooklynObjectRebindSuppor
                 } catch (Exception e) {
                     rebindContext.getExceptionHandler().onAddFeedFailed(entity, feed, e);
                 }
-                
-                try {
-                    if (!rebindContext.isReadOnly(feed)) {
-                        feed.start();
-                    }
-                } catch (Exception e) {
-                    rebindContext.getExceptionHandler().onRebindFailed(BrooklynObjectType.ENTITY, entity, e);
-                }
             } else {
                 LOG.warn("Feed not found; discarding feed {} of entity {}({})",
                         new Object[] {feedId, memento.getType(), memento.getId()});

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/AbstractAddTriggerableSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/AbstractAddTriggerableSensor.java
@@ -53,6 +53,8 @@ public abstract class AbstractAddTriggerableSensor<T> extends AbstractAddSensorF
             "Sensors which should trigger this feed, supplied with list of maps containing sensor (name or sensor instance) and entity (ID or entity instance), or just sensor names or just one sensor");
     public static final ConfigKey<DslPredicates.DslPredicate> CONDITION = ConfigKeys.newConfigKey(DslPredicates.DslPredicate.class, "condition", "Optional condition required for this sensor feed to run");
 
+    public static final ConfigKey<Boolean> ONLY_IF_SERVICE_UP = ConfigKeys.newBooleanConfigKey("onlyIfServiceUp", "Whether to run only if service is up.", null);
+
     protected AbstractAddTriggerableSensor() {}
     public AbstractAddTriggerableSensor(ConfigBag parameters) {
         super(parameters);

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/http/HttpRequestSensor.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Functionals;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
@@ -135,6 +136,7 @@ public class HttpRequestSensor<T> extends AbstractAddTriggerableSensor<T> {
                 .baseUri(uri)
                 .credentialsIfNotNull(username, password)
                 .preemptiveBasicAuth(Boolean.TRUE.equals(preemptiveBasicAuth))
+                .onlyIfServiceUp(Maybe.ofDisallowingNull(EntityInitializers.resolve(initParams(), ONLY_IF_SERVICE_UP)).or(false))
                 .poll(pollConfig);
 
         if (headers != null) {

--- a/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/ssh/SshCommandSensor.java
@@ -165,7 +165,7 @@ public final class SshCommandSensor<T> extends AbstractAddTriggerableSensor<T> {
 
         SshFeed feed = SshFeed.builder()
                 .entity(entity)
-                .onlyIfServiceUp()
+                .onlyIfServiceUp(Maybe.ofDisallowingNull(EntityInitializers.resolve(params, ONLY_IF_SERVICE_UP)).or(true))
                 .poll(pollConfig)
                 .build();
 

--- a/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/group/GroupsChangePolicy.java
@@ -188,7 +188,7 @@ public class GroupsChangePolicy extends AbstractMembershipTrackingPolicy {
                             EntityInitializer initializer = entityInitializerMaybe.get();
                             initializer.apply((EntityInternal) member);
                         } else {
-                            LOG.debug("Unable to initialize {} due to {}", type, Maybe.getException(entityInitializerMaybe));
+                            LOG.debug("Unable to initialize {} due to {}", type, Maybe.getException(entityInitializerMaybe), Maybe.getException(entityInitializerMaybe));
                         }
                     } catch (Throwable e) {
                         throw Exceptions.propagate(e);

--- a/core/src/main/java/org/apache/brooklyn/feed/AbstractCommandFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/AbstractCommandFeed.java
@@ -38,6 +38,7 @@ import org.apache.brooklyn.core.feed.DelegatingPollHandler;
 import org.apache.brooklyn.core.feed.Poller;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.sensor.AbstractAddTriggerableSensor;
+import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.feed.ssh.SshPollValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -157,10 +158,7 @@ public abstract class AbstractCommandFeed extends AbstractFeed {
 
         public T build() {
             built = true;
-            T result = instantiateFeed();
-            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
-            result.start();
-            return result;
+            return AbstractFeed.initAndMaybeStart(instantiateFeed(), entity);
         }
 
         @Override

--- a/core/src/main/java/org/apache/brooklyn/feed/AbstractCommandFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/AbstractCommandFeed.java
@@ -227,24 +227,7 @@ public abstract class AbstractCommandFeed extends AbstractFeed {
     
     @Override
     protected void preStart() {
-        SetMultimap<CommandPollIdentifier, CommandPollConfig<?>> polls = config().get(POLLS);
-        
-        for (final CommandPollIdentifier pollInfo : polls.keySet()) {
-            Set<CommandPollConfig<?>> configs = polls.get(pollInfo);
-            long minPeriod = Integer.MAX_VALUE;
-            Set<AttributePollHandler<? super SshPollValue>> handlers = Sets.newLinkedHashSet();
-
-            for (CommandPollConfig<?> config : configs) {
-                handlers.add(new AttributePollHandler<SshPollValue>(config, entity, this));
-                if (config.getPeriod() > 0) minPeriod = Math.min(minPeriod, config.getPeriod());
-            }
-
-            AbstractAddTriggerableSensor.scheduleWithTriggers(this, getPoller(), new Callable<SshPollValue>() {
-                @Override
-                public SshPollValue call() throws Exception {
-                    return exec(pollInfo.command.get(), pollInfo.env.get());
-                }}, new DelegatingPollHandler(handlers), minPeriod, configs);
-        }
+        getPoller().scheduleFeed(this, getConfig(POLLS), pollInfo -> () -> exec(pollInfo.command.get(), pollInfo.env.get()));
     }
     
     @Override

--- a/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
@@ -33,7 +33,11 @@ import org.apache.brooklyn.core.feed.AbstractFeed;
 import org.apache.brooklyn.core.feed.AttributePollHandler;
 import org.apache.brooklyn.core.feed.DelegatingPollHandler;
 import org.apache.brooklyn.core.sensor.AbstractAddTriggerableSensor;
+import org.apache.brooklyn.util.core.javalang.BrooklynHttpConfig;
 import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.apache.brooklyn.util.http.auth.UsernamePassword;
+import org.apache.brooklyn.util.http.executor.HttpRequest;
+import org.apache.brooklyn.util.http.executor.HttpResponse;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -200,18 +204,6 @@ public class FunctionFeed extends AbstractFeed {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     protected void preStart() {
-        SetMultimap<FunctionPollIdentifier, FunctionPollConfig<?, ?>> polls = getConfig(POLLS);
-        for (final FunctionPollIdentifier pollInfo : polls.keySet()) {
-            Set<FunctionPollConfig<?,?>> configs = polls.get(pollInfo);
-            long minPeriod = Integer.MAX_VALUE;
-            Set<AttributePollHandler<?>> handlers = Sets.newLinkedHashSet();
-
-            for (FunctionPollConfig<?,?> config : configs) {
-                handlers.add(new AttributePollHandler(config, entity, this));
-                if (config.getPeriod() > 0) minPeriod = Math.min(minPeriod, config.getPeriod());
-            }
-
-            AbstractAddTriggerableSensor.scheduleWithTriggers(this, getPoller(), (Callable)pollInfo.job, new DelegatingPollHandler(handlers), minPeriod, configs);
-        }
+        getPoller().scheduleFeed(this, getConfig(POLLS), pollInfo -> pollInfo.job);
     }
 }

--- a/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/function/FunctionFeed.java
@@ -21,23 +21,13 @@ package org.apache.brooklyn.feed.function;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.feed.AbstractFeed;
-import org.apache.brooklyn.core.feed.AttributePollHandler;
-import org.apache.brooklyn.core.feed.DelegatingPollHandler;
-import org.apache.brooklyn.core.sensor.AbstractAddTriggerableSensor;
-import org.apache.brooklyn.util.core.javalang.BrooklynHttpConfig;
-import org.apache.brooklyn.util.http.HttpToolResponse;
-import org.apache.brooklyn.util.http.auth.UsernamePassword;
-import org.apache.brooklyn.util.http.executor.HttpRequest;
-import org.apache.brooklyn.util.http.executor.HttpResponse;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +36,6 @@ import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.SetMultimap;
-import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -146,10 +135,7 @@ public class FunctionFeed extends AbstractFeed {
         }
         public FunctionFeed build() {
             built = true;
-            FunctionFeed result = new FunctionFeed(this);
-            result.setEntity(checkNotNull((EntityInternal)entity, "entity"));
-            result.start();
-            return result;
+            return AbstractFeed.initAndMaybeStart(new FunctionFeed(this), entity);
         }
         @Override
         protected void finalize() {

--- a/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/http/HttpFeed.java
@@ -38,6 +38,7 @@ import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.location.internal.LocationInternal;
 import org.apache.brooklyn.core.sensor.AbstractAddTriggerableSensor;
+import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.util.core.javalang.BrooklynHttpConfig;
 import org.apache.brooklyn.util.executor.HttpExecutorFactory;
 import org.apache.brooklyn.util.guava.Maybe;
@@ -253,11 +254,18 @@ public class HttpFeed extends AbstractFeed {
             }
         }
         public HttpFeed build() {
+            return build(null);
+        }
+        /** normally no arg is required, but if feed is not attached to entity, it will need starting here */
+        public HttpFeed build(Boolean feedStart) {
             built = true;
             HttpFeed result = new HttpFeed(this);
             result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
             if (suspended) result.suspend();
-            result.start();
+            if ((feedStart==null && Entities.isManagedActive(entity)) || Boolean.TRUE.equals(feedStart)) {
+                // this feed is used a lot without being attached to an entity, not ideal, but let's support it
+                result.start();
+            }
             return result;
         }
         @Override

--- a/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
+++ b/core/src/main/java/org/apache/brooklyn/feed/shell/ShellFeed.java
@@ -138,10 +138,7 @@ public class ShellFeed extends AbstractFeed {
         }
         public ShellFeed build() {
             built = true;
-            ShellFeed result = new ShellFeed(this);
-            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
-            result.start();
-            return result;
+            return AbstractFeed.initAndMaybeStart(new ShellFeed(this), entity);
         }
         @Override
         protected void finalize() {

--- a/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
+++ b/core/src/test/java/org/apache/brooklyn/core/test/entity/TestEntity.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.BasicNotificationSensor;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.core.predicates.DslPredicates;
 import org.apache.brooklyn.util.time.Duration;
 
 import com.google.common.collect.ImmutableList;
@@ -74,6 +75,7 @@ public interface TestEntity extends Entity, Startable, EntityLocal, EntityIntern
     public static final SetConfigKey<String> CONF_SET_THING = new SetConfigKey<String>(String.class, "test.confSetThing", "Configuration key that's a set thing");
     public static final SetConfigKey<Object> CONF_SET_OBJ_THING = new SetConfigKey<Object>(Object.class, "test.confSetObjThing", "Configuration key that's a set thing, of objects");
     public static final BasicConfigKey<Object> CONF_OBJECT = new BasicConfigKey<Object>(Object.class, "test.confObject", "Configuration key that's an object");
+    public static final BasicConfigKey<DslPredicates.DslPredicate> CONF_PREDICATE = new BasicConfigKey<DslPredicates.DslPredicate>(DslPredicates.DslPredicate.class, "test.confPredicate", "Configuration key that's a predicate/filter");
     public static final ConfigKey<Integer> CONF_INTEGER = ConfigKeys.newConfigKey(Integer.class, "test.confInteger", "Configuration key, an integer");
     public static final ConfigKey<Double> CONF_DOUBLE = ConfigKeys.newConfigKey(Double.class, "test.confDouble", "Configuration key, a double");
     public static final ConfigKey<EntitySpec<? extends Entity>> CHILD_SPEC = ConfigKeys.newConfigKey(new TypeToken<EntitySpec<? extends Entity>>() {}, "test.childSpec", "Spec to be used for creating children");

--- a/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateEntityTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateEntityTest.java
@@ -87,7 +87,7 @@ public class DslPredicateEntityTest extends BrooklynAppUnitTestSupport {
         Asserts.assertFalse(p.test(app));
     }
 
-    // TODO would be nice to add tag, location tests -- but manual checking has confirmed they work
+    // ----- some weird stuff -----
 
     @Test
     // would be nice to support all the EntityPredicates with the new mechanism; but coercion works well enough in practice,
@@ -132,5 +132,7 @@ public class DslPredicateEntityTest extends BrooklynAppUnitTestSupport {
         Asserts.assertFalse(p.test("y"));
     }
 
+
+    // note: tags, config, dsl values, etc are tested in camp project DslPredicateYamlTest
 
 }

--- a/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateTest.java
@@ -273,6 +273,30 @@ public class DslPredicateTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test
+    public void testJsonpath() {
+        DslPredicates.DslPredicate p = TypeCoercions.coerce(MutableMap.of("jsonpath", "name", "regex", "[Bb].*"), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue(p.test(MutableMap.of("id", 123, "name", "Bob")));
+        Asserts.assertFalse(p.test(MutableMap.of("id", 124, "name", "Astrid")));
+        Asserts.assertFalse(p.test(MutableMap.of("id", 0)));
+        Asserts.assertFalse(p.test(MutableList.of("id", 0)));
+        Asserts.assertFalse(p.test("not json"));
+
+        p = TypeCoercions.coerce(MutableMap.of("jsonpath", "$.[*].name", "has-element", MutableMap.of("regex", "[Bb].*")), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue(p.test(MutableList.of(MutableMap.of("id", 123, "name", "Bob"), MutableMap.of("id", 124, "name", "Astrid"))));
+        Asserts.assertFalse(p.test(MutableList.of(MutableMap.of("id", 125), MutableMap.of("id", 124, "name", "Astrid"))));
+        Asserts.assertFalse(p.test(MutableList.of(MutableMap.of("id", 125))));
+
+        p = TypeCoercions.coerce(MutableMap.of("jsonpath", "[*].name",
+                "check",
+                    MutableMap.of("filter", MutableMap.of("regex", "[Bb].*"),
+                        "size", 1))
+                , DslPredicates.DslPredicate.class);
+        Asserts.assertTrue(p.test(MutableList.of(MutableMap.of("id", 123, "name", "Bob"), MutableMap.of("id", 124, "name", "Astrid"))));
+        Asserts.assertFalse(p.test(MutableList.of(MutableMap.of("id", 125), MutableMap.of("id", 124, "name", "Astrid"))));
+        Asserts.assertFalse(p.test(MutableList.of(MutableMap.of("id", 125))));
+    }
+
+    @Test
     public void testLocationTagImplicitEquals() {
         DslPredicates.DslPredicate p = TypeCoercions.coerce(MutableMap.of(
                 "target", "location",

--- a/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/predicates/DslPredicateTest.java
@@ -215,41 +215,6 @@ public class DslPredicateTest extends BrooklynMgmtUnitTestSupport {
         }
     }
 
-    // auto-unflattening was too weird; instead prompt for "element", also "map-key", "map-value"
-//    @Test
-//    public void testAllWithListWithVariousFlattening() {
-//        Asserts.assertTrue(SetAllowingEqualsToList.of(MutableSet.of("y", "x")).equals(MutableList.of("x", "y")));
-//
-//        DslPredicates.DslPredicate p = TypeCoercions.coerce(MutableMap.of("equals", MutableList.of("x", "y")), DslPredicates.DslPredicate.class);
-//        Asserts.assertTrue(p.test(Arrays.asList("x", "y")));
-//        // list not equal because of order and equal
-//        Asserts.assertFalse(p.test(Arrays.asList("y", "x")));
-//        Asserts.assertFalse(p.test(Arrays.asList("x", "y", "z")));
-//        // set equality _does_ match without order
-//        Asserts.assertTrue(p.test(SetAllowingEqualsToList.of(MutableSet.of("y", "x"))));
-//
-//        // "all" works because it attempts unflattened at all, then flattens on each test
-//        p = TypeCoercions.coerce(MutableMap.of("all", MutableList.of("x", "y")), DslPredicates.DslPredicate.class);
-//        Asserts.assertTrue(p.test(Arrays.asList("y", "x")));
-//        Asserts.assertTrue(p.test(Arrays.asList("x", "y", "z")));
-//        // set equality _does_ match!
-//        Asserts.assertTrue(p.test(SetAllowingEqualsToList.of(MutableSet.of("y", "x"))));
-//
-//        // specify unflattening also works, but is unnecessary
-//        p = TypeCoercions.coerce(MutableMap.of("unflattened", MutableMap.of("all", MutableList.of("x", "y"))), DslPredicates.DslPredicate.class);
-//        Asserts.assertTrue(p.test(Arrays.asList("x", "y", "z")));
-//
-//        p = TypeCoercions.coerce(MutableMap.of("unflattened", MutableMap.of("equals", MutableList.of("x", "y"))), DslPredicates.DslPredicate.class);
-//        Asserts.assertFalse(p.test(Arrays.asList("x", "y", "z")));
-//        Asserts.assertTrue(p.test(Arrays.asList("x", "y")));
-//
-//        p = TypeCoercions.coerce("x", DslPredicates.DslPredicate.class);
-//        Asserts.assertTrue(p.test(Arrays.asList("x", "y", "z")));
-//
-////        DslPredicates.DslPredicate
-//                p = TypeCoercions.coerce(MutableMap.of("unflattened", "x"), DslPredicates.DslPredicate.class);
-//        Asserts.assertFalse(p.test(Arrays.asList("x", "y", "z")));
-//    }
     @Test
     public void testListsAndElement() {
         Asserts.assertTrue(SetAllowingEqualsToList.of(MutableSet.of("y", "x")).equals(MutableList.of("x", "y")));
@@ -287,6 +252,24 @@ public class DslPredicateTest extends BrooklynMgmtUnitTestSupport {
         p = TypeCoercions.coerce(MutableMap.of("has-element", MutableMap.of("glob", "?")), DslPredicates.DslPredicate.class);
         Asserts.assertTrue(p.test(Arrays.asList("xx", "y")));
         Asserts.assertFalse(p.test(Arrays.asList("xx", "yy")));
+    }
+
+    @Test
+    public void testKeyAndAtIndex() {
+        DslPredicates.DslPredicate p = TypeCoercions.coerce(MutableMap.of("key", "name", "regex", "[Bb].*"), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue(p.test(MutableMap.of("id", 123, "name", "Bob")));
+        Asserts.assertFalse(p.test(MutableMap.of("id", 124, "name", "Astrid")));
+
+        p = TypeCoercions.coerce(MutableMap.of("index", -1, "regex", "[Bb].*"), DslPredicates.DslPredicate.class);
+        Asserts.assertTrue(p.test(MutableList.of("Astrid", "Bob")));
+        Asserts.assertFalse(p.test(MutableList.of("Astrid", "Bob", "Carver")));
+
+        // nested check
+        p = TypeCoercions.coerce(MutableMap.of("index", 1,
+                "check", MutableMap.of("key", "name", "regex", "[Bb].*")), DslPredicates.DslPredicate.class);
+        Asserts.assertFalse(p.test(MutableList.of(MutableMap.of("name", "Bob"))));
+        Asserts.assertTrue(p.test(MutableList.of("Astrid", MutableMap.of("name", "Bob"))));
+        Asserts.assertFalse(p.test(MutableList.of("Astrid", MutableMap.of("name", "Carver"))));
     }
 
     @Test

--- a/policy/src/main/java/org/apache/brooklyn/policy/enricher/HttpLatencyDetector.java
+++ b/policy/src/main/java/org/apache/brooklyn/policy/enricher/HttpLatencyDetector.java
@@ -151,7 +151,7 @@ public class HttpLatencyDetector extends AbstractEnricher implements Enricher {
                         .onResult(new ComputeLatencyAndRecordError())
                         .setOnException(null))
                 .suspended()
-                .build();
+                .build(true);
 
         if (getUniqueTag()==null) 
             uniqueTag = JavaClassNames.simpleClassName(getClass())+":"+
@@ -195,6 +195,7 @@ public class HttpLatencyDetector extends AbstractEnricher implements Enricher {
             Boolean currentVal = entity.getAttribute(Startable.SERVICE_UP);
             if (currentVal != null) {
                 AtomicReferences.setIfDifferent(serviceUp, currentVal);
+                updateEnablement();
             }
         }
 

--- a/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorImpl.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/brooklynnode/BrooklynEntityMirrorImpl.java
@@ -139,7 +139,8 @@ public class BrooklynEntityMirrorImpl extends AbstractEntity implements Brooklyn
                         return null;
                     }
                 }))
-            .poll(HttpPollConfig.forSensor(MIRROR_SUMMARY).onSuccess(new MirrorSummary())).build();
+            .poll(HttpPollConfig.forSensor(MIRROR_SUMMARY).onSuccess(new MirrorSummary()))
+            .build(true);
 
         populateEffectors();
     }

--- a/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxFeed.java
+++ b/software/base/src/main/java/org/apache/brooklyn/feed/jmx/JmxFeed.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.core.feed.DelegatingPollHandler;
 import org.apache.brooklyn.core.feed.PollHandler;
 import org.apache.brooklyn.core.feed.Poller;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
+import org.apache.brooklyn.feed.windows.WindowsPerformanceCounterFeed;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,10 +168,7 @@ public class JmxFeed extends AbstractFeed {
         }
         public JmxFeed build() {
             built = true;
-            JmxFeed result = new JmxFeed(this);
-            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
-            result.start();
-            return result;
+            return AbstractFeed.initAndMaybeStart(new JmxFeed(this), entity);
         }
         @Override
         protected void finalize() {

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerSensor.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerSensor.java
@@ -32,6 +32,7 @@ import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.feed.function.FunctionPollConfig;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,7 @@ public class ContainerSensor<T> extends AbstractAddTriggerableSensor<T> implemen
 
         ((EntityInternal) entity).feeds().add(FunctionFeed.builder()
                 .entity(entity)
-                .onlyIfServiceUp()
+                .onlyIfServiceUp(Maybe.ofDisallowingNull(EntityInitializers.resolve(initParams(), ONLY_IF_SERVICE_UP)).or(false))
                 .poll(poll)
                 .build());
     }

--- a/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/core/sensor/windows/WinRmCommandSensor.java
@@ -42,6 +42,7 @@ import org.apache.brooklyn.util.core.internal.winrm.WinRmTool;
 import org.apache.brooklyn.util.core.json.ShellEnvironmentSerializer;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -136,7 +137,7 @@ public final class WinRmCommandSensor<T> extends AbstractAddTriggerableSensor<T>
 
         CmdFeed feed = CmdFeed.builder()
                 .entity(entity)
-                .onlyIfServiceUp()
+                .onlyIfServiceUp(Maybe.ofDisallowingNull(EntityInitializers.resolve(initParams(), ONLY_IF_SERVICE_UP)).or(true))
                 .poll(pollConfig)
                 .build();
 

--- a/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
+++ b/software/winrm/src/main/java/org/apache/brooklyn/feed/windows/WindowsPerformanceCounterFeed.java
@@ -46,6 +46,7 @@ import org.apache.brooklyn.core.feed.PollHandler;
 import org.apache.brooklyn.core.feed.Poller;
 import org.apache.brooklyn.core.location.Machines;
 import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.feed.function.FunctionFeed;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.internal.winrm.WinRmToolResponse;
@@ -150,10 +151,7 @@ public class WindowsPerformanceCounterFeed extends AbstractFeed {
         }
         public WindowsPerformanceCounterFeed build() {
             built = true;
-            WindowsPerformanceCounterFeed result = new WindowsPerformanceCounterFeed(this);
-            result.setEntity(checkNotNull((EntityLocal)entity, "entity"));
-            result.start();
-            return result;
+            return AbstractFeed.initAndMaybeStart(new WindowsPerformanceCounterFeed(this), entity);
         }
         @Override
         protected void finalize() {

--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Duration.java
@@ -50,6 +50,8 @@ public class Duration implements Comparable<Duration>, Serializable {
     
     /** longest supported duration, 2^{63}-1 nanoseconds, approx ten billion seconds, or 300 years */ 
     public static final Duration PRACTICALLY_FOREVER = of(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+    /** used to indicate forever */
+    private static final Duration ALMOST_PRACTICALLY_FOREVER = PRACTICALLY_FOREVER.subtract(Duration.days(365*50));
 
     private final long nanos;
 
@@ -71,7 +73,7 @@ public class Duration implements Comparable<Duration>, Serializable {
 
     @Override
     public String toString() {
-        if (equals(PRACTICALLY_FOREVER)) return "forever";
+        if (isLongerThan(ALMOST_PRACTICALLY_FOREVER)) return "forever";
         return Time.makeTimeStringExact(this);
     }
 


### PR DESCRIPTION
Add 'jsonpath` and key/index accessors for predicates.  Replace unflattened behaviour with `has-element`.

Most feeds now support conditions.  Initial execution logic improved (to run after entity starts, so it isn't denied due to failed `isManagedActive` check), with special handling for those which require service up to automatically subscribe to it.