### PR TITLE
Use libraries as search path more

### DIFF
--- a/api/src/main/java/org/apache/brooklyn/api/mgmt/classloading/BrooklynClassLoadingContext.java
+++ b/api/src/main/java/org/apache/brooklyn/api/mgmt/classloading/BrooklynClassLoadingContext.java
@@ -19,7 +19,10 @@
 package org.apache.brooklyn.api.mgmt.classloading;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.typereg.OsgiBundleWithUrl;
 import org.apache.brooklyn.util.javalang.ClassLoadingContext;
+
+import java.util.Collection;
 
 /** 
  * As {@link ClassLoadingContext} but the {@link ManagementContext} is also available.
@@ -27,5 +30,7 @@ import org.apache.brooklyn.util.javalang.ClassLoadingContext;
 public interface BrooklynClassLoadingContext extends ClassLoadingContext {
 
     public ManagementContext getManagementContext();
+    // bundle search path, if defined
+    public Collection<? extends OsgiBundleWithUrl> getBundles();
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogMakeOsgiBundleTest.java
@@ -149,8 +149,8 @@ public class CatalogMakeOsgiBundleTest extends AbstractYamlTest {
         
         RegisteredType item = mgmt().getTypeRegistry().get( basic1.getCatalogItemId() );
         Collection<OsgiBundleWithUrl> libs = item.getLibraries();
-        Asserts.assertSize(libs, 1);
-        Assert.assertEquals(Iterables.getOnlyElement(libs).getSymbolicName(), customName);
+        Asserts.assertSize(libs, 2);
+        Assert.assertEquals(MutableList.copyOf(libs).get(1).getSymbolicName(), customName);
     }
 
     private void installBundle(File jf) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiVersionMoreEntityTest.java
@@ -101,7 +101,7 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest implement
         Assert.assertNotNull(item);
         Assert.assertEquals(item.getVersion(), "1.0");
         Assert.assertTrue(RegisteredTypePredicates.IS_ENTITY.apply(item));
-        Assert.assertEquals(item.getLibraries().size(), 1);
+        Assert.assertEquals(item.getLibraries().size(), 2);
         
         Entity app = createAndStartApplication("services: [ { type: 'more-entity:1.0' } ]");
         Entity moreEntity = Iterables.getOnlyElement(app.getChildren());
@@ -151,20 +151,20 @@ public class CatalogOsgiVersionMoreEntityTest extends AbstractYamlTest implement
     }
 
     @Test
-    /** Now assumes highest version wins regardless of install order */
-    public void testMoreEntityV1AndV2GivesV2() throws Exception {
+    /** Uses libraries to find references */
+    public void testMoreEntityV2ThenV1GivesV1() throws Exception {
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-more-entities_0.1.0.jar");
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-more-entities_0.2.0.jar");
         TestResourceUnavailableException.throwIfResourceUnavailable(getClass(), "/brooklyn/osgi/brooklyn-test-osgi-entities.jar");
 
-        addCatalogItems(getLocalResource("more-entity-v2-osgi-catalog.yaml"));
+        addCatalogItems(getLocalResource("more-entity-v2-osgi-catalog.yaml"));  // expects MoreEntity to come from 0.2.0 bundle, installed as more-entity:1.0
         forceCatalogUpdate();
-        addCatalogItems(getLocalResource("more-entity-v1-osgi-catalog.yaml"));
+        addCatalogItems(getLocalResource("more-entity-v1-osgi-catalog.yaml"));  // expects MoreEntity to come from 0.1.0 bundle, installed as more-entity:1.0; replaces previous
         Entity app = createAndStartApplication("services: [ { type: 'more-entity:1.0' } ]");
         Entity moreEntity = Iterables.getOnlyElement(app.getChildren());
         
-        OsgiVersionMoreEntityTest.assertV2EffectorCall(moreEntity);
-        OsgiVersionMoreEntityTest.assertV2MethodCall(moreEntity);
+        OsgiVersionMoreEntityTest.assertV1EffectorCall(moreEntity);
+        OsgiVersionMoreEntityTest.assertV1MethodCall(moreEntity);
     }
 
     /** unlike {@link #testMoreEntityV2ThenV1GivesV1()} this test should always work,

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlLocationTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogOsgiYamlLocationTest.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.core.mgmt.osgi.OsgiStandaloneTest;
 import org.apache.brooklyn.core.typereg.RegisteredTypePredicates;
 import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.text.StringFunctions;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -99,8 +100,8 @@ public class CatalogOsgiYamlLocationTest extends AbstractYamlTest {
     private void assertOsgi(String symbolicName) {
         RegisteredType item = mgmt().getTypeRegistry().get(symbolicName, TEST_VERSION);
         Collection<OsgiBundleWithUrl> libs = item.getLibraries();
-        assertEquals(libs.size(), 1);
-        assertEquals(Iterables.getOnlyElement(libs).getUrl(), Iterables.getOnlyElement(getOsgiLibraries()));
+        assertEquals(libs.size(), 2);
+        assertEquals(MutableList.copyOf(libs).get(1).getUrl(), Iterables.getOnlyElement(getOsgiLibraries()));
     }
 
     private void assertAdded(String symbolicName, String expectedJavaType) {

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogScanOsgiTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/CatalogScanOsgiTest.java
@@ -18,32 +18,16 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
-import java.util.function.Predicate;
+import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
-import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult.ResultCode;
-import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.stream.InputStreamSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import static org.testng.Assert.assertEquals;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.typereg.ManagedBundle;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.camp.brooklyn.test.lite.CampYamlLiteTest;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult;
+import org.apache.brooklyn.core.mgmt.ha.OsgiBundleInstallationResult.ResultCode;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.Asserts;
@@ -52,14 +36,24 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.osgi.BundleMaker;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.osgi.OsgiTestResources;
+import org.apache.brooklyn.util.stream.InputStreamSource;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Iterables;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.testng.Assert.assertEquals;
 
 public class CatalogScanOsgiTest extends AbstractYamlTest {
 
@@ -108,13 +102,13 @@ public class CatalogScanOsgiTest extends AbstractYamlTest {
 
         RegisteredType hereItem = mgmt().getTypeRegistry().get("here-item");
         assertEquals(hereItem.getVersion(), "2.0-test_java");
-        Asserts.assertSize(hereItem.getLibraries(), 2);
+        Asserts.assertSize(hereItem.getLibraries(), 3);
         assertEquals(hereItem.getContainingBundle(), "test-items:2.0-test_java");
         
         RegisteredType item = mgmt().getTypeRegistry().get(OsgiTestResources.BROOKLYN_TEST_MORE_ENTITIES_MORE_ENTITY);
         // versions and libraries _are_ inherited in this legacy mode
         assertEquals(item.getVersion(), "2.0-test_java");
-        Asserts.assertSize(hereItem.getLibraries(), 2);
+        Asserts.assertSize(hereItem.getLibraries(), 3);
         // and the containing bundle is recorded as the 
         assertEquals(item.getContainingBundle(), "test-items"+":"+"2.0-test_java");
     }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/NestedRefsCatalogYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/NestedRefsCatalogYamlTest.java
@@ -18,49 +18,20 @@
  */
 package org.apache.brooklyn.camp.brooklyn.catalog;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import org.apache.brooklyn.api.catalog.BrooklynCatalog;
-import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
-import org.apache.brooklyn.api.objs.Identifiable;
-import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry;
-import org.apache.brooklyn.api.typereg.BrooklynTypeRegistry.RegisteredTypeKind;
+import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
 import org.apache.brooklyn.api.typereg.RegisteredType;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
-import org.apache.brooklyn.camp.brooklyn.ConfigYamlTest;
-import org.apache.brooklyn.config.ConfigKey;
-import org.apache.brooklyn.core.catalog.internal.BasicBrooklynCatalog;
-import org.apache.brooklyn.core.catalog.internal.CatalogUtils;
-import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Dumper;
-import org.apache.brooklyn.core.mgmt.BrooklynTags;
-import org.apache.brooklyn.core.mgmt.BrooklynTags.SpecSummary;
-import org.apache.brooklyn.core.test.entity.TestEntity;
-import org.apache.brooklyn.core.test.entity.TestEntityImpl;
-import org.apache.brooklyn.core.typereg.RegisteredTypes;
-import org.apache.brooklyn.core.workflow.WorkflowBasicTest;
-import org.apache.brooklyn.entity.stock.BasicApplication;
-import org.apache.brooklyn.entity.stock.BasicEntity;
-import org.apache.brooklyn.entity.stock.BasicEntityImpl;
+import org.apache.brooklyn.core.mgmt.classloading.OsgiBrooklynClassLoadingContext;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.testng.Assert.*;
 
 
 public class NestedRefsCatalogYamlTest extends AbstractYamlTest {
@@ -73,23 +44,126 @@ public class NestedRefsCatalogYamlTest extends AbstractYamlTest {
     }
 
     @Test
-    public void testManyAddCatalogItems() throws Exception {
+    public void testPreferHighestVersion() {
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv2\n" +
+                "  version: \"2\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av2\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n");
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv1\n" +
+                "  version: \"1\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av1\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n");
 
-        /* test that invoke-effector doesn't cause confusion */
+        AbstractBrooklynObjectSpec<?, ?> x = mgmt().getTypeRegistry().createSpec(
+                mgmt().getTypeRegistry().get("A"), null, null);
 
+        Asserts.assertEquals(x.getDisplayName(), "Av2");
+    }
+
+    @Test
+    public void testPreferSameBundle() {
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv2\n" +
+                "  version: \"2\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av2\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n");
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv1\n" +
+                "  version: \"1\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av1\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n" +
+                "    - id: X\n" +
+                "      item:\n" +
+                "        type: A");
+        AbstractBrooklynObjectSpec<?, ?> x = mgmt().getTypeRegistry().createSpec(
+                mgmt().getTypeRegistry().get("X"), null, null);
+
+        Asserts.assertEquals(x.getDisplayName(), "Av1");
+    }
+
+    @Test
+    public void testPreferSameBundleComplex() {
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv2\n" +
+                "  version: \"2\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av2\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n"+
+                "    - id: Z\n" +
+                "      item:\n" +
+                "        name: Z\n" +
+                "        type: org.apache.brooklyn.entity.stock.BasicEntity\n");
+        addCatalogItems("brooklyn.catalog:\n" +
+                "  bundle: Bv1\n" +
+                "  version: \"1\"\n" +
+                "  items:\n" +
+                "    - id: A\n" +
+                "      item:\n" +
+                "        name: Av1\n" +
+                "        type: Z\n" +
+                "    - id: X\n" +
+                "      item:\n" +
+                "        type: A");
+        AbstractBrooklynObjectSpec<?, ?> x = mgmt().getTypeRegistry().createSpec(
+                mgmt().getTypeRegistry().get("X"), null, null);
+
+        Asserts.assertEquals(x.getDisplayName(), "Av1");
+    }
+
+    /* test that invoke-effector doesn't cause confusion */
+    void doTestAddAfterWorkflow(String url) {
+
+        // add invoke-effector bean via a bundle
 //        WorkflowBasicTest.addWorkflowStepTypes(mgmt());
-
         Collection<RegisteredType> typesW = addCatalogItems(ResourceUtils.create(this).getResourceAsString("classpath://nested-refs-catalog-yaml-workflow-test.bom.yaml"));
         Map<RegisteredType, Collection<Throwable>> resultW = mgmt().getCatalog().validateTypes(typesW);
         if (!resultW.isEmpty()) {
             Asserts.fail("Should be empty: " + resultW);
         }
 
-        Collection<RegisteredType> types = addCatalogItems(ResourceUtils.create(this).getResourceAsString("classpath://nested-refs-catalog-yaml-test.bom.yaml"));
+        // now add it as a type, in various ways
+        Collection<RegisteredType> types = addCatalogItems(ResourceUtils.create(this).getResourceAsString(url));
+
+        // should prefer from local bundle
+        Asserts.assertEquals(mgmt().getTypeRegistry().get("invoke-effector", RegisteredTypeLoadingContexts.loader(
+                new OsgiBrooklynClassLoadingContext(mgmt(), types.iterator().next().getId(), null))).getContainingBundle(), "test-bundle:0.1.0-SNAPSHOT");
+
+        // which should allow it to validate
         Map<RegisteredType, Collection<Throwable>> result = mgmt().getCatalog().validateTypes(types);
         if (!result.isEmpty()) {
-            Asserts.fail("Should be empty: " + result);
+            Asserts.fail("Failed validation should be empty: " + result);
         }
+    }
+
+    @Test
+    public void testAddAmbiguousCatalogItemsPreferEntitySpecAsParent() throws Exception {
+        doTestAddAfterWorkflow("classpath://nested-refs-catalog-yaml-test.bom.yaml");
+    }
+
+    @Test
+    public void testAddAmbiguousCatalogItemsPreferFromSameBundle() throws Exception {
+        doTestAddAfterWorkflow("classpath://nested-refs-catalog-yaml-test-2.bom.yaml");
+    }
+
+    @Test(groups = "Broken")  // need to defer loading until all items pre-parsed, or correct loading later
+    public void testAddAmbiguousCatalogItemsPreferFromSameBundleEvenIfDefinedLater() throws Exception {
+        doTestAddAfterWorkflow("classpath://nested-refs-catalog-yaml-test-3.bom.yaml");
     }
 
 }

