### PR TITLE
Workflow entity child and member access pt 184904864

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
@@ -56,6 +56,7 @@ import java.io.*;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 
@@ -618,6 +619,7 @@ public class TemplateProcessor {
         protected final EntityDriver driver;
         protected final ManagementContext mgmt;
         protected final DotSplittingTemplateModel extraSubstitutionsModel;
+        protected final Collection<Entity> children;
 
         // TODO the extra substitutions here (and in LocationAndMapTemplateModel) could be replaced with
         // FirstAvailableTemplateModel(entityModel, mapHashModel)
@@ -627,6 +629,7 @@ public class TemplateProcessor {
             this.entity = entity !=null ? entity : driver!=null ? (EntityInternal) driver.getEntity() : null;
             this.mgmt = mgmt != null ? mgmt : this.entity!=null ? this.entity.getManagementContext() : null;
             extraSubstitutionsModel = new DotSplittingTemplateModel(null);
+            this.children = this.entity !=null ? this.entity.getChildren(): null;
         }
 
         @Override
@@ -649,6 +652,7 @@ public class TemplateProcessor {
         @Deprecated /** @deprecated since 1.1 use {@link #forEntity(Entity, Map)} and related instead; substitions added separately using {@link FirstAvailableTemplateModel }*/
         protected EntityAndMapTemplateModel(ManagementContext mgmt, Map<String,? extends Object> extraSubstitutions) {
             this.entity = null;
+            this.children = null;
             this.driver = null;
             this.mgmt = mgmt;
             this.extraSubstitutionsModel = new DotSplittingTemplateModel(extraSubstitutions);
@@ -658,6 +662,7 @@ public class TemplateProcessor {
         protected EntityAndMapTemplateModel(EntityDriver driver, Map<String,? extends Object> extraSubstitutions) {
             this.driver = driver;
             this.entity = (EntityInternal) driver.getEntity();
+            this.children = this.entity != null ? this.entity.getChildren(): null;
             this.mgmt = entity.getManagementContext();
             this.extraSubstitutionsModel = new DotSplittingTemplateModel(extraSubstitutions);
         }
@@ -665,6 +670,7 @@ public class TemplateProcessor {
         @Deprecated /** @deprecated since 1.1 use {@link #forEntity(Entity, Map)} and related instead; substitions added separately using {@link FirstAvailableTemplateModel }*/
         protected EntityAndMapTemplateModel(EntityInternal entity, Map<String,? extends Object> extraSubstitutions) {
             this.entity = entity;
+            this.children = this.entity != null ? this.entity.getChildren(): null;
             this.driver = null;
             this.mgmt = entity.getManagementContext();
             this.extraSubstitutionsModel = new DotSplittingTemplateModel(extraSubstitutions);
@@ -698,7 +704,8 @@ public class TemplateProcessor {
                 if (entity!=null)
                     return wrapAsTemplateModel( Iterables.getOnlyElement( entity.getLocations() ) );
             }
-
+            if ("children".equals(key) && children!=null)
+                return wrapAsTemplateModel( children );
             if ("sensor".equals(key)) return new EntityAttributeTemplateModel(entity, EntityAttributeTemplateModel.SensorResolutionMode.ATTRIBUTE_VALUE);
             if ("attribute".equals(key)) return new EntityAttributeTemplateModel(entity, EntityAttributeTemplateModel.SensorResolutionMode.ATTRIBUTE_VALUE);
             if ("attributeWhenReady".equals(key)) return new EntityAttributeTemplateModel(entity, EntityAttributeTemplateModel.SensorResolutionMode.ATTRIBUTE_WHEN_READY);

--- a/core/src/test/java/org/apache/brooklyn/util/core/text/TemplateProcessorTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/text/TemplateProcessorTest.java
@@ -186,6 +186,14 @@ public class TemplateProcessorTest extends BrooklynAppUnitTestSupport {
         assertEquals(result, location.getId());
     }
 
+    @Test
+    public void testEntityChildren() {
+        String templateContents = "${entity.children[0].id}";
+        app.createAndManageChild( EntitySpec.create(TestApplication.class));
+        String result = TemplateProcessor.processTemplateContents(templateContents, app, ImmutableMap.<String,Object>of());
+        assertEquals(result, Iterables.getOnlyElement(app.getChildren()).getId());
+    }
+
     // Test takes 2.5s.
     @Test(groups = "Integration")
     public void testLocationConfig() {


### PR DESCRIPTION
Improves access to child entities in workflow allowing children to be accessed as ${entity.children[n]} in addition to the current syntax $brooklyn:child("id")