### PR TITLE
don't remove the location from an entity on stop until it is confirmed released

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
+++ b/core/src/main/java/org/apache/brooklyn/core/entity/Entities.java
@@ -693,6 +693,9 @@ public class Entities {
      * Actual actions performed will depend on the entity type and its current state.
      */
     public static void destroy(Entity e, boolean unmanageOnErrors) {
+        destroy(e, unmanageOnErrors, null);
+    }
+    public static void destroy(Entity e, boolean unmanageOnErrors, Duration timeout) {
         if (isManaged(e)) {
             if (isReadOnly(e)) {
                 unmanage(e);
@@ -701,7 +704,7 @@ public class Entities {
                 List<Exception> errors = MutableList.of();
 
                 try {
-                    if (e instanceof Startable) Entities.invokeEffector(e, e, Startable.STOP).getUnchecked();
+                    if (e instanceof Startable) Entities.invokeEffector(e, e, Startable.STOP).getUnchecked(timeout);
                 } catch (Exception error) {
                     Exceptions.propagateIfFatal(error);
                     if (!unmanageOnErrors) Exceptions.propagate(error);
@@ -780,6 +783,9 @@ public class Entities {
      * Apps will be stopped+destroyed+unmanaged concurrently, waiting for all to complete.
      */
     public static void destroyAll(final ManagementContext mgmt) {
+        destroyAll(mgmt, null);
+    }
+    public static void destroyAll(final ManagementContext mgmt, Duration timeout) {
         final int MAX_THREADS = 100;
         
         if (mgmt instanceof NonDeploymentManagementContext) {
@@ -803,7 +809,7 @@ public class Entities {
                     public void run() {
                         log.debug("destroying app "+app+" (managed? "+isManaged(app)+"; mgmt is "+mgmt+")");
                         try {
-                            destroy(app, true);
+                            destroy(app, true, timeout);
                             log.debug("destroyed app "+app+"; mgmt now "+mgmt);
                         } catch (Exception e) {
                             log.warn("problems destroying app "+app+" (mgmt now "+mgmt+", will rethrow at least one exception): "+e);

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/BasicTask.java
@@ -495,7 +495,7 @@ public class BasicTask<T> implements TaskInternal<T> {
             if (cancelled) throw new CancellationException();
             if (internalFuture == null) {
                 synchronized (this) {
-                    long remaining = end - System.currentTimeMillis();
+                    long remaining = end==null ? 100 : end - System.currentTimeMillis();
                     if (internalFuture==null && remaining>0)
                         wait(remaining);
                 }

--- a/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
+++ b/core/src/test/java/org/apache/brooklyn/core/mgmt/rebind/RebindTestFixture.java
@@ -232,14 +232,18 @@ public abstract class RebindTestFixture<T extends StartableApplication> {
 
     @AfterMethod(alwaysRun=true)
     public void tearDown() throws Exception {
-        if (origApp != null) Entities.destroyAll(origApp.getManagementContext());
-        if (newApp != null) Entities.destroyAll(newApp.getManagementContext());
-        if (newManagementContext != null) Entities.destroyAll(newManagementContext);
+        tearDown(null);
+    }
+
+    protected void tearDown(Duration timeout) throws Exception {
+        if (origApp != null) Entities.destroyAll(origApp.getManagementContext(), timeout);
+        if (newApp != null) Entities.destroyAll(newApp.getManagementContext(), timeout);
+        if (newManagementContext != null) Entities.destroyAll(newManagementContext, timeout);
         origApp = null;
         newApp = null;
         newManagementContext = null;
 
-        if (origManagementContext != null) Entities.destroyAll(origManagementContext);
+        if (origManagementContext != null) Entities.destroyAll(origManagementContext, timeout);
         if (mementoDir != null) FileBasedObjectStore.deleteCompletely(mementoDir);
         if (mementoDirBackup != null) FileBasedObjectStore.deleteCompletely(mementoDir);
         origManagementContext = null;


### PR DESCRIPTION
previously there was a window where a location instance might be removed from the parent before the provisioner releases it, and if the provisioner fails in that window the reference to the location is lost and cannot be subsequently deleted