### PR TITLE
Added new step type for setting entity name

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
@@ -112,7 +112,7 @@ public abstract class WorkflowStepDefinition {
         return timeout;
     }
 
-    // might be nice to support a shorthand for on-error; but not yet
+    // TODO: might be nice to support a shorthand for on-error; but not yet
     @JsonProperty("on-error")
     protected Object onError = MutableList.of();
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/AddPolicyWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/AddPolicyWorkflowStep.java
@@ -18,10 +18,8 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.objs.BrooklynObject;
@@ -31,16 +29,15 @@ import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
-import org.apache.brooklyn.core.resolve.jackson.JsonPassThroughDeserializer;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.core.workflow.WorkflowStepResolution;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.flags.FlagUtils;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.text.StringEscapes;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.yaml.Yamls;
 import org.slf4j.Logger;
@@ -78,7 +75,7 @@ public class AddPolicyWorkflowStep extends WorkflowStepDefinition implements Has
     @Override
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
         Object entityToFind = context.getInput(ENTITY);
-        Entity entity = entityToFind != null ? DeleteEntityWorkflowStep.findEntity(context, entityToFind).get() : context.getEntity();
+        Entity entity = entityToFind != null ? WorkflowStepResolution.findEntity(context, entityToFind).get() : context.getEntity();
 
         Object blueprint = resolveBlueprint(context);
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ApplyInitializerWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ApplyInitializerWorkflowStep.java
@@ -18,27 +18,21 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityInitializer;
 import org.apache.brooklyn.api.entity.EntityLocal;
-import org.apache.brooklyn.api.internal.AbstractBrooklynObjectSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.EntityAdjuncts;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
-import org.apache.brooklyn.core.resolve.jackson.JsonPassThroughDeserializer;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.core.workflow.WorkflowStepResolution;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.exceptions.Exceptions;
-import org.apache.brooklyn.util.text.StringEscapes;
 import org.apache.brooklyn.util.yaml.Yamls;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +65,7 @@ public class ApplyInitializerWorkflowStep extends WorkflowStepDefinition impleme
     @Override
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
         Object entityToFind = context.getInput(ENTITY);
-        Entity entity = entityToFind != null ? DeleteEntityWorkflowStep.findEntity(context, entityToFind).get() : context.getEntity();
+        Entity entity = entityToFind != null ? WorkflowStepResolution.findEntity(context, entityToFind).get() : context.getEntity();
 
         Object blueprint = resolveBlueprint(context);
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/DeletePolicyWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/DeletePolicyWorkflowStep.java
@@ -18,28 +18,21 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
-import com.google.common.base.Predicates;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.objs.EntityAdjunct;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAdjuncts;
-import org.apache.brooklyn.core.entity.EntityPredicates;
-import org.apache.brooklyn.core.mgmt.internal.AppGroupTraverser;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
-import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.javalang.Boxing;
+import org.apache.brooklyn.core.workflow.WorkflowStepResolution;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 public class DeletePolicyWorkflowStep extends WorkflowStepDefinition {
 
@@ -78,7 +71,7 @@ public class DeletePolicyWorkflowStep extends WorkflowStepDefinition {
 
         if (found==null) {
             Object entityToFind = context.getInput(ENTITY);
-            entity = entityToFind!=null ? DeleteEntityWorkflowStep.findEntity(context, entityToFind).get() : context.getEntity();
+            entity = entityToFind!=null ? WorkflowStepResolution.findEntity(context, entityToFind).get() : context.getEntity();
             policy = EntityAdjuncts.tryFindOnEntity(entity, context.getInput(POLICY)).get();
             setStepState(context, Pair.of(entity.getId(), policy.getUniqueTag()));
         } else {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ReparentEntityWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/ReparentEntityWorkflowStep.java
@@ -18,17 +18,14 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.EntityAdjuncts;
-import org.apache.brooklyn.core.resolve.jackson.JsonPassThroughDeserializer;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.brooklyn.core.workflow.WorkflowStepResolution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +56,8 @@ public class ReparentEntityWorkflowStep extends WorkflowStepDefinition {
 
     @Override
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
-        Entity child = DeleteEntityWorkflowStep.findEntity(context, context.getInput(CHILD)).get();
-        Entity parent = DeleteEntityWorkflowStep.findEntity(context, context.getInput(PARENT)).get();
+        Entity child = WorkflowStepResolution.findEntity(context, context.getInput(CHILD)).get();
+        Entity parent = WorkflowStepResolution.findEntity(context, context.getInput(PARENT)).get();
 
         Entity oldParent = child.getParent();
         if (!Objects.equals(oldParent, parent)) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/SetEntityNameWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/SetEntityNameWorkflowStep.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.steps.appmodel;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
+import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.core.workflow.WorkflowStepResolution;
+
+/**
+ * shorthandTypeName = set-entity-name
+ */
+public class SetEntityNameWorkflowStep extends WorkflowStepDefinition {
+
+    public static final String SHORTHAND = "${value...}";
+
+    // decide config keys here
+    public static final ConfigKey<String> VALUE = ConfigKeys.newConfigKey(String.class, "value");
+    public static final ConfigKey<Object> ENTITY = ConfigKeys.newConfigKey(Object.class, "entity");
+
+    @Override
+    public void populateFromShorthand(String value) {
+        populateFromShorthandTemplate(SHORTHAND, value);
+    }
+
+    @Override
+    protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
+        Object entityToFind = context.getInput(ENTITY);
+        Entity entity = entityToFind != null ? WorkflowStepResolution.findEntity(context, entityToFind).get() : context.getEntity();
+        entity.setDisplayName(context.getInput(VALUE));
+        return context.getPreviousStepOutput();
+    }
+
+    @Override
+    protected Boolean isDefaultIdempotent() {
+        return true;
+    }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/external/HttpWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/external/HttpWorkflowStep.java
@@ -108,7 +108,6 @@ public class HttpWorkflowStep extends WorkflowStepDefinition {
             throw Exceptions.propagateAnnotated("Invalid URI: "+endpoint, e);
         }
 
-        UsernamePassword creds = null;
         String username = context.getInput(USERNAME);
         String password = context.getInput(PASSWORD);
         if (Strings.isNonBlank(username) || Strings.isNonBlank(password)) {
@@ -147,7 +146,7 @@ public class HttpWorkflowStep extends WorkflowStepDefinition {
 
         final long startTime = System.currentTimeMillis();
         HttpExecutor httpExecutor = BrooklynHttpConfig.newHttpExecutor(context.getEntity());
-        HttpResponse response = null;
+        HttpResponse response;
         try {
             response = httpExecutor.execute(httpb.build());
         } catch (IOException e) {

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/ShorthandProcessorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/ShorthandProcessorTest.java
@@ -54,6 +54,7 @@ public class ShorthandProcessorTest extends BrooklynMgmtUnitTestSupport {
     @Test
     public void testShorthandQuoted() {
         assertShorthandOfGives("${x}", "hello world", MutableMap.of("x", "hello world"));
+        assertShorthandOfGives("${x}", "hello world", MutableMap.of("x", "hello world"));
 
         assertShorthandOfGives("${x} \" is \" ${y}", "a is b c", MutableMap.of("x", "a", "y", "b c"));
         assertShorthandOfGives("${x} \" is \" ${y}", "a is b \"c\"", MutableMap.of("x", "a", "y", "b \"c\""));

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
@@ -98,6 +98,7 @@ public class WorkflowBasicTest extends BrooklynMgmtUnitTestSupport {
         addRegisteredTypeBean(mgmt, "sleep", SleepWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "no-op", NoOpWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "set-config", SetConfigWorkflowStep.class);
+        addRegisteredTypeBean(mgmt, "set-entity-name", SetEntityNameWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "clear-config", ClearConfigWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "set-sensor", SetSensorWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "clear-sensor", ClearSensorWorkflowStep.class);

--- a/karaf/init/src/main/resources/catalog.bom
+++ b/karaf/init/src/main/resources/catalog.bom
@@ -110,6 +110,13 @@ brooklyn.catalog:
     itemType: bean
     item:
       type: org.apache.brooklyn.core.workflow.steps.appmodel.SetSensorWorkflowStep
+
+  - id: set-entity-name
+    format: java-type-name
+    itemType: bean
+    item:
+      type: org.apache.brooklyn.core.workflow.steps.appmodel.SetEntityNameWorkflowStep
+
   - id: clear-sensor
     format: java-type-name
     itemType: bean


### PR DESCRIPTION
Added a new step type. Added to the catalog as `set-entity-name`. 
Sample usage (shorthand):
```
name: test-set-entity-name-step
location: localhost
services:
  - type: server
    name: renamer
    brooklyn.initializers:
      - type: workflow-effector
        brooklyn.config:
          name: change-entity-name
          steps:
          # shorthand
          - set-entity-name new-name # renames itself
```

Sample usage (expanded):
```
name: test-set-entity-name-step
location: localhost
services:
  - type: server
    id: the-other-server
  - type: server
    name: renamer
    brooklyn.initializers:
      - type: workflow-effector
        brooklyn.config:
          name: change-entity-name
          steps:
          - type: set-entity-name
            value: new-name1
          - type: set-entity-name
            value: new-name2
            entity: $brooklyn:entity("the-other-server") # or $brooklyn:component("the-other-server")
```