### PR TITLE
Workflow startable, and map sensor key access

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/trait/StartableMethods.java
@@ -67,7 +67,7 @@ public class StartableMethods {
         log.debug("Restarted children of entity "+e);
     }
     
-    private static <T extends Entity> Iterable<T> filterStartableManagedEntities(Iterable<T> contenders) {
+    public static <T extends Entity> Iterable<T> filterStartableManagedEntities(Iterable<T> contenders) {
         return Iterables.filter(contenders, Predicates.and(Predicates.instanceOf(Startable.class), EntityPredicates.isManaged()));
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -65,6 +65,12 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
 
     private static final String WORKFLOW_SETTING_SHORTHAND = "[ \"replayable\" ${replayable...} ] [ \"retention\" ${retention...} ] ";
 
+    public CustomWorkflowStep() {}
+    public CustomWorkflowStep(String name, List<Object> steps) {
+        this.name = name;
+        this.steps = steps;
+    }
+
     String shorthand;
     @Override
     public void populateFromShorthand(String value) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ClearSensorWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ClearSensorWorkflowStep.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
+import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.config.ConfigKey;
@@ -27,7 +28,16 @@ import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class ClearSensorWorkflowStep extends WorkflowStepDefinition {
 
@@ -44,12 +54,92 @@ public class ClearSensorWorkflowStep extends WorkflowStepDefinition {
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
         EntityValueToSet sensor = context.getInput(SENSOR);
         if (sensor==null) throw new IllegalArgumentException("Sensor name is required");
-        String sensorName = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, sensor.name, String.class);
-        if (Strings.isBlank(sensorName)) throw new IllegalArgumentException("Sensor name is required");
+        String sensorNameFull = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, sensor.name, String.class);
+        if (Strings.isBlank(sensorNameFull)) throw new IllegalArgumentException("Sensor name is required");
+
+        List<Object> sensorNameIndexes = MutableList.of();
+        String sensorNameBase = SetSensorWorkflowStep.extractSensorNameBaseAndPopulateIndices(sensorNameFull, sensorNameIndexes);
+
         TypeToken<?> type = context.lookupType(sensor.type, () -> TypeToken.of(Object.class));
         Entity entity = sensor.entity;
         if (entity==null) entity = context.getEntity();
-        ((EntityInternal)entity).sensors().remove(Sensors.newSensor(Object.class, sensorName));
+
+        if (sensorNameIndexes.isEmpty()) {
+            ((EntityInternal) entity).sensors().remove(Sensors.newSensor(Object.class, sensorNameFull));
+        } else {
+            ((EntityInternal) entity).sensors().modify(Sensors.newSensor(Object.class, sensorNameBase), old -> {
+
+                boolean setLast = false;
+
+                Object newTarget = SetSensorWorkflowStep.makeMutable(old, sensorNameIndexes);
+                Object target = newTarget;
+
+                MutableList<Object> indexes = MutableList.copyOf(sensorNameIndexes);
+                while (!indexes.isEmpty()) {
+                    Object i = indexes.remove(0);
+                    boolean isLast = indexes.isEmpty();
+                    Object nextTarget;
+
+                    if (target==null) {
+                        // not found, exit
+                        break;
+                    }
+
+                    if (target instanceof Map) {
+                        if (isLast) {
+                            setLast = true;
+                            ((Map) target).remove(i);
+                            nextTarget = null;
+                        } else {
+                            nextTarget = ((Map) target).get(i);
+                            if (nextTarget==null) break;
+                            ((Map) target).put(i, SetSensorWorkflowStep.makeMutable(nextTarget, indexes));
+                        }
+
+                    } else if (target instanceof Iterable && i instanceof Integer) {
+                        int ii = (Integer)i;
+                        int size = Iterables.size((Iterable) target);
+                        if (ii==-1) ii = size-1;
+                        boolean outOfBounds = ii < 0 || ii >= size;
+
+                        if (outOfBounds) {
+                            nextTarget = null;
+                            break;
+                        } else if (isLast) {
+                            setLast = true;
+                            if (target instanceof List) {
+                                ((List) target).remove(ii);
+                            } else {
+                                Iterator ti = ((Iterable) target).iterator();
+                                for (int j=0; j<ii; j++) {
+                                    ti.next();
+                                }
+                                ti.remove();
+                            }
+
+                            nextTarget = null;
+                            break;
+                        } else {
+                            Object t0 = Iterables.get((Iterable) target, ii);
+                            nextTarget = SetSensorWorkflowStep.makeMutable(t0, indexes);
+                            if (t0!=nextTarget) {
+                                if (!(target instanceof List)) throw new IllegalStateException("Cannot set numerical position index in a non-list collection (and was not otherwise known as mutable; e.g. use MutableSet): "+target);
+                                ((List) target).set(ii, nextTarget);
+                            }
+                        }
+
+                    } else {
+                        throw new IllegalArgumentException("Cannot find argument '" + i + "' in " + target);
+                    }
+
+                    target = nextTarget;
+                }
+
+                if (setLast) return Maybe.of(newTarget);
+                else return Maybe.ofDisallowingNull(old);
+            });
+        }
+
         return context.getPreviousStepOutput();
     }
 

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/AbstractStartableImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/AbstractStartableImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.entity.trait.StartableMethods;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.util.collections.QuorumCheck;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public abstract class AbstractStartableImpl extends AbstractEntity implements BasicStartable {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractStartableImpl.class);
+
+    @Override
+    public void start(Collection<? extends Location> locations) {
+        try {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.STARTING);
+
+            // Opportunity to block startup until other dependent components are available
+            Object val = config().get(START_LATCH);
+            if (val != null) log.debug("{} finished waiting for start-latch; continuing...", this);
+
+            addLocations(locations);
+            locations = Locations.getLocationsCheckingAncestors(locations, this);
+            log.info("Starting entity "+this+" at "+locations);
+
+            doStart(locations);
+            sensors().set(Attributes.SERVICE_UP, true);
+        } finally {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.RUNNING);
+        }
+    }
+
+    protected abstract void doStart(Collection<? extends Location> locations);
+
+    @Override
+    public void stop() {
+        ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPING);
+        sensors().set(SERVICE_UP, false);
+        try {
+            doStop();
+            ServiceStateLogic.setExpectedState(this, Lifecycle.STOPPED);
+        } catch (Exception e) {
+            ServiceStateLogic.setExpectedState(this, Lifecycle.ON_FIRE);
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    protected abstract void doStop();
+
+    @Override
+    public void restart() {
+        StartableMethods.restart(this);
+    }
+
+    @Override
+    protected void initEnrichers() {
+        super.initEnrichers();
+        enrichers().add(ServiceStateLogic.newEnricherFromChildrenUp()
+                .checkChildrenOnly()
+                .requireUpChildren(QuorumCheck.QuorumChecks.all())
+                .suppressDuplicates(true));
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/BasicStartable.java
@@ -46,20 +46,4 @@ public interface BasicStartable extends Entity, Startable {
             "brooklyn.locationsFilter", 
             "Provides a hook for customizing locations to be used for a given context");
 
-    /** @deprecated since 0.7.0; use {@link Locations#LocationFilter} */
-    @Deprecated
-    public interface LocationsFilter extends Locations.LocationsFilter {
-        /** @deprecated since 0.7.0; use {@link Locations#USE_FIRST_LOCATION} */
-        @Deprecated
-        public static final LocationsFilter USE_FIRST_LOCATION = new LocationsFilter() {
-            private static final long serialVersionUID = 3100091615409115890L;
-
-            @Override
-            public List<Location> filterForContext(List<Location> locations, Object context) {
-                if (locations.size()<=1) return locations;
-                return ImmutableList.of(locations.get(0));
-            }
-        };
-    }
-
 }

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/WorkflowStartable.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/WorkflowStartable.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import com.google.common.base.Predicates;
+import org.apache.brooklyn.api.catalog.CatalogConfig;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.config.ConfigInheritance;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.BasicConfigInheritance;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.config.ConfigPredicates;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.core.location.Locations;
+import org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
+
+import java.util.Arrays;
+
+/**
+ * Provides a Startable entity that runs workflow to start/stop and optionally restart
+ */
+@ImplementedBy(WorkflowStartableImpl.class)
+public interface WorkflowStartable extends BasicStartable {
+
+    @CatalogConfig(label = "Start Workflow", priority=5)
+    ConfigKey<CustomWorkflowStep> START_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "start")
+            .description("workflow to start the entity")
+            .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+            .constraint(Predicates.notNull())
+            .build();
+
+    @CatalogConfig(label = "Stop Workflow", priority=1)
+    ConfigKey<CustomWorkflowStep> STOP_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "stop")
+            .description("workflow to stop the entity")
+            .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+            .constraint(Predicates.notNull())
+            .build();
+
+    static final CustomWorkflowStep DEFAULT_RESTART_WORKFLOW = new CustomWorkflowStep("Restart (default workflow)", Arrays.asList("invoke-effector stop", "invoke-effector start"));
+
+    @CatalogConfig(label = "Restart Workflow", priority=1)
+    ConfigKey<CustomWorkflowStep> RESTART_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "restart")
+            .description("workflow to restart the entity; default is to stop then start")
+            .runtimeInheritance(BasicConfigInheritance.NEVER_INHERITED)
+            .defaultValue(DEFAULT_RESTART_WORKFLOW)
+            .build();
+
+}

