### PR TITLE
Makes WorkflowSensor public and extensible

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowSensor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowSensor.java
@@ -55,7 +55,7 @@ import java.util.concurrent.Callable;
  * Configurable {@link EntityInitializer} which adds a sensor feed running a given workflow.
  */
 @Beta
-public final class WorkflowSensor<T> extends AbstractAddTriggerableSensor<T> implements WorkflowCommonConfig {
+public class WorkflowSensor<T> extends AbstractAddTriggerableSensor<T> implements WorkflowCommonConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowSensor.class);
 
@@ -142,7 +142,7 @@ public final class WorkflowSensor<T> extends AbstractAddTriggerableSensor<T> imp
         return s;
     }
 
-    static class WorkflowPollCallable implements Callable<Object> {
+    public static class WorkflowPollCallable implements Callable<Object> {
         private final String workflowCallableName;
         private BrooklynObject entityOrAdjunct;
         private final Map<String,Object> params;
@@ -192,6 +192,10 @@ public final class WorkflowSensor<T> extends AbstractAddTriggerableSensor<T> imp
 
                 throw e;
             }
+        }
+
+        public Map<String,Object> getParams() {
+            return params;
         }
 
         @Override

--- a/core/src/test/java/org/apache/brooklyn/util/core/xstream/XmlSerializerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/xstream/XmlSerializerTest.java
@@ -32,8 +32,6 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.xstream.LambdaPreventionMapper.LambdaPersistenceMode;
-import org.omg.CORBA.ObjectHolder;
-import org.omg.CORBA.StringHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.testng.Assert.assertEquals;


### PR DESCRIPTION

Removes final designation from WorkflowSensor allowing downstream projects to extend it. WorkflowPollCallable params are made visible to allow comparison of workflowsensors to determine if they've changed (e.g. for a diff)