--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/NestedRefsCatalogYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/catalog/NestedRefsCatalogYamlTest.java
@@ -128,14 +128,9 @@ public class NestedRefsCatalogYamlTest extends AbstractYamlTest {
 
     /* test that invoke-effector doesn't cause confusion */
     void doTestAddAfterWorkflow(String url) {
-
         // add invoke-effector bean via a bundle
 //        WorkflowBasicTest.addWorkflowStepTypes(mgmt());
         Collection<RegisteredType> typesW = addCatalogItems(ResourceUtils.create(this).getResourceAsString("classpath://nested-refs-catalog-yaml-workflow-test.bom.yaml"));
-        Map<RegisteredType, Collection<Throwable>> resultW = mgmt().getCatalog().validateTypes(typesW);
-        if (!resultW.isEmpty()) {
-            Asserts.fail("Should be empty: " + resultW);
-        }
 
         // now add it as a type, in various ways
         Collection<RegisteredType> types = addCatalogItems(ResourceUtils.create(this).getResourceAsString(url));
@@ -144,7 +139,7 @@ public class NestedRefsCatalogYamlTest extends AbstractYamlTest {
         Asserts.assertEquals(mgmt().getTypeRegistry().get("invoke-effector", RegisteredTypeLoadingContexts.loader(
                 new OsgiBrooklynClassLoadingContext(mgmt(), types.iterator().next().getId(), null))).getContainingBundle(), "test-bundle:0.1.0-SNAPSHOT");
 
-        // which should allow it to validate
+        // re-do the validation to be sure
         Map<RegisteredType, Collection<Throwable>> result = mgmt().getCatalog().validateTypes(types);
         if (!result.isEmpty()) {
             Asserts.fail("Failed validation should be empty: " + result);
@@ -161,7 +156,7 @@ public class NestedRefsCatalogYamlTest extends AbstractYamlTest {
         doTestAddAfterWorkflow("classpath://nested-refs-catalog-yaml-test-2.bom.yaml");
     }
 
-    @Test(groups = "Broken")  // need to defer loading until all items pre-parsed, or correct loading later
+    @Test  // allow validation to change the kind once all peers are loaded
     public void testAddAmbiguousCatalogItemsPreferFromSameBundleEvenIfDefinedLater() throws Exception {
         doTestAddAfterWorkflow("classpath://nested-refs-catalog-yaml-test-3.bom.yaml");
     }

--- a/camp/camp-brooklyn/src/test/resources/nested-refs-catalog-yaml-test-2.bom.yaml
+++ b/camp/camp-brooklyn/src/test/resources/nested-refs-catalog-yaml-test-2.bom.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  bundle: test-bundle
+  version: "0.1.0-SNAPSHOT"
+  items:
+
+    - id: invoke-effector
+      item:
+        type: org.apache.brooklyn.entity.stock.BasicEntity
+
+    - id: child
+      item:
+        type: invoke-effector
+
+    - id: parent
+      item:
+        type: org.apache.brooklyn.entity.stock.BasicEntity
+        brooklyn.children:
+          - type: child
+

--- a/camp/camp-brooklyn/src/test/resources/nested-refs-catalog-yaml-test-3.bom.yaml
+++ b/camp/camp-brooklyn/src/test/resources/nested-refs-catalog-yaml-test-3.bom.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  bundle: test-bundle
+  version: "0.1.0-SNAPSHOT"
+  items:
+
+    - id: child
+      item:
+        type: invoke-effector
+
+    - id: parent
+      item:
+        type: org.apache.brooklyn.entity.stock.BasicEntity
+        brooklyn.children:
+          - type: child
+
+    - id: invoke-effector
+      item:
+        type: org.apache.brooklyn.entity.stock.BasicEntity

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/BasicBrooklynCatalog.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.brooklyn.api.catalog.BrooklynCatalog;
@@ -1886,7 +1887,10 @@ public class BasicBrooklynCatalog implements BrooklynCatalog {
 
         Map<RegisteredType, Collection<Throwable>> validation = validateTypes(result.keySet());
         if (Iterables.concat(validation.values()).iterator().hasNext()) {
-            throw new IllegalStateException("Could not validate one or more items: "+validation);
+            log.debug("Detail of failed validation:\n"+
+                    validation.entrySet().stream().map(en -> "  "+en.getKey()+"\n"+en.getValue().stream().map(vv->"    "+Exceptions.collapseText(vv)).collect(Collectors.joining("\n")))
+                            .collect(Collectors.joining("\n")));
+            throw Exceptions.propagate("Could not validate one or more items: "+validation.keySet(), validation.values().stream().flatMap(Collection::stream).collect(Collectors.toList()));
         }
         return result.keySet();
     }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/BrooklynClassLoadingContextSequential.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/BrooklynClassLoadingContextSequential.java
@@ -18,12 +18,10 @@
  */
 package org.apache.brooklyn.core.mgmt.classloading;
 
-import java.net.URL;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.base.Objects;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.classloading.BrooklynClassLoadingContext;
+import org.apache.brooklyn.api.typereg.OsgiBundleWithUrl;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -31,7 +29,10 @@ import org.apache.brooklyn.util.guava.Maybe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 public final class BrooklynClassLoadingContextSequential extends AbstractBrooklynClassLoadingContext {
 
@@ -46,7 +47,15 @@ public final class BrooklynClassLoadingContextSequential extends AbstractBrookly
         for (BrooklynClassLoadingContext target: targets)
             add(target);
     }
-    
+
+    @Override
+    public Collection<? extends OsgiBundleWithUrl> getBundles() {
+        MutableSet<OsgiBundleWithUrl> result = MutableSet.of();
+        primaries.forEach(c -> result.addAll(c.getBundles()));
+        secondaries.forEach(c -> result.addAll(c.getBundles()));
+        return result;
+    }
+
     public void add(BrooklynClassLoadingContext target) {
         if (target instanceof BrooklynClassLoadingContextSequential) {
             for (BrooklynClassLoadingContext targetN: ((BrooklynClassLoadingContextSequential)target).primaries )

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/JavaBrooklynClassLoadingContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/JavaBrooklynClassLoadingContext.java
@@ -22,8 +22,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.api.typereg.OsgiBundleWithUrl;
 import org.apache.brooklyn.core.mgmt.persist.DeserializingClassRenamesProvider;
 import org.apache.brooklyn.util.core.ClassLoaderUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -48,7 +51,12 @@ public class JavaBrooklynClassLoadingContext extends AbstractBrooklynClassLoadin
     public static JavaBrooklynClassLoadingContext create(ClassLoader loader) {
         return new JavaBrooklynClassLoadingContext(null, checkNotNull(loader, "loader"));
     }
-    
+
+    @Override
+    public Collection<? extends OsgiBundleWithUrl> getBundles() {
+        return Collections.emptySet();
+    }
+
     /**
      * At least one of mgmt or loader must not be null.
      * @deprecated since 0.7.0 only for legacy catalog items which provide a non-osgi loader; see {@link #newDefault(ManagementContext)}

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/classloading/OsgiBrooklynClassLoadingContext.java
@@ -30,9 +30,11 @@ import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.mgmt.entitlement.Entitlements;
 import org.apache.brooklyn.core.mgmt.ha.OsgiManager;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.guava.Maybe;
 
 import com.google.common.base.Objects;
+import org.apache.brooklyn.util.osgi.VersionedName;
 
 public class OsgiBrooklynClassLoadingContext extends AbstractBrooklynClassLoadingContext {
 

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/entity/CatalogEntitySpecResolver.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/entity/CatalogEntitySpecResolver.java
@@ -62,7 +62,7 @@ public class CatalogEntitySpecResolver extends AbstractEntitySpecResolver {
     @Override
     protected boolean canResolve(String type, BrooklynClassLoadingContext loader) {
         String localType = getLocalType(type);
-        RegisteredType item = mgmt.getTypeRegistry().get(localType);
+        RegisteredType item = mgmt.getTypeRegistry().get(localType, RegisteredTypeLoadingContexts.loader(loader));
         if (item==null) {
             item = loadUpgrade(localType);
         }
@@ -78,7 +78,7 @@ public class CatalogEntitySpecResolver extends AbstractEntitySpecResolver {
     @Override
     public EntitySpec<?> resolve(String type, BrooklynClassLoadingContext loader, Set<String> parentEncounteredTypes) {
         String localType = getLocalType(type);
-        RegisteredType item = mgmt.getTypeRegistry().get(localType, RegisteredTypeLoadingContexts.spec(Entity.class));
+        RegisteredType item = mgmt.getTypeRegistry().get(localType, RegisteredTypeLoadingContexts.withLoader(RegisteredTypeLoadingContexts.spec(Entity.class), loader));
         boolean upgradeRequired = item==null;
         
         if (upgradeRequired) {

--- a/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
+++ b/core/src/main/java/org/apache/brooklyn/core/resolve/jackson/BrooklynRegisteredTypeJacksonSerialization.java
@@ -45,6 +45,7 @@ import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyButNotIfFieldConflictTypeDeserializer;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.AsPropertyIfAmbiguousTypeSerializer;
 import org.apache.brooklyn.core.resolve.jackson.AsPropertyIfAmbiguous.HasBaseType;
+import org.apache.brooklyn.core.typereg.RegisteredTypeLoadingContexts;
 import org.apache.brooklyn.util.core.flags.BrooklynTypeNameResolution;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 
@@ -124,7 +125,7 @@ public class BrooklynRegisteredTypeJacksonSerialization {
             }
 
             if (allowRegisteredTypes && mgmt!=null) {
-                RegisteredType rt = mgmt.getTypeRegistry().get(id);
+                RegisteredType rt = mgmt.getTypeRegistry().get(id, RegisteredTypeLoadingContexts.loader(loader));
                 if (rt != null) {
                     return new BrooklynJacksonType(rt);
                 }

--- a/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
+++ b/core/src/main/java/org/apache/brooklyn/core/typereg/BasicBrooklynTypeRegistry.java
@@ -207,7 +207,7 @@ public class BasicBrooklynTypeRegistry implements BrooklynTypeRegistry {
         }
         
         if (!Iterables.isEmpty(types)) {
-            RegisteredType type = RegisteredTypes.getBestVersion(types);
+            RegisteredType type = RegisteredTypes.getBestVersionInContext(types, context);
             if (type!=null) return Maybe.of(type);
         }
         

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/BundleAndTypeResourcesTest.java
@@ -184,8 +184,8 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
         RegisteredType item = getManagementContext().getTypeRegistry().get(symbolicName, TEST_VERSION);
         Assert.assertNotNull(item);
         Collection<OsgiBundleWithUrl> libs = item.getLibraries();
-        assertEquals(libs.size(), 1);
-        assertEquals(Iterables.getOnlyElement(libs).getUrl(), bundleUrl);
+        assertEquals(libs.size(), 2);
+        assertEquals(Iterables.get(libs, 1).getUrl(), bundleUrl);
 
         // now let's check other things on the item
         URI expectedIconUrl = URI.create(getEndpointAddress() + "/catalog/types/" + symbolicName + "/" + entityItem.getVersion()+"/icon").normalize();
@@ -727,8 +727,8 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
         RegisteredType item = getManagementContext().getTypeRegistry().get(symbolicName, version);
         Assert.assertNotNull(item);
         Collection<OsgiBundleWithUrl> libs = item.getLibraries();
-        assertEquals(libs.size(), 1);
-        OsgiBundleWithUrl lib = Iterables.getOnlyElement(libs);
+        assertEquals(libs.size(), 2);
+        OsgiBundleWithUrl lib = Iterables.get(libs, 1);
         Assert.assertNull(lib.getUrl());
 
         assertEquals(lib.getSymbolicName(), "org.apache.brooklyn.test.resources.osgi.brooklyn-test-osgi-entities");
@@ -803,8 +803,8 @@ public class BundleAndTypeResourcesTest extends BrooklynRestResourceTest {
         RegisteredType item = getManagementContext().getTypeRegistry().get(symbolicName, version);
         Assert.assertNotNull(item);
         Collection<OsgiBundleWithUrl> libs = item.getLibraries();
-        assertEquals(libs.size(), 1);
-        OsgiBundleWithUrl lib = Iterables.getOnlyElement(libs);
+        assertEquals(libs.size(), 2);
+        OsgiBundleWithUrl lib = Iterables.get(libs, 1);
         Assert.assertNull(lib.getUrl());
 
         // check we can find it with ResourceUtils

--- a/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
+++ b/rest/rest-resources/src/test/java/org/apache/brooklyn/rest/resources/CatalogResourceTest.java
@@ -170,8 +170,8 @@ public class CatalogResourceTest extends BrooklynRestResourceTest {
                 .applyAsserts(() -> client());
 
         RegisteredTypeAsserts.newInstance(itemSymbolicName, TEST_VERSION)
-                .libraryNames(bundleName)
-                .libraryUrls(bundleUrl)
+                .libraryNames(new VersionedName("my.catalog.entity.id", "0.1.2"), bundleName)
+                .libraryUrls(null, bundleUrl)
                 .iconUrl("classpath:/org/apache/brooklyn/test/osgi/entities/icon.gif")
                 .applyAsserts(getManagementContext().getTypeRegistry());
     }

--- a/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
+++ b/utils/rt-felix/src/test/java/org/apache/brooklyn/rt/felix/EmbeddedFelixFrameworkTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.jar.JarInputStream;
 
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.io.FileUtil;
 import org.apache.brooklyn.util.os.Os;
@@ -72,14 +73,16 @@ public class EmbeddedFelixFrameworkTest {
         log.info("Bundles and exported packages:");
         MutableSet<String> allPackages = MutableSet.of();
         while (manifests.hasMoreElements()) {
-            String fullNameManifests = Streams.readFullyStringAndClose(manifests.nextElement().openStream());
+            URL mfUrl = manifests.nextElement();
+            String fullNameManifests = Streams.readFullyStringAndClose(mfUrl.openStream());
             ManifestHelper mf = null;
             try {
                 mf = ManifestHelper.forManifestContents(fullNameManifests);
                 List<String> mfPackages = mf.getExportedPackages();
-                log.info("  " + mf.getSymbolicNameVersion() + ": " + mfPackages);
+                log.info("   " + mfUrl+" / " + mf.getSymbolicNameVersion() + ": " + mfPackages);
                 allPackages.addAll(mfPackages);
             } catch (BundleException e) {
+                log.info(" x " + mfUrl+": " + e);
                 // non valid manifest
             }
         }


### PR DESCRIPTION
prefer local bundle then libraries when resolving entity references in a definition.
previously this was done in some places, esp for resources, but missed a lot of places where would be needed for entities or bean types.

two key changes to allow this:
* item libraries now explicitly includes its containing bundle
* catalog validateResolve is now able to switch the kind if that is determined as appropriate once all peers are loaded