--- a/core/src/main/java/org/apache/brooklyn/entity/stock/WorkflowStartableImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/entity/stock/WorkflowStartableImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
+import org.apache.brooklyn.core.entity.trait.StartableMethods;
+import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
+import org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep;
+import org.apache.brooklyn.util.collections.QuorumCheck;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class WorkflowStartableImpl extends AbstractStartableImpl implements WorkflowStartable {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowStartableImpl.class);
+
+    protected Maybe<Object> runWorkflow(ConfigKey<CustomWorkflowStep> key) {
+        CustomWorkflowStep workflow = getConfig(key);
+        if (workflow==null) return Maybe.absent("No workflow defined for: "+key.getName());
+
+        WorkflowExecutionContext workflowContext = workflow.newWorkflowExecution(this, key.getName().toLowerCase(),
+                null /* could getInput from workflow, and merge shell environment here */);
+
+        return Maybe.of(DynamicTasks.queueIfPossible( workflowContext.getTask(true).get() ).orSubmitAsync(this).getTask().getUnchecked());
+    }
+
+    @Override
+    protected void doStart(Collection<? extends Location> locations) {
+        runWorkflow(START_WORKFLOW).get();
+    }
+
+    @Override
+    protected void doStop() {
+        runWorkflow(STOP_WORKFLOW).get();
+    }
+
+    @Override
+    public void restart() {
+        runWorkflow(RESTART_WORKFLOW).get();
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/WorkflowStartableTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/WorkflowStartableTest.java
@@ -90,8 +90,7 @@ public class WorkflowStartableTest extends BrooklynAppUnitTestSupport {
 
         WorkflowEffector eff = new WorkflowEffector(ConfigBag.newInstance()
                 .configure(WorkflowEffector.EFFECTOR_NAME, "make-problem")
-                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems = { some_problem: Testing }")) );
-//                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems['some_problem'] = Testing a problem")) );
+                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems['some_problem'] = Testing a problem")) );
         eff.apply((EntityLocal)entity);
         entity.invoke(entity.getEntityType().getEffectorByName("make-problem").get(), null).getUnchecked();
 
@@ -101,8 +100,7 @@ public class WorkflowStartableTest extends BrooklynAppUnitTestSupport {
 
         eff = new WorkflowEffector(ConfigBag.newInstance()
                 .configure(WorkflowEffector.EFFECTOR_NAME, "fix-problem")
-                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems = {}")) );
-//                .configure(WorkflowEffector.STEPS, MutableList.of("clear-sensor service.problems['some_problem']")) );
+                .configure(WorkflowEffector.STEPS, MutableList.of("clear-sensor service.problems['some_problem']")) );
         eff.apply((EntityLocal)entity);
         entity.invoke(entity.getEntityType().getEffectorByName("fix-problem").get(), null).getUnchecked();
 

--- a/core/src/test/java/org/apache/brooklyn/entity/stock/WorkflowStartableTest.java
+++ b/core/src/test/java/org/apache/brooklyn/entity/stock/WorkflowStartableTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.stock;
+
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.entity.*;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.location.Locations.LocationsFilter;
+import org.apache.brooklyn.core.location.SimulatedLocation;
+import org.apache.brooklyn.core.sensor.Sensors;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
+import org.apache.brooklyn.core.test.entity.TestEntity;
+import org.apache.brooklyn.core.workflow.WorkflowBasicTest;
+import org.apache.brooklyn.core.workflow.WorkflowEffector;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class WorkflowStartableTest extends BrooklynAppUnitTestSupport {
+
+    @Override
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        super.setUp();
+        WorkflowBasicTest.addWorkflowStepTypes(mgmt);
+    }
+
+    @Test
+    public void testSettingSensors() throws Exception {
+        WorkflowStartable entity = app.addChild(EntitySpec.create(WorkflowStartable.class)
+                .configure(WorkflowStartable.START_WORKFLOW.getName(), MutableMap.of("steps", MutableList.of("set-sensor started = yes")))
+                .configure(WorkflowStartable.STOP_WORKFLOW.getName(), MutableMap.of("steps", MutableList.of("set-sensor started = no", "set-sensor stopped = yes")))
+        );
+        app.start(null);
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newStringSensor("started"), "yes");
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        entity.invoke(entity.getEntityType().getEffectorByName("stop").get(), null).getUnchecked();
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newStringSensor("started"), "no");
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newStringSensor("stopped"), "yes");
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+
+        entity.sensors().set(Sensors.newStringSensor("stopped"), "manually no");  // make sure this is cleared
+        entity.invoke(entity.getEntityType().getEffectorByName("restart").get(), null).getUnchecked();
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newStringSensor("started"), "yes");
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newStringSensor("stopped"), "yes");  // because stop ran before start
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEquals(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        WorkflowEffector eff = new WorkflowEffector(ConfigBag.newInstance()
+                .configure(WorkflowEffector.EFFECTOR_NAME, "make-problem")
+                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems = { some_problem: Testing }")) );
+//                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems['some_problem'] = Testing a problem")) );
+        eff.apply((EntityLocal)entity);
+        entity.invoke(entity.getEntityType().getEffectorByName("make-problem").get(), null).getUnchecked();
+
+        Time.sleep(Duration.ONE_SECOND);
+        Dumper.dumpInfo(entity);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.ON_FIRE);
+
+        eff = new WorkflowEffector(ConfigBag.newInstance()
+                .configure(WorkflowEffector.EFFECTOR_NAME, "fix-problem")
+                .configure(WorkflowEffector.STEPS, MutableList.of("set-sensor service.problems = {}")) );
+//                .configure(WorkflowEffector.STEPS, MutableList.of("clear-sensor service.problems['some_problem']")) );
+        eff.apply((EntityLocal)entity);
+        entity.invoke(entity.getEntityType().getEffectorByName("fix-problem").get(), null).getUnchecked();
+
+        Time.sleep(Duration.ONE_SECOND);
+        Dumper.dumpInfo(entity);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+    }
+
+}

--- a/karaf/init/src/main/resources/catalog.bom
+++ b/karaf/init/src/main/resources/catalog.bom
@@ -260,3 +260,12 @@ brooklyn.catalog:
     itemType: policy
     item:
       type: org.apache.brooklyn.core.workflow.WorkflowPolicy
+
+  - id: workflow-entity
+    itemType: entity
+    item:
+      type: org.apache.brooklyn.entity.stock.WorkflowStartable
+  - id: workflow-software-process
+    itemType: entity
+    item:
+      type: org.apache.brooklyn.entity.software.base.WorkflowSoftwareProcess

--- a/software/base/src/main/java/org/apache/brooklyn/entity/software/base/WorkflowSoftwareProcess.java
+++ b/software/base/src/main/java/org/apache/brooklyn/entity/software/base/WorkflowSoftwareProcess.java
@@ -33,33 +33,33 @@ import org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep;
 @ImplementedBy(WorkflowSoftwareProcessImpl.class)
 public interface WorkflowSoftwareProcess extends SoftwareProcess {
 
-    @CatalogConfig(label = "Install Command", priority=5)
+    @CatalogConfig(label = "Install Workflow", priority=5)
     ConfigKey<CustomWorkflowStep> INSTALL_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "install.workflow")
-            .description("command to run during the install phase")
+            .description("workflow to run during the software install phase")
             .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
-    @CatalogConfig(label = "Customize command", priority=4)
+    @CatalogConfig(label = "Customize Workflow", priority=4)
     ConfigKey<CustomWorkflowStep> CUSTOMIZE_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "customize.workflow")
-            .description("command to run during the customization phase")
+            .description("workflow to run during the software customization phase")
             .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
-    @CatalogConfig(label = "Launch Command", priority=3)
+    @CatalogConfig(label = "Launch Workflow", priority=3)
     ConfigKey<CustomWorkflowStep> LAUNCH_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "launch.workflow")
-            .description("command to run to launch the process")
+            .description("workflow to run to launch the software process")
             .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
-    @CatalogConfig(label = "Check-running Command", priority=2)
+    @CatalogConfig(label = "Check-running Workflow", priority=2)
     ConfigKey<CustomWorkflowStep> CHECK_RUNNING_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "checkRunning.workflow")
-            .description("command to determine whether the process is running")
+            .description("workflow to determine whether the software process is running")
             .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 
-    @CatalogConfig(label = "Stop Command", priority=1)
+    @CatalogConfig(label = "Stop Workflow", priority=1)
     ConfigKey<CustomWorkflowStep> STOP_WORKFLOW = ConfigKeys.builder(CustomWorkflowStep.class, "stop.workflow")
-            .description("command to run to stop the process")
+            .description("workflow to run to stop the software process")
             .runtimeInheritance(ConfigInheritance.NONE)
             .build();
 

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/StringEscapesTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/StringEscapesTest.java
@@ -228,4 +228,9 @@ public class StringEscapesTest {
                 MutableList.of(MutableMap.of("a", MutableList.<Object>of("b", 2)), "world"));
     }
 
+    @Test
+    public void testBashUnwrap() {
+        Assert.assertEquals(StringEscapes.BashStringEscapes.unwrapBashQuotesAndEscapes("\"back\\\\slash\""), "back\\slash");
+        Assert.assertEquals(StringEscapes.BashStringEscapes.unwrapBashQuotesAndEscapes("\'back\\\\slash\'"), "back\\slash");
+    }
 }


### PR DESCRIPTION
Add a `workflow-entity` where `start` / `stop` are defined by workflow.
Also allow `set-sensor service.problems['key'] = "value"` syntax, and same for `clear-sensor`, to allow updating map entries.