### PR TITLE
Added support for command containers in workflow steps, containers ...

### DIFF
--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerTaskFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.tasks.kubectl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import org.apache.brooklyn.api.entity.Entity;
@@ -599,6 +600,10 @@ public class ContainerTaskFactory<T extends ContainerTaskFactory<T,RET>,RET> imp
     public T summary(String summary) { this.summary = summary; return self(); }
     public T timeout(Duration timeout) { config.put(TIMEOUT, timeout); return self(); }
     public T command(List<String> commands) { config.put(COMMAND, commands); return self(); }
+
+    public T arguments(String[] arguments) {
+        config.put(ARGUMENTS, Arrays.asList(arguments)); return self();
+    }
     public T command(String baseCommandWithNoArgs, String ...extraCommandArguments) { config.put(COMMAND, MutableList.of(baseCommandWithNoArgs).appendAll(Arrays.asList(extraCommandArguments))); return self(); }
     public T bashScriptCommands(List<String> commands) {
         config.put(BASH_SCRIPT, commands);

--- a/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerWorkflowStep.java
+++ b/software/base/src/main/java/org/apache/brooklyn/tasks/kubectl/ContainerWorkflowStep.java
@@ -44,6 +44,7 @@ public class ContainerWorkflowStep extends WorkflowStepDefinition {
 
     public static final ConfigKey<String> IMAGE = ConfigKeys.newStringConfigKey("image");
     public static final ConfigKey<String> COMMAND = ConfigKeys.newStringConfigKey("command");
+    public static final ConfigKey<String> ARGS = ConfigKeys.newStringConfigKey("args");
     public static final ConfigKey<List<String>> COMMANDS = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {}, "commands");
     public static final ConfigKey<List<String>> RAW_COMMAND = ConfigKeys.newConfigKey(new TypeToken<List<String>>() {}, "raw_command");
     public static final ConfigKey<PullPolicy> PULL_POLICY = ConfigKeys.newConfigKey(PullPolicy.class, "pull_policy", ContainerCommons.CONTAINER_IMAGE_PULL_POLICY.getDescription(), ContainerCommons.CONTAINER_IMAGE_PULL_POLICY.getDefaultValue());
@@ -90,6 +91,11 @@ public class ContainerWorkflowStep extends WorkflowStepDefinition {
 
         if (commandTypesSet.size()>1) {
             throw new IllegalStateException("Incompatible command specification, max 1, received: "+commandTypesSet);
+        }
+
+        String args = context.getInput(ARGS);
+        if (Strings.isNonBlank(args)) {
+            tf.arguments(args.split(" +"));
         }
 
         Map<String, Object> env = context.getInput(ENV);

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/ContainerEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/ContainerEffectorTest.java
@@ -237,23 +237,19 @@ public class ContainerEffectorTest extends BrooklynAppUnitTestSupport {
     // prior to executing this test make sure you create an ec2 instance and tag it with "a2/vm"
     // equivalent of: // docker run -e "AWS_ACCESS_KEY_ID=.." -e "AWS_SECRET_ACCESS_KEY=.." -e "AWS_REGION=eu-north-1" --rm -it amazon/aws-cli ec2 describe-instances --filters "Name=tag:Name,Values=a2/vm"
     @Test(groups="Live")
-    public void testAwsCLI(){
+    public void testTerraformCommandContainer(){
         ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
-                ContainerEffector.EFFECTOR_NAME, "test-container-effector",
-                ContainerCommons.CONTAINER_IMAGE, "amazon/aws-cli",
-                ContainerCommons.ARGUMENTS, ImmutableList.of( "ec2", "describe-instances", "--filters", "Name=tag:Name,Values=a2/vm"),
-                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of(
-                        "AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID"),
-                        "AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY"),
-                        "AWS_REGION", "eu-north-1"
-                )));
+                ContainerEffector.EFFECTOR_NAME, "test-command-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "hashicorp/terraform:1.5.6",
+                ContainerCommons.ARGUMENTS, ImmutableList.of( "version")
+              ));
         ContainerEffector initializer = new ContainerEffector(parameters);
         TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
         app.start(ImmutableList.of());
 
         EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
-        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
-        assertTrue(output.toString().contains("PublicIpAddress"));
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-command-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains("Terraform v1.5.6"));
     }
 
 }

--- a/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/ContainerEffectorTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/tasks/kubectl/ContainerEffectorTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -231,4 +232,28 @@ public class ContainerEffectorTest extends BrooklynAppUnitTestSupport {
         Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
         assertTrue(output.toString().contains("WORLD"), "Wrong output: "+output);
     }
+
+
+    // prior to executing this test make sure you create an ec2 instance and tag it with "a2/vm"
+    // equivalent of: // docker run -e "AWS_ACCESS_KEY_ID=.." -e "AWS_SECRET_ACCESS_KEY=.." -e "AWS_REGION=eu-north-1" --rm -it amazon/aws-cli ec2 describe-instances --filters "Name=tag:Name,Values=a2/vm"
+    @Test(groups="Live")
+    public void testAwsCLI(){
+        ConfigBag parameters = ConfigBag.newInstance(ImmutableMap.of(
+                ContainerEffector.EFFECTOR_NAME, "test-container-effector",
+                ContainerCommons.CONTAINER_IMAGE, "amazon/aws-cli",
+                ContainerCommons.ARGUMENTS, ImmutableList.of( "ec2", "describe-instances", "--filters", "Name=tag:Name,Values=a2/vm"),
+                BrooklynConfigKeys.SHELL_ENVIRONMENT, ImmutableMap.<String, Object>of(
+                        "AWS_ACCESS_KEY_ID", System.getenv("AWS_ACCESS_KEY_ID"),
+                        "AWS_SECRET_ACCESS_KEY", System.getenv("AWS_SECRET_ACCESS_KEY"),
+                        "AWS_REGION", "eu-north-1"
+                )));
+        ContainerEffector initializer = new ContainerEffector(parameters);
+        TestEntity parentEntity = app.createAndManageChild(EntitySpec.create(TestEntity.class).addInitializer(initializer));
+        app.start(ImmutableList.of());
+
+        EntityAsserts.assertAttributeEqualsEventually(parentEntity, Attributes.SERVICE_UP, true);
+        Object output = Entities.invokeEffector(app, parentEntity, parentEntity.getEffector("test-container-effector")).getUnchecked(Duration.ONE_MINUTE);
+        assertTrue(output.toString().contains("PublicIpAddress"));
+    }
+
 }


### PR DESCRIPTION
...that are run as a command and only require arguments. (e.g. `amazon/aws-cli`,  `hashicorp/terraform`). 
Steps examples: 

```
-  step: "container amazon/aws-cli"
   args: "dynamodb scan --table-name mytable --select COUNT"
   env: 
     AWS_ACCESS_KEY_ID: mytable
     AWS_SECRET_ACCESS_KEY: mysecret
     AWS_REGION: myregion
```
or

```
-  step: "container hashicorp/terraform"
   args: "version"
```