### PR TITLE
Removes final from WorkflowPolicy

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowPolicy.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowPolicy.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
  * Configurable policy which runs workflow according to schedule and/or trigger.
  */
 @Beta
-public final class WorkflowPolicy<T> extends AbstractPolicy {
+public class WorkflowPolicy<T> extends AbstractPolicy {
 
     private static final Logger LOG = LoggerFactory.getLogger(WorkflowPolicy.class);
 


### PR DESCRIPTION
Removes `final` designator from WorkflowPolicy to allow extension in downstream