### PR TITLE
Allow on fire in workflow expressions

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
+++ b/core/src/main/java/org/apache/brooklyn/core/sensor/DependentConfiguration.java
@@ -121,7 +121,11 @@ public class DependentConfiguration {
     public static <T> Task<T> attributeWhenReady(Entity source, AttributeSensor<T> sensor) {
         return attributeWhenReady(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
     }
-    
+
+    public static <T> Task<T> attributeWhenReadyAllowingOnFire(Entity source, AttributeSensor<T> sensor) {
+        return attributeWhenReadyAllowingOnFire(source, sensor, JavaGroovyEquivalents.groovyTruthPredicate());
+    }
+
     /**
      * @deprecated since 0.11.0; explicit groovy utilities/support will be deleted.
      */
@@ -136,6 +140,16 @@ public class DependentConfiguration {
      */
     public static <T> Task<T> attributeWhenReady(final Entity source, final AttributeSensor<T> sensor, final Predicate<? super T> ready) {
         Builder<T, T> builder = builder().attributeWhenReady(source, sensor);
+        if (ready != null) builder.readiness(ready);
+        return builder.build();
+
+    }
+
+    /** returns an unsubmitted {@link Task} which blocks until the given sensor on the given source entity gives a value that satisfies ready, then returns that value;
+     * particular useful in Entity configuration where config will block until Tasks have a value
+     */
+    public static <T> Task<T> attributeWhenReadyAllowingOnFire(final Entity source, final AttributeSensor<T> sensor, final Predicate<? super T> ready) {
+        Builder<T, T> builder = builder().attributeWhenReadyAllowingOnFire(source, sensor).timeoutIfStoppingOrDestroyed(Duration.ONE_MINUTE);
         if (ready != null) builder.readiness(ready);
         return builder.build();
 

--- a/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/text/TemplateProcessor.java
@@ -626,7 +626,7 @@ public class TemplateProcessor {
             try {
                 result =
                         mode == SensorResolutionMode.ATTRIBUTE_WHEN_READY ?
-                                ((EntityInternal)entity).getExecutionContext().get( DependentConfiguration.attributeWhenReady(entity,
+                                ((EntityInternal)entity).getExecutionContext().get( DependentConfiguration.attributeWhenReadyAllowingOnFire(entity,
                                     Sensors.builder(Object.class, key).persistence(AttributeSensor.SensorPersistenceMode.NONE).build()))
                         : mode == SensorResolutionMode.ATTRIBUTE_VALUE ?
                                 entity.sensors().get( Sensors.newSensor(Object.class, key) )


### PR DESCRIPTION
When calling attributeWhenReady using workflow syntax we should not abort when the entity is on fire.  This is different from what we do using DSL expressions.

This gives us more control in pure workflow based entities where we can choose how to respond to the entities status