### PR TITLE
fix for the test failing in different timezone

### DIFF
--- a/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/time/Time.java
@@ -153,7 +153,7 @@ public class Time {
 
     /** as {@link #makeDateStampString()}, with millis and possibly seconds removed if 0, with 'Z' at the end to indicate UTC */
     public static String makeDateStampStringZ(Instant instant) {
-        String s = makeDateStampString(instant.toEpochMilli());
+        String s = makeDateStampStringZ(instant.toEpochMilli());
         if (s.endsWith("000")) {
             s = Strings.removeFromEnd(s, "000");
             s = Strings.removeFromEnd(s, "00");
@@ -163,7 +163,7 @@ public class Time {
 
     /** as {@link #makeDateStampString()}, with millis and possibly seconds removed if 0, with 'Z' at the end to indicate UTC */
     public static String makeDateStampStringZ(Date date) {
-        String s = makeDateStampString(date.getTime());
+        String s = makeDateStampStringZ(date.getTime());
         if (s.endsWith("000")) {
             s = Strings.removeFromEnd(s, "000");
             s = Strings.removeFromEnd(s, "00");
@@ -204,6 +204,14 @@ public class Time {
      * cf {@link #makeDateStampString()} */
     public static String makeDateStampString(long date) {
         return new SimpleDateFormat(DATE_FORMAT_STAMP).format(new Date(date));
+    }
+
+    /** returns the time in {@value #DATE_FORMAT_STAMP} format, given a long (e.g. returned by System.currentTimeMillis), in UTC timezone;
+     * cf {@link #makeDateStampStringZ()} */
+    public static String makeDateStampStringZ(long date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT_STAMP);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(new Date(date));
     }
 
     /** returns the current time in {@value #DATE_FORMAT_SIMPLE_STAMP} format, 


### PR DESCRIPTION
Problem with test and one of the assertions in a different timezone.

`Assert.assertEquals(Time.makeDateStampStringZ(instant), "20200101-1200Z");` - that is the problematic one - `Time.makeDateStampStringZ` as per its annotation should represent time in the UTC zone, however it calls `makeDateStampString` which uses `SimpleDateFormat` from `Date` which is aware of the timezone and uses default timezone, therefore returning time in current zone rather than UTC. Given the above, I have implemented another function `makeDateStampStringZ` that sets the timezone in SimpleDateFormat to be UTC which solves the issue  (in summary, we didn't set the UTC timezone where we expected to have it)