### PR TITLE
Workflow - foreach, reducing, update-children, and more

### DIFF
--- a/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WorkflowYamlTest.java
+++ b/camp/camp-brooklyn/src/test/java/org/apache/brooklyn/camp/brooklyn/WorkflowYamlTest.java
@@ -119,6 +119,42 @@ public class WorkflowYamlTest extends AbstractYamlTest {
     }
 
     @Test
+    public void testWorkflowInitializeBasicSensor() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicEntity.class.getName(),
+                "  brooklyn.initializers:",
+                "  - type: workflow-initializer",
+                "    brooklyn.config:",
+                "      steps:",
+                "        - set-sensor foo = bar",
+                "");
+        waitForApplicationTasks(app);
+
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newSensor(Object.class, "foo"), "bar");
+    }
+
+    @Test
+    public void testWorkflowParsesAColonSetsSensorType() throws Exception {
+        Entity app = createAndStartApplication(
+                "services:",
+                "- type: " + BasicEntity.class.getName(),
+                "  brooklyn.initializers:",
+                "  - type: workflow-initializer",
+                "    brooklyn.config:",
+                "      steps:",
+                // special trickery is done to allow this (with one colon; two colons still not allowed)
+                "        - set-sensor map foo = { k: v }",
+//                "        - \"set-sensor map foo = { k: v }\"",
+                "");
+        waitForApplicationTasks(app);
+
+        Entity entity = Iterables.getOnlyElement(app.getChildren());
+        EntityAsserts.assertAttributeEquals(entity, Sensors.newSensor(Object.class, "foo"), MutableMap.of("k", "v"));
+    }
+
+    @Test
     public void testWorkflowEffector() throws Exception {
         Entity app = createAndStartApplication(
                 "services:",

--- a/core/src/main/java/org/apache/brooklyn/core/effector/EffectorBase.java
+++ b/core/src/main/java/org/apache/brooklyn/core/effector/EffectorBase.java
@@ -102,5 +102,8 @@ public class EffectorBase<T> implements Effector<T> {
             Objects.equal(getParameters(), ((EffectorBase<?>)other).getParameters()) &&
             Objects.equal(getDescription(), ((EffectorBase<?>)other).getDescription());
     }
-    
+
+    public static <T> EffectorBase<T> of(Effector<T> eff) {
+        return new EffectorBase<T>(eff.getName(), eff.getReturnType(), eff.getParameters(), eff.getDescription());
+    }
 }

--- a/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/mgmt/EntityManagementUtils.java
@@ -207,7 +207,12 @@ public class EntityManagementUtils {
                 try {
                     Object yo = Iterables.getOnlyElement(Yamls.parseAll(yaml));
                     // coercion does this at: org.apache.brooklyn.camp.brooklyn.spi.dsl.methods.BrooklynDslCommon.registerSpecCoercionAdapter
+                    // but is too forgiving -- will coerce an empty map; so we do an extra check
                     spec = TypeCoercions.tryCoerce(yo, EntitySpec.class).orNull();
+                    if (spec.getType()==null && spec.getImplementation()==null) {
+                        if (log.isTraceEnabled()) log.trace("Failed converting entity spec YAML as YAML, transformer error will throw, but also created a bogus empty spec: "+spec+", from "+yo);
+                        spec = null;
+                    }
                 } catch (Exception e2) {
                     log.debug("Failed converting entity spec YAML as YAML, transformer error will throw, but also encountered: "+e2);
                 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowCommonConfig.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowCommonConfig.java
@@ -46,9 +46,11 @@ public interface WorkflowCommonConfig {
     ConfigKey<String> RETENTION = ConfigKeys.newStringConfigKey("retention",
             "Specification for how long workflow should be retained");
 
+    // see docs settings.md - eg 'from start' on workflow, or 'from here [only]' on step
     ConfigKey<String> REPLAYABLE = ConfigKeys.newStringConfigKey("replayable",
             "Indication of from what points the workflow is replayable");
 
+    // see docs settings.md - 'all' if set on workflow (use with case), or yes/no/default on a step; consider also 'replayable'
     ConfigKey<String> IDEMPOTENT = ConfigKeys.newStringConfigKey("idempotent",
             "Indication of which steps in the workflow are idempotent");
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowExecutionContext.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowExecutionContext.java
@@ -78,6 +78,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.apache.brooklyn.core.workflow.WorkflowReplayUtils.ReplayResumeDepthCheck.RESUMABLE_WHENEVER_NESTED_WORKFLOWS_PRESENT;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowExecutionContext {
 
@@ -451,7 +453,8 @@ public class WorkflowExecutionContext {
             }
 
             if (!forced && replayFromStep == null) {
-                if (!WorkflowReplayUtils.isReplayResumable(WorkflowExecutionContext.this, false, allowInternallyEvenIfDisabled)) {
+                // instructions should be made even if subworkflows might reject them; that's the intention of "resume" without force, vs replay from last
+                if (!WorkflowReplayUtils.isReplayResumable(WorkflowExecutionContext.this, RESUMABLE_WHENEVER_NESTED_WORKFLOWS_PRESENT, allowInternallyEvenIfDisabled)) {
                     if (code != null) {
                         // we could allow this, but we don't need it
                         throw new IllegalArgumentException("Cannot supply code to here without forcing as workflow does not support replay resuming at this point");
@@ -933,6 +936,7 @@ public class WorkflowExecutionContext {
                         if (!replaying) initializeWithoutContinuationInstructions(replayFromStep);
 
                         continueOnErrorHandledOrNextReplay = false;
+                        lastErrorHandlerOutput = null;
 
                         WorkflowReplayUtils.updateOnWorkflowTaskStartupOrReplay(WorkflowExecutionContext.this, task, getStepsResolved(), !replaying, replayFromStep);
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
@@ -443,9 +443,17 @@ public class WorkflowReplayUtils {
     public static void setNewSubWorkflows(WorkflowStepInstanceExecutionContext context, List<BrooklynTaskTags.WorkflowTaskTag> tags, String supersededId) {
         // make sure parent knows about child before child workflow is persisted, otherwise there is a chance the child workflow gets orphaned (if interrupted before parent persists)
         // supersede old and save the new sub-workflow ID before submitting it, and before child knows about parent, per invoke effector step notes
-        context.getSubWorkflows().forEach(tag -> tag.setSupersededByTaskId(supersededId));
-        tags.forEach(nw ->  context.getSubWorkflows().add(nw));
+        markSubWorkflowsSupersededByTask(context, supersededId);
+        tags.forEach(nw -> addNewSubWorkflow(context, nw));
         context.getWorkflowExectionContext().persist();
+    }
+
+    public static void markSubWorkflowsSupersededByTask(WorkflowStepInstanceExecutionContext context, String supersededId) {
+        context.getSubWorkflows().forEach(tag -> tag.setSupersededByTaskId(supersededId));
+    }
+
+    public static boolean addNewSubWorkflow(WorkflowStepInstanceExecutionContext context, BrooklynTaskTags.WorkflowTaskTag nw) {
+        return context.getSubWorkflows().add(nw);
     }
 
     public static List<WorkflowExecutionContext> getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
@@ -25,7 +25,6 @@ import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.core.workflow.store.WorkflowStatePersistenceViaSensors;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
 import org.apache.brooklyn.util.core.task.Tasks;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -49,7 +48,12 @@ public class WorkflowReplayUtils {
     private static final Logger log = LoggerFactory.getLogger(WorkflowReplayUtils.class);
 
 
-    public static boolean isReplayResumable(WorkflowExecutionContext workflowExecutionContext, boolean requireDeeplyReplayable, boolean allowInternallyEvenIfDisabled) {
+    public enum ReplayResumeDepthCheck {
+        RESUMABLE_IFF_NESTED_WORKFLOWS_RESUMABLE,
+        RESUMABLE_IFF_NESTED_WORKFLOWS_REPLAYABLE_OR_RESUMABLE,
+        RESUMABLE_WHENEVER_NESTED_WORKFLOWS_PRESENT,
+    }
+    public static boolean isReplayResumable(WorkflowExecutionContext workflowExecutionContext, ReplayResumeDepthCheck requireDeeplyReplayable, boolean allowInternallyEvenIfDisabled) {
         WorkflowStepInstanceExecutionContext csi = workflowExecutionContext.currentStepInstance;
         if (csi!=null) {
             if (csi.getStepIndex()!=workflowExecutionContext.currentStepIndex) {
@@ -64,17 +68,28 @@ public class WorkflowReplayUtils {
                 // 'no' is (currently) not overridable by auto-detection, but `yes` is.
                 if (Boolean.FALSE.equals(idempotence)) return false;
 
-                // if 'yes' or null, we check.
+                // if 'yes' or null, we check subworkflows
                 if (stepDefinition instanceof WorkflowStepDefinition.WorkflowStepDefinitionWithSubWorkflow) {
-                    List<WorkflowExecutionContext> subWorkflows = ((WorkflowStepDefinition.WorkflowStepDefinitionWithSubWorkflow) stepDefinition).getSubWorkflowsForReplay(csi, false, true, allowInternallyEvenIfDisabled);
-                    if (subWorkflows == null) return false;
-                    if (!requireDeeplyReplayable) return true;
-                    return subWorkflows.stream().allMatch(sub -> isReplayResumable(sub, requireDeeplyReplayable, allowInternallyEvenIfDisabled));
+                    WorkflowStepDefinition.SubWorkflowsForReplay subWorkflowReplayable = ((WorkflowStepDefinition.WorkflowStepDefinitionWithSubWorkflow) stepDefinition).getSubWorkflowsForReplay(csi, false, true, allowInternallyEvenIfDisabled);
+
+                    if (!subWorkflowReplayable.isResumableAtSubworkflows) {
+                        if (subWorkflowReplayable.hasNonResumableWorkflows && requireDeeplyReplayable==ReplayResumeDepthCheck.RESUMABLE_IFF_NESTED_WORKFLOWS_RESUMABLE) return false;
+                        return subWorkflowReplayable.isResumableOnlyAtParent;
+                    }
+
+                    // non-null subworkflows, so need to inspect subworkflows
+                    if (requireDeeplyReplayable==ReplayResumeDepthCheck.RESUMABLE_WHENEVER_NESTED_WORKFLOWS_PRESENT) return true;
+                    if (requireDeeplyReplayable==ReplayResumeDepthCheck.RESUMABLE_IFF_NESTED_WORKFLOWS_REPLAYABLE_OR_RESUMABLE)
+                        return subWorkflowReplayable.subworkflows.stream().allMatch(sub -> isReplayableAnywhere(sub, allowInternallyEvenIfDisabled));
+                    if (requireDeeplyReplayable==ReplayResumeDepthCheck.RESUMABLE_IFF_NESTED_WORKFLOWS_RESUMABLE)
+                        return subWorkflowReplayable.subworkflows.stream().allMatch(sub -> isReplayResumable(sub, requireDeeplyReplayable, allowInternallyEvenIfDisabled));
+                    // shouldn't come here
+                    throw new IllegalArgumentException("Invalid requireDeeply mode: "+requireDeeplyReplayable);
                 }
 
                 if (idempotence!=null) return idempotence;
 
-                // shouldn't come here
+                // comes here if a workflow step without subworkflows declares null default idempotence, which should not normally happen
                 return false;
 
             } else {
@@ -115,7 +130,7 @@ public class WorkflowReplayUtils {
                 || (workflowExecutionContext.currentStepInstance!=null && workflowExecutionContext.currentStepInstance.getStepIndex()!=workflowExecutionContext.currentStepIndex)
                 || workflowExecutionContext.currentStepIndex==WorkflowExecutionContext.STEP_INDEX_FOR_START
                 || workflowExecutionContext.currentStepIndex==WorkflowExecutionContext.STEP_INDEX_FOR_END
-                || isReplayResumable(workflowExecutionContext, true, allowInternallyEvenIfDisabled);
+                || isReplayResumable(workflowExecutionContext, ReplayResumeDepthCheck.RESUMABLE_IFF_NESTED_WORKFLOWS_REPLAYABLE_OR_RESUMABLE, allowInternallyEvenIfDisabled);
     }
 
     /** throws error if any argument non-blank invalid; null if nothing to do; otherwise a consumer which will initialize the WEC */
@@ -128,7 +143,7 @@ public class WorkflowReplayUtils {
         boolean idempotentAll = "all".equals(idempotent);
         if (idempotentAll) idempotent = "";
 
-        if (!Strings.isBlank(idempotent)) throw new IllegalArgumentException("Invalid value for `idemopotent` on workflow step");
+        if (!Strings.isBlank(idempotent)) throw new IllegalArgumentException("Invalid value for `idempotent` on workflow step");
 
         // replayable:
         //
@@ -431,7 +446,7 @@ public class WorkflowReplayUtils {
             }
         } catch (Exception e) {
             Exceptions.propagateIfFatal(e);
-            log.debug("Step " + context.getWorkflowStepReference() + " could not resume nested workflow " + w.getWorkflowId() + " (running anew): "+e);
+            log.debug("Step " + context.getWorkflowStepReference() + " could not resume nested workflow " + (w==null ? "<null>" : w.getWorkflowId()) + " (running alternate): "+e);
 
             return Pair.of(false, ifNotReplayable.apply(w, e));
         }
@@ -453,11 +468,14 @@ public class WorkflowReplayUtils {
     }
 
     public static boolean addNewSubWorkflow(WorkflowStepInstanceExecutionContext context, BrooklynTaskTags.WorkflowTaskTag nw) {
+        if (nw==null) throw new IllegalArgumentException("Workflow tag must not be null");
         return context.getSubWorkflows().add(nw);
     }
 
-    public static List<WorkflowExecutionContext> getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {
+    public static WorkflowStepDefinition.SubWorkflowsForReplay getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled,
+                                                                                        Consumer<WorkflowStepDefinition.SubWorkflowsForReplay> ifNoSubworkflows) {
         Set<BrooklynTaskTags.WorkflowTaskTag> sws = context.getSubWorkflows();
+        WorkflowStepDefinition.SubWorkflowsForReplay result = new WorkflowStepDefinition.SubWorkflowsForReplay();
         if (sws!=null && !sws.isEmpty()) {
             // replaying
 
@@ -471,25 +489,32 @@ public class WorkflowReplayUtils {
                         return new WorkflowStatePersistenceViaSensors(context.getManagementContext()).getWorkflows(targetEntity).get(tag.getWorkflowId());
                     }).collect(Collectors.toList());
 
+            result.subworkflows = nestedWorkflowsToReplay;
+
             if (nestedWorkflowsToReplay.isEmpty()) {
                 if (!peekingOnly) log.info("Step "+context.getWorkflowStepReference()+" has all sub workflows superseded; replaying from start");
                 if (!peekingOnly) log.debug("Step "+context.getWorkflowStepReference()+" superseded sub workflows detail: "+sws+" -> "+nestedWorkflowsToReplay);
-                // fall through to below
+                ifNoSubworkflows.accept(result);
+
             } else if (nestedWorkflowsToReplay.contains(null)) {
                 if (!peekingOnly) log.info("Step "+context.getWorkflowStepReference()+" has uninitialized sub workflows; replaying from start");
                 if (!peekingOnly) log.debug("Step "+context.getWorkflowStepReference()+" uninitialized/unpersisted sub workflow detail: "+sws+" -> "+nestedWorkflowsToReplay);
-                // fall through to below
+                ifNoSubworkflows.accept(result);
+
             } else if (!forced && nestedWorkflowsToReplay.stream().anyMatch(nest -> !isReplayableAnywhere(nest, allowInternallyEvenIfDisabled))) {
                 if (!peekingOnly) log.info("Step "+context.getWorkflowStepReference()+" has non-replayable sub workflows; replaying from start");
                 if (!peekingOnly) log.debug("Step "+context.getWorkflowStepReference()+" non-replayable sub workflow detail: "+sws+" -> "+nestedWorkflowsToReplay);
-                // fall through to below
-            } else {
+                result.hasNonResumableWorkflows = true;
+                // parent not resumable
 
+            } else {
                 if (!peekingOnly) log.debug("Step "+context.getWorkflowStepReference()+" replay sub workflow detail: "+sws+" -> "+nestedWorkflowsToReplay);
-                return nestedWorkflowsToReplay;
+                result.isResumableAtSubworkflows = true;
             }
+        } else {
+            ifNoSubworkflows.accept(result);
         }
-        return null;
+        return result;
     }
 
     public static Object getNext(Object ...sources) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowReplayUtils.java
@@ -359,6 +359,11 @@ public class WorkflowReplayUtils {
         public String getTaskId() {
             return taskId;
         }
+
+        @Override
+        public String toString() {
+            return super.toString()+"[task="+taskId+"]";
+        }
     }
 
     /** called when the task is being created */

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
@@ -308,6 +308,7 @@ public abstract class WorkflowStepDefinition {
         /** if supplied, custom behavior run before the primary doTaskBody; may throw exceptions or set things in stepState which are interpreted by the body */
         public final Runnable customBehavior;
         public final boolean forced;
+        public Map<String,Object> customWorkflowScratchVariables;
 
         public ReplayContinuationInstructions(Integer stepToReplayFrom, String customBehaviourExplanation, Runnable customBehavior, boolean forced) {
             this.stepToReplayFrom = stepToReplayFrom;

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
@@ -169,7 +169,7 @@ public abstract class WorkflowStepDefinition {
         Task<?> t = Tasks.builder().displayName(specialName!=null ? specialName : computeName(context, true))
                 .tag(tagOverride != null ? tagOverride : BrooklynTaskTags.tagForWorkflow(context))
                 .tag(BrooklynTaskTags.WORKFLOW_TAG)
-                .tag(TaskTags.INESSENTIAL_TASK)  // we handle this specially, don't want the thread to fail
+                .tag(TaskTags.INESSENTIAL_TASK)   // need this so parent's queue doesn't abort if this fails, parent is able to run error handling
                 .body(() -> {
             log.debug("Starting " +
                     (specialName!=null ? specialName : "step "+context.getWorkflowExectionContext().getWorkflowStepReference(context.stepIndex, this))

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
@@ -54,27 +54,32 @@ public abstract class WorkflowStepDefinition {
     private static final Logger log = LoggerFactory.getLogger(WorkflowStepDefinition.class);
 
     protected String id;
+
     public String getId() {
         return id;
     }
 
     //    name:  a name to display in the UI; if omitted it is constructed from the step ID and step type
     protected String name;
+
     public String getName() {
         return name;
     }
+
     public void setName(String name) {
         this.name = name;
     }
 
-    /** freeform data for use by tools and clients */
+    /**
+     * freeform data for use by tools and clients
+     */
     protected Object metadata;
 
     protected String userSuppliedShorthand;
     protected String shorthandTypeName;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    protected Map<String,Object> input = MutableMap.of();
+    protected Map<String, Object> input = MutableMap.of();
 
     //    next:  the next step to go to, assuming the step runs and succeeds; if omitted, or if the condition does not apply, it goes to the next step per the ordering (described below)
     @JsonProperty("next")  //use this field for access, not the getter/setter
@@ -82,31 +87,38 @@ public abstract class WorkflowStepDefinition {
 
     //    condition:  a condition to require for the step to run; if false, the step is skipped
     protected Object condition;
+
     @JsonIgnore
     public Object getConditionRaw() {
         return condition;
     }
+
     @JsonIgnore
     public DslPredicates.DslPredicate getConditionResolved(WorkflowStepInstanceExecutionContext context) {
         try {
             return context.resolveWrapped(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, getConditionRaw(), TypeToken.of(DslPredicates.DslPredicate.class));
         } catch (Exception e) {
-            throw Exceptions.propagateAnnotated("Unresolveable condition ("+getConditionRaw()+")", e);
+            throw Exceptions.propagateAnnotated("Unresolveable condition (" + getConditionRaw() + ")", e);
         }
     }
 
     // output of steps can be overridden
     protected Object output;
-    protected boolean isOutputHandledByTask() { return false; }
+
+    protected boolean isOutputHandledByTask() {
+        return false;
+    }
 
     protected String replayable;
     protected String idempotent;
+
     protected Pair<WorkflowReplayUtils.ReplayableAtStepOption, Boolean> validateReplayableAndIdempotent() {
         return WorkflowReplayUtils.validateReplayableAndIdempotentAtStep(replayable, idempotent, false);
     }
 
     @JsonProperty("timeout")
     protected Duration timeout;
+
     @JsonIgnore
     public Duration getTimeout() {
         return timeout;
@@ -115,6 +127,7 @@ public abstract class WorkflowStepDefinition {
     // TODO: might be nice to support a shorthand for on-error; but not yet
     @JsonProperty("on-error")
     protected Object onError = MutableList.of();
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Object getOnError() {
         return onError;
@@ -133,20 +146,26 @@ public abstract class WorkflowStepDefinition {
         this.input.putAll(input);
     }
 
-    /** Returns the unresolved map of inputs */
+    /**
+     * Returns the unresolved map of inputs
+     */
     public Map<String, Object> getInput() {
         return input;
     }
 
-    /** note, this should _not_ have the type string first, whereas in YAML the shorthand must have the type string first */
+    /**
+     * note, this should _not_ have the type string first, whereas in YAML the shorthand must have the type string first
+     */
     abstract public void populateFromShorthand(String value);
 
     protected void populateFromShorthandTemplate(String template, String value) {
         populateFromShorthandTemplate(template, value, false, true);
     }
+
     protected Maybe<Map<String, Object>> populateFromShorthandTemplate(String template, String value, boolean finalMatchRaw, boolean failOnMismatch) {
         Maybe<Map<String, Object>> result = new ShorthandProcessor(template).withFinalMatchRaw(finalMatchRaw).withFailOnMismatch(failOnMismatch).process(value);
-        if (result.isAbsent()) throw new IllegalArgumentException("Invalid shorthand expression: '"+value+"'", Maybe.Absent.getException(result));
+        if (result.isAbsent())
+            throw new IllegalArgumentException("Invalid shorthand expression: '" + value + "'", Maybe.Absent.getException(result));
 
         input.putAll((Map<? extends String, ?>) CollectionMerger.builder().build().merge(input, result.get()));
         return result;
@@ -166,43 +185,51 @@ public abstract class WorkflowStepDefinition {
 
     protected Task<?> newTask(WorkflowStepInstanceExecutionContext context, ReplayContinuationInstructions continuationInstructions,
                               String specialName, BrooklynTaskTags.WorkflowTaskTag tagOverride) {
-        Task<?> t = Tasks.builder().displayName(specialName!=null ? specialName : computeName(context, true))
+        Task<?> t = Tasks.builder().displayName(specialName != null ? specialName : computeName(context, true))
                 .tag(tagOverride != null ? tagOverride : BrooklynTaskTags.tagForWorkflow(context))
                 .tag(BrooklynTaskTags.WORKFLOW_TAG)
                 .tag(TaskTags.INESSENTIAL_TASK)   // need this so parent's queue doesn't abort if this fails, parent is able to run error handling
                 .body(() -> {
-            log.debug("Starting " +
-                    (specialName!=null ? specialName : "step "+context.getWorkflowExectionContext().getWorkflowStepReference(context.stepIndex, this))
-                    + (Strings.isNonBlank(name) ? " '"+name+"'" : "")
-                    + (continuationInstructions!=null ? " (continuation"
-                            + (continuationInstructions.customBehaviorExplanation !=null ? " - "+continuationInstructions.customBehaviorExplanation : "")
+                    log.debug("Starting " +
+                            (specialName != null ? specialName : "step " + context.getWorkflowExectionContext().getWorkflowStepReference(context.stepIndex, this))
+                            + (Strings.isNonBlank(name) ? " '" + name + "'" : "")
+                            + (continuationInstructions != null ? " (continuation"
+                            + (continuationInstructions.customBehaviorExplanation != null ? " - " + continuationInstructions.customBehaviorExplanation : "")
                             + ")"
-                        : "")
-                    + " in task "+Tasks.current().getId());
-            Callable<Object> handler = null;
+                            : "")
+                            + " in task " + Tasks.current().getId());
+                    Callable<Object> handler = null;
 
-            if (continuationInstructions!=null && this instanceof WorkflowStepDefinitionWithSubWorkflow) {
-                List<WorkflowExecutionContext> unfinished = ((WorkflowStepDefinitionWithSubWorkflow) this).getSubWorkflowsForReplay(context, continuationInstructions.forced, false, true);
-                if (unfinished!=null) {
-                    handler = () ->
-                            ((WorkflowStepDefinitionWithSubWorkflow) this).doTaskBodyWithSubWorkflowsForReplay(context, unfinished, continuationInstructions);
-                } else {
-                    // fall through to below; the sub-workflows were not persisted so shouldn't have been started
-                }
-            }
-            if (handler==null) {
-                handler = () -> {
-                    if (continuationInstructions != null && continuationInstructions.customBehavior != null) {
-                        continuationInstructions.customBehavior.run();
+                    if (continuationInstructions != null && this instanceof WorkflowStepDefinitionWithSubWorkflow) {
+                        // what is the difference between this block and
+                        // WorkflowReplayUtils.replayResumingInSubWorkflow(...)
+
+                        SubWorkflowsForReplay unfinished = ((WorkflowStepDefinitionWithSubWorkflow) this).getSubWorkflowsForReplay(context, continuationInstructions.forced, false, true);
+                        if (unfinished.isResumableAtSubworkflows) {
+                            handler = () ->
+                                    ((WorkflowStepDefinitionWithSubWorkflow) this).doTaskBodyWithSubWorkflowsForReplay(context, unfinished.subworkflows, continuationInstructions);
+                        } else if (!unfinished.isResumableOnlyAtParent) {
+                            if (!continuationInstructions.forced) throw new IllegalStateException("Cannot continue, due to non-idempotent workflows and not forced");
+                            // fall through to below because forced
+                        } else {
+                            // fall through to below; no sub-workflows
+                        }
                     }
-                    return doTaskBody(context);
-                };
-            };
+                    if (handler == null) {
+                        handler = () -> {
+                            if (continuationInstructions != null && continuationInstructions.customBehavior != null) {
+                                continuationInstructions.customBehavior.run();
+                            }
+                            // if continuing, all the info needed is now in the step state on the context and should be used by the method below
+                            return doTaskBody(context);
+                        };
+                    };
 
-            Object result = handler.call();
-            if (log.isTraceEnabled()) log.trace("Completed task for "+computeName(context, true)+", output "+result);
-            return result;
-        }).build();
+                    Object result = handler.call();
+                    if (log.isTraceEnabled())
+                        log.trace("Completed task for " + computeName(context, true) + ", output " + result);
+                    return result;
+                }).build();
         context.taskId = t.getId();
         return t;
     }
@@ -233,9 +260,9 @@ public abstract class WorkflowStepDefinition {
 
         if (Strings.isNonBlank(context.name)) {
             // if there is a name, add that also, removing id if name starts with id
-            String last = parts.isEmpty() ? null : parts.get(parts.size()-1);
-            if (last!=null && context.name.startsWith(last)) {
-                parts.remove(parts.size()-1);
+            String last = parts.isEmpty() ? null : parts.get(parts.size() - 1);
+            if (last != null && context.name.startsWith(last)) {
+                parts.remove(parts.size() - 1);
             }
             parts.add(context.name);
         } else if (!hasId) {
@@ -251,7 +278,10 @@ public abstract class WorkflowStepDefinition {
         return Strings.join(parts, " - ");
     }
 
-    public void setShorthandTypeName(String shorthandTypeDefinition) { this.shorthandTypeName = shorthandTypeDefinition; }
+    public void setShorthandTypeName(String shorthandTypeDefinition) {
+        this.shorthandTypeName = shorthandTypeDefinition;
+    }
+
     @JsonProperty("shorthandTypeName")  // REST API should prefer this accessor
     public String getShorthandTypeName() {
         if (Strings.isNonBlank(shorthandTypeName)) return shorthandTypeName;
@@ -262,7 +292,9 @@ public abstract class WorkflowStepDefinition {
         return name;
     }
 
-    /** allows subclasses to throw exception early if required fields not set */
+    /**
+     * allows subclasses to throw exception early if required fields not set
+     */
     public void validateStep(@Nullable ManagementContext mgmt, @Nullable WorkflowExecutionContext workflow) {
         validateReplayableAndIdempotent();
     }
@@ -272,28 +304,50 @@ public abstract class WorkflowStepDefinition {
         return context.getStepState();
     }
 
+    /**
+     * whether a step is idempotent, meaning it can be re-run if interrupted there;
+     * false is a hard no; true or null mean that for {@link WorkflowStepDefinitionWithSubWorkflow}, it depends on subworkflows if they have been computed and stored;
+     * and for other (non-subworkflow) steps, null means not sure, defaulting to false.
+     * <p>
+     * computed based on replayable and idempotent settings, then falling back to workflow-level setting 'idempotent: all' then step default idempotence
+     */
     Boolean isIdempotent(WorkflowStepInstanceExecutionContext csi) {
         Boolean idempotence = validateReplayableAndIdempotent().getRight();
 
-        if (idempotence==null) {
-            if (csi!=null && csi.getWorkflowExectionContext()!=null) idempotence = csi.getWorkflowExectionContext().idempotentAll;
+        if (idempotence == null) {
+            if (csi != null && csi.getWorkflowExectionContext() != null)
+                idempotence = csi.getWorkflowExectionContext().idempotentAll;
         }
-        if (idempotence==null) {
+        if (idempotence == null) {
             idempotence = isDefaultIdempotent();
         }
 
         return idempotence;
     }
 
+    /**
+     * default value for whether this step type is idempotent; can be overridden if idempotent is set on the step or workflow;
+     * see {@link #isIdempotent(WorkflowStepInstanceExecutionContext)};
+     * for {@link WorkflowStepDefinitionWithSubWorkflow}, null is preferred and is equivalent to true (in both cases meaning to check subworkflow state),
+     * otherwise null is discouraged and is equivalent to false
+     */
     protected abstract Boolean isDefaultIdempotent();
 
     public interface WorkflowStepDefinitionWithSpecialDeserialization {
         WorkflowStepDefinition applySpecialDefinition(ManagementContext mgmt, Object definition, String typeBestGuess, WorkflowStepDefinitionWithSpecialDeserialization firstParse);
     }
 
+    public static class SubWorkflowsForReplay {
+        public String notes;
+        public boolean hasNonResumableWorkflows;
+        public boolean isResumableOnlyAtParent;
+        public boolean isResumableAtSubworkflows;
+        /** subworkflows, or null if not available. in either case, this does not imply whether it is valid to resume the step. */
+        public List<WorkflowExecutionContext> subworkflows;
+    }
+
     public interface WorkflowStepDefinitionWithSubWorkflow {
-        /** returns null if this task hasn't yet recorded its subworkflows; otherwise list of those which are replayable, empty if none need to be replayed (ended successfully) */
-        @JsonIgnore List<WorkflowExecutionContext> getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled);
+        @JsonIgnore SubWorkflowsForReplay getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled);
         /** called by framework if {@link #getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext, boolean, boolean, boolean)} returns non-null (empty is okay),
          * and the implementation pass the replay and optional custom behaviour to the subworkflows before doing any finalization;
          * if the subworkflow for replay is null,  the normal {@link #doTaskBody(WorkflowStepInstanceExecutionContext)} is called. */

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepResolution.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepResolution.java
@@ -19,6 +19,7 @@
 package org.apache.brooklyn.core.workflow;
 
 import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -90,7 +91,18 @@ public class WorkflowStepResolution {
                 if (s == null) s = defM.remove("shorthand");
                 if (s == null) s = defM.remove("s");
                 if (s == null) {
-                    throw new IllegalArgumentException("Step definition must indicate a `type` or a `step` / `shorthand` / `s` ("+def+")");
+                    if (defM.size()==1) {
+                        // assume the colon caused it accidentally to be a map
+                        s = Iterables.getOnlyElement(defM.keySet());
+                        if (s instanceof String && ((String)s).contains(" ")) {
+                            s = s + " : " + Iterables.getOnlyElement(defM.values());
+                        } else {
+                            s = null;
+                        }
+                    }
+                    if (s==null) {
+                        throw new IllegalArgumentException("Step definition must indicate a `type` or a `step` / `shorthand` / `s` (" + def + ")");
+                    }
                 }
                 if (!(s instanceof String)) {
                     throw new IllegalArgumentException("step shorthand must be a string");

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -82,6 +82,32 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
         this.steps = steps;
     }
 
+    public CustomWorkflowStep(CustomWorkflowStep base) {
+        this.retention = base.retention;
+        this.target = base.target;
+        this.target_var_name = base.target_var_name;
+        this.target_index_var_name = base.target_index_var_name;
+        this.lock = base.lock;
+        this.concurrency = base.concurrency;
+        this.parameters = base.parameters;
+        this.steps = base.steps;
+        this.workflowOutput = base.workflowOutput;
+        this.reducing = base.reducing;
+        this.id = base.id;
+        this.name = base.name;
+        this.metadata = base.metadata;
+        this.userSuppliedShorthand = base.userSuppliedShorthand;
+        this.shorthandTypeName = base.shorthandTypeName;
+        this.input = base.input;
+        this.next = base.next;
+        this.condition = base.condition;
+        this.output = base.output;
+        this.replayable = base.replayable;
+        this.idempotent = base.idempotent;
+        this.timeout = base.timeout;
+        this.onError = base.onError;
+    }
+
     @JsonCreator
     /** special creator for when a list is supplied as the workflow; treat those as steps, without requiring a superfluous `steps` entry in a map.
      *  this is useful especially for config key / parameters of type `workflow` ({@link CustomWorkflowStep)}. */

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -499,7 +499,7 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
         return typeBestGuess==null || SHORTHAND_TYPE_NAME_DEFAULT.equals(typeBestGuess) || CustomWorkflowStep.class.getName().equals(typeBestGuess);
     }
 
-    private WorkflowExecutionContext newWorkflow(WorkflowStepInstanceExecutionContext context, Object target, Integer targetIndexOrNull) {
+    protected WorkflowExecutionContext newWorkflow(WorkflowStepInstanceExecutionContext context, Object target, Integer targetIndexOrNull) {
         if (steps==null) throw new IllegalArgumentException("Cannot make new workflow with no steps");
 
         String indexName = targetIndexOrNull==null ? "" : " "+(targetIndexOrNull+1);
@@ -516,12 +516,16 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
                 ConfigBag.newInstance(getInput()), null);
 
 
-        String tvn = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, target_var_name, String.class);
-        nestedWorkflowContext.getWorkflowScratchVariables().put(tvn==null ? TARGET_VAR_NAME_DEFAULT : tvn, target);
         String tivn = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, target_index_var_name, String.class);
         if (targetIndexOrNull!=null) nestedWorkflowContext.getWorkflowScratchVariables().put(tivn==null ? TARGET_INDEX_VAR_NAME_DEFAULT : tivn, targetIndexOrNull);
+        initializeSubWorkflowForTarget(context, target, nestedWorkflowContext);
 
         return nestedWorkflowContext;
+    }
+
+    protected void initializeSubWorkflowForTarget(WorkflowStepInstanceExecutionContext context, Object target, WorkflowExecutionContext nestedWorkflowContext) {
+        String tvn = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, target_var_name, String.class);
+        nestedWorkflowContext.getWorkflowScratchVariables().put(tvn==null ? TARGET_VAR_NAME_DEFAULT : tvn, target);
     }
 
     /** Returns a top-level workflow running the workflow defined here */

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.core.workflow.steps;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -69,6 +70,13 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
     public CustomWorkflowStep() {}
     public CustomWorkflowStep(String name, List<Object> steps) {
         this.name = name;
+        this.steps = steps;
+    }
+
+    @JsonCreator
+    /** special creator for when a list is supplied as the workflow; treat those as steps, without requiring a superfluous `steps` entry in a map.
+     *  this is useful especially for config key / parameters of type `workflow` ({@link CustomWorkflowStep)}. */
+    public CustomWorkflowStep(List<Object> steps) {
         this.steps = steps;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -191,8 +191,8 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
     }
 
     @Override @JsonIgnore
-    public List<WorkflowExecutionContext> getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {
-        return WorkflowReplayUtils.getSubWorkflowsForReplay(context, forced, peekingOnly, allowInternallyEvenIfDisabled);
+    public SubWorkflowsForReplay getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {
+        return WorkflowReplayUtils.getSubWorkflowsForReplay(context, forced, peekingOnly, allowInternallyEvenIfDisabled, sw -> sw.isResumableOnlyAtParent = true);
     }
 
     @Override

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/CustomWorkflowStep.java
@@ -68,6 +68,8 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
     private static final Logger LOG = LoggerFactory.getLogger(CustomWorkflowStep.class);
 
     // Name of the scratch variable used to store the target of a nested workflow when being run as a subworkflow over a target collection
+    public static final String SHORTHAND_TYPE_NAME_DEFAULT = "workflow";
+
     public static final String TARGET_VAR_NAME_DEFAULT = "target";
     // Name of the scratch variable used to store the index of a nested workflow when being run as a subworkflow over a target collection
     public static final String TARGET_INDEX_VAR_NAME_DEFAULT = "target_index";
@@ -91,7 +93,7 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
     @Override
     public void populateFromShorthand(String value) {
         if (shorthand==null) {
-            if ("workflow".equals(shorthandTypeName)) {
+            if (SHORTHAND_TYPE_NAME_DEFAULT.equals(shorthandTypeName)) {
                 shorthand = WORKFLOW_SETTING_SHORTHAND;
             } else {
                 throw new IllegalStateException("Shorthand not supported for " + getNameOrDefault());
@@ -494,7 +496,7 @@ public class CustomWorkflowStep extends WorkflowStepDefinition implements Workfl
     }
 
     protected boolean isPermittedToSetSteps(String typeBestGuess) {
-        return "workflow".equals(typeBestGuess);
+        return typeBestGuess==null || SHORTHAND_TYPE_NAME_DEFAULT.equals(typeBestGuess) || CustomWorkflowStep.class.getName().equals(typeBestGuess);
     }
 
     private WorkflowExecutionContext newWorkflow(WorkflowStepInstanceExecutionContext context, Object target, Integer targetIndexOrNull) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/DeployApplicationWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/DeployApplicationWorkflowStep.java
@@ -84,7 +84,7 @@ public class DeployApplicationWorkflowStep extends WorkflowStepDefinition implem
 
     @Override
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
-        Object blueprint = resolveBlueprint(context, () -> "services: [ { type: " + StringEscapes.JavaStringEscapes.wrapJavaString(context.getInput(TYPE)) + " } ]");
+        Object blueprint = resolveBlueprint(context, () -> "services: [ { type: " + StringEscapes.JavaStringEscapes.wrapJavaString(context.getInput(TYPE)) + " } ]", null, null);
 
         String createdAppId = getStepState(context);
         Application app = null;

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/HasBlueprintWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/HasBlueprintWorkflowStep.java
@@ -59,17 +59,18 @@ public interface HasBlueprintWorkflowStep {
             String type = context.getInput(TYPE);
             if (Strings.isBlank(type)) throw new IllegalStateException("blueprint or type must be supplied"); // should've been caught earlier but check again for good measure
             return "type: " + StringEscapes.JavaStringEscapes.wrapJavaString(type);
-        });
+        }, null, null);
     }
 
-    default Object resolveBlueprint(WorkflowStepInstanceExecutionContext context, Supplier<String> defaultValue) {
+    default Object resolveBlueprint(WorkflowStepInstanceExecutionContext context, Supplier<String> defaultValue, SetVariableWorkflowStep.InterpolationMode interpolationMode, TemplateProcessor.InterpolationErrorMode interpolationErrorMode) {
         Object blueprint = getInput().get(BLUEPRINT.getName());
         if (blueprint == null) {
             return defaultValue.get();
         }
         logger().debug("Blueprint (pre-resolution) is: "+blueprint);
         Object result = new SetVariableWorkflowStep.ConfigurableInterpolationEvaluation(context, null, blueprint,
-                context.getInputOrDefault(INTERPOLATION_MODE), context.getInputOrDefault(INTERPOLATION_ERRORS)).evaluate();
+                interpolationMode!=null ? interpolationMode : context.getInputOrDefault(INTERPOLATION_MODE),
+                interpolationErrorMode!=null ? interpolationErrorMode : context.getInputOrDefault(INTERPOLATION_ERRORS)).evaluate();
         logger().debug("Blueprint (post-resolution: "+context.getInputOrDefault(INTERPOLATION_MODE)+"/"+context.getInputOrDefault(INTERPOLATION_ERRORS)+") is: "+result);
         if (result instanceof String && ((String)result).matches("[^\\s]+")) {
             // single word value treated as a type

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/UpdateChildrenWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/UpdateChildrenWorkflowStep.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.steps.appmodel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityInternal;
+import org.apache.brooklyn.core.mgmt.EntityManagementUtils;
+import org.apache.brooklyn.core.mgmt.internal.EntityManagerInternal;
+import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
+import org.apache.brooklyn.core.workflow.*;
+import org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.core.flags.TypeCoercions;
+import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.core.task.Tasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class UpdateChildrenWorkflowStep extends WorkflowStepDefinition implements HasBlueprintWorkflowStep {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateChildrenWorkflowStep.class);
+
+    public static final String SHORTHAND = "[ \"of \" ${parent} \" \" ] \"type \" ${type} \" id \" ${identifier} [ \" from \" ${items} ]";
+
+    public static final ConfigKey<Object> PARENT = ConfigKeys.newConfigKey(Object.class, "parent",
+            "the entity or entity ID whose children are to be updated, defaulting to the current entity; " +
+                    "any children which do not match something in `items` may be removed");
+
+    public static final ConfigKey<String> IDENTIFIER = ConfigKeys.newStringConfigKey("identifier", "an expression in terms of a local variable `item` to use to identify the same child; " +
+                    "e.g. if the `items` is of the form `[{ field_id: ticket1, name: \"Ticket 1\" },...]` then " +
+                    "and `identifier: ${item.field_id}` will create/update/delete a child whose ID is `ticket1`; " +
+                    "ignored unless `item_check_workflow` is specified");
+
+    public static final ConfigKey<List> ITEMS = ConfigKeys.newConfigKey(List.class, "items",
+                    "the list of items to be used to create/update/delete the children");
+
+    /*
+        * `on_create`: an optionally supplied workflow to run at any newly created child, where no pre-existing child was found
+          corresponding to an item in `items` and `update-children` created it from `blueprint`,
+          passed the `item` (and all inputs to the `update-children` step)
+          and typically doing initial setup as required on the child;
+          the default behavior is to invoke an `on_create` effector at the child (if there is such an effector, otherwise do nothing), passing `item`;
+          this is invoked prior to `on_update` so if there is nothing special needed for creation this can be omitted
+
+        * `on_update`: a workflow to run on each child which has a corresponding item,
+          passed the `item` (and all inputs to the `update-children` step),
+          and typically updating config and sensors as appropriate on the child;
+          the default behavior is to invoke an `on_update` effector at the child (if there is such an effector, otherwise do nothing), passing `item`;
+          if the name or any policies may need to change on update, that should be considered in this workflow;
+          if the `update-children` is performed frequently, it might be efficient in this method to check whether the `item` has changed
+
+        * `on_delete`: a workflow to run on each child which no longer has a corresponding item prior to its being deleted;
+          the default behavior is to invoke an `on_delete` effector at the child (if there is such an effector, or nothing);
+          if this workflow returns `false` the framework will not delete it;
+          this workflow may reparent or delete the entity, although if deletion is desired there is no need as that will be done after this workflow
+
+        * `match_check`:
+          this optionally supplied workflow allows the matching process to be customized;
+          it will be invoked for each item in `items` to find a matching child/entity if one is already present;
+          the workflow is passed input variable `item` (and all inputs to the `update-children` step)
+          and should return the existing child that corresponds to it,
+          or `true` or `null` if there is none and the item should be passed to the `creation_check`,
+          or `false` if the `item` should be ignored (no child created or updated, identical to the `creation_check` but in some cases it may be easier to test in this workflow);
+          the default implementation of this workflow is to compute and return `${parent.child[${${identifier}}]} ?? true`
+
+        * `creation_check`:
+          this optionally supplied workflow allows filtering and custom creation;
+          it will be invoked for each item in `items` for which the `match_check` returned `null` or `true`;
+          the workflow is passed input variable `item` (and all inputs to the `update-children` step)
+          and can return the same semantics as `match_check`, with the difference that this method can create and return a custom entity;
+          if `null` or `true` is returned, the child will be created and `on_create` called;
+          and if an entity is returned or created (i.e. this workflow does not return `false`) then `on_update` will be called;
+          the default implementation of this workflow is to return `true`;
+          this workflow may, for example, check whether an entity that exists elsewhere (e.g. something previously created then reparented away in the `deletion_check`)
+          should be reparented again under the `parent` and re-connected to this synchronization process
+
+        * `deletion_check`:
+          this optionally supplied workflow allows customizing pre-deletion activities and/or the deletion itself;
+          it will be invoked for each pre-existing child which was not
+          returned by the `item_check_workflow`,
+          with each such entity passed as an input variable `child` (along with all inputs to the `update-children` step);
+          it can then return `true` or `false` to specify whether the child should be deleted
+          (with `on_delete` called prior to deletion if `true` is returned);
+          this workflow may reparent the entity and return `false` if it is intended to keep the entity but
+          disconnected from this synchronization process,
+          or may even `delete-entity ${child}` (although that is not usually necessary)
+
+ - step: foreach item in ${items}
+   reducing:
+     result: {}
+   steps:
+   - match-check
+   x
+     */
+    @Override
+    public Logger logger() {
+        return LOG;
+    }
+
+    @Override
+    public void populateFromShorthand(String expression) {
+        populateFromShorthandTemplate(SHORTHAND, expression);
+    }
+
+    @Override
+    public void validateStep(@Nullable ManagementContext mgmt, @Nullable WorkflowExecutionContext workflow) {
+        super.validateStep(mgmt, workflow);
+        validateStepBlueprint(mgmt, workflow);
+    }
+
+    static class UpdateChildrenStepState {
+        Entity parent;
+        String identifier;
+        List items;
+
+        WorkflowExecutionContext matchWorkflow;
+        List matchChecks;
+        List creationChecks;
+    }
+
+    @Override
+    protected UpdateChildrenStepState getStepState(WorkflowStepInstanceExecutionContext context) {
+        return (UpdateChildrenStepState) super.getStepState(context);
+    }
+    void setStepState(WorkflowStepInstanceExecutionContext context, UpdateChildrenStepState stepState) {
+        context.setStepState(stepState, true);
+    }
+
+    @Override
+    protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
+        ManagementContext mgmt = context.getManagementContext();
+        UpdateChildrenStepState stepState = getStepState(context);
+
+        if (stepState==null) {
+            stepState = new UpdateChildrenStepState();
+
+            Object parentId = context.getInput(PARENT);
+            stepState.parent = parentId!=null ? WorkflowStepResolution.findEntity(context, parentId).get() : context.getEntity();
+
+            stepState.identifier = TypeCoercions.coerce(context.getInputRaw(IDENTIFIER.getName()), String.class);
+            stepState.items = context.getInput(ITEMS);
+            if (stepState.items==null) throw new IllegalStateException("Items cannot be null");
+            setStepState(context, stepState);
+        }
+
+        if (stepState.matchChecks==null) {
+            if (stepState.matchWorkflow==null) {
+                CustomWorkflowStep matchCheck = null;  // TODO getInput(MATCH_CHECL);
+                if (matchCheck == null) {
+                    try {
+                        matchCheck =
+                                BeanWithTypeUtils.convert(mgmt,
+                                    MutableList.of("let match_id_or_create = ${parent.child[${${identifier}}]} ?? true",
+                                        "return ${match_id_or_create}"),
+                                    TypeToken.of(CustomWorkflowStep.class), true, null, true);
+                    } catch (JsonProcessingException e) {
+                        throw Exceptions.propagate(e);
+                    }
+                }
+                ConfigBag matchConfig = ConfigBag.newInstance()
+                        .configure(WorkflowCommonConfig.STEPS,
+                                MutableList.of(
+                                        MutableMap.of("step", "foreach item",
+                                                "target", stepState.items,
+                                                "steps", MutableList.of(matchCheck),
+                                            "input", MutableMap.of(
+                                                    "parent", stepState.parent,
+                                                    "identifier", stepState.identifier
+                                                    // TODO others?
+                                            ),
+                                            "idempotent", idempotent
+                                            // TODO concurrency?
+                                )))
+                        .configure(WorkflowCommonConfig.IDEMPOTENT, idempotent);
+
+                stepState.matchWorkflow = WorkflowExecutionContext.newInstanceUnpersistedWithParent(
+                        context.getEntity(), context.getWorkflowExectionContext(), WorkflowExecutionContext.WorkflowContextType.NESTED_WORKFLOW,
+                        "Matching items against children",
+                        matchConfig, null, null, null);
+                setStepState(context, stepState);
+                stepState.matchChecks = (List) DynamicTasks.queue(stepState.matchWorkflow.getTask(true).get()).getUnchecked();
+            } else {
+                // TODO replay matchWorkflow
+                throw new IllegalStateException("TODO replay matching");
+//                stepState.matchChecks = ...
+            }
+            setStepState(context, stepState);
+        }
+
+        if (stepState.creationChecks==null) {
+            // TODO creation check
+            stepState.creationChecks = stepState.matchChecks;
+            setStepState(context, stepState);
+        }
+
+        // TODO default lock on parent -> "update-children"
+
+        Set<Entity> addedChildren = MutableSet.of();
+        Set<Entity> updatedChildren = MutableSet.of();
+
+        Object oldItem = context.getWorkflowExectionContext().getWorkflowScratchVariables().get("item");
+        for (int i = 0; i<stepState.items.size(); i++) {
+            Object item = stepState.items.get(i);
+            Object create = stepState.creationChecks.get(i);
+            if (create==null || Boolean.TRUE.equals(create) || "true".equals(create)) {
+                context.getWorkflowExectionContext().getWorkflowScratchVariables().put("item", item);
+                Object blueprint = resolveBlueprint(context);
+                try {
+                    List<? extends EntitySpec> specs = blueprint instanceof EntitySpec ? MutableList.of((EntitySpec) blueprint)
+                            : EntityManagementUtils.getAddChildrenSpecs(mgmt,
+                            blueprint instanceof String ? (String) blueprint :
+                                    BeanWithTypeUtils.newYamlMapper(mgmt, false, null, false).writeValueAsString(blueprint));
+                    if (specs.size()!=1) {
+                        throw new IllegalStateException("Wrong number of specs returned: "+specs);
+                    }
+                    EntitySpec spec = Iterables.getOnlyElement(specs);
+                    spec.parent(Entities.proxy(stepState.parent));
+                    if (Strings.isBlank(stepState.identifier)) throw new IllegalStateException("'identifier' expression is required");
+
+                    String identifier = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, stepState.identifier, String.class);
+                    if (stepState.identifier.equals(identifier)) throw new IllegalStateException("'identifier' must be an expression, e.g. '${item.id_field}' not the static value '"+stepState.identifier+"'");
+                    if (Strings.isBlank(identifier)) throw new IllegalStateException("'identifier' must not resolve to an empty string");
+                    spec.configure(BrooklynConfigKeys.PLAN_ID, identifier);
+
+                    Entity child = (Entity) ((EntityInternal) context.getEntity()).getExecutionContext().get(Tasks.<Entity>builder().dynamic(false)
+                            .displayName("Creating entity " +
+                                    (Strings.isNonBlank(spec.getDisplayName()) ? spec.getDisplayName() : spec.getType().getName()))
+                            .body(() -> mgmt.getEntityManager().createEntity(spec /* TODO , idempotentIdentifier */))
+                            .build());
+
+                    addedChildren.add(child);
+
+                    // TODO on_create
+
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
+
+            } else if (Boolean.FALSE.equals(create) || "false".equals(create)) {
+                // ignore
+
+            } else if (create instanceof Entity) {
+                updatedChildren.add( (Entity)create );
+
+                // TODO on_update
+
+            } else {
+                throw new IllegalStateException("Invalid result from match/creation check for item '"+item+"': "+create);
+            }
+        }
+        context.getWorkflowExectionContext().getWorkflowScratchVariables().put("item", oldItem);
+
+        Map<String,Entity> oldChildren = MutableMap.of();
+        stepState.parent.getChildren().forEach(c -> oldChildren.put(c.getId(), c));
+        addedChildren.forEach(c -> oldChildren.remove(c.getId()));
+        updatedChildren.forEach(c -> oldChildren.remove(c.getId()));
+
+        // TODO deletion_check, on_delete
+        for (Entity oldChild: oldChildren.values()) {
+            stepState.parent.removeChild(oldChild);
+        }
+
+        return context.getPreviousStepOutput();
+    }
+
+    @Override protected Boolean isDefaultIdempotent() { return true; }
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
@@ -33,6 +33,8 @@ public class ForeachWorkflowStep extends CustomWorkflowStep {
 
     public static final String SHORTHAND = "${target_var_name} [ \" in \" ${target...} ]";
 
+    public static final String SHORTHAND_TYPE_NAME_DEFAULT = "foreach";
+
     @Override
     public void populateFromShorthand(String value) {
         if (input==null) input = MutableMap.of();
@@ -49,7 +51,7 @@ public class ForeachWorkflowStep extends CustomWorkflowStep {
     }
 
     protected boolean isPermittedToSetSteps(String typeBestGuess) {
-        return "foreach".equals(typeBestGuess);
+        return typeBestGuess==null || SHORTHAND_TYPE_NAME_DEFAULT.equals(typeBestGuess) || ForeachWorkflowStep.class.getName().equals(typeBestGuess);
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.steps.flow;
+
+import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
+import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.time.Duration;
+import org.apache.brooklyn.util.time.Time;
+
+public class ForeachWorkflowStep extends CustomWorkflowStep {
+
+    public static final String SHORTHAND = "${target_var_name} [ \" in \" ${target...} ]";
+
+    @Override
+    public void populateFromShorthand(String value) {
+        if (input==null) input = MutableMap.of();
+        populateFromShorthandTemplate(SHORTHAND, value);
+
+        if (input.containsKey("target")) target = input.remove("target");
+        target_var_name = input.remove("target_var_name");
+    }
+
+    protected Iterable checkTarget(Object targetR) {
+        if (targetR instanceof Iterable) return (Iterable)targetR;
+
+        throw new IllegalArgumentException("Target of foreach must be a list or an expression that resolves to a list, not "+targetR);
+    }
+
+    protected boolean isPermittedToSetSteps(String typeBestGuess) {
+        return "foreach".equals(typeBestGuess);
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/ForeachWorkflowStep.java
@@ -31,6 +31,15 @@ public class ForeachWorkflowStep extends CustomWorkflowStep {
 
     public static final String SHORTHAND_TYPE_NAME_DEFAULT = "foreach";
 
+    public ForeachWorkflowStep() {}
+
+    public ForeachWorkflowStep(CustomWorkflowStep base) {
+        super(base);
+    }
+
+    public void setTarget(Object x) { this.target = x; }
+    public void setTargetVarName(Object x) { this.target_var_name = x; }
+
     @Override
     public void populateFromShorthand(String value) {
         if (input==null) input = MutableMap.of();
@@ -66,6 +75,26 @@ public class ForeachWorkflowStep extends CustomWorkflowStep {
         }
 
         super.initializeSubWorkflowForTarget(context, target, nestedWorkflowContext);
+    }
+
+    public void setIdempotent(String idempotent) {
+        this.idempotent = idempotent;
+    }
+
+    public String getIdempotent() {
+        return idempotent;
+    }
+
+    public void setConcurrency(Object concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public Object getConcurrency() {
+        return concurrency;
+    }
+
+    public void setWorkflowOutput(Object x) {
+        this.workflowOutput = x;
     }
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/LogWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/LogWorkflowStep.java
@@ -68,7 +68,8 @@ public class LogWorkflowStep extends WorkflowStepDefinition {
         }
         context.noteOtherMetadata("Message", messageLogged, false);  // show this so it is displayed on the step in the UI
 
-        // TODO all workflow log messages should include step id as logging MDC, or message to start/end each workflow/task
+        // TODO workflow log messages should include step id as logging MDC, or message to start/end each workflow/task
+
         return context.getPreviousStepOutput();
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/SwitchWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/flow/SwitchWorkflowStep.java
@@ -83,7 +83,7 @@ public class SwitchWorkflowStep extends WorkflowStepDefinition implements Workfl
         StepState state = new StepState();
         state.selectedStepDefinition = selectedStepDefinition;
         state.selectedStepContext = selectedStepContext;
-        context.setStepState(context, persist);
+        context.setStepState(state, persist);
     }
     protected <T> Maybe<T> runOnStepStateIfHasSubWorkflows(WorkflowStepInstanceExecutionContext context, Function<WorkflowStepDefinitionWithSubWorkflow,T> fn) {
         StepState state = getStepState(context);
@@ -141,7 +141,7 @@ public class SwitchWorkflowStep extends WorkflowStepDefinition implements Workfl
     }
 
     @Override
-    public List<WorkflowExecutionContext> getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {
+    public SubWorkflowsForReplay getSubWorkflowsForReplay(WorkflowStepInstanceExecutionContext context, boolean forced, boolean peekingOnly, boolean allowInternallyEvenIfDisabled) {
         return runOnStepStateIfHasSubWorkflows(context, s -> s.getSubWorkflowsForReplay(context, forced, peekingOnly, allowInternallyEvenIfDisabled)).get();
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformJsonish.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformJsonish.java
@@ -25,6 +25,7 @@ import org.apache.brooklyn.core.resolve.jackson.BeanWithTypeUtils;
 import org.apache.brooklyn.core.resolve.jackson.BrooklynJacksonType;
 import org.apache.brooklyn.core.resolve.jackson.JsonPassThroughDeserializer;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
+import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
 import org.apache.brooklyn.util.collections.Jsonya;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -51,8 +52,7 @@ public class TransformJsonish extends WorkflowTransformDefault {
     }
 
     @Override
-    public void init(WorkflowExecutionContext context, List<String> definition) {
-        super.init(context, null);
+    protected void initCheckingDefinition() {
         Set<String> d = MutableSet.copyOf(definition);
         json |= d.remove("json");
         yaml |= d.remove("yaml");

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformMerge.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformMerge.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
+import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
 import org.apache.brooklyn.util.collections.CollectionMerger;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -49,8 +50,7 @@ public class TransformMerge extends WorkflowTransformDefault {
     boolean set;
 
     @Override
-    public void init(WorkflowExecutionContext context, List<String> definition) {
-        super.init(context, null);
+    protected void initCheckingDefinition() {
         Set<String> d = MutableSet.copyOf(definition.subList(1, definition.size()));
         deep = d.remove("deep");
         wait = d.remove("wait");

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReplace.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReplace.java
@@ -37,9 +37,7 @@ public class TransformReplace extends WorkflowTransformDefault {
     String SHORTHAND = "\"replace\" [ ?${all} \"all\" ] [ ?${regex} \"regex\" ] [ ?${glob} \"glob\" ] [ ?${literal} \"literal\" ] ${patternToMatch} ${replacement}";
 
     @Override
-    public void init(WorkflowExecutionContext context, List<String> definition, String transformDef) {
-        super.init(context, null);
-
+    protected void initCheckingDefinition() {
         Maybe<Map<String, Object>> maybeResult = new ShorthandProcessor(SHORTHAND)
                 .withFinalMatchRaw(true)
                 .withFailOnMismatch(true)

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformResolveExpression.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformResolveExpression.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.steps.variables;
+
+import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
+
+public class TransformResolveExpression extends WorkflowTransformDefault {
+
+    @Override
+    public Object apply(Object v) {
+        return context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, v, Object.class);
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReturn.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReturn.java
@@ -18,14 +18,14 @@
  */
 package org.apache.brooklyn.core.workflow.steps.variables;
 
-import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
-import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import static org.apache.brooklyn.core.workflow.WorkflowExecutionContext.STEP_TARGET_NAME_FOR_END;
 
-import java.util.List;
+public class TransformReturn extends WorkflowTransformDefault {
 
-public interface WorkflowTransformWithContext extends WorkflowTransform {
+    @Override
+    public Object apply(Object v) {
+        stepContext.next = STEP_TARGET_NAME_FOR_END;
+        return v;
+    }
 
-    void init(WorkflowExecutionContext context, WorkflowStepInstanceExecutionContext stepContext, List<String> definition, String transformDef);
-
-    boolean isResolver();
 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSetWorkflowVariable.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSetWorkflowVariable.java
@@ -19,29 +19,28 @@
 package org.apache.brooklyn.core.workflow.steps.variables;
 
 import com.google.common.collect.Iterables;
-import com.google.common.reflect.TypeToken;
-import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
-import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
 import org.apache.brooklyn.util.collections.MutableSet;
 
-import java.util.List;
 import java.util.Set;
 
-public class TransformType extends WorkflowTransformDefault {
-    private TypeToken<?> type;
+public class TransformSetWorkflowVariable extends WorkflowTransformDefault {
+    private String name;
 
     @Override
     protected void initCheckingDefinition() {
         Set<String> d = MutableSet.copyOf(definition.subList(1, definition.size()));
-        if (d.isEmpty()) throw new IllegalArgumentException("Transform 'type' requires a type argument");
+        if (d.isEmpty()) throw new IllegalArgumentException("Transform 'set' requires a variable name");
         if (d.size() > 1)
-            throw new IllegalArgumentException("Transform 'type' requires a single argument being the type; not " + d);
-        type = context.lookupType(Iterables.getOnlyElement(d), () -> null);
+            throw new IllegalArgumentException("Transform 'set' requires a single argument being the variable name; not " + d);
+        name = Iterables.getOnlyElement(d);
     }
 
     @Override
     public Object apply(Object v) {
-        return context.resolveCoercingOnly(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, v, type);
+        String nameToSet = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, name, String.class);
+        SetVariableWorkflowStep.setWorkflowScratchVariableDotSeparated(stepContext, nameToSet, v);
+        return v;
     }
+
 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
@@ -211,6 +211,7 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
         TRANSFORMATIONS.put("to_lower_case", () -> v -> ((String)v).toLowerCase());
         TRANSFORMATIONS.put("return", () -> new TransformReturn());
         TRANSFORMATIONS.put("set", () -> new TransformSetWorkflowVariable());
+        TRANSFORMATIONS.put("resolve_expression", () -> new TransformResolveExpression());
     }
 
     static final Object minmax(Object v, String word, Predicate<Integer> test) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
@@ -46,6 +46,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.brooklyn.core.workflow.WorkflowExecutionContext.STEP_TARGET_NAME_FOR_END;
 import static org.apache.brooklyn.core.workflow.steps.variables.SetVariableWorkflowStep.setWorkflowScratchVariableDotSeparated;
 
 public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
@@ -53,10 +54,11 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
     private static final Logger log = LoggerFactory.getLogger(TransformVariableWorkflowStep.class);
 
     public static final String SHORTHAND =
-            "[ [ ${variable.type} ] ${variable.name} " +
+            "[ [ ${variable.type} ] [ ?${value_is_initial} \"value\" ] ${variable.name} " +
             "[ [ \"=\" ${value...} ] \"|\" ${transform...} ] ]";
 
     public static final ConfigKey<TypedValueToSet> VARIABLE = ConfigKeys.newConfigKey(TypedValueToSet.class, "variable");
+    public static final ConfigKey<Boolean> VALUE_IS_INITIAL = ConfigKeys.newConfigKey(Boolean.class, "value_is_initial");
     public static final ConfigKey<Object> VALUE = ConfigKeys.newConfigKey(Object.class, "value");
     public static final ConfigKey<Object> TRANSFORM = ConfigKeys.newConfigKey(Object.class, "transform");
 
@@ -80,7 +82,7 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
     @Override
     protected Object doTaskBody(WorkflowStepInstanceExecutionContext context) {
         TypedValueToSet variable = context.getInput(VARIABLE);
-        if (variable ==null) throw new IllegalArgumentException("Variable name is required");
+        if (variable==null) throw new IllegalArgumentException("Variable name is required");
         String name = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, variable.name, String.class);
         if (Strings.isBlank(name)) throw new IllegalArgumentException("Variable name is required");
 
@@ -92,12 +94,25 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
             else throw new IllegalArgumentException("Argument to transform should be a string or list of strings, not: "+t);
         }
 
-
         Object v;
-        if (input.containsKey(VALUE.getName())) v = input.get(VALUE.getName());
-        else v = "${"+variable.name+"}";
+        if (input.containsKey(VALUE.getName())) {
+            if (Boolean.TRUE.equals(context.getInput(VALUE_IS_INITIAL))) throw new IllegalArgumentException("Cannot specifiy value_is_initial (keyword \"value\") with an = value");
 
-        if (Strings.isNonBlank(variable.type)) transforms.add("type "+variable.type);
+            v = input.get(VALUE.getName());
+            if (Strings.isNonBlank(variable.type)) transforms.add("type "+variable.type);
+        } else {
+            v = "${" + variable.name + "}";
+            if (Boolean.TRUE.equals(context.getInput(VALUE_IS_INITIAL)) || "value".equals(variable.type)) {
+                // special keyword to treat name as a literal expression
+                v = variable.name;
+            }
+            if (Strings.isNonBlank(variable.type)) {
+                if (Boolean.TRUE.equals(context.getInput(VALUE_IS_INITIAL)) || !"value".equals(variable.type)) {
+                    transforms.add(0, "type " + variable.type);
+                }
+            }
+            name = null;
+        }
 
         boolean isResolved = false;
         for (String t: transforms) {
@@ -116,10 +131,18 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
             v = tt.apply(v);
         }
 
-        Object oldValue = setWorkflowScratchVariableDotSeparated(context, name, v);
-        context.noteOtherMetadata("Value set", v);
-        if (oldValue!=null) context.noteOtherMetadata("Previous value", oldValue);
-        return context.getPreviousStepOutput();
+        if (name!=null) {
+            Object oldValue = setWorkflowScratchVariableDotSeparated(context, name, v);
+            context.noteOtherMetadata("Value set", v);
+            if (oldValue != null) context.noteOtherMetadata("Previous value", oldValue);
+
+            if (context.getOutput()!=null) throw new IllegalStateException("Transform that produces output results cannot be used when setting a variable");
+            if (STEP_TARGET_NAME_FOR_END.equals(context.next)) throw new IllegalStateException("Return transform cannot be used when setting a variable");
+
+            return context.getPreviousStepOutput();
+        } else {
+            return v;
+        }
     }
 
     static WorkflowTransformWithContext transformOf(final Function f) {
@@ -145,7 +168,7 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
         }
         if (t==null) throw new IllegalStateException("Unknown transform '"+transformType+"'");
         WorkflowTransformWithContext ta = transformOf(t);
-        ta.init(context.getWorkflowExectionContext(), transformWords, transformDef);
+        ta.init(context.getWorkflowExectionContext(), context, transformWords, transformDef);
         return ta;
     }
 
@@ -184,6 +207,10 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
             return v;
         });
         TRANSFORMATIONS.put("to_string", () -> v -> Strings.toString(v));
+        TRANSFORMATIONS.put("to_upper_case", () -> v -> ((String)v).toUpperCase());
+        TRANSFORMATIONS.put("to_lower_case", () -> v -> ((String)v).toLowerCase());
+        TRANSFORMATIONS.put("return", () -> new TransformReturn());
+        TRANSFORMATIONS.put("set", () -> new TransformSetWorkflowVariable());
     }
 
     static final Object minmax(Object v, String word, Predicate<Integer> test) {

--- a/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicSequentialTask.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/task/DynamicSequentialTask.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.brooklyn.api.mgmt.HasTaskChildren;
@@ -297,6 +298,7 @@ public class DynamicSequentialTask<T> extends BasicTask<T> implements HasTaskChi
                     List<Object> result = new ArrayList<Object>();
                     try { 
                         while (!secondaryQueueAborted && (!primaryFinished || !secondaryJobsRemaining.isEmpty())) {
+                            if (isCancelled()) throw new CancellationException();
                             synchronized (jobTransitionLock) {
                                 if (!primaryFinished && secondaryJobsRemaining.isEmpty()) {
                                     currentSecondary = null;
@@ -306,6 +308,7 @@ public class DynamicSequentialTask<T> extends BasicTask<T> implements HasTaskChi
                             @SuppressWarnings("rawtypes")
                             Task secondaryJob = secondaryJobsRemaining.poll();
                             if (secondaryJob != null) {
+                                if (isCancelled()) throw new CancellationException();
                                 synchronized (jobTransitionLock) {
                                     currentSecondary = secondaryJob;
                                     submitBackgroundInheritingContext(secondaryJob);

--- a/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.util.core.text;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import freemarker.cache.StringTemplateLoader;
 import freemarker.core.Environment;
@@ -37,6 +38,7 @@ import org.apache.brooklyn.api.objs.BrooklynObject;
 import org.apache.brooklyn.api.objs.Identifiable;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.EffectorBase;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
@@ -752,6 +754,7 @@ public class TemplateProcessor {
             if ("attributeWhenReady".equals(key)) return new EntityAttributeTemplateModel(entity, EntityAttributeTemplateModel.SensorResolutionMode.ATTRIBUTE_WHEN_READY);
             // new option
             if ("sensor_definition".equals(key)) return new EntityAttributeTemplateModel(entity, EntityAttributeTemplateModel.SensorResolutionMode.SENSOR_DEFINITION);
+            if ("effector".equals(key)) return wrapAsTemplateModel(Maps.transformValues(entity.getMutableEntityType().getEffectors(), EffectorBase::of));
 
 //            // getters work for these
 //            if ("id".equals(key)) return wrapAsTemplateModel(entity.getId());

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
@@ -202,7 +202,7 @@ public class WorkflowBasicTest extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test
-    public void testWorkflowDefinitionResolution() {
+    public void testWorkflowStepsResolution() {
         loadTypes();
 
         List<Object> stepsDefinition =
@@ -215,6 +215,34 @@ public class WorkflowBasicTest extends BrooklynMgmtUnitTestSupport {
 
         List<WorkflowStepDefinition> steps = WorkflowStepResolution.resolveSteps(mgmt, stepsDefinition);
         Asserts.assertSize(steps, 4);
+    }
+
+    @Test
+    public void testWorkflowObjectResolution() throws JsonProcessingException {
+        loadTypes();
+
+        Consumer<Object> test = wf -> {
+            Asserts.assertInstanceOf(wf, WorkflowStepDefinition.class);
+            Asserts.assertInstanceOf(wf, CustomWorkflowStep.class);
+            Asserts.assertSize(((CustomWorkflowStep) wf).peekSteps(), 1);
+            Asserts.assertInstanceOf(
+                    WorkflowStepResolution.resolveSteps( mgmt, ((CustomWorkflowStep) wf).peekSteps() ).get(0), LogWorkflowStep.class);
+        };
+
+        test.accept( BeanWithTypeUtils.convert(mgmt,
+                MutableMap.of(
+                        "type", "workflow",
+                        "steps", MutableList.of("log hi: bob")),
+                    TypeToken.of(Object.class), true, null, true) );
+
+        test.accept( BeanWithTypeUtils.convert(mgmt,
+                MutableMap.of(
+                        "steps", MutableList.of("log hi: bob")),
+                TypeToken.of(CustomWorkflowStep.class), true, null, true) );
+
+        test.accept( BeanWithTypeUtils.convert(mgmt,
+                MutableList.of("log hi: bob"),
+                TypeToken.of(CustomWorkflowStep.class), true, null, true) );
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
@@ -123,6 +123,7 @@ public class WorkflowBasicTest extends BrooklynMgmtUnitTestSupport {
 
         addRegisteredTypeBean(mgmt, "retry", RetryWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "workflow", CustomWorkflowStep.class);
+        addRegisteredTypeBean(mgmt, "foreach", ForeachWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "ssh", SshWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "http", HttpWorkflowStep.class);
 

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBasicTest.java
@@ -120,6 +120,7 @@ public class WorkflowBasicTest extends BrooklynMgmtUnitTestSupport {
         addRegisteredTypeBean(mgmt, "add-policy", AddPolicyWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "delete-policy", DeletePolicyWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "apply-initializer", ApplyInitializerWorkflowStep.class);
+        addRegisteredTypeBean(mgmt, "update-children", UpdateChildrenWorkflowStep.class);
 
         addRegisteredTypeBean(mgmt, "retry", RetryWorkflowStep.class);
         addRegisteredTypeBean(mgmt, "workflow", CustomWorkflowStep.class);

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBeefyStepTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowBeefyStepTest.java
@@ -93,17 +93,22 @@ public class WorkflowBeefyStepTest extends BrooklynMgmtUnitTestSupport {
         Object result = runSteps(MutableList.of(
                 "let x = ${entity.sensor.x} + 1 ?? 0",
                 "set-sensor x = ${x}",
+                "set-sensor myWorkflow-ret-type = ${entity.effector[\"myWorkflow\"].returnType}",
                 "set-sensor last-param = ${p1}",
                 MutableMap.of(
                         "s", "invoke-effector myWorkflow",
                         "args", MutableMap.of("p1", "from-invocation"),
                         "condition", MutableMap.of("target", "${x}", "less-than", 2),
                         "next", "end"),
+                MutableMap.of(
+                        "s", "invoke-effector nonExistentEffector",
+                        "condition", MutableMap.of("target", "${entity.effector[\"nonExistentEffector\"]}")),
                 "return ${x}"  // if effector isn't invoked
         ), null);
         Asserts.assertEquals(result, 2);
         EntityAsserts.assertAttributeEquals(lastApp, Sensors.newSensor(Object.class, "x"), 2);
         EntityAsserts.assertAttributeEquals(lastApp, Sensors.newSensor(Object.class, "last-param"), "from-invocation");
+        EntityAsserts.assertAttributeEquals(lastApp, Sensors.newSensor(Object.class, "myWorkflow-ret-type"), Object.class);
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowMapAndListTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowMapAndListTest.java
@@ -47,7 +47,7 @@ public class WorkflowMapAndListTest  extends BrooklynMgmtUnitTestSupport {
                 .configure(WorkflowEffector.STEPS, (List) steps)
         );
         eff.apply((EntityLocal)app);
-        return app.invoke(app.getEntityType().getEffectorByName("myWorkflow").get(), null).getUnchecked();
+        return app.invoke(app.getEntityType().getEffectorByName ("myWorkflow").get(), null).getUnchecked();
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -886,4 +886,13 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
         Asserts.assertEquals(output, MutableMap.of("answer", 6));
     }
 
+    @Test
+    public void testForeachSpread() throws Exception {
+        Object output = invokeWorkflowStepsWithLogging(MutableList.of(
+                MutableMap.of("step", "let LM",
+                    "value", MutableList.of(MutableMap.of("key", "K1", "value", "V1"), MutableMap.of("key", "K2", "value", "V2"))),
+                MutableMap.of("step", "foreach {key,value} in ${LM}",
+                        "steps", MutableList.of("return element-${key}-${value}"))));
+        Asserts.assertEquals(output, MutableList.of("element-K1-V1", "element-K2-V2"));
+    }
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -306,8 +306,9 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
                 WorkflowExecutionContext lastWf = new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(app).get(wfId);
                 log.info("replaying from last");
                 lastInvocation = lastWf.factory(false).createTaskReplaying(lastWf.factory(false)
-//                        .makeInstructionsForReplayingFromLastReplayable("test", true));
                         .makeInstructionsForReplayResuming("test", true));
+                // can also test this, but less interesting
+//                        .makeInstructionsForReplayingFromLastReplayable("test", true));
                 Entities.submit(app, lastInvocation);
             }
             log.info("success for iteration "+(i+1)+"\n");

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -743,7 +743,12 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
                     if (!t.isDone()) {
                         Asserts.fail("Workflow task should have finished: " + t.getStatusDetail(true));
                     }
-                    if (!t.isError() || expectRightAnswer) result.add((Integer) t.getUnchecked());
+                    if (!t.isError() || expectRightAnswer) {
+                        if (!(t.getUnchecked() instanceof Integer)) {
+                            log.warn("ERROR - task "+t+" did not return integer; returned: "+t.getUnchecked());
+                        }
+                        result.add((Integer) t.getUnchecked());
+                    }
                 }
             }
 

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -240,10 +240,6 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
     }
 
     protected void checkTargetReducing(Object output) {
-        if (output==null) {
-            Map<String, WorkflowExecutionContext> wfs = new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(app);
-            log.info("WF - "+wfs);
-        }
         Asserts.assertEquals(output, MutableMap.of("sum", 6, "squares", MutableList.of(0, 1, 4, 9)));
     }
 
@@ -869,6 +865,25 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
                 "      step: fail message deliberate failure on ${target}",
                 ""
         )))), error -> Asserts.expectedFailureContainsIgnoreCase(error, "error running sub-workflows ", "deliberate failure on B"));
+    }
+
+    @Test
+    public void testForeachBasic() throws Exception {
+        Object output = invokeWorkflowStepsWithLogging(MutableList.of(
+                "let list L = [ \"a\" , 1 ]",
+                MutableMap.of("step", "foreach x in ${L}",
+                        "steps", MutableList.of("return element-${x}"))));
+        Asserts.assertEquals(output, MutableList.of("element-a", "element-1"));
+    }
+
+    @Test
+    public void testForeachReducingAndSeparateValue() throws Exception {
+        Object output = invokeWorkflowStepsWithLogging(MutableList.of(
+                MutableMap.of("step", "foreach x",
+                        "target", "1..3",
+                        "reducing", MutableMap.of("answer", 0),
+                        "steps", MutableList.of("let answer = ${answer} + ${x}"))));
+        Asserts.assertEquals(output, MutableMap.of("answer", 6));
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -26,6 +26,7 @@ import org.apache.brooklyn.api.mgmt.HasTaskChildren;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.typereg.RegisteredType;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
@@ -38,8 +39,8 @@ import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
 import org.apache.brooklyn.core.workflow.steps.flow.LogWorkflowStep;
 import org.apache.brooklyn.core.workflow.store.WorkflowRetentionAndExpiration;
-import org.apache.brooklyn.core.workflow.utils.WorkflowConcurrencyParser;
 import org.apache.brooklyn.core.workflow.store.WorkflowStatePersistenceViaSensors;
+import org.apache.brooklyn.core.workflow.utils.WorkflowConcurrencyParser;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.ClassLogWatcher;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -47,6 +48,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.task.DynamicTasks;
+import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.CountdownTimer;
@@ -60,6 +62,8 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -228,6 +232,93 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
     public void testTargetRangeSyntax() throws Exception {
         doTestTargetExplicitList("1..5");
     }
+
+    @Test
+    public void testTargetReducing() throws Exception {
+        Object output = doTestTargetReducing(null);
+        checkTargetReducing(output);
+    }
+
+    protected void checkTargetReducing(Object output) {
+        if (output==null) {
+            Map<String, WorkflowExecutionContext> wfs = new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(app);
+            log.info("WF - "+wfs);
+        }
+        Asserts.assertEquals(output, MutableMap.of("sum", 6, "squares", MutableList.of(0, 1, 4, 9)));
+    }
+
+    protected Object doTestTargetReducing(Duration sleep) throws Exception {
+        return invokeWorkflowStepsWithLogging(MutableList.of(Iterables.getOnlyElement(Yamls.parseAll(Strings.lines(
+                "type: workflow",
+                "name: reducing-test-main",
+                "steps:",
+                "  - log starting workflow",
+                "  - let list<integer> squares = [ 0 ]",
+                "  - type: workflow",
+                "    name: reducing-test-sub",
+                "    target: 1..3",
+                "    reducing:",
+                "      squares: ${squares}",
+                "      sum: 0",
+                "    steps:",
+                "    - log starting subworkflow ${target_index}",
+                (sleep==null ? "" : "    - sleep "+sleep),
+                "    - let sum = ${sum} + ${target}",
+                "    - let square = ${target} * ${target}",
+                "    - step: transform squares2",
+                "      value:",
+                "        - ${squares}",
+                "        -",
+                "          - ${square}",
+                "      transform: merge",
+                "    - log ending subworkflow ${target_index}",
+                "    - step: return",
+                "      value:",
+                "        squares: ${squares2}",   // test that output overrides local vars
+                "  - log ending workflow",
+                ""
+        )))));
+    }
+
+    @Test(groups="Integration", invocationCount = 10)  // because slow
+    public void testTargetReducingInterrupted() throws Exception {
+        checkTargetReducing(doTestTargetReducing(Duration.millis(10)));
+
+        for (int i=0; i<10; i++) {
+            log.info("submitting for iteration "+(i+1));
+            lastInvocation = app.invoke(app.getEntityType().getEffectorByName("myWorkflow").get(), null);
+            String wfId = lastInvocation.getId();
+            for (int j=0; ; j++) {
+                // increase in case running on slow system, if 200ms not enough will never exit, and because retention is forever, persistence takes longer each time
+                Duration sleep = Duration.millis((int) ((200+100*j) * Math.random() * Math.random()));
+                log.info("sleeping "+sleep);
+                Time.sleep(sleep);
+                lastInvocation.cancel(true);
+                try {
+                    Object result = lastInvocation.get(Duration.ONE_SECOND);
+                    checkTargetReducing(result);
+                    // completed without error
+                    break;
+                } catch (Exception e) {
+                    if (Exceptions.getFirstThrowableMatching(e, e2 -> (e2 instanceof InterruptedException || e2 instanceof CancellationException))==null) {
+                        throw Exceptions.propagate(e);
+                    } else {
+                        // interrupted
+                    }
+                }
+
+                WorkflowExecutionContext lastWf = new WorkflowStatePersistenceViaSensors(mgmt()).getWorkflows(app).get(wfId);
+                log.info("replaying from last");
+                lastInvocation = lastWf.factory(false).createTaskReplaying(lastWf.factory(false)
+//                        .makeInstructionsForReplayingFromLastReplayable("test", true));
+                        .makeInstructionsForReplayResuming("test", true));
+                Entities.submit(app, lastInvocation);
+            }
+            log.info("success for iteration "+(i+1)+"\n");
+        }
+    }
+
+
 
     public void doTestTargetExplicitList(String body) throws Exception {
         Object output = invokeWorkflowStepsWithLogging(MutableList.of(Iterables.getOnlyElement(Yamls.parseAll(Strings.lines(

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowTransformTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowTransformTest.java
@@ -31,9 +31,11 @@ import org.apache.brooklyn.test.ClassLogWatcher;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
+import org.apache.brooklyn.util.text.Strings;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 
 public class WorkflowTransformTest extends BrooklynMgmtUnitTestSupport {
 
@@ -201,7 +203,6 @@ public class WorkflowTransformTest extends BrooklynMgmtUnitTestSupport {
 
     @Test
     public void testMapDirect() {
-
         loadTypes();
 
         BasicApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
@@ -221,6 +222,46 @@ public class WorkflowTransformTest extends BrooklynMgmtUnitTestSupport {
         Object result = invocation.getUnchecked();
         Asserts.assertNotNull(result);
         Asserts.assertEquals(result, "2");
+    }
+
+    @Test
+    public void testReturnTransformWithMapYaml() {
+        loadTypes();
+
+        BasicApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+        Object result = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                "- step: let s",
+                "  value: |",
+                "    bogus",
+                "    - not valid: yaml: here",
+                "    that's: okay",
+                "    ---",
+                "     key: value",
+                "- transform s | yaml | return",
+                "- return should not come here",
+        ""), "test").getTask(false).get().getUnchecked();
+        Asserts.assertInstanceOf(result, Map.class);
+        Asserts.assertEquals(result, MutableMap.of("key", "value"));
+    }
+
+    @Test
+    public void testSetVarTransform() {
+        loadTypes();
+
+        BasicApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+        Object result = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                "- step: let s",
+                "  value: \"key: Value\"",
+                "- transform s | yaml | set y",
+                "- transform y.key2 = ${output.key} | to_upper_case",
+                "- transform output.key | to_lower_case",  // output should still be the yaml map transformed from ${s}
+                "- transform output | set y.key3",   // output passed in here will be 'value' from previous step
+                "- transform value true | set y.key4",
+                "- transform boolean value true | set y.key5",
+                "- return ${y}",
+                ""), "test").getTask(false).get().getUnchecked();
+        Asserts.assertInstanceOf(result, Map.class);
+        Asserts.assertEquals(result, MutableMap.of("key", "Value", "key2", "VALUE", "key3", "value", "key4", "true", "key5", true));
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowTransformTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowTransformTest.java
@@ -264,4 +264,19 @@ public class WorkflowTransformTest extends BrooklynMgmtUnitTestSupport {
         Asserts.assertEquals(result, MutableMap.of("key", "Value", "key2", "VALUE", "key3", "value", "key4", "true", "key5", true));
     }
 
+
+    @Test
+    public void testResolveTransform() {
+        loadTypes();
+
+        BasicApplication app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+        Object result = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                "- let a = b",
+                "- let b = c",
+                "- let x = \"${\" ${a} \"}\"",
+                "- transform x | resolve_expression | return",
+                ""), "test").getTask(false).get().getUnchecked();
+        Asserts.assertEquals(result, "c");
+    }
+
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowUpdateChildrenStepTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowUpdateChildrenStepTest.java
@@ -18,21 +18,35 @@
  */
 package org.apache.brooklyn.core.workflow;
 
+import com.google.common.collect.Iterables;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.api.mgmt.Task;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.effector.EffectorBody;
+import org.apache.brooklyn.core.effector.Effectors;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.entity.stock.BasicEntityImpl;
+import org.apache.brooklyn.entity.stock.BasicStartable;
 import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.text.Strings;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -100,7 +114,7 @@ public class WorkflowUpdateChildrenStepTest extends BrooklynMgmtUnitTestSupport 
                         "    x_name: name2",
                         "- step: update-children id ${item.x_id} from ${items}",
                         "  blueprint:",
-                        "    type: "+BasicEntity.class.getName(),
+                        "    type: " + BasicEntity.class.getName(),
                         "    name: ${item.x_name}",
                         ""),
                 "first run at children");
@@ -146,7 +160,6 @@ public class WorkflowUpdateChildrenStepTest extends BrooklynMgmtUnitTestSupport 
         Asserts.assertFailsWith(() -> execution.getTask(false).get().getUnchecked(),
                 e -> Asserts.expectedFailureContainsIgnoreCase(e, "non-static", "item"));
     }
-
 
     @Test
     public void testCrudWithHandlers() {
@@ -225,6 +238,64 @@ public class WorkflowUpdateChildrenStepTest extends BrooklynMgmtUnitTestSupport 
         childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
         Asserts.assertSize(childrenIds, 0);
         EntityAsserts.assertAttributeEquals(app, Sensors.newStringSensor("deleted"), "name3");
+    }
+
+    static class UpdateableChildThing extends BasicEntityImpl {
+
+        static final AttributeSensor<String> BLOCKAGE = Sensors.newStringSensor("blockage");
+
+        @Override
+        public void init() {
+            super.init();
+            WorkflowEffector eff = new WorkflowEffector(ConfigBag.newInstance()
+                    .configure(WorkflowEffector.EFFECTOR_NAME, "on_update")
+                    .configure(WorkflowEffector.EFFECTOR_PARAMETER_DEFS,
+                            MutableMap.of("items", null))
+                    .configure(WorkflowEffector.STEPS, MutableList.of(
+                            MutableMap.of("condition", MutableMap.of("sensor", "blockage"),
+                                    "s", "fail message Blockage ${entity.sensor.blockage}"),
+                            "set-entity-name ${item.x_name}"))
+                    .configure(WorkflowEffector.REPLAYABLE, "from start")
+                    );
+            eff.apply(this);
+        }
+    }
+
+    @Test
+    public void testCrudHandlersAsEffectorsReplaying() {
+        WorkflowBasicTest.addRegisteredTypeSpec(mgmt, "updateable-thing", UpdateableChildThing.class, Entity.class);
+        String updateWorkflow = Strings.lines(
+                "- update-children type updateable-thing id ${item.x_id} from ${entity.sensor.items}"
+        );
+        Runnable update = () -> WorkflowBasicTest.runWorkflow(app, updateWorkflow, "test").getTask(false).get().getUnchecked();
+
+        app.sensors().set(Sensors.newSensor(Object.class, "items"),
+                MutableList.of(MutableMap.of("x_id", "one", "x_name", "name1"), MutableMap.of("x_id", "two", "x_name", "name2")));
+        update.run();
+        Set<String> childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertEquals(childrenIds, MutableSet.of("one", "two"));
+        Set<String> childrenNames = app.getChildren().stream().map(c -> c.getDisplayName()).collect(Collectors.toSet());
+        Asserts.assertEquals(childrenNames, MutableSet.of("name1", "name2"));
+
+        // setting a sensor to fail in a sub-workflow should fail the update
+        Entity child2 = Iterables.get(app.getChildren(), 1);
+        child2.sensors().set(UpdateableChildThing.BLOCKAGE, "blocked!");
+        WorkflowExecutionContext w1 = WorkflowBasicTest.runWorkflow(app, updateWorkflow, "test");
+        Asserts.assertFailsWith(() -> w1.getTask(true).get().getUnchecked(),
+            e -> Asserts.expectedFailureContainsIgnoreCase(e, "blocked!"));
+        child2.sensors().set(UpdateableChildThing.BLOCKAGE, null);
+        WorkflowExecutionContext.Factory w1f = w1.factory(false);
+        // but we can resume and this time it works
+        Task<Object> w1r = Entities.submit(app, w1f.createTaskReplaying(w1f.makeInstructionsForReplayResuming("blockage fixed", false)));
+        w1r.getUnchecked();
+        // and we still have the two children
+        childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertEquals(childrenIds, MutableSet.of("one", "two"));
+
+        app.sensors().set(Sensors.newSensor(Object.class, "items"), MutableList.of());
+        update.run();
+        childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertSize(childrenIds, 0);
     }
 
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowUpdateChildrenStepTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowUpdateChildrenStepTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.entity.stock.BasicApplication;
+import org.apache.brooklyn.entity.stock.BasicEntity;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.text.Strings;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class WorkflowUpdateChildrenStepTest extends BrooklynMgmtUnitTestSupport {
+
+    private BasicApplication app;
+
+    protected void loadTypes() {
+        WorkflowBasicTest.addWorkflowStepTypes(mgmt);
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        loadTypes();
+        app = mgmt.getEntityManager().createEntity(EntitySpec.create(BasicApplication.class));
+    }
+
+    @Test
+    public void testSimpleCrud() {
+        WorkflowExecutionContext execution = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                        "- step: let items",
+                        "  value:",
+                        "  - x_id: one",
+                        "    x_name: name1",
+                        "  - x_id: two",
+                        "    x_name: name2",
+                        "- update-children type " + BasicEntity.class.getName() + " id ${item.x_id} from ${items}"),
+                "first run at children");
+        execution.getTask(false).get().getUnchecked();
+
+        Set<String> childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertEquals(childrenIds, MutableSet.of("one", "two"));
+
+        execution = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                        "- step: let items",
+                        "  value:",
+                        "  - x_id: one",
+                        "    x_name: name1",
+                        "  - x_id: two",
+                        "    x_name: name-too",
+                        "- update-children type " + BasicEntity.class.getName() + " id ${item.x_id} from ${items}"),
+                "first run at children");
+        execution.getTask(false).get().getUnchecked();
+
+        childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertEquals(childrenIds, MutableSet.of("one", "two"));
+
+        execution = WorkflowBasicTest.runWorkflow(app, Strings.lines(
+                        "- step: let list items",
+                        "  value: []",
+                        "- update-children type " + BasicEntity.class.getName() + " id ${item.x_id} from ${items}"),
+                "first run at children");
+        execution.getTask(false).get().getUnchecked();
+
+        childrenIds = app.getChildren().stream().map(c -> c.config().get(BrooklynConfigKeys.PLAN_ID)).collect(Collectors.toSet());
+        Asserts.assertSize(childrenIds, 0);
+    }
+}

--- a/karaf/init/src/main/resources/catalog.bom
+++ b/karaf/init/src/main/resources/catalog.bom
@@ -179,6 +179,11 @@ brooklyn.catalog:
     itemType: bean
     item:
       type: org.apache.brooklyn.core.workflow.steps.CustomWorkflowStep
+  - id: foreach
+    format: java-type-name
+    itemType: bean
+    item:
+      type: org.apache.brooklyn.core.workflow.steps.flow.ForeachWorkflowStep
   - id: retry
     format: java-type-name
     itemType: bean

--- a/karaf/init/src/main/resources/catalog.bom
+++ b/karaf/init/src/main/resources/catalog.bom
@@ -230,6 +230,11 @@ brooklyn.catalog:
     itemType: bean
     item:
       type: org.apache.brooklyn.core.workflow.steps.appmodel.ApplyInitializerWorkflowStep
+  - id: update-children
+    format: java-type-name
+    itemType: bean
+    item:
+      type: org.apache.brooklyn.core.workflow.steps.appmodel.UpdateChildrenWorkflowStep
 
   - id: ssh
     format: java-type-name


### PR DESCRIPTION
implementation of the enhancements described in https://github.com/apache/brooklyn-docs/pull/379, specifically:

* `reducing` on `workflow` and on a new `foreach` step
* ability to test if an effector is defined, eg `${entity.effector.start}` for if there is a `start` effector on `entity`
* tidy to forgive a rogue colon and to allow a list of steps to be interpreted as a workflow
* `update-children` (WIP)
