### PR TITLE
add a Secret object which can be used to capture a secret

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WorkflowExpressionsYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WorkflowExpressionsYamlTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.effector.Effector;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.workflow.WorkflowBasicTest;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
@@ -30,6 +31,7 @@ import org.apache.brooklyn.entity.stock.BasicEntity;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.ClassLogWatcher;
 import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Secret;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
@@ -214,6 +216,13 @@ public class WorkflowExpressionsYamlTest extends AbstractYamlTest {
                         "      ${entity.sensor.my_id}",
                         "- return ${x}"),
                 lastEntity);
+    }
+
+    @Test
+    public void testWorkflowSecretGet() throws Exception {
+        createEntityWithWorkflowEffector("- s: transform x = ${entity.config.a_secret} | get", "  output: ${x}");
+        lastEntity.config().set(ConfigKeys.newConfigKey(Secret.class, "a_secret"), new Secret("53cr37"));
+        Asserts.assertEquals(invokeWorkflowStepsWithLogging(), "53cr37");
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -43,6 +43,7 @@ import org.apache.brooklyn.util.core.osgi.Osgis;
 import org.apache.brooklyn.util.internal.StringSystemProperty;
 import org.apache.brooklyn.util.javalang.Boxing;
 import org.apache.brooklyn.util.stream.Streams;
+import org.apache.brooklyn.util.text.Secret;
 import org.apache.brooklyn.util.text.StringEscapes.BashStringEscapes;
 import org.apache.brooklyn.util.text.Strings;
 
@@ -171,10 +172,7 @@ public final class Sanitizer {
     }
 
     public static String suppress(Object value) {
-        if (value==null) return null;
-        // only include the first few chars so that malicious observers can't uniquely brute-force discover the source
-        String md5Checksum = Strings.maxlen(Streams.getMd5Checksum(new ByteArrayInputStream(("" + value).getBytes())), 8);
-        return "<suppressed> (MD5 hash: " + md5Checksum + ")";
+        return Secret.SecretHelper.suppress(value);
     }
 
     public static String suppressJson(Object value, boolean excludeBrooklynDslExpressions) {
@@ -253,6 +251,7 @@ public final class Sanitizer {
         @Override
         public boolean apply(Object name) {
             if (name == null) return false;
+            if (name instanceof Secret) return true;
             String lowerName = name.toString().toLowerCase();
             for (String secretName : getSensitiveFieldsTokens()) {
                 if (lowerName.contains(secretName))

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
@@ -171,6 +171,10 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
         TRANSFORMATIONS.put("sum", () -> v -> sum(v, "sum"));
         TRANSFORMATIONS.put("average", () -> v -> average(v, "average"));
         TRANSFORMATIONS.put("size", () -> v -> size(v, "size"));
+        TRANSFORMATIONS.put("get", () -> v -> {
+            if (v instanceof Supplier) return ((Supplier)v).get();
+            return v;
+        });
     }
 
     static final Object minmax(Object v, String word, Predicate<Integer> test) {

--- a/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynMiscJacksonSerializationTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/resolve/jackson/BrooklynMiscJacksonSerializationTest.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.core.resolve.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.reflect.TypeToken;
 import java.io.IOException;
@@ -45,6 +46,7 @@ import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.units.ByteSize;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
+import org.apache.brooklyn.util.text.Secret;
 import org.apache.brooklyn.util.text.StringEscapes.JavaStringEscapes;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
@@ -246,4 +248,9 @@ public class BrooklynMiscJacksonSerializationTest implements MapperTestFixture {
         check.accept("[\"a\",{\"type\":\""+Duration.class.getName()+"\",\"value\":\"1s\"}]",
                 MutableList.of("a", MutableMap.of("type", Duration.class.getName(), "value", "1s")));
     }
+
+    static class WrappedSecretHolder {
+        WrappedValue<Secret<String>> s1;
+    }
+
 }

--- a/utils/common/src/main/java/org/apache/brooklyn/util/text/Secret.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/text/Secret.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.text;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.brooklyn.util.stream.Streams;
+
+import java.io.ByteArrayInputStream;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+/** Wraps something which should be recognized as a secret.
+ *
+ * Jackson serialization returns a suppressed message with a checksum, and deserialization is blocked,
+ * unless the serialization/deserialization is performed in a `runWithJacksonSerializationEnabled` block.
+ */
+public class Secret<T> implements Supplier<T> {
+
+    public Secret(T secret) {
+        this.secret = secret;
+    }
+
+    private final T secret;
+
+    public T get() {
+        return secret;
+    }
+
+    @JsonValue
+    public Object getSanitized() {
+        if (SecretHelper.permitJacksonSerializationInThisThread.get()!=null) {
+            return secret;
+        }
+
+        return SecretHelper.suppress(secret);
+    }
+
+    @JsonCreator
+    static <T> Secret<T> jacksonNotNormallyAllowedToCreate(T possiblySuppressedValue) {
+        if (SecretHelper.permitJacksonSerializationInThisThread.get()!=null) {
+            return new Secret(possiblySuppressedValue);
+        }
+        if (SecretHelper.isProbablySuppressed(possiblySuppressedValue)) {
+            throw new IllegalStateException("Secrets deserialization detected on value which appears suppressed");
+        }
+
+        // we could allow, if that makes some coercion easier. but for now require callers to opt-in,
+        // using runWithJacksonSerializationEnabledInThread
+//        return new Secret(possiblySuppressedValue);
+        throw new IllegalStateException("Secrets cannot be deserialized from JSON");
+    }
+
+    public static class SecretHelper {
+        public static boolean isProbablySuppressed(Object value) {
+            if ((""+value).startsWith("<suppressed>")) return true;
+            return false;
+        }
+
+        public static String suppress(Object value) {
+            if (value == null) return null;
+            // only include the first few chars so that malicious observers can't uniquely brute-force discover the source
+            String md5Checksum = Strings.maxlen(Streams.getMd5Checksum(new ByteArrayInputStream(("" + value).getBytes())), 8);
+            return "<suppressed> (MD5 hash: " + md5Checksum + ")";
+        }
+
+        static ThreadLocal<Integer> permitJacksonSerializationInThisThread = new ThreadLocal<>();
+
+        static <T> T runWithJacksonSerializationEnabledInThread(Callable<T> callable) throws Exception {
+            try {
+                Integer old = permitJacksonSerializationInThisThread.get();
+                if (old==null) old = 0;
+                old++;
+                permitJacksonSerializationInThisThread.set(old);
+
+                return callable.call();
+
+            } finally {
+                Integer old = permitJacksonSerializationInThisThread.get();
+                old--;
+                if (old==0) permitJacksonSerializationInThisThread.remove();
+                else permitJacksonSerializationInThisThread.set(old);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Secret) return Objects.equals(get(), ((Secret)obj).get());
+        return Objects.equals(get(), obj);
+    }
+
+    @Override
+    public int hashCode() {
+        Object x = get();
+        return x==null ? 0 : x.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Secret["+SecretHelper.suppress(secret)+"]";
+    }
+
+}

--- a/utils/common/src/test/java/org/apache/brooklyn/util/text/SecretTest.java
+++ b/utils/common/src/test/java/org/apache/brooklyn/util/text/SecretTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.util.text;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.apache.brooklyn.test.Asserts;
+import org.testng.annotations.Test;
+
+public class SecretTest {
+
+    @Test
+    public void testJacksonNormallySuppressesWriteAndFailsRead() throws JsonProcessingException {
+        JsonMapper mapper = JsonMapper.builder().build();
+        Asserts.assertEquals(mapper.writeValueAsString(new Secret("my secret")), StringEscapes.JavaStringEscapes.wrapJavaString("<suppressed> (MD5 hash: 0003D04B)"));
+        Asserts.assertFailsWith(() -> mapper.readValue("\"my secret\"", Secret.class), err -> Asserts.expectedFailureContainsIgnoreCase(err, "Secrets", "cannot be deserialized"));
+    }
+
+    @Test
+    public void testJacksonAllowedInSpecialBlock() throws Exception {
+        JsonMapper mapper = JsonMapper.builder().build();
+        Secret<String> s0 = new Secret<>("my secret");
+        String r1 = Secret.SecretHelper.runWithJacksonSerializationEnabledInThread(() -> mapper.writeValueAsString(s0));
+        Asserts.assertEquals(r1, StringEscapes.JavaStringEscapes.wrapJavaString("my secret"));
+
+        Secret r2 = Secret.SecretHelper.runWithJacksonSerializationEnabledInThread(() -> mapper.readValue(r1, Secret.class));
+        Asserts.assertEquals(s0.get(), r2.get());
+        Asserts.assertEquals(s0, r2);
+    }
+
+}


### PR DESCRIPTION
tostring and json serialization automatically suppress the payload; it is a `Supplier` so can be unwrapped where needed, including now in workflow with the `get` transform

cc @iuliana @jcabrerizo this can be used wherever we need extra assurance that credentials are not accidentally logged or shown in ui