### PR TITLE
Activities tab rest optimization

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -262,36 +262,6 @@ public final class Sanitizer {
         }
     }
 
-    public static Object suppressWorkflowOutputs(Object x) {
-        if (x instanceof Map) {
-            Map y = MutableMap.of();
-            ((Map)x).forEach((k,v) -> {
-                y.put(k, v!=null && Sanitizer.IS_OUTPUT.apply(k) ? "(output suppressed)": suppressWorkflowOutputs(v) );
-            });
-            return y;
-        }else if (x instanceof Iterable){
-            List y = MutableList.of();
-            ((Iterable)x).forEach(xi -> y.add(suppressWorkflowOutputs(xi)));
-            return y;
-        }else {
-            return x;
-        }
-    }
-
-    public static final Predicate<Object> IS_OUTPUT = new IsOutputPredicate();
-
-    private static class IsOutputPredicate implements Predicate<Object> {
-        @Override
-        public boolean apply(Object name) {
-            if (name == null) return false;
-            String lowerName = name.toString().toLowerCase();
-            for (String outputFieldName : ImmutableList.of("output", "stdout", "stderr")) {
-                if (lowerName.contains(outputFieldName))
-                    return true;
-            }
-            return false;
-        }
-    }
 
     /**
      * Kept only in case this anonymous inner class has made it into any persisted state.

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -262,7 +262,6 @@ public final class Sanitizer {
         }
     }
 
-
     /**
      * Kept only in case this anonymous inner class has made it into any persisted state.
      * 

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
@@ -266,7 +266,7 @@ public abstract class AbstractBrooklynRestResource {
 
         public static Object getValueForDisplay(ManagementContext mgmt, ObjectMapper mapper, Object value, boolean preferJson, boolean isJerseyReturnValue, Boolean suppressNestedSecrets, Boolean suppressOutput) {
             suppressNestedSecrets = checkAndGetSecretsSuppressed(mgmt, suppressNestedSecrets, false);
-            return getValueForDisplayAfterSecretsCheck(mgmt, mapper, value, preferJson, isJerseyReturnValue, suppressNestedSecrets,suppressOutput);
+            return getValueForDisplayAfterSecretsCheck(mgmt, mapper, value, preferJson, isJerseyReturnValue, suppressNestedSecrets, suppressOutput);
         }
 
         static Object getValueForDisplayAfterSecretsCheck(ManagementContext mgmt, ObjectMapper mapper, Object value, boolean preferJson, boolean isJerseyReturnValue, Boolean suppressNestedSecrets, Boolean suppressOutput) {
@@ -299,7 +299,7 @@ public abstract class AbstractBrooklynRestResource {
                             String resultS = mapper.writeValueAsString(result);
                             result = BeanWithTypeUtils.newSimpleMapper().readValue(resultS, Object.class);
                             if (suppressOutput){
-                                result = TaskTransformer.suppressWorkflowOutputs(result);
+                                result = TaskTransformer.suppressOutputs(result);
                             }
                             //the below treats all numbers as doubles
                             //new Gson().fromJson(resultS, Object.class);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/AbstractBrooklynRestResource.java
@@ -34,6 +34,7 @@ import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.mgmt.internal.ManagementContextInternal;
 import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
 import org.apache.brooklyn.rest.domain.ApiError;
+import org.apache.brooklyn.rest.transform.TaskTransformer;
 import org.apache.brooklyn.rest.util.BrooklynRestResourceUtils;
 import org.apache.brooklyn.rest.util.DefaultExceptionMapper;
 import org.apache.brooklyn.rest.util.ManagementContextProvider;
@@ -298,7 +299,7 @@ public abstract class AbstractBrooklynRestResource {
                             String resultS = mapper.writeValueAsString(result);
                             result = BeanWithTypeUtils.newSimpleMapper().readValue(resultS, Object.class);
                             if (suppressOutput){
-                                result = Sanitizer.suppressWorkflowOutputs(result);
+                                result = TaskTransformer.suppressWorkflowOutputs(result);
                             }
                             //the below treats all numbers as doubles
                             //new Gson().fromJson(resultS, Object.class);

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/EntityResource.java
@@ -156,7 +156,7 @@ public class EntityResource extends AbstractBrooklynRestResource implements Enti
     public List<TaskSummary> listTasks(String applicationId, String entityId, int limit, Boolean recurse, Boolean suppressSecrets) {
         Entity entity = brooklyn().getEntity(applicationId, entityId);
         return TaskTransformer.fromTasks(MutableList.copyOf(BrooklynTaskTags.getTasksInEntityContext(mgmt().getExecutionManager(), entity)),
-            limit, recurse, entity, ui, resolving(null), suppressSecrets);
+            limit, recurse, entity, ui, resolving(null), suppressSecrets, TaskTransformer.TaskSummaryMode.NONE);
     }
 
     /** API does not guarantee order, but this is a the one we use (when there are lots of tasks):
@@ -387,7 +387,7 @@ public class EntityResource extends AbstractBrooklynRestResource implements Enti
     @Override
     public Response getWorkflows(String applicationId, String entityId, Boolean suppressSecrets) {
         Entity entity = brooklyn().getEntity(applicationId, entityId);
-        return Response.ok(resolving(null).getValueForDisplay(MutableList.copyOf(new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(entity).values()), true, true, suppressSecrets)).build();
+        return Response.ok(resolving(null).getValueForDisplay(MutableList.copyOf(new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(entity).values()), true, true, suppressSecrets, true)).build();
     }
 
     @Override

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TaskTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TaskTransformer.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.rest.transform;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -26,6 +27,7 @@ import com.google.common.collect.Ordering;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags.WrappedStream;
 import org.apache.brooklyn.rest.api.ActivityApi;
@@ -234,4 +236,35 @@ public class TaskTransformer {
             return taskTaskSummaryFunction.apply(task);
         }).collect(Collectors.toList());
     }
+    public static Object suppressWorkflowOutputs(Object x) {
+        if (x instanceof Map) {
+            Map y = MutableMap.of();
+            ((Map)x).forEach((k,v) -> {
+                y.put(k, v!=null && TaskTransformer.IS_OUTPUT.apply(k) ? "(output suppressed)": suppressWorkflowOutputs(v) );
+            });
+            return y;
+        }else if (x instanceof Iterable){
+            List y = MutableList.of();
+            ((Iterable)x).forEach(xi -> y.add(suppressWorkflowOutputs(xi)));
+            return y;
+        }else {
+            return x;
+        }
+    }
+
+    public static final Predicate<Object> IS_OUTPUT = new IsOutputPredicate();
+
+    private static class IsOutputPredicate implements Predicate<Object> {
+        @Override
+        public boolean apply(Object name) {
+            if (name == null) return false;
+            String lowerName = name.toString().toLowerCase();
+            for (String outputFieldName : ImmutableList.of("output", "stdout", "stderr")) {
+                if (lowerName.contains(outputFieldName))
+                    return true;
+            }
+            return false;
+        }
+    }
+
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TaskTransformer.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/transform/TaskTransformer.java
@@ -18,9 +18,9 @@
  */
 package org.apache.brooklyn.rest.transform;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
 import org.apache.brooklyn.api.entity.Entity;
@@ -49,6 +49,8 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.brooklyn.rest.util.WebResourceUtils.serviceUriBuilder;
 
@@ -58,14 +60,16 @@ public class TaskTransformer {
     private static final Logger log = LoggerFactory.getLogger(TaskTransformer.class);
 
     public static final Function<Task<?>, TaskSummary> fromTask(final UriBuilder ub, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets) {
+        return fromTask(ub,resolver,suppressSecrets,true);
+    };
+    public static final Function<Task<?>, TaskSummary> fromTask(final UriBuilder ub, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets, boolean includeDetail) {
         return new Function<Task<?>, TaskSummary>() {
             @Override
             public TaskSummary apply(@Nullable Task<?> input) {
-                return taskSummary(input, ub, resolver, suppressSecrets);
+                return taskSummary(input, ub, resolver, suppressSecrets, includeDetail);
             }
         };
     };
-
     public static TaskSummary taskSummary(Task<?> task, UriBuilder ub, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets) {
         return taskSummary(task, ub, resolver, suppressSecrets, true);
     }
@@ -165,11 +169,13 @@ public class TaskTransformer {
         URI taskUri = serviceUriBuilder(ub, ActivityApi.class, "get").build(t.getId());
         return new LinkWithMetadata(taskUri.toString(), data);
     }
-    
-    public static List<TaskSummary> fromTasks(List<Task<?>> tasksToScan, int limit, Boolean recurse, @Nullable Entity entity, UriInfo ui, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets) {
-        return fromTasks(tasksToScan, limit, recurse, entity, ui, resolver, suppressSecrets, !Boolean.TRUE.equals(recurse));
+    public enum TaskSummaryMode{
+        ALL, NONE, SUBSET
     }
-    public static List<TaskSummary> fromTasks(List<Task<?>> tasksToScan, int limit, Boolean recurse, @Nullable Entity entity, UriInfo ui, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets, boolean includeDetail) {
+    public static List<TaskSummary> fromTasks(List<Task<?>> tasksToScan, int limit, Boolean recurse, @Nullable Entity entity, UriInfo ui, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets) {
+        return fromTasks(tasksToScan, limit, recurse, entity, ui, resolver, suppressSecrets, TaskSummaryMode.ALL);
+    }
+    public static List<TaskSummary> fromTasks(List<Task<?>> tasksToScan, int limit, Boolean recurse, @Nullable Entity entity, UriInfo ui, AbstractBrooklynRestResource.RestValueResolver resolver, Boolean suppressSecrets, TaskSummaryMode taskSummaryMode) {
         int sizeRemaining = limit;
         InterestingTasksFirstComparator comparator = new InterestingTasksFirstComparator(entity);
         if (limit>0 && tasksToScan.size() > limit) {
@@ -206,21 +212,26 @@ public class TaskTransformer {
         tasksToScan = MutableList.copyOf(Ordering.from(comparator).sortedCopy(tasksToScan));
 
         Map<String,Task<?>> tasksLoaded = MutableMap.of();
-        
+
+        boolean isRecurse = Boolean.TRUE.equals(recurse);
         while (!tasksToScan.isEmpty()) {
             Task<?> t = tasksToScan.remove(0);
             if (tasksLoaded.put(t.getId(), t)==null) {
                 if (--sizeRemaining==0) {
                     break;
                 }
-                if (Boolean.TRUE.equals(recurse)) {
+                if (isRecurse) {
                     if (t instanceof HasTaskChildren) {
                         Iterables.addAll(tasksToScan, ((HasTaskChildren) t).getChildren() );
                     }
                 }
             }
         }
-        return new LinkedList<TaskSummary>(Collections2.transform(tasksLoaded.values(), 
-            TaskTransformer.fromTask(ui.getBaseUriBuilder(), resolver, suppressSecrets)));
+        List<Task<?>> finalTasksToScan = ImmutableList.copyOf(tasksToScan);
+        return tasksLoaded.values().stream().map(task->{
+            boolean includeDetail = (taskSummaryMode == TaskSummaryMode.ALL && !isRecurse) || (taskSummaryMode == TaskSummaryMode.SUBSET && finalTasksToScan.contains(task));
+            Function<Task<?>, TaskSummary> taskTaskSummaryFunction = TaskTransformer.fromTask(ui.getBaseUriBuilder(), resolver, suppressSecrets, includeDetail);
+            return taskTaskSummaryFunction.apply(task);
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
It avoids to return the `task-summary` and the `output` of each step inside a workflow.
The automatic refresh of the view was pulling those, sometimes, huge objects few times per minute make the UI work slower than expected