### PR TITLE
Expression parsing

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessor.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessor.java
@@ -18,337 +18,36 @@
  */
 package org.apache.brooklyn.core.workflow;
 
-import org.apache.brooklyn.util.collections.CollectionMerger;
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.text.QuotedStringTokenizer;
-import org.apache.brooklyn.util.text.Strings;
-
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+
+import org.apache.brooklyn.util.guava.Maybe;
 
 /**
- * Accepts a shorthand template, and converts it to a map of values,
- * e.g. given template "[ ?${type_set} ${sensor.type} ] ${sensor.name} \"=\" ${value}"
- * and input "integer foo=3", this will return
- * { sensor: { type: integer, name: foo }, value: 3, type_set: true }.
- *
- * Expects space-separated TOKEN where TOKEN is either:
- *
- * ${VAR} - to set VAR, which should be of the regex [A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*, with dot separation used to set nested maps;
- *   will match a quoted string if supplied, else up to the next literal if the next token is a literal, else the next work.
- * ${VAR...} - as above, but will collect multiple args if needed (if the next token is a literal matched further on, or if at end of word)
- * "LITERAL" - to expect a literal expression. this must include the quotation marks and should include spaces if spaces are required.
- * [ TOKEN ] - to indicate TOKEN is optional, where TOKEN is one of the above sections. parsing is attempted first with it, then without it.
- * [ ?${VAR} TOKEN ] - as `[ TOKEN ]` but VAR is set true or false depending whether this optional section was matched.
- *
- * Would be nice to support A | B (exclusive or) for A or B but not both (where A might contain a literal for disambiguation),
- * and ( X ) for X required but grouped (for use with | (exclusive or) where one option is required).
- * Would also be nice to support any order, which could be ( A & B ) to allow A B or B A.
- *
- * But for now we've made do without it, with some compromises:
- * * keywords must follow the order indicated
- * * exclusive alternatives are disallowed by code subsequently or checked separately (eg Transform)
+ * This impl delegates to one of the various classes that do this -- see notes in individual ones.
  */
 public class ShorthandProcessor {
 
-    private final String template;
-    boolean finalMatchRaw = false;
-    boolean failOnMismatch = true;
+    ShorthandProcessorEpToQst delegate;
 
     public ShorthandProcessor(String template) {
-        this.template = template;
+        delegate = new ShorthandProcessorEpToQst(template);
     }
 
     public Maybe<Map<String,Object>> process(String input) {
-        return new ShorthandProcessorAttempt(this, input).call();
+        return delegate.process(input);
     }
 
     /** whether the last match should preserve quotes and spaces; default false */
     public ShorthandProcessor withFinalMatchRaw(boolean finalMatchRaw) {
-        this.finalMatchRaw = finalMatchRaw;
+        delegate.withFinalMatchRaw(finalMatchRaw);
         return this;
     }
 
     /** whether to fail on mismatched quotes in the input, default true */
     public ShorthandProcessor withFailOnMismatch(boolean failOnMismatch) {
-        this.failOnMismatch = failOnMismatch;
+        // only supported for some
+        delegate.withFailOnMismatch(failOnMismatch);
         return this;
     }
-
-    static class ShorthandProcessorAttempt {
-        private final List<String> templateTokens;
-        private final String inputOriginal;
-        private final QuotedStringTokenizer qst;
-        private final String template;
-        private final ShorthandProcessor options;
-        int optionalDepth = 0;
-        int optionalSkippingInput = 0;
-        private String inputRemaining;
-        Map<String, Object> result;
-        Consumer<String> valueUpdater;
-
-        ShorthandProcessorAttempt(ShorthandProcessor proc, String input) {
-            this.template = proc.template;
-            this.options = proc;
-            this.qst = qst(template);
-            this.templateTokens = qst.remainderAsList();
-            this.inputOriginal = input;
-        }
-
-        private QuotedStringTokenizer qst(String x) {
-            return QuotedStringTokenizer.builder().includeQuotes(true).includeDelimiters(false).expectQuotesDelimited(true).failOnOpenQuote(options.failOnMismatch).build(x);
-        }
-
-        public synchronized Maybe<Map<String,Object>> call() {
-            if (result == null) {
-                result = MutableMap.of();
-                inputRemaining = inputOriginal;
-            } else {
-                throw new IllegalStateException("Only allowed to use once");
-            }
-            Maybe<Object> error = doCall();
-            if (error.isAbsent()) return Maybe.Absent.castAbsent(error);
-            inputRemaining = Strings.trimStart(inputRemaining);
-            if (Strings.isNonBlank(inputRemaining)) {
-                if (valueUpdater!=null) {
-                    QuotedStringTokenizer qstInput = qst(inputRemaining);
-                    valueUpdater.accept(getRemainderPossiblyRaw(qstInput));
-                } else {
-                    // shouldn't come here
-                    return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
-                }
-            }
-            return Maybe.of(result);
-        }
-
-        protected Maybe<Object> doCall() {
-            boolean isEndOfOptional = false;
-            outer: while (true) {
-                if (isEndOfOptional) {
-                    if (optionalDepth <= 0) {
-                        throw new IllegalStateException("Unexpected optional block closure");
-                    }
-                    optionalDepth--;
-                    if (optionalSkippingInput>0) {
-                        // we were in a block where we skipped something optional because it couldn't be matched; outer parser is now canonical,
-                        // and should stop skipping
-                        return Maybe.of(true);
-                    }
-                    isEndOfOptional = false;
-                }
-
-                if (templateTokens.isEmpty()) {
-                    if (Strings.isNonBlank(inputRemaining) && valueUpdater==null) {
-                        return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
-                    }
-                    if (optionalDepth>0)
-                        return Maybe.absent("Mismatched optional marker in template");
-                    return Maybe.of(true);
-                }
-                String t = templateTokens.remove(0);
-
-                if (t.startsWith("[")) {
-                    t = t.substring(1);
-                    if (!t.isEmpty()) {
-                        templateTokens.add(0, t);
-                    }
-                    String optionalPresentVar = null;
-                    if (!templateTokens.isEmpty() && templateTokens.get(0).startsWith("?")) {
-                        String v = templateTokens.remove(0);
-                        if (v.startsWith("?${") && v.endsWith("}")) {
-                            optionalPresentVar = v.substring(3, v.length() - 1);
-                        } else {
-                            throw new IllegalStateException("? after [ should indicate optional presence variable using syntax '?${var}', not '"+v+"'");
-                        }
-                    }
-                    Maybe<Object> cr;
-                    if (optionalSkippingInput<=0) {
-                        // make a deep copy so that valueUpdater writes get replayed
-                        Map<String, Object> backupResult = (Map) CollectionMerger.builder().deep(true).build().merge(MutableMap.of(), result);
-                        Consumer<String> backupValueUpdater = valueUpdater;
-                        String backupInputRemaining = inputRemaining;
-                        List<String> backupTemplateTokens = MutableList.copyOf(templateTokens);
-                        int oldDepth = optionalDepth;
-                        int oldSkippingDepth = optionalSkippingInput;
-
-                        optionalDepth++;
-                        cr = doCall();
-                        if (cr.isPresent()) {
-                            // succeeded
-                            if (optionalPresentVar!=null) result.put(optionalPresentVar, true);
-                            continue;
-
-                        } else {
-                            // restore
-                            result = backupResult;
-                            valueUpdater = backupValueUpdater;
-                            if (optionalPresentVar!=null) result.put(optionalPresentVar, false);
-                            inputRemaining = backupInputRemaining;
-                            templateTokens.clear();
-                            templateTokens.addAll(backupTemplateTokens);
-                            optionalDepth = oldDepth;
-                            optionalSkippingInput = oldSkippingDepth;
-
-                            optionalSkippingInput++;
-                            optionalDepth++;
-                            cr = doCall();
-                            if (cr.isPresent()) {
-                                optionalSkippingInput--;
-                                continue;
-                            }
-                        }
-                    } else {
-                        if (optionalPresentVar!=null) {
-                            result.put(optionalPresentVar, false);
-                            valueUpdater = null;
-                        }
-                        optionalDepth++;
-                        cr = doCall();
-                        if (cr.isPresent()) {
-                            continue;
-                        }
-                    }
-                    return cr;
-                }
-
-                isEndOfOptional = t.endsWith("]");
-
-                if (isEndOfOptional) {
-                    t = t.substring(0, t.length() - 1);
-                    if (t.isEmpty()) continue;
-                    // next loop will process the end of the optionality
-                }
-
-                if (qst.isQuoted(t)) {
-                    if (optionalSkippingInput>0) continue;
-
-                    String literal = qst.unwrapIfQuoted(t);
-                    do {
-                        // ignore leading spaces (since the quoted string tokenizer will have done that anyway); but their _absence_ can be significant for intra-token searching when matching a var
-                        inputRemaining = Strings.trimStart(inputRemaining);
-                        if (inputRemaining.startsWith(Strings.trimStart(literal))) {
-                            // literal found
-                            inputRemaining = inputRemaining.substring(Strings.trimStart(literal).length());
-                            continue outer;
-                        }
-                        if (inputRemaining.isEmpty()) return Maybe.absent("Literal '"+literal+"' expected, when end of input reached");
-                        if (valueUpdater!=null) {
-                            QuotedStringTokenizer qstInput = qst(inputRemaining);
-                            if (!qstInput.hasMoreTokens()) return Maybe.absent("Literal '"+literal+"' expected, when end of input tokens reached");
-                            String value = getNextInputTokenUpToPossibleExpectedLiteral(qstInput, literal);
-                            valueUpdater.accept(value);
-                            continue;
-                        }
-                        return Maybe.absent("Literal '"+literal+"' expected, when encountered '"+inputRemaining+"'");
-                    } while (true);
-                }
-
-                if (t.startsWith("${") && t.endsWith("}")) {
-                    if (optionalSkippingInput>0) continue;
-
-                    t = t.substring(2, t.length()-1);
-                    String value;
-
-                    inputRemaining = inputRemaining.trim();
-                    QuotedStringTokenizer qstInput = qst(inputRemaining);
-                    if (!qstInput.hasMoreTokens()) return Maybe.absent("End of input when looking for variable "+t);
-
-                    if (!templateTokens.stream().filter(x -> !x.equals("]")).findFirst().isPresent()) {
-                        // last word (whether optional or not) takes everything
-                        value = getRemainderPossiblyRaw(qstInput);
-                        inputRemaining = "";
-
-                    } else {
-                        value = getNextInputTokenUpToPossibleExpectedLiteral(qstInput, null);
-                    }
-                    boolean multiMatch = t.endsWith("...");
-                    if (multiMatch) t = Strings.removeFromEnd(t, "...");
-                    String keys[] = t.split("\\.");
-                    final String tt = t;
-                    valueUpdater = v2 -> {
-                        Map target = result;
-                        for (int i=0; i<keys.length; i++) {
-                            if (!Pattern.compile("[A-Za-z0-9_-]+").matcher(keys[i]).matches()) {
-                                throw new IllegalArgumentException("Invalid variable '"+tt+"'");
-                            }
-                            if (i == keys.length - 1) {
-                                target.compute(keys[i], (k, v) -> v == null ? v2 : v + " " + v2);
-                            } else {
-                                // need to make sure we have a map or null
-                                target = (Map) target.compute(keys[i], (k, v) -> {
-                                    if (v == null) return MutableMap.of();
-                                    if (v instanceof Map) return v;
-                                    return Maybe.absent("Cannot process shorthand for " + Arrays.asList(keys) + " because entry '" + k + "' is not a map (" + v + ")");
-                                });
-                            }
-                        }
-                    };
-                    valueUpdater.accept(value);
-                    if (!multiMatch) valueUpdater = null;
-                    continue;
-                }
-
-                // unexpected token
-                return Maybe.absent("Unexpected token in shorthand pattern '"+template+"' at position "+(template.lastIndexOf(t)+1));
-            }
-        }
-
-        private String getRemainderPossiblyRaw(QuotedStringTokenizer qstInput) {
-            String value;
-            value = Strings.join(qstInput.remainderRaw(), "");
-            if (!options.finalMatchRaw) {
-                return qstInput.unwrapIfQuoted(value);
-            }
-            return value;
-        }
-
-        private String getNextInputTokenUpToPossibleExpectedLiteral(QuotedStringTokenizer qstInput, String nextLiteral) {
-            String value;
-            String v = qstInput.nextToken();
-            if (qstInput.isQuoted(v)) {
-                // input was quoted, eg "\"foo=b\" ..." -- ignore the = in "foo=b"
-                value = qstInput.unwrapIfQuoted(v);
-                inputRemaining = inputRemaining.substring(v.length());
-            } else {
-                // input not quoted, if next template token is literal, look for it
-                boolean isLiteralExpected;
-                if (nextLiteral==null) {
-                    nextLiteral = templateTokens.get(0);
-                    if (qstInput.isQuoted(nextLiteral)) {
-                        nextLiteral = qstInput.unwrapIfQuoted(nextLiteral);
-                        isLiteralExpected = true;
-                    } else {
-                        isLiteralExpected = false;
-                    }
-                } else {
-                    isLiteralExpected = true;
-                }
-                if (isLiteralExpected) {
-                    int nli = v.indexOf(nextLiteral);
-                    if (nli>0) {
-                        // literal found in unquoted string, eg "foo=bar" when literal is =
-                        value = v.substring(0, nli);
-                        inputRemaining = inputRemaining.substring(value.length());
-                    } else {
-                        // literal not found
-                        value = v;
-                        inputRemaining = inputRemaining.substring(value.length());
-                    }
-                } else {
-                    // next is not a literal, so the whole token is the value
-                    value = v;
-                    inputRemaining = inputRemaining.substring(value.length());
-                }
-            }
-            return value;
-        }
-    }
-
 
 }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorEpToQst.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorEpToQst.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.apache.brooklyn.core.workflow.utils.ExpressionParser;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNode;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNodeOrValue;
+import org.apache.brooklyn.util.collections.CollectionMerger;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.QuotedStringTokenizer;
+import org.apache.brooklyn.util.text.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the latest version of the SP which uses the EP for input, and the QST for templates,
+ * to keep backwards compatibility but allow better handling for internal double quotes and interpolated expressions with spaces.
+ * It falls back to QST when there are errors to maximize compatibility.
+ *
+ * ===
+ *
+ * Accepts a shorthand template, and converts it to a map of values,
+ * e.g. given template "[ ?${type_set} ${sensor.type} ] ${sensor.name} \"=\" ${value}"
+ * and input "integer foo=3", this will return
+ * { sensor: { type: integer, name: foo }, value: 3, type_set: true }.
+ *
+ * Expects space-separated TOKEN where TOKEN is either:
+ *
+ * ${VAR} - to set VAR, which should be of the regex [A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*, with dot separation used to set nested maps;
+ *   will match a quoted string if supplied, else up to the next literal if the next token is a literal, else the next work.
+ * ${VAR...} - as above, but will collect multiple args if needed (if the next token is a literal matched further on, or if at end of word)
+ * "LITERAL" - to expect a literal expression. this must include the quotation marks and should include spaces if spaces are required.
+ * [ TOKEN ] - to indicate TOKEN is optional, where TOKEN is one of the above sections. parsing is attempted first with it, then without it.
+ * [ ?${VAR} TOKEN ] - as `[ TOKEN ]` but VAR is set true or false depending whether this optional section was matched.
+ *
+ * Would be nice to support A | B (exclusive or) for A or B but not both (where A might contain a literal for disambiguation),
+ * and ( X ) for X required but grouped (for use with | (exclusive or) where one option is required).
+ * Would also be nice to support any order, which could be ( A & B ) to allow A B or B A.
+ *
+ * But for now we've made do without it, with some compromises:
+ * * keywords must follow the order indicated
+ * * exclusive alternatives are disallowed by code subsequently or checked separately (eg Transform)
+ */
+public class ShorthandProcessorEpToQst {
+
+    private static final Logger log = LoggerFactory.getLogger(ShorthandProcessorEpToQst.class);
+
+    static final boolean TRY_HARDER_FOR_QST_COMPATIBILITY = true;
+
+    private final String template;
+    boolean finalMatchRaw = false;
+    boolean failOnMismatch = true;
+
+    public ShorthandProcessorEpToQst(String template) {
+        this.template = template;
+    }
+
+    public Maybe<Map<String,Object>> process(String input) {
+        return new ShorthandProcessorQstAttempt(this, input).call();
+    }
+
+    /** whether the last match should preserve quotes and spaces; default false */
+    public ShorthandProcessorEpToQst withFinalMatchRaw(boolean finalMatchRaw) {
+        this.finalMatchRaw = finalMatchRaw;
+        return this;
+    }
+
+    /** whether to fail on mismatched quotes in the input, default true */
+    public ShorthandProcessorEpToQst withFailOnMismatch(boolean failOnMismatch) {
+        this.failOnMismatch = failOnMismatch;
+        return this;
+    }
+
+    static class ShorthandProcessorQstAttempt {
+        private final List<String> templateTokens;
+        private final String inputOriginal;
+        private final QuotedStringTokenizer qst0;
+        private final String template;
+        private final ShorthandProcessorEpToQst options;
+        int optionalDepth = 0;
+        int optionalSkippingInput = 0;
+        private String inputRemaining;
+        Map<String, Object> result;
+        Consumer<String> valueUpdater;
+
+        ShorthandProcessorQstAttempt(ShorthandProcessorEpToQst proc, String input) {
+            this.template = proc.template;
+            this.options = proc;
+            this.qst0 = qst0(template);
+            this.templateTokens = qst0.remainderAsList();  // QST works fine for the template
+            this.inputOriginal = input;
+        }
+
+        private QuotedStringTokenizer qst0(String x) {
+            return QuotedStringTokenizer.builder().includeQuotes(true).includeDelimiters(false).expectQuotesDelimited(true).failOnOpenQuote(options.failOnMismatch).build(x);
+        }
+
+        public synchronized Maybe<Map<String,Object>> call() {
+            if (result == null) {
+                result = MutableMap.of();
+                inputRemaining = inputOriginal;
+            } else {
+                throw new IllegalStateException("Only allowed to use once");
+            }
+            Maybe<Object> error = doCall();
+            if (error.isAbsent()) return Maybe.Absent.castAbsent(error);
+            inputRemaining = Strings.trimStart(inputRemaining);
+            if (Strings.isNonBlank(inputRemaining)) {
+                if (valueUpdater!=null) {
+                    //QuotedStringTokenizer qstInput = qst(inputRemaining);
+                    valueUpdater.accept(getRemainderPossiblyRaw(inputRemaining));
+                } else {
+                    // shouldn't come here
+                    return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
+                }
+            }
+            return Maybe.of(result);
+        }
+
+        protected Maybe<Object> doCall() {
+            boolean isEndOfOptional = false;
+            outer: while (true) {
+                if (isEndOfOptional) {
+                    if (optionalDepth <= 0) {
+                        throw new IllegalStateException("Unexpected optional block closure");
+                    }
+                    optionalDepth--;
+                    if (optionalSkippingInput>0) {
+                        // we were in a block where we skipped something optional because it couldn't be matched; outer parser is now canonical,
+                        // and should stop skipping
+                        return Maybe.of(true);
+                    }
+                    isEndOfOptional = false;
+                }
+
+                if (templateTokens.isEmpty()) {
+                    if (Strings.isNonBlank(inputRemaining) && valueUpdater==null) {
+                        return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
+                    }
+                    if (optionalDepth>0)
+                        return Maybe.absent("Mismatched optional marker in template");
+                    return Maybe.of(true);
+                }
+                String t = templateTokens.remove(0);
+
+                if (t.startsWith("[")) {
+                    t = t.substring(1);
+                    if (!t.isEmpty()) {
+                        templateTokens.add(0, t);
+                    }
+                    String optionalPresentVar = null;
+                    if (!templateTokens.isEmpty() && templateTokens.get(0).startsWith("?")) {
+                        String v = templateTokens.remove(0);
+                        if (v.startsWith("?${") && v.endsWith("}")) {
+                            optionalPresentVar = v.substring(3, v.length() - 1);
+                        } else {
+                            throw new IllegalStateException("? after [ should indicate optional presence variable using syntax '?${var}', not '"+v+"'");
+                        }
+                    }
+                    Maybe<Object> cr;
+                    if (optionalSkippingInput<=0) {
+                        // make a deep copy so that valueUpdater writes get replayed
+                        Map<String, Object> backupResult = (Map) CollectionMerger.builder().deep(true).build().merge(MutableMap.of(), result);
+                        Consumer<String> backupValueUpdater = valueUpdater;
+                        String backupInputRemaining = inputRemaining;
+                        List<String> backupTemplateTokens = MutableList.copyOf(templateTokens);
+                        int oldDepth = optionalDepth;
+                        int oldSkippingDepth = optionalSkippingInput;
+
+                        optionalDepth++;
+                        cr = doCall();
+                        if (cr.isPresent()) {
+                            // succeeded
+                            if (optionalPresentVar!=null) result.put(optionalPresentVar, true);
+                            continue;
+
+                        } else {
+                            // restore
+                            result = backupResult;
+                            valueUpdater = backupValueUpdater;
+                            if (optionalPresentVar!=null) result.put(optionalPresentVar, false);
+                            inputRemaining = backupInputRemaining;
+                            templateTokens.clear();
+                            templateTokens.addAll(backupTemplateTokens);
+                            optionalDepth = oldDepth;
+                            optionalSkippingInput = oldSkippingDepth;
+
+                            optionalSkippingInput++;
+                            optionalDepth++;
+                            cr = doCall();
+                            if (cr.isPresent()) {
+                                optionalSkippingInput--;
+                                continue;
+                            }
+                        }
+                    } else {
+                        if (optionalPresentVar!=null) {
+                            result.put(optionalPresentVar, false);
+                            valueUpdater = null;
+                        }
+                        optionalDepth++;
+                        cr = doCall();
+                        if (cr.isPresent()) {
+                            continue;
+                        }
+                    }
+                    return cr;
+                }
+
+                isEndOfOptional = t.endsWith("]");
+
+                if (isEndOfOptional) {
+                    t = t.substring(0, t.length() - 1);
+                    if (t.isEmpty()) continue;
+                    // next loop will process the end of the optionality
+                }
+
+                if (qst0.isQuoted(t)) {
+                    if (optionalSkippingInput>0) continue;
+
+                    String literal = qst0.unwrapIfQuoted(t);
+                    do {
+                        // ignore leading spaces (since the quoted string tokenizer will have done that anyway); but their _absence_ can be significant for intra-token searching when matching a var
+                        inputRemaining = Strings.trimStart(inputRemaining);
+                        if (inputRemaining.startsWith(Strings.trimStart(literal))) {
+                            // literal found
+                            inputRemaining = inputRemaining.substring(Strings.trimStart(literal).length());
+                            continue outer;
+                        }
+                        if (inputRemaining.isEmpty()) return Maybe.absent("Literal '"+literal+"' expected, when end of input reached");
+                        if (valueUpdater!=null) {
+                            if (inputRemaining.isEmpty()) return Maybe.absent("Literal '"+literal+"' expected, when end of input tokens reached");
+                            String value = getNextInputTokenUpToPossibleExpectedLiteral(literal);
+                            valueUpdater.accept(value);
+                            continue;
+                        }
+                        return Maybe.absent("Literal '"+literal+"' expected, when encountered '"+inputRemaining+"'");
+                    } while (true);
+                }
+
+                if (t.startsWith("${") && t.endsWith("}")) {
+                    if (optionalSkippingInput>0) continue;
+
+                    t = t.substring(2, t.length()-1);
+                    String value;
+
+                    inputRemaining = inputRemaining.trim();
+                    if (inputRemaining.isEmpty()) return Maybe.absent("End of input when looking for variable "+t);
+
+                    if (!templateTokens.stream().filter(x -> !x.equals("]")).findFirst().isPresent()) {
+                        // last word (whether optional or not) takes everything
+                        value = getRemainderPossiblyRaw(inputRemaining);
+                        inputRemaining = "";
+
+                    } else {
+                        value = getNextInputTokenUpToPossibleExpectedLiteral(null);
+                    }
+                    boolean multiMatch = t.endsWith("...");
+                    if (multiMatch) t = Strings.removeFromEnd(t, "...");
+                    String keys[] = t.split("\\.");
+                    final String tt = t;
+                    valueUpdater = v2 -> {
+                        Map target = result;
+                        for (int i=0; i<keys.length; i++) {
+                            if (!Pattern.compile("[A-Za-z0-9_-]+").matcher(keys[i]).matches()) {
+                                throw new IllegalArgumentException("Invalid variable '"+tt+"'");
+                            }
+                            if (i == keys.length - 1) {
+                                target.compute(keys[i], (k, v) -> v == null ? v2 : v + " " + v2);
+                            } else {
+                                // need to make sure we have a map or null
+                                target = (Map) target.compute(keys[i], (k, v) -> {
+                                    if (v == null) return MutableMap.of();
+                                    if (v instanceof Map) return v;
+                                    return Maybe.absent("Cannot process shorthand for " + Arrays.asList(keys) + " because entry '" + k + "' is not a map (" + v + ")");
+                                });
+                            }
+                        }
+                    };
+                    valueUpdater.accept(value);
+                    if (!multiMatch) valueUpdater = null;
+                    continue;
+                }
+
+                // unexpected token
+                return Maybe.absent("Unexpected token in shorthand pattern '"+template+"' at position "+(template.lastIndexOf(t)+1));
+            }
+        }
+
+        private String getRemainderPossiblyRawQst(QuotedStringTokenizer qstInput) {
+            String value;
+            value = Strings.join(qstInput.remainderRaw(), "");
+            if (!options.finalMatchRaw) {
+                return qstInput.unwrapIfQuoted(value);
+            }
+            return value;
+        }
+
+        private String getRemainderPossiblyRaw(String inputRemaining) {
+            Maybe<String> mp = getRemainderPossiblyRawEp(inputRemaining);
+
+            if (TRY_HARDER_FOR_QST_COMPATIBILITY || (mp.isAbsent() && !options.failOnMismatch)) {
+                String qstResult = getRemainderPossiblyRawQst(qst0(inputRemaining));
+                if (mp.isPresent() && !mp.get().equals(qstResult)) {
+                    log.debug("Shorthand parsing semantics change for: "+inputOriginal+"\n" +
+                            "  old qst: "+qstResult+"\n"+
+                            "  new exp: "+mp.get());
+                    // to debug
+//                    getRemainderPossiblyRawEp(inputRemaining);
+                }
+                if (mp.isAbsent()) {
+                    return qstResult;
+                }
+            }
+
+            return mp.get();
+        }
+        private Maybe<String> getRemainderPossiblyRawEp(String inputRemaining) {
+            if (options.finalMatchRaw) {
+                return Maybe.of(inputRemaining);
+            }
+            Maybe<List<ParseNodeOrValue>> mp = ShorthandProcessorExprParser.tokenizer().parseEverything(inputRemaining);
+            return mp.map(pnl -> {
+                final boolean UNQUOTE_INDIVIDUAL_WORDS = false;  // legacy behaviour
+
+                if (pnl.size()==1 || UNQUOTE_INDIVIDUAL_WORDS) {
+                    return ExpressionParser.getAllUnquoted(pnl);
+                } else {
+                    return ExpressionParser.getUnescapedButNotUnquoted(pnl);
+                }
+            });
+        }
+
+        private String getNextInputTokenUpToPossibleExpectedLiteralQst(QuotedStringTokenizer qstInput, String nextLiteral) {
+            String value;
+            if (!qstInput.hasMoreTokens()) {
+                return "";  // shouldn't happen
+            }
+            String v = qstInput.nextToken();
+            if (qstInput.isQuoted(v)) {
+                // input was quoted, eg "\"foo=b\" ..." -- ignore the = in "foo=b"
+                value = qstInput.unwrapIfQuoted(v);
+                inputRemaining = inputRemaining.substring(v.length());
+            } else {
+                // input not quoted, if next template token is literal, look for it
+                boolean isLiteralExpected;
+                if (nextLiteral==null) {
+                    nextLiteral = templateTokens.get(0);
+                    if (qstInput.isQuoted(nextLiteral)) {
+                        nextLiteral = qstInput.unwrapIfQuoted(nextLiteral);
+                        isLiteralExpected = true;
+                    } else {
+                        isLiteralExpected = false;
+                    }
+                } else {
+                    isLiteralExpected = true;
+                }
+                if (isLiteralExpected) {
+                    int nli = v.indexOf(nextLiteral);
+                    if (nli>0) {
+                        // literal found in unquoted string, eg "foo=bar" when literal is =
+                        value = v.substring(0, nli);
+                        inputRemaining = inputRemaining.substring(value.length());
+                    } else {
+                        // literal not found
+                        value = v;
+                        inputRemaining = inputRemaining.substring(value.length());
+                    }
+                } else {
+                    // next is not a literal, so the whole token is the value
+                    value = v;
+                    inputRemaining = inputRemaining.substring(value.length());
+                }
+            }
+            return value;
+        }
+
+        private String getNextInputTokenUpToPossibleExpectedLiteral(String nextLiteral) {
+            String oi = inputRemaining;
+            Maybe<String> v1 = getNextInputTokenUpToPossibleExpectedLiteralEp(nextLiteral);
+
+            if (TRY_HARDER_FOR_QST_COMPATIBILITY || (v1.isAbsent() && !options.failOnMismatch)) {
+                String ni = inputRemaining;
+
+                inputRemaining = oi;
+                String qstResult = getNextInputTokenUpToPossibleExpectedLiteralQst(qst0(inputRemaining), nextLiteral);
+                if (v1.isPresent() && !v1.get().equals(qstResult)) {
+                    log.debug("Shorthand parsing semantics change for literal " + nextLiteral + ": " + inputOriginal + "\n" +
+                            "  old qst: " + qstResult + "\n" +
+                            "  new exp: " + v1.get());
+
+//                    // to debug differences
+//                    inputRemaining = oi;
+////                    getNextInputTokenUpToPossibleExpectedLiteralQst(qst0(inputRemaining), nextLiteral);
+//                    getNextInputTokenUpToPossibleExpectedLiteralEp(nextLiteral);
+                }
+                if (v1.isAbsent()) {
+                    return qstResult;
+                }
+                inputRemaining = ni;
+            }
+
+            return v1.get();
+        }
+
+        private Maybe<String> getNextInputTokenUpToPossibleExpectedLiteralEp(String nextLiteral) {
+            String result = "";
+            boolean canRepeat = true;
+
+            Maybe<ParseNode> parseM = ShorthandProcessorExprParser.tokenizer().parse(inputRemaining);
+            while (canRepeat) {
+                String value;
+                if (parseM.isAbsent()) return Maybe.castAbsent(parseM);
+
+                List<ParseNodeOrValue> tokens = parseM.get().getContents();
+                ParseNodeOrValue t = tokens.iterator().next();
+
+                if (ExpressionParser.isQuotedExpressionNode(t)) {
+                    // input was quoted, eg "\"foo=b\" ..." -- ignore the = in "foo=b"
+                    value = ExpressionParser.getUnquoted(t);
+                    inputRemaining = inputRemaining.substring(t.getSource().length());
+
+                } else {
+                    // input not quoted, if next template token is literal, look for it
+                    boolean isLiteralExpected;
+                    if (nextLiteral == null) {
+                        String nl = templateTokens.get(0);
+                        if (qst0.isQuoted(nl)) {
+                            nextLiteral = qst0.unwrapIfQuoted(nl);
+                            isLiteralExpected = true;
+                        } else {
+                            isLiteralExpected = false;
+                        }
+                    } else {
+                        isLiteralExpected = true;
+                    }
+                    if (isLiteralExpected) {
+                        int nli =
+                                // previously took next QST token
+                                qst0(inputRemaining).nextToken().indexOf(nextLiteral);
+
+//                            // this is simple, slightly greedier;
+//                            // slightly too greedy, in that nextLiteral inside quotes further away will match
+//                            // and it breaks backwards compatibility
+//                            inputRemaining.indexOf(nextLiteral);
+
+//                            // this parse node is probably too short
+//                            t.getSource().indexOf(nextLiteral);
+
+                        final boolean ALLOW_NOTHING_BEFORE_LITERAL = false;
+                        if ((nli == 0 && ALLOW_NOTHING_BEFORE_LITERAL) || nli > 0) {
+                            // literal found in unquoted string, eg "foo=bar" when literal is =
+                            if (!qst0(inputRemaining).nextToken().startsWith(inputRemaining.substring(0, nli))) {
+                                String v = qst0(inputRemaining).nextToken();
+                            }
+                            value = inputRemaining.substring(0, nli);
+                            inputRemaining = inputRemaining.substring(nli);
+                            canRepeat = false;
+
+                        } else {
+                            // literal not found
+                            value = t.getSource();  // since we know it isn't quoted
+                            inputRemaining = inputRemaining.substring(value.length());
+                        }
+                    } else {
+                        // next is not a literal, so the whole token is the value - not unquoted
+                        value = t.getSource();
+                        inputRemaining = inputRemaining.substring(value.length());
+                    }
+                }
+                result += value;
+
+                canRepeat &= !inputRemaining.isEmpty();
+                if (canRepeat) {
+                    parseM = ShorthandProcessorExprParser.tokenizer().parse(inputRemaining);
+                    if (parseM.isAbsent()) canRepeat = false;
+                    else {
+                        if (ExpressionParser.startsWithWhitespace(parseM.get())) canRepeat = false;
+                        // otherwise, to act like QST, we treat non-whitespace-separated things all as one token
+                    }
+                }
+            }
+
+            return Maybe.of(result);
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorExprParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorExprParser.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.brooklyn.core.workflow.utils.ExpressionParser;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.CharactersCollectingParseMode;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNode;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNodeOrValue;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseValue;
+import org.apache.brooklyn.util.collections.CollectionMerger;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * An implentation of {@link ShorthandProcessor} which tries to use the ExpressionParser for everything.
+ * However the semantics of a parse tree vs a linear string are too different so this is deprecated.
+ *
+ * It would be better to write this anew, and accept a breakage of semantics -- or use SPEpToQst (which we do)
+ */
+@Deprecated
+public class ShorthandProcessorExprParser {
+
+    private final String template;
+    boolean finalMatchRaw = false;
+
+    public ShorthandProcessorExprParser(String template) {
+        this.template = template;
+    }
+
+    public Maybe<Map<String,Object>> process(String input) {
+        return new ShorthandProcessorAttempt(this, input).call();
+    }
+
+    /** whether the last match should preserve quotes and spaces; default false */
+    public ShorthandProcessorExprParser withFinalMatchRaw(boolean finalMatchRaw) {
+        this.finalMatchRaw = finalMatchRaw;
+        return this;
+    }
+
+    public static ExpressionParser tokenizer() {
+        return ExpressionParser
+                .newDefaultAllowingUnquotedAndSplittingOnWhitespace()
+                .includeGroupingBracketsAtUsualPlaces()
+
+                // including = means we can handle let x=1 !
+                .includeAllowedTopLevelTransition(new CharactersCollectingParseMode("equals", '='))
+
+                // whitespace in square brackets might be interesting -- though i don't think it is
+//                .includeAllowedSubmodeTransition(ExpressionParser.SQUARE_BRACKET, ExpressionParser.WHITESPACE)
+                ;
+    }
+    private static Maybe<List<ParseNodeOrValue>> tokenized(String x) {
+        return tokenizer().parseEverything(x);
+    }
+
+    static class ShorthandProcessorAttempt {
+        private final List<ParseNodeOrValue> templateTokensOriginal;
+        private final String inputOriginal2;
+        private final String template;
+        private final ShorthandProcessorExprParser options;
+        int optionalDepth = 0;
+        int optionalSkippingInput = 0;
+        Map<String, Object> result;
+        Consumer<String> valueUpdater;
+
+        ShorthandProcessorAttempt(ShorthandProcessorExprParser proc, String input) {
+            this.template = proc.template;
+            this.options = proc;
+            this.templateTokensOriginal = tokenized(template).get();
+            this.inputOriginal2 = input;
+        }
+
+        public synchronized Maybe<Map<String,Object>> call() {
+            if (result != null) {
+                throw new IllegalStateException("Only allowed to use once");
+            }
+            result = MutableMap.of();
+            List<ParseNodeOrValue> templateTokens = MutableList.copyOf(templateTokensOriginal);
+            List<ParseNodeOrValue> inputTokens = tokenized(inputOriginal2).get();
+            Maybe<Boolean> error = doCall(templateTokens, inputTokens, 0);
+            if (error.isAbsent()) return Maybe.Absent.castAbsent(error);
+            if (!error.get()) return Maybe.absent("Template could not be matched."); // shouldn't happen
+            chompWhitespace(inputTokens);
+            if (!inputTokens.isEmpty()) {
+                if (valueUpdater!=null) {
+                    valueUpdater.accept(getRemainderPossiblyRaw(inputTokens));
+                } else {
+                    // shouldn't come here
+                    return Maybe.absent("Input has trailing characters after template is matched: '" + inputTokens.stream().map(x -> x.getSource()).collect(Collectors.joining()) + "'");
+                }
+            }
+            return Maybe.of(result);
+        }
+
+        private static final Object EMPTY = "empty";
+
+        protected Maybe<Boolean> doCall(List<ParseNodeOrValue> templateTokens, List<ParseNodeOrValue> inputTokens, int depth) {
+//            boolean isEndOfOptional = false;
+            outer: while (true) {
+//                if (isEndOfOptional) {
+//                    if (optionalDepth <= 0) {
+//                        throw new IllegalStateException("Unexpected optional block closure");
+//                    }
+//                    optionalDepth--;
+//                    if (optionalSkippingInput>0) {
+//                        // we were in a block where we skipped something optional because it couldn't be matched; outer parser is now canonical,
+//                        // and should stop skipping
+//                        return Maybe.of(true);
+//                    }
+//                    isEndOfOptional = false;
+//                }
+
+                if (templateTokens.isEmpty()) {
+////                    if (Strings.isNonBlank(inputRemaining) && valueUpdater==null) {
+////                        return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
+////                    }
+//                    if (optionalDepth>0)
+//                        return Maybe.absent("Mismatched optional marker in template");
+                    return Maybe.of(true);
+                }
+                ParseNodeOrValue tnv = templateTokens.remove(0);
+
+                if (tnv.isParseNodeMode(ExpressionParser.SQUARE_BRACKET)) {
+                    List<ParseNodeOrValue> tt = ((ParseNode) tnv).getContents();
+                    String optionalPresentVar = null;
+                    chompWhitespace(tt);
+                    if (!tt.isEmpty() && tt.get(0).getParseNodeMode().equals(ParseValue.MODE) &&
+                            ((String)tt.get(0).getContents()).startsWith("?")) {
+                        ParseNodeOrValue vt = tt.remove(0);
+                        ParseNodeOrValue vt2 = tt.stream().findFirst().orElse(null);
+                        if (vt2!=null && vt2.isParseNodeMode(ExpressionParser.INTERPOLATED)) {
+                            ParseValue vt2c = ((ParseNode) vt2).getOnlyContent()
+                                    .mapMaybe(x -> x instanceof ParseValue ? Maybe.of((ParseValue)x) : Maybe.absent())
+                                    .orThrow(() -> new IllegalStateException("? after [ should be followed by optional presence variable using syntax '?${var}', not '" + vt2.getSource() + "'"));
+                            optionalPresentVar = vt2c.getContents();
+                            tt.remove(0);
+                        } else {
+                            throw new IllegalStateException("? after [ should indicate optional presence variable using syntax '?${var}', not '"+vt.getSource()+"'");
+                        }
+                    }
+                    Maybe<Boolean> cr;
+                    if (optionalSkippingInput<=0) {
+                        // make a deep copy so that valueUpdater writes get replayed
+                        Map<String, Object> backupResult = (Map) CollectionMerger.builder().deep(true).build().merge(MutableMap.of(), result);
+                        Consumer<String> backupValueUpdater = valueUpdater;
+                        List<ParseNodeOrValue> backupInputRemaining = MutableList.copyOf(inputTokens);
+                        List<ParseNodeOrValue> backupTT = tt;
+                        int oldDepth = optionalDepth;
+                        int oldSkippingDepth = optionalSkippingInput;
+
+                        optionalDepth++;
+                        tt = MutableList.copyOf(tt);
+                        tt.addAll(templateTokens);
+                        // this nested call handles the bracketed nodes, and everything after, to make sure the inclusion of the optional works to the end
+                        cr = doCall(tt, inputTokens, depth+1);
+                        if (cr.isPresent()) {
+                            if (cr.get()) {
+                                // succeeded
+                                templateTokens.clear();  // because the subcall handled them
+                                if (optionalPresentVar != null) result.put(optionalPresentVar, true);
+                                continue;
+                            } else {
+                                // go into next block, we'll re-run, but with optional skipping turned on
+                            }
+                        }
+                        // restore
+                        result = backupResult;
+                        valueUpdater = backupValueUpdater;
+                        if (optionalPresentVar!=null) result.put(optionalPresentVar, false);
+                        inputTokens.clear();
+                        inputTokens.addAll(backupInputRemaining);
+                        tt = backupTT;
+                        optionalDepth = oldDepth;
+                        optionalSkippingInput = oldSkippingDepth;
+
+                        optionalSkippingInput++;
+                        optionalDepth++;
+//                        tt.add(0, tnv); // put our bracket back on the head so we come back in to this block
+                        cr = doCall(tt, inputTokens, depth+1);
+                        if (cr.isPresent()) {
+                            optionalSkippingInput--;
+                            continue;
+                        }
+                    } else {
+                        if (optionalPresentVar!=null) {
+                            result.put(optionalPresentVar, false);
+                            valueUpdater = null;
+                        }
+                        optionalDepth++;
+                        cr = doCall(tt, inputTokens, depth+1);
+                        if (cr.isPresent()) {
+                            continue;
+                        }
+                    }
+                    // failed
+                    return cr;
+                }
+
+                if (ExpressionParser.isQuotedExpressionNode(tnv)) {
+                    if (optionalSkippingInput>0) continue;
+
+                    Maybe<String> literalM = getSingleStringContents(tnv, "inside shorthand template quote");
+                    if (literalM.isAbsent()) return Maybe.castAbsent(literalM);
+                    String literal = Strings.trimStart(literalM.get());
+//                    boolean foundSomething = false;
+                    valueUpdater: do {
+                        chompWhitespace(inputTokens);
+                        literal: while (!inputTokens.isEmpty()) {
+                            if (!literal.isEmpty()) {
+                                Maybe<String> nextInputM = getSingleStringContents(inputTokens.stream().findFirst().orElse(null), "matching literal '" + literal + "'");
+                                String nextInput = Strings.trimStart(nextInputM.orNull());
+                                if (nextInput == null) {
+                                    break; // shouldn't happen, but if so, fall through to error below
+                                }
+                                if (literal.startsWith(nextInput)) {
+                                    literal = Strings.removeFromStart(literal, nextInput.trim());
+                                    inputTokens.remove(0);
+                                    chompWhitespace(inputTokens);
+                                    literal = Strings.trimStart(literal);
+                                    continue literal;
+                                }
+                                if (nextInput.startsWith(literal)) {
+                                    String putBackOnInput = nextInput.substring(literal.length());
+                                    literal = "";
+                                    inputTokens.remove(0);
+                                    if (!putBackOnInput.isEmpty()) inputTokens.add(0, new ParseValue(putBackOnInput));
+                                    else chompWhitespace(inputTokens);
+                                    // go into next block
+                                }
+                            }
+                            if (literal.isEmpty()) {
+                                // literal found
+                                continue outer;
+                            }
+                            break;
+                        }
+                        if (inputTokens.isEmpty()) {
+                            return Maybe.absent("Literal '" + literalM.get() + "' expected, when end of input reached");
+                        }
+                        if (valueUpdater!=null) {
+                            if (inputTokens.isEmpty()) return Maybe.absent("Literal '"+literal+"' expected, when end of input tokens reached");
+                            Pair<String,Boolean> value = getNextInputTokenUpToPossibleExpectedLiteral(inputTokens, templateTokens, literal, false);
+                            if (value.getRight()) valueUpdater.accept(value.getLeft());
+                            // always continue, until we see the literal
+//                            if (!value.getRight()) {
+//                                return Maybe.of(foundSomething);
+//                            }
+//                            foundSomething = true;
+                            continue valueUpdater;
+                        }
+                        return Maybe.absent("Literal '"+literal+"' expected, when encountered '"+inputTokens+"'");
+                    } while (true);
+                }
+
+                if (tnv.isParseNodeMode(ExpressionParser.INTERPOLATED)) {
+                    if (optionalSkippingInput>0) continue;
+
+                    Maybe<String> varNameM = getSingleStringContents(tnv, "in template interpolated variable definition");
+                    if (varNameM.isAbsent()) return Maybe.castAbsent(varNameM);
+                    String varName = varNameM.get();
+
+                    if (inputTokens.isEmpty()) return Maybe.absent("End of input when looking for variable "+varName);
+
+                    chompWhitespace(inputTokens);
+                    String value;
+                    if (templateTokens.isEmpty()) {
+                        // last word (whether optional or not) takes everything
+                        value = getRemainderPossiblyRaw(inputTokens);
+                        inputTokens.clear();
+
+                    } else {
+                        Pair<String,Boolean> valueM = getNextInputTokenUpToPossibleExpectedLiteral(inputTokens, templateTokens, null, false);
+                        if (!valueM.getRight()) {
+                            // if we didn't find an expression, bail out
+                            return Maybe.absent("Did not find expression prior to expected literal");
+                        }
+                        value = valueM.getLeft();
+                    }
+                    boolean dotsMultipleWordMatch = varName.endsWith("...");
+                    if (dotsMultipleWordMatch) varName = Strings.removeFromEnd(varName, "...");
+                    String keys[] = varName.split("\\.");
+                    final String tt = varName;
+                    valueUpdater = v2 -> {
+                        Map target = result;
+                        for (int i=0; i<keys.length; i++) {
+                            if (!Pattern.compile("[A-Za-z0-9_-]+").matcher(keys[i]).matches()) {
+                                throw new IllegalArgumentException("Invalid variable '"+tt+"'");
+                            }
+                            if (i == keys.length - 1) {
+                                target.compute(keys[i], (k, v) -> v == null ? v2 : v + " " + v2);
+                            } else {
+                                // need to make sure we have a map or null
+                                target = (Map) target.compute(keys[i], (k, v) -> {
+                                    if (v == null) return MutableMap.of();
+                                    if (v instanceof Map) return v;
+                                    return Maybe.absent("Cannot process shorthand for " + Arrays.asList(keys) + " because entry '" + k + "' is not a map (" + v + ")");
+                                });
+                            }
+                        }
+                    };
+                    valueUpdater.accept(value);
+                    if (!dotsMultipleWordMatch && !templateTokens.isEmpty()) valueUpdater = null;
+                    continue;
+                }
+
+                if (tnv.isParseNodeMode(ExpressionParser.WHITESPACE)) {
+                    chompWhitespace(templateTokens);
+                    continue;
+                }
+
+                // unexpected token
+                return Maybe.absent("Unexpected token in shorthand pattern '"+template+"' at "+tnv+", followed by "+templateTokens);
+            }
+        }
+
+        private static Maybe<String> getSingleStringContents(ParseNodeOrValue tnv, String where) {
+            if (tnv==null)
+                Maybe.absent(()-> new IllegalArgumentException("No remaining tokens "+where));
+            if (tnv instanceof ParseValue) return Maybe.of(((ParseValue)tnv).getContents());
+            Maybe<ParseNodeOrValue> c = ((ParseNode) tnv).getOnlyContent();
+            if (c.isAbsent()) Maybe.absent(()-> new IllegalArgumentException("Expected single string "+where));
+            return getSingleStringContents(c.get(), where);
+        }
+
+        private static String getEscapedForInsideQuotedString(ParseNodeOrValue tnv, String where) {
+            if (tnv==null) throw new IllegalArgumentException("No remaining tokens "+where);
+            if (tnv instanceof ParseValue) return ((ParseValue)tnv).getContents();
+            if (ExpressionParser.isQuotedExpressionNode(tnv))
+                return ((ParseNode) tnv).getContents().stream().map(x -> getEscapedForInsideQuotedString(x, where)).collect(Collectors.joining());
+            else
+                return ((ParseNode) tnv).getContents().stream().map(x -> x.getSource()).collect(Collectors.joining());
+        }
+
+        private void chompWhitespace(List<ParseNodeOrValue> tt) {
+            while (!tt.isEmpty() && tt.get(0).isParseNodeMode(ExpressionParser.WHITESPACE)) tt.remove(0);
+        }
+
+        private String getRemainderPossiblyRaw(List<ParseNodeOrValue> remainder) {
+            if (options.finalMatchRaw) {
+                return remainder.stream().map(ParseNodeOrValue::getSource).collect(Collectors.joining());
+            } else {
+                return remainder.stream().map(x -> {
+                    if (x instanceof ParseValue) return ((ParseValue)x).getContents();
+                    return getRemainderPossiblyRaw(((ParseNode)x).getContents());
+                }).collect(Collectors.joining());
+            }
+        }
+
+        private Pair<String,Boolean> getNextInputTokenUpToPossibleExpectedLiteral(List<ParseNodeOrValue> inputTokens, List<ParseNodeOrValue> templateTokens, String nextLiteral, boolean removeLiteralFromInput) {
+            String value;
+            ParseNodeOrValue nextInput = inputTokens.iterator().next();
+            Boolean foundLiteral;
+            Boolean foundContentsPriorToLiteral;
+            if (ExpressionParser.isQuotedExpressionNode(nextInput)) {
+                // quoted expressions in input won't match template literals
+                value = getEscapedForInsideQuotedString(nextInput, "reading quoted input");
+                inputTokens.remove(0);
+                foundLiteral = false;
+                foundContentsPriorToLiteral = true;
+            } else {
+                boolean isLiteralExpected;
+                if (nextLiteral==null) {
+                    // input not quoted, no literal supplied; if next template token is literal, look for it
+                    chompWhitespace(templateTokens);
+                    ParseNodeOrValue nextTT = templateTokens.isEmpty() ? null : templateTokens.get(0);
+                    if (ExpressionParser.isQuotedExpressionNode(nextTT)) {
+                        Maybe<String> nextLiteralM = getSingleStringContents(nextTT, "identifying expected literal");
+                        isLiteralExpected = nextLiteralM.isPresent();
+                        nextLiteral = nextLiteralM.orNull();
+                    } else {
+                        isLiteralExpected = false;
+                    }
+                } else {
+                    isLiteralExpected = true;
+                }
+                if (isLiteralExpected) {
+                    value = "";
+                    while (true) {
+                        Maybe<String> vsm = getSingleStringContents(nextInput, "looking for literal '" + nextLiteral + "'");
+                        if (vsm.isAbsent()) {
+                            foundLiteral = false;
+                            break;
+                        }
+                        String vs = vsm.get();
+                        int nli = (" "+vs+" ").indexOf(nextLiteral); // wrap the token we got in spaces in case there is a quoted space in the next literal
+                        if (nli >= 0) {
+                            // literal found in unquoted string, eg "foo=bar" when literal is =
+                            if (nli>0) nli--; // walk back the space
+                            value += vs.substring(0, nli);
+                            value = Strings.trimEnd(value);
+                            if (removeLiteralFromInput) nli += nextLiteral.length();
+                            String putBackOnInput = vs.substring(nli);
+                            inputTokens.remove(0);
+                            if (!putBackOnInput.isEmpty()) inputTokens.add(0, new ParseValue(putBackOnInput));
+                            foundLiteral = true;
+                            break;
+                        } else {
+                            nli = (" "+value + vs).indexOf(nextLiteral);
+                            if (nli >= 0) {
+                                // found in concatenation
+                                if (nli>0) nli--; // walk back the space
+                                String putBackOnInput = (value + vs).substring(nli);
+                                value = (value + vs).substring(0, nli);
+                                value = Strings.trimEnd(value);
+                                inputTokens.remove(0);
+                                if (removeLiteralFromInput) putBackOnInput = putBackOnInput.substring(nextLiteral.length());
+                                if (!putBackOnInput.isEmpty()) inputTokens.add(0, new ParseValue(putBackOnInput));
+                                foundLiteral = true;
+                                break;
+                            } else {
+                                // literal not found
+                                value += vs;
+                                inputTokens.remove(0);
+                                if (inputTokens.isEmpty()) {
+                                    foundLiteral = false;
+                                    break;
+                                } else {
+                                    nextInput = inputTokens.iterator().next();
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                    foundContentsPriorToLiteral = Strings.isNonEmpty(value);
+                } else {
+                    // next is not a literal, so take the next, and caller will probably recurse, taking the entire rest as the value
+                    value = getSingleStringContents(nextInput, "taking remainder when no literal").or("");
+                    foundLiteral = false;
+                    foundContentsPriorToLiteral = true;
+                    inputTokens.remove(0);
+                }
+            }
+            return Pair.of(value, foundContentsPriorToLiteral);
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorQst.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/ShorthandProcessorQst.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.apache.brooklyn.util.collections.CollectionMerger;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.QuotedStringTokenizer;
+import org.apache.brooklyn.util.text.Strings;
+
+/**
+ * This is the original processor which relied purely on the QST.
+ *
+ * ===
+ *
+ * Accepts a shorthand template, and converts it to a map of values,
+ * e.g. given template "[ ?${type_set} ${sensor.type} ] ${sensor.name} \"=\" ${value}"
+ * and input "integer foo=3", this will return
+ * { sensor: { type: integer, name: foo }, value: 3, type_set: true }.
+ *
+ * Expects space-separated TOKEN where TOKEN is either:
+ *
+ * ${VAR} - to set VAR, which should be of the regex [A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*, with dot separation used to set nested maps;
+ *   will match a quoted string if supplied, else up to the next literal if the next token is a literal, else the next work.
+ * ${VAR...} - as above, but will collect multiple args if needed (if the next token is a literal matched further on, or if at end of word)
+ * "LITERAL" - to expect a literal expression. this must include the quotation marks and should include spaces if spaces are required.
+ * [ TOKEN ] - to indicate TOKEN is optional, where TOKEN is one of the above sections. parsing is attempted first with it, then without it.
+ * [ ?${VAR} TOKEN ] - as `[ TOKEN ]` but VAR is set true or false depending whether this optional section was matched.
+ *
+ * Would be nice to support A | B (exclusive or) for A or B but not both (where A might contain a literal for disambiguation),
+ * and ( X ) for X required but grouped (for use with | (exclusive or) where one option is required).
+ * Would also be nice to support any order, which could be ( A & B ) to allow A B or B A.
+ *
+ * But for now we've made do without it, with some compromises:
+ * * keywords must follow the order indicated
+ * * exclusive alternatives are disallowed by code subsequently or checked separately (eg Transform)
+ */
+public class ShorthandProcessorQst {
+
+    private final String template;
+    boolean finalMatchRaw = false;
+    boolean failOnMismatch = true;
+
+    public ShorthandProcessorQst(String template) {
+        this.template = template;
+    }
+
+    public Maybe<Map<String,Object>> process(String input) {
+        return new ShorthandProcessorQstAttempt(this, input).call();
+    }
+
+    /** whether the last match should preserve quotes and spaces; default false */
+    public ShorthandProcessorQst withFinalMatchRaw(boolean finalMatchRaw) {
+        this.finalMatchRaw = finalMatchRaw;
+        return this;
+    }
+
+    /** whether to fail on mismatched quotes in the input, default true */
+    public ShorthandProcessorQst withFailOnMismatch(boolean failOnMismatch) {
+        this.failOnMismatch = failOnMismatch;
+        return this;
+    }
+
+    static class ShorthandProcessorQstAttempt {
+        private final List<String> templateTokens;
+        private final String inputOriginal;
+        private final QuotedStringTokenizer qst;
+        private final String template;
+        private final ShorthandProcessorQst options;
+        int optionalDepth = 0;
+        int optionalSkippingInput = 0;
+        private String inputRemaining;
+        Map<String, Object> result;
+        Consumer<String> valueUpdater;
+
+        ShorthandProcessorQstAttempt(ShorthandProcessorQst proc, String input) {
+            this.template = proc.template;
+            this.options = proc;
+            this.qst = qst(template);
+            this.templateTokens = qst.remainderAsList();
+            this.inputOriginal = input;
+        }
+
+        private QuotedStringTokenizer qst(String x) {
+            return QuotedStringTokenizer.builder().includeQuotes(true).includeDelimiters(false).expectQuotesDelimited(true).failOnOpenQuote(options.failOnMismatch).build(x);
+        }
+
+        public synchronized Maybe<Map<String,Object>> call() {
+            if (result == null) {
+                result = MutableMap.of();
+                inputRemaining = inputOriginal;
+            } else {
+                throw new IllegalStateException("Only allowed to use once");
+            }
+            Maybe<Object> error = doCall();
+            if (error.isAbsent()) return Maybe.Absent.castAbsent(error);
+            inputRemaining = Strings.trimStart(inputRemaining);
+            if (Strings.isNonBlank(inputRemaining)) {
+                if (valueUpdater!=null) {
+                    QuotedStringTokenizer qstInput = qst(inputRemaining);
+                    valueUpdater.accept(getRemainderPossiblyRaw(qstInput));
+                } else {
+                    // shouldn't come here
+                    return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
+                }
+            }
+            return Maybe.of(result);
+        }
+
+        protected Maybe<Object> doCall() {
+            boolean isEndOfOptional = false;
+            outer: while (true) {
+                if (isEndOfOptional) {
+                    if (optionalDepth <= 0) {
+                        throw new IllegalStateException("Unexpected optional block closure");
+                    }
+                    optionalDepth--;
+                    if (optionalSkippingInput>0) {
+                        // we were in a block where we skipped something optional because it couldn't be matched; outer parser is now canonical,
+                        // and should stop skipping
+                        return Maybe.of(true);
+                    }
+                    isEndOfOptional = false;
+                }
+
+                if (templateTokens.isEmpty()) {
+                    if (Strings.isNonBlank(inputRemaining) && valueUpdater==null) {
+                        return Maybe.absent("Input has trailing characters after template is matched: '" + inputRemaining + "'");
+                    }
+                    if (optionalDepth>0)
+                        return Maybe.absent("Mismatched optional marker in template");
+                    return Maybe.of(true);
+                }
+                String t = templateTokens.remove(0);
+
+                if (t.startsWith("[")) {
+                    t = t.substring(1);
+                    if (!t.isEmpty()) {
+                        templateTokens.add(0, t);
+                    }
+                    String optionalPresentVar = null;
+                    if (!templateTokens.isEmpty() && templateTokens.get(0).startsWith("?")) {
+                        String v = templateTokens.remove(0);
+                        if (v.startsWith("?${") && v.endsWith("}")) {
+                            optionalPresentVar = v.substring(3, v.length() - 1);
+                        } else {
+                            throw new IllegalStateException("? after [ should indicate optional presence variable using syntax '?${var}', not '"+v+"'");
+                        }
+                    }
+                    Maybe<Object> cr;
+                    if (optionalSkippingInput<=0) {
+                        // make a deep copy so that valueUpdater writes get replayed
+                        Map<String, Object> backupResult = (Map) CollectionMerger.builder().deep(true).build().merge(MutableMap.of(), result);
+                        Consumer<String> backupValueUpdater = valueUpdater;
+                        String backupInputRemaining = inputRemaining;
+                        List<String> backupTemplateTokens = MutableList.copyOf(templateTokens);
+                        int oldDepth = optionalDepth;
+                        int oldSkippingDepth = optionalSkippingInput;
+
+                        optionalDepth++;
+                        cr = doCall();
+                        if (cr.isPresent()) {
+                            // succeeded
+                            if (optionalPresentVar!=null) result.put(optionalPresentVar, true);
+                            continue;
+
+                        } else {
+                            // restore
+                            result = backupResult;
+                            valueUpdater = backupValueUpdater;
+                            if (optionalPresentVar!=null) result.put(optionalPresentVar, false);
+                            inputRemaining = backupInputRemaining;
+                            templateTokens.clear();
+                            templateTokens.addAll(backupTemplateTokens);
+                            optionalDepth = oldDepth;
+                            optionalSkippingInput = oldSkippingDepth;
+
+                            optionalSkippingInput++;
+                            optionalDepth++;
+                            cr = doCall();
+                            if (cr.isPresent()) {
+                                optionalSkippingInput--;
+                                continue;
+                            }
+                        }
+                    } else {
+                        if (optionalPresentVar!=null) {
+                            result.put(optionalPresentVar, false);
+                            valueUpdater = null;
+                        }
+                        optionalDepth++;
+                        cr = doCall();
+                        if (cr.isPresent()) {
+                            continue;
+                        }
+                    }
+                    return cr;
+                }
+
+                isEndOfOptional = t.endsWith("]");
+
+                if (isEndOfOptional) {
+                    t = t.substring(0, t.length() - 1);
+                    if (t.isEmpty()) continue;
+                    // next loop will process the end of the optionality
+                }
+
+                if (qst.isQuoted(t)) {
+                    if (optionalSkippingInput>0) continue;
+
+                    String literal = qst.unwrapIfQuoted(t);
+                    do {
+                        // ignore leading spaces (since the quoted string tokenizer will have done that anyway); but their _absence_ can be significant for intra-token searching when matching a var
+                        inputRemaining = Strings.trimStart(inputRemaining);
+                        if (inputRemaining.startsWith(Strings.trimStart(literal))) {
+                            // literal found
+                            inputRemaining = inputRemaining.substring(Strings.trimStart(literal).length());
+                            continue outer;
+                        }
+                        if (inputRemaining.isEmpty()) return Maybe.absent("Literal '"+literal+"' expected, when end of input reached");
+                        if (valueUpdater!=null) {
+                            QuotedStringTokenizer qstInput = qst(inputRemaining);
+                            if (!qstInput.hasMoreTokens()) return Maybe.absent("Literal '"+literal+"' expected, when end of input tokens reached");
+                            String value = getNextInputTokenUpToPossibleExpectedLiteral(qstInput, literal);
+                            valueUpdater.accept(value);
+                            continue;
+                        }
+                        return Maybe.absent("Literal '"+literal+"' expected, when encountered '"+inputRemaining+"'");
+                    } while (true);
+                }
+
+                if (t.startsWith("${") && t.endsWith("}")) {
+                    if (optionalSkippingInput>0) continue;
+
+                    t = t.substring(2, t.length()-1);
+                    String value;
+
+                    inputRemaining = inputRemaining.trim();
+                    QuotedStringTokenizer qstInput = qst(inputRemaining);
+                    if (!qstInput.hasMoreTokens()) return Maybe.absent("End of input when looking for variable "+t);
+
+                    if (!templateTokens.stream().filter(x -> !x.equals("]")).findFirst().isPresent()) {
+                        // last word (whether optional or not) takes everything
+                        value = getRemainderPossiblyRaw(qstInput);
+                        inputRemaining = "";
+
+                    } else {
+                        value = getNextInputTokenUpToPossibleExpectedLiteral(qstInput, null);
+                    }
+                    boolean multiMatch = t.endsWith("...");
+                    if (multiMatch) t = Strings.removeFromEnd(t, "...");
+                    String keys[] = t.split("\\.");
+                    final String tt = t;
+                    valueUpdater = v2 -> {
+                        Map target = result;
+                        for (int i=0; i<keys.length; i++) {
+                            if (!Pattern.compile("[A-Za-z0-9_-]+").matcher(keys[i]).matches()) {
+                                throw new IllegalArgumentException("Invalid variable '"+tt+"'");
+                            }
+                            if (i == keys.length - 1) {
+                                target.compute(keys[i], (k, v) -> v == null ? v2 : v + " " + v2);
+                            } else {
+                                // need to make sure we have a map or null
+                                target = (Map) target.compute(keys[i], (k, v) -> {
+                                    if (v == null) return MutableMap.of();
+                                    if (v instanceof Map) return v;
+                                    return Maybe.absent("Cannot process shorthand for " + Arrays.asList(keys) + " because entry '" + k + "' is not a map (" + v + ")");
+                                });
+                            }
+                        }
+                    };
+                    valueUpdater.accept(value);
+                    if (!multiMatch) valueUpdater = null;
+                    continue;
+                }
+
+                // unexpected token
+                return Maybe.absent("Unexpected token in shorthand pattern '"+template+"' at position "+(template.lastIndexOf(t)+1));
+            }
+        }
+
+        private String getRemainderPossiblyRaw(QuotedStringTokenizer qstInput) {
+            String value;
+            value = Strings.join(qstInput.remainderRaw(), "");
+            if (!options.finalMatchRaw) {
+                return qstInput.unwrapIfQuoted(value);
+            }
+            return value;
+        }
+
+        private String getNextInputTokenUpToPossibleExpectedLiteral(QuotedStringTokenizer qstInput, String nextLiteral) {
+            String value;
+            String v = qstInput.nextToken();
+            if (qstInput.isQuoted(v)) {
+                // input was quoted, eg "\"foo=b\" ..." -- ignore the = in "foo=b"
+                value = qstInput.unwrapIfQuoted(v);
+                inputRemaining = inputRemaining.substring(v.length());
+            } else {
+                // input not quoted, if next template token is literal, look for it
+                boolean isLiteralExpected;
+                if (nextLiteral==null) {
+                    nextLiteral = templateTokens.get(0);
+                    if (qstInput.isQuoted(nextLiteral)) {
+                        nextLiteral = qstInput.unwrapIfQuoted(nextLiteral);
+                        isLiteralExpected = true;
+                    } else {
+                        isLiteralExpected = false;
+                    }
+                } else {
+                    isLiteralExpected = true;
+                }
+                if (isLiteralExpected) {
+                    int nli = v.indexOf(nextLiteral);
+                    if (nli>0) {
+                        // literal found in unquoted string, eg "foo=bar" when literal is =
+                        value = v.substring(0, nli);
+                        inputRemaining = inputRemaining.substring(value.length());
+                    } else {
+                        // literal not found
+                        value = v;
+                        inputRemaining = inputRemaining.substring(value.length());
+                    }
+                } else {
+                    // next is not a literal, so the whole token is the value
+                    value = v;
+                    inputRemaining = inputRemaining.substring(value.length());
+                }
+            }
+            return value;
+        }
+    }
+
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/WorkflowStepDefinition.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.api.mgmt.Task;
 import org.apache.brooklyn.config.ConfigKey;
@@ -159,11 +158,11 @@ public abstract class WorkflowStepDefinition {
     abstract public void populateFromShorthand(String value);
 
     protected void populateFromShorthandTemplate(String template, String value) {
-        populateFromShorthandTemplate(template, value, false, true, true);
+        populateFromShorthandTemplate(template, value, false, true);
     }
 
-    protected Map<String, Object> populateFromShorthandTemplate(String template, String value, boolean finalMatchRaw, boolean failOnMismatch, boolean failOnError) {
-        Maybe<Map<String, Object>> result = new ShorthandProcessor(template).withFinalMatchRaw(finalMatchRaw).withFailOnMismatch(failOnMismatch).process(value);
+    protected Map<String, Object> populateFromShorthandTemplate(String template, String value, boolean finalMatchRaw, boolean failOnError) {
+        Maybe<Map<String, Object>> result = new ShorthandProcessor(template).withFinalMatchRaw(finalMatchRaw).process(value);
         if (result.isAbsent()) {
             if (failOnError) throw new IllegalArgumentException("Invalid shorthand expression: '" + value + "'", Maybe.Absent.getException(result));
             return null;

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/SetSensorWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/SetSensorWorkflowStep.java
@@ -18,43 +18,41 @@
  */
 package org.apache.brooklyn.core.workflow.steps.appmodel;
 
-import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.AbstractEntity;
+import org.apache.brooklyn.core.entity.AbstractEntity.BasicSensorSupport;
 import org.apache.brooklyn.core.resolve.jackson.WrappedValue;
 import org.apache.brooklyn.core.sensor.Sensors;
-import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
 import org.apache.brooklyn.core.workflow.WorkflowStepDefinition;
 import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
-import org.apache.brooklyn.util.collections.MutableList;
-import org.apache.brooklyn.util.collections.MutableMap;
-import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.core.workflow.utils.WorkflowSettingItemsUtils;
 import org.apache.brooklyn.util.core.predicates.DslPredicates;
+import org.apache.brooklyn.util.core.predicates.DslPredicates.DslEntityPredicateDefault;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.text.StringEscapes;
-import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class SetSensorWorkflowStep extends WorkflowStepDefinition {
 
     private static final Logger LOG = LoggerFactory.getLogger(SetSensorWorkflowStep.class);
 
+    static final boolean ALWAYS_USE_SENSOR_MODIFY = true;
+
     public static final String SHORTHAND = "[ ${sensor.type} ] ${sensor.name} [ \"=\" ${value...} ]";
 
     public static final ConfigKey<EntityValueToSet> SENSOR = ConfigKeys.newConfigKey(EntityValueToSet.class, "sensor");
     public static final ConfigKey<Object> VALUE = ConfigKeys.newConfigKey(Object.class, "value");
-    public static final ConfigKey<DslPredicates.DslPredicate> REQUIRE = ConfigKeys.newConfigKey(DslPredicates.DslPredicate.class, "require");
+    public static final ConfigKey<DslPredicates.DslPredicate> REQUIRE = ConfigKeys.newConfigKey(DslPredicates.DslPredicate.class, "require",
+            "Require a condition in order to set the value; if the condition is not satisfied, the sensor is not set");
 
     @Override
     public void populateFromShorthand(String expression) {
@@ -84,172 +82,82 @@ public class SetSensorWorkflowStep extends WorkflowStepDefinition {
         EntityValueToSet sensor = context.getInput(SENSOR);
         if (sensor==null) throw new IllegalArgumentException("Sensor name is required");
 
-        String sensorNameFull = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_INPUT, sensor.name, String.class);
-        if (Strings.isBlank(sensorNameFull)) throw new IllegalArgumentException("Sensor name is required");
+        Pair<String, List<Object>> sensorNameAndIndices = WorkflowSettingItemsUtils.resolveNameAndBracketedIndices(context, sensor.name, false);
+        if (sensorNameAndIndices==null) throw new IllegalArgumentException("Sensor name is required");
 
-        List<Object> sensorNameIndexes = MutableList.of();
-        String sensorNameBase = extractSensorNameBaseAndPopulateIndices(sensorNameFull, sensorNameIndexes);
-
-        TypeToken<?> type = context.lookupType(sensor.type, () -> TypeToken.of(Object.class));
+        final TypeToken<?> type = context.lookupType(sensor.type, () -> TypeToken.of(Object.class));
         final Entity entity = sensor.entity!=null ? sensor.entity : context.getEntity();
-        AttributeSensor<Object> sensorBase = (AttributeSensor<Object>) Sensors.newSensor(type, sensorNameBase);
-        AtomicReference<Object> resolvedValue = new AtomicReference<>();
-        Object oldValue;
 
-        Runnable resolve = () -> {
+        Supplier<Object> resolveOnceValueSupplier = Suppliers.memoize(() -> {
 //        // might need to be careful if defined type is different or more generic than type specified here;
 //        // but that should be fine as XML persistence preserves types
 //        Sensor<?> sd = entity.getEntityType().getSensor(sensorName);
 //        if (!type.isSupertypeOf(sd.getTypeToken())) {
 //            ...
 //        }
+            return context.getInput(VALUE.getName(), type);
+        });
 
-            resolvedValue.set(context.getInput(VALUE.getName(), type));
-        };
-
+        AttributeSensor<Object> sensorBase = (AttributeSensor<Object>) Sensors.newSensor(type, sensorNameAndIndices.getLeft());
         DslPredicates.DslPredicate require = context.getInput(REQUIRE);
-        if (require==null && sensorNameIndexes.isEmpty()) {
-            resolve.run();
-            oldValue = entity.sensors().set(sensorBase, resolvedValue.get());
+        AtomicReference<Pair<Object, Object>> oldValues = new AtomicReference<>();
+        if (!ALWAYS_USE_SENSOR_MODIFY && require == null && sensorNameAndIndices.getRight().isEmpty()) {
+            // can do simple if not using 'require' and no indices - though there is no reason not to
+            // and if there is some special value which does an operation on the sensor, it's nice if we do
+            Pair<Object, Object> oldValuesP = WorkflowSettingItemsUtils.setAtIndex(sensorNameAndIndices, true,
+                    _oldInner -> resolveOnceValueSupplier.get(),
+                    // outer getter
+                    _name -> entity.sensors().get(sensorBase),
+                    // outer setter
+                    (_name, nv) -> entity.sensors().set(sensorBase, nv)
+            );
+            oldValues.set(oldValuesP);
+
         } else {
-            oldValue = entity.sensors().modify(sensorBase, oldBase -> {
-                if (require!=null) {
-                    Object old = oldBase;
-                    MutableList<Object> indexes = MutableList.copyOf(sensorNameIndexes);
-                    while (!indexes.isEmpty()) {
-                        Object i = indexes.remove(0);
-                        if (old == null) break;
-                        if (old instanceof Map) old = ((Map) old).get(i);
-                        else if (old instanceof Iterable && i instanceof Integer) {
-                            int ii = (Integer)i;
-                            int size = Iterables.size((Iterable) old);
-                            if (ii==-1) ii = size-1;
-                            old = (ii<0 || ii>=size) ? null : Iterables.get((Iterable) old, ii);
-                        } else {
-                            throw new IllegalArgumentException("Cannot find argument '" + i + "' in " + old);
-                        }
-                    }
+            // with 'require' we contractually need to do it all in the modify loop,
+            // performing the check (on the inner value if there are indices);
+            // even without, there might be concurrent blocks updating the same map/list if indexes are supplied
 
-                    if (old == null && !((AbstractEntity.BasicSensorSupport) entity.sensors()).contains(sensorBase.getName())) {
-                        DslPredicates.DslEntityPredicateDefault requireTweaked = new DslPredicates.DslEntityPredicateDefault();
-                        requireTweaked.sensor = sensorNameFull;
-                        requireTweaked.check = WrappedValue.of(require);
-                        if (!requireTweaked.apply(entity)) {
-                            throw new SensorRequirementFailedAbsent("Sensor " + sensorNameFull + " unset or unavailable when there is a non-absent requirement");
-                        }
-                    } else {
-                        if (!require.apply(old)) {
-                            throw new SensorRequirementFailed("Sensor " + sensorNameFull + " value does not match requirement", old);
-                        }
-                    }
-                }
+            // see testBeefySensorRequireForAtomicityAndConfigCountsMap for a thorough test
+            // (look for references to SetSensorWorkflowStep.REQUIRE)
 
-                resolve.run();
+            entity.sensors().modify(sensorBase,
+                    (oldOuterX) -> {
+                        AtomicReference<Object> newValue = new AtomicReference<>();
+                        Pair<Object, Object> oldValuesP = WorkflowSettingItemsUtils.setAtIndex(sensorNameAndIndices, true,
+                                oldInner -> {
+                                    if (require!=null) {
+                                        if (oldInner == null && !((BasicSensorSupport) entity.sensors()).contains(sensorBase.getName())) {
+                                            DslEntityPredicateDefault requireTweaked = new DslEntityPredicateDefault();
+                                            requireTweaked.sensor = sensorNameAndIndices.getLeft();
+                                            requireTweaked.check = WrappedValue.of(require);
+                                            if (!requireTweaked.apply(entity)) {
+                                                throw new SensorRequirementFailedAbsent("Sensor " + sensorNameAndIndices.getLeft() + " unset or unavailable when there is a non-absent requirement");
+                                            }
+                                        } else {
+                                            if (!require.apply(oldInner)) {
+                                                throw new SensorRequirementFailed("Sensor " + sensorNameAndIndices.getLeft() + " value does not match requirement", oldInner);
+                                            }
+                                        }
+                                    }
 
-                // now set
-                Object result;
-
-                if (!sensorNameIndexes.isEmpty()) {
-                    result = oldBase;
-
-                    // ensure mutable
-                    result = makeMutable(result, sensorNameIndexes);
-
-                    Object target = result;
-                    MutableList<Object> indexes = MutableList.copyOf(sensorNameIndexes);
-                    while (!indexes.isEmpty()) {
-                        Object i = indexes.remove(0);
-                        boolean isLast = indexes.isEmpty();
-                        Object nextTarget;
-
-                        if (target instanceof Map) {
-                            nextTarget = ((Map) target).get(i);
-                            if (nextTarget==null || isLast || !(nextTarget instanceof MutableMap)) {
-                                // ensure mutable
-                                nextTarget = isLast ? resolvedValue.get() : makeMutable(nextTarget, indexes);
-                                ((Map) target).put(i, nextTarget);
-                            }
-
-                        } else if (target instanceof Iterable && i instanceof Integer) {
-                            int ii = (Integer)i;
-                            int size = Iterables.size((Iterable) target);
-                            if (ii==-1) ii = size-1;
-                            boolean outOfBounds = ii < 0 || ii >= size;
-                            nextTarget = outOfBounds ? null : Iterables.get((Iterable) target, ii);
-
-                            if (nextTarget==null || isLast || (!(nextTarget instanceof MutableMap) && !(nextTarget instanceof MutableSet) && !(nextTarget instanceof MutableList))) {
-                                nextTarget = isLast ? resolvedValue.get() : makeMutable(nextTarget, indexes);
-                                if (outOfBounds) {
-                                    ((Collection) target).add(nextTarget);
-                                } else {
-                                    if (!(target instanceof List)) throw new IllegalStateException("Cannot set numerical position index in a non-list collection (and was not otherwise known as mutable; e.g. use MutableSet): "+target);
-                                    ((List) target).set(ii, nextTarget);
+                                    return resolveOnceValueSupplier.get();
+                                },
+                                // outer getter
+                                _name -> oldOuterX,
+                                // outer setter
+                                (_name, nv) -> {
+                                    newValue.set(nv);
+                                    return oldOuterX;
                                 }
-                            }
-
-                        } else {
-                            throw new IllegalArgumentException("Cannot find argument '" + i + "' in " + target);
-                        }
-                        target = nextTarget;
-                    }
-                } else {
-                    result = resolvedValue.get();
-                }
-
-                return Maybe.of(result);
-            });
+                        );
+                        oldValues.set(oldValuesP);
+                        return Maybe.of(newValue.get());
+                    });
         }
 
-        context.noteOtherMetadata("Value set", resolvedValue.get());
-        if (oldValue!=null) context.noteOtherMetadata("Previous value", oldValue);
-
+        WorkflowSettingItemsUtils.noteValueSetNestedMetadata(context, sensorNameAndIndices, resolveOnceValueSupplier.get(), oldValues.get());
         return context.getPreviousStepOutput();
-    }
-
-    static String extractSensorNameBaseAndPopulateIndices(String sensorNameFull, List<Object> sensorNameIndexes) {
-        int bracket = sensorNameFull.indexOf('[');
-        String sensorNameBase;
-        if (bracket > 0) {
-            sensorNameBase = sensorNameFull.substring(0, bracket);
-            String brackets = sensorNameFull.substring(bracket);
-            while (!brackets.isEmpty()) {
-                if (!brackets.startsWith("[")) throw new IllegalArgumentException("Expected '[' for sensor index");
-                brackets = brackets.substring(1).trim();
-                int bi = brackets.indexOf(']');
-                if (bi<0) throw new IllegalArgumentException("Mismatched ']' in sensor name");
-                String bs = brackets.substring(0, bi).trim();
-                if (bs.startsWith("\"") || bs.startsWith("\'")) bs = StringEscapes.BashStringEscapes.unwrapBashQuotesAndEscapes(bs);
-                else if (bs.matches("-? *[0-9]+")) {
-                    sensorNameIndexes.add(Integer.parseInt(bs));
-                    bs = null;
-                }
-                if (bs!=null) {
-                    sensorNameIndexes.add(bs);
-                }
-                brackets = brackets.substring(bi+1).trim();
-            }
-        } else if (bracket == 0) {
-            throw new IllegalArgumentException("Sensor name cannot start with '['");
-        } else {
-            sensorNameBase = sensorNameFull;
-        }
-        return sensorNameBase;
-    }
-
-    static Object makeMutable(Object x, List<Object> indexesRemaining) {
-        if (x==null) {
-            // look ahead to see if it should be a list
-            if (indexesRemaining!=null && !indexesRemaining.isEmpty() && indexesRemaining.get(0) instanceof Integer) return MutableList.of();
-            return MutableMap.of();
-        }
-
-        if (x instanceof Set) {
-            if (!(x instanceof MutableSet)) return MutableSet.copyOf((Set) x);
-            return x;
-        }
-        if (x instanceof Map && !(x instanceof MutableMap)) return MutableMap.copyOf((Map) x);
-        else if (x instanceof Iterable && !(x instanceof MutableList)) return MutableList.copyOf((Iterable) x);
-        return x;
     }
 
     @Override protected Boolean isDefaultIdempotent() { return true; }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/UpdateChildrenWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/appmodel/UpdateChildrenWorkflowStep.java
@@ -241,7 +241,11 @@ public class UpdateChildrenWorkflowStep extends WorkflowStepDefinition implement
             stepState.parent = parentId!=null ? WorkflowStepResolution.findEntity(context, parentId).get() : context.getEntity();
 
             stepState.identifier_expression = TypeCoercions.coerce(context.getInputRaw(IDENTIFIER_EXRPESSION.getName()), String.class);
-            stepState.items = context.getInput(ITEMS);
+            try {
+                stepState.items = context.getInput(ITEMS);
+            } catch (Exception e) {
+                throw new IllegalStateException("Cannot resolve items as a list", e);
+            }
             if (stepState.items==null) throw new IllegalStateException("Items cannot be null");
             setStepState(context, stepState);
         } else {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/SetVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/SetVariableWorkflowStep.java
@@ -74,7 +74,7 @@ public class SetVariableWorkflowStep extends WorkflowStepDefinition {
 
     @Override
     public void populateFromShorthand(String expression) {
-        Map<String, Object> newInput = populateFromShorthandTemplate(SHORTHAND, expression, true, true, true);
+        Map<String, Object> newInput = populateFromShorthandTemplate(SHORTHAND, expression, true, true);
         if (newInput.get(VALUE.getName())!=null && input.get(INTERPOLATION_MODE.getName())==null) {
             setInput(INTERPOLATION_MODE, InterpolationMode.WORDS);
         }

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReplace.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformReplace.java
@@ -19,10 +19,8 @@
 package org.apache.brooklyn.core.workflow.steps.variables;
 
 import org.apache.brooklyn.core.workflow.ShorthandProcessor;
-import org.apache.brooklyn.core.workflow.WorkflowExecutionContext;
 import org.apache.brooklyn.util.guava.Maybe;
 
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -40,7 +38,6 @@ public class TransformReplace extends WorkflowTransformDefault {
     protected void initCheckingDefinition() {
         Maybe<Map<String, Object>> maybeResult = new ShorthandProcessor(SHORTHAND)
                 .withFinalMatchRaw(false)
-                .withFailOnMismatch(true)
                 .process(transformDef);
 
         if (maybeResult.isPresent()) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSetWorkflowVariable.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSetWorkflowVariable.java
@@ -39,7 +39,7 @@ public class TransformSetWorkflowVariable extends WorkflowTransformDefault {
     @Override
     public Object apply(Object v) {
         String nameToSet = context.resolve(WorkflowExpressionResolution.WorkflowExpressionStage.STEP_RUNNING, name, String.class);
-        SetVariableWorkflowStep.setWorkflowScratchVariableDotSeparated(stepContext, nameToSet, v);
+        SetVariableWorkflowStep.setWorkflowScratchVariableDotSeparated(stepContext, nameToSet, v, false);
         return v;
     }
 

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSplit.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformSplit.java
@@ -18,22 +18,14 @@
  */
 package org.apache.brooklyn.core.workflow.steps.variables;
 
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import com.google.common.base.Splitter;
 import org.apache.brooklyn.core.workflow.ShorthandProcessor;
-import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.guava.Maybe;
-import org.apache.brooklyn.util.javalang.Boxing;
-import org.apache.brooklyn.util.text.Strings;
-import org.apache.commons.lang3.StringUtils;
 
 public class TransformSplit extends WorkflowTransformDefault {
 
@@ -47,7 +39,6 @@ public class TransformSplit extends WorkflowTransformDefault {
     protected void initCheckingDefinition() {
         Maybe<Map<String, Object>> maybeResult = new ShorthandProcessor(SHORTHAND)
                 .withFinalMatchRaw(false)
-                .withFailOnMismatch(true)
                 .process(transformDef);
 
         if (maybeResult.isPresent()) {

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
@@ -86,7 +86,7 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
     public void populateFromShorthand(String expression) {
         Map<String, Object> match = null;
         for (int i=0; i<SHORTHAND_OPTIONS.length && match==null; i++)
-            match = populateFromShorthandTemplate(SHORTHAND_OPTIONS[i], expression, false, true, false);
+            match = populateFromShorthandTemplate(SHORTHAND_OPTIONS[i], expression, false, false);
 
         if (match==null && Strings.isNonBlank(expression)) {
             throw new IllegalArgumentException("Invalid shorthand expression for transform: '" + expression + "'");

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/steps/variables/TransformVariableWorkflowStep.java
@@ -18,6 +18,16 @@
  */
 package org.apache.brooklyn.core.workflow.steps.variables;
 
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
@@ -41,16 +51,6 @@ import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.apache.brooklyn.core.workflow.WorkflowExecutionContext.STEP_TARGET_NAME_FOR_END;
 import static org.apache.brooklyn.core.workflow.steps.variables.SetVariableWorkflowStep.setWorkflowScratchVariableDotSeparated;
@@ -218,12 +218,7 @@ public class TransformVariableWorkflowStep extends WorkflowStepDefinition {
         if (setVariableAtEnd) {
             if (varName==null) throw new IllegalStateException("Variable name not specified when setting variable"); // shouldn't happen
 
-            setWorkflowScratchVariableDotSeparated(context, varName, v);
-            // easily inferred from workflow vars, now that updates are stored separately
-//            Object oldValue =
-//              <above> setWorkflowScratchVariableDotSeparated(context, varName, v);
-//            context.noteOtherMetadata("Value set", v);
-//            if (oldValue != null) context.noteOtherMetadata("Previous value", oldValue);
+            setWorkflowScratchVariableDotSeparated(context, varName, v, false);
 
             if (context.getOutput()!=null) throw new IllegalStateException("Transform that produces output results cannot be used when setting a variable");
             if (STEP_TARGET_NAME_FOR_END.equals(context.next)) throw new IllegalStateException("Return transform cannot be used when setting a variable");

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/utils/ExpressionParser.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/utils/ExpressionParser.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.utils;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.BackslashParseMode;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.brooklyn.util.text.Strings;
+
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.CharactersCollectingParseMode;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.CommonParseMode;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseMode;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNode;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNodeOrValue;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseValue;
+import static org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.TopLevelParseMode;
+
+/** simplistic parser for workflow expressions and strings, recognizing single and double quotes, backslash escapes, and interpolated strings with ${...} */
+public abstract class ExpressionParser {
+
+    public abstract Maybe<ParseNode> parse(String input);
+    public abstract Maybe<List<ParseNodeOrValue>> parseEverything(String inputRemaining);
+
+
+    public static final ParseMode BACKSLASH_ESCAPE = new BackslashParseMode();
+    public static final ParseMode WHITESPACE = new CharactersCollectingParseMode("whitespace", Character::isWhitespace);
+
+    public static final ParseMode DOUBLE_QUOTE = CommonParseMode.transitionNested("double_quote", "\"", "\"");
+    public static final ParseMode SINGLE_QUOTE = CommonParseMode.transitionNested("single_quote", "\'", "\'");
+    public static final ParseMode INTERPOLATED = CommonParseMode.transitionNested("interpolated_expression", "${", "}");
+
+    public static final ParseMode SQUARE_BRACKET = CommonParseMode.transitionNested("square_bracket", "[", "]");
+    public static final ParseMode PARENTHESES = CommonParseMode.transitionNested("parenthesis", "(", ")");
+    public static final ParseMode CURLY_BRACES = CommonParseMode.transitionNested("curly_brace", "{", "}");
+
+
+    private static Multimap<ParseMode,ParseMode> getCommonInnerTransitions() {
+        ListMultimap<ParseMode,ParseMode> m = Multimaps.newListMultimap(MutableMap.of(), MutableList::of);
+        m.putAll(BACKSLASH_ESCAPE, MutableList.of());
+        m.putAll(SINGLE_QUOTE, MutableList.of(BACKSLASH_ESCAPE, INTERPOLATED));
+        m.putAll(DOUBLE_QUOTE, MutableList.of(BACKSLASH_ESCAPE, INTERPOLATED));
+        m.putAll(INTERPOLATED, MutableList.of(BACKSLASH_ESCAPE, DOUBLE_QUOTE, SINGLE_QUOTE, INTERPOLATED));
+        return Multimaps.unmodifiableMultimap(m);
+    }
+    public static final Multimap<ParseMode,ParseMode> COMMON_INNER_TRANSITIONS = getCommonInnerTransitions();
+    public static final List<ParseMode> COMMON_TOP_LEVEL_TRANSITIONS = MutableList.of(BACKSLASH_ESCAPE, DOUBLE_QUOTE, SINGLE_QUOTE, INTERPOLATED).asUnmodifiable();
+
+
+    public static ExpressionParserImpl newDefaultAllowingUnquotedAndSplittingOnWhitespace() {
+        return new ExpressionParserImpl(new TopLevelParseMode(true),
+                MutableList.copyOf(COMMON_TOP_LEVEL_TRANSITIONS).append(WHITESPACE),
+                COMMON_INNER_TRANSITIONS);
+    }
+    public static ExpressionParserImpl newDefaultAllowingUnquotedLiteralValues() {
+        return new ExpressionParserImpl(new TopLevelParseMode(true),
+                MutableList.copyOf(COMMON_TOP_LEVEL_TRANSITIONS),
+                COMMON_INNER_TRANSITIONS);
+    }
+    public static ExpressionParserImpl newDefaultRequiringQuotingOrExpressions() {
+        return new ExpressionParserImpl(new TopLevelParseMode(false),
+                MutableList.copyOf(COMMON_TOP_LEVEL_TRANSITIONS),
+                COMMON_INNER_TRANSITIONS);
+    }
+
+    public static ExpressionParserImpl newEmptyDefault(boolean requiresQuoting) {
+        return newEmpty(new TopLevelParseMode(!requiresQuoting));
+    }
+    public static ExpressionParserImpl newEmpty(TopLevelParseMode topLevel) {
+        return new ExpressionParserImpl(topLevel, MutableList.of());
+    }
+
+
+    public static boolean isQuotedExpressionNode(ParseNodeOrValue next) {
+        if (next==null) return false;
+        return next.isParseNodeMode(SINGLE_QUOTE) || next.isParseNodeMode(DOUBLE_QUOTE);
+    }
+
+    public static String getAllUnquoted(List<ParseNodeOrValue> mp) {
+        return join(mp, ExpressionParser::getUnquoted);
+    }
+
+    public static String getAllSource(List<ParseNodeOrValue> mp) {
+        return join(mp, ParseNodeOrValue::getSource);
+    }
+
+    public static String getUnescapedButNotUnquoted(List<ParseNodeOrValue> mp) {
+        return join(mp, ExpressionParser::getUnescapedButNotUnquoted);
+    }
+
+    public static String getUnescapedButNotUnquoted(ParseNodeOrValue mp) {
+        if (mp instanceof ParseValue) return ((ParseValue)mp).getContents();
+
+        // backslashes are unescaped
+        if (mp.isParseNodeMode(BACKSLASH_ESCAPE)) return getAllSource(((ParseNode)mp).getContents());
+
+        // in interpolations we don't unescape
+        if (mp.isParseNodeMode(INTERPOLATED)) return mp.getSource();
+        // in double quotes we don't unescape
+        if (isQuotedExpressionNode(mp)) return mp.getSource();
+
+        // everything else is recursed
+        return getContentsWithStartAndEnd((ParseNode) mp, ExpressionParser::getUnescapedButNotUnquoted);
+    }
+
+    public static String getContentsWithStartAndEnd(ParseNode mp, Function<List<ParseNodeOrValue>,String> fn) {
+        String v = fn.apply(mp.getContents());
+        ParseMode m = mp.getParseNodeModeClass();
+        if (m instanceof CommonParseMode) {
+            return Strings.toStringWithValueForNull(((CommonParseMode)m).enterOnString, "")
+                    + v
+                    + Strings.toStringWithValueForNull(((CommonParseMode)m).exitOnString, "");
+        }
+        return v;
+    }
+
+    public static boolean startsWithWhitespace(ParseNodeOrValue pn) {
+        if (pn.isParseNodeMode(WHITESPACE)) return true;
+        if (pn instanceof ParseValue) return ((ParseValue)pn).getContents().startsWith(" ");
+        return ((ParseNode)pn).getStartingContent().map(ExpressionParser::startsWithWhitespace).or(false);
+    }
+
+
+    public static String join(List<ParseNodeOrValue> mp, Function<ParseNodeOrValue,String> fn) {
+        return mp.stream().map(fn).collect(Collectors.joining());
+    }
+
+    public static String getUnquoted(ParseNodeOrValue mp) {
+        if (mp instanceof ParseValue) return ((ParseValue)mp).getContents();
+        ParseNode mpn = (ParseNode) mp;
+
+        // unquote, unescaping what's inside
+        if (isQuotedExpressionNode(mp)) return getUnescapedButNotUnquoted(((ParseNode) mp).getContents());
+
+        // source for anything else
+        return mp.getSource();
+    }
+
+    /** removes whitespace, either WHITESPACE nodes, or values containing whitespace */
+    public static boolean isBlank(ParseNodeOrValue n) {
+        if (n.isParseNodeMode(WHITESPACE)) return true;
+        if (n instanceof ParseValue) return Strings.isBlank(((ParseValue) n).getContents());
+        return false;
+    }
+
+    /** removes whitespace, either WHITESPACE or empty/blank ParseValue nodes,
+     * and changing ParseValues starting or ending with whitespace and the start or end (once other whitespace removed) */
+    public static List<ParseNodeOrValue> trimWhitespace(List<ParseNodeOrValue> contents) {
+        return trimWhitespace(contents, true, true);
+    }
+    public static List<ParseNodeOrValue> trimWhitespace(List<ParseNodeOrValue> contents, boolean removeFromStart, boolean removeFromEnd) {
+        List<ParseNodeOrValue> result = MutableList.of();
+        boolean changed = false;
+        Iterator<ParseNodeOrValue> ni = contents.iterator();
+        while (ni.hasNext()) {
+            ParseNodeOrValue n = ni.next();
+            if (isBlank(n)) {
+                changed = true;
+                continue;
+
+            } else {
+                if (n instanceof ParseValue) {
+                    String c = ((ParseValue) n).getContents();
+                    if (Character.isWhitespace(c.charAt(0))) {
+                        changed = true;
+                        while (!c.isEmpty() && Character.isWhitespace(c.charAt(0))) c = c.substring(1);
+                        n = new ParseValue(c);
+                    }
+                }
+                result.add(n);
+                break;
+            }
+        }
+        if (ni.hasNext()) {
+            // did the start - now need to identify the last non-whitespace thing, and then will need to replay it
+            ParseNodeOrValue lastNonWhite = null;
+            for (ParseNodeOrValue pn: contents) {
+                if (!isBlank(pn)) lastNonWhite = pn;
+            }
+            if (lastNonWhite==null) throw new IllegalStateException("Non-whitespace was found but then not found"); // shouldn't happen
+
+            ParseNodeOrValue n;
+            do {
+                n = ni.next();
+                if (n == lastNonWhite) break;
+                result.add(n);
+            } while (ni.hasNext());
+
+            if (n instanceof ParseValue) {
+                String c = ((ParseValue) n).getContents();
+                if (Character.isWhitespace(c.charAt(c.length()-1))) {
+                    changed = true;
+                    while (!c.isEmpty() && Character.isWhitespace(c.charAt(c.length()-1))) c = c.substring(0, c.length()-1);
+                    n = new ParseValue(c);
+                }
+            }
+            result.add(n);
+
+            // and ignore the rest
+        }
+
+        if (!changed) return contents;
+        return result;
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/utils/ExpressionParserImpl.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/utils/ExpressionParserImpl.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.utils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.guava.Maybe;
+
+/** simplistic parser for workflow expressions and strings, recognizing single and double quotes, backslash escapes, and interpolated strings with ${...} */
+public class ExpressionParserImpl extends ExpressionParser {
+
+    public interface ParseNodeOrValue {
+        String getParseNodeMode();
+        default boolean isParseNodeMode(String pm, String ...pmi) {
+            if (Objects.equals(getParseNodeMode(), pm)) return true;
+            for (String pmx: pmi) {
+                if (Objects.equals(getParseNodeMode(), pmx)) return true;
+            }
+            return false;
+        }
+        default boolean isParseNodeMode(ParseMode pm, ParseMode ...pmi) {
+            if (Objects.equals(getParseNodeMode(), pm.getModeName())) return true;
+            for (ParseMode pmx: pmi) {
+                if (Objects.equals(getParseNodeMode(), pmx.getModeName())) return true;
+            }
+            return false;
+        }
+        default boolean isParseNodeMode(Collection<ParseMode> pm) {
+            return pm.stream().anyMatch(pmx -> Objects.equals(getParseNodeMode(), pmx.getModeName()));
+        }
+        String getSource();
+        Object getContents();
+    }
+    public static class ParseValue implements ParseNodeOrValue {
+        public final static String MODE = "value";
+        final String value;
+
+        public ParseValue(String value) { this.value = value; }
+
+        @Override
+        public String getSource() {
+            return value;
+        }
+
+        @Override public String getContents() { return value; }
+
+        @Override
+        public String toString() {
+            return "["+value+"]";
+        }
+
+        @Override
+        public String getParseNodeMode() {
+            return MODE;
+        }
+    }
+    public static class ParseNode implements ParseNodeOrValue {
+        String source;
+        ParseMode mode;
+        public ParseNode(ParseMode mode, String source) {
+            this.mode = mode;
+            this.source = source;
+        }
+        public static ParseNode ofValue(ParseMode mode, String source, String value) {
+            ParseNode pr = new ParseNode(mode, source);
+            pr.contents = MutableList.of(new ParseValue(value));
+            return pr;
+        }
+        List<ParseNodeOrValue> contents = null;
+
+        public String getSource() {
+            return source;
+        }
+        @Override public String getParseNodeMode() {
+            return mode.name;
+        }
+        public ParseMode getParseNodeModeClass() {
+            return mode;
+        }
+
+        public List<ParseNodeOrValue> getContents() {
+            return contents;
+        }
+        public Maybe<ParseNodeOrValue> getOnlyContent() {
+            if (contents==null) return Maybe.absent("no contents set");
+            if (contents.size()==1) return Maybe.of(contents.iterator().next());
+            return Maybe.absent(contents.isEmpty() ? "no items" : contents.size()+" items");
+        }
+        public Maybe<ParseNodeOrValue> getFinalContent() {
+            if (contents==null) return Maybe.absent("no contents set");
+            if (contents.isEmpty()) return Maybe.absent("contents empty");
+            return Maybe.of(contents.get(contents.size() - 1));
+        }
+        public Maybe<ParseNodeOrValue> getStartingContent() {
+            if (contents==null) return Maybe.absent("no contents set");
+            if (contents.isEmpty()) return Maybe.absent("contents empty");
+            return Maybe.of(contents.get(0));
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(mode.name);
+            if (contents==null) sb.append("?");
+
+            if (contents!=null && contents.size()==1 && getOnlyContent().get() instanceof ParseValue) sb.append(contents.iterator().next().toString());
+            else {
+                sb.append("[");
+                if (contents == null) sb.append(source);
+                else sb.append(contents.stream().map(c -> c.toString()).collect(Collectors.joining()));
+                sb.append("]");
+            }
+            return sb.toString();
+        }
+    }
+
+    public static class InternalParseResult {
+        public final boolean skip;
+        public boolean earlyTerminationRequested;
+        @Nullable /** null means no error and no result */
+        public final Maybe<ParseNode> resultOrError;
+        protected InternalParseResult(boolean skip, Maybe<ParseNode> resultOrError) {
+            this.skip = skip;
+            this.resultOrError = resultOrError;
+        }
+        public static final InternalParseResult SKIP = new InternalParseResult(true, null);
+
+        public static InternalParseResult of(ParseNode parseModeResult) {
+            return new InternalParseResult(false, Maybe.of(parseModeResult));
+        }
+        public static InternalParseResult ofValue(ParseMode mode, String source, String value) {
+            return of(ParseNode.ofValue(mode, source, value));
+        }
+        public static InternalParseResult ofError(String message) {
+            return new InternalParseResult(false, Maybe.absent(message));
+        }
+        public static InternalParseResult ofError(Throwable t) {
+            return new InternalParseResult(false, Maybe.absent(t));
+        }
+    }
+
+    public abstract static class ParseMode {
+        final String name;
+
+        public ParseMode(String name) {
+            this.name = name;
+        }
+
+        public String getModeName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        public abstract InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> allowedTransitions, @Nullable Collection<ParseMode> transitionsAllowedHereOverride);
+    }
+
+    public static class CommonParseMode extends ParseMode {
+        public final String enterOnString;
+        public final String exitOnString;
+
+        /** parses anything starting with 'enterOnString'; if exitOnString is not null, it does so until 'exitOnString' is encountered, then reverts to previous mode */
+        protected CommonParseMode(String name, String enterOnString, @Nullable String exitOnString) {
+            super(name);
+            Preconditions.checkNotNull(enterOnString);
+            this.enterOnString = enterOnString;
+            this.exitOnString = exitOnString;
+        }
+
+        /** parses anything starting with 'enterOnString', until another mode is entered */
+        public static CommonParseMode transitionSimple(String name, String enterOnString) {
+            Preconditions.checkNotNull(enterOnString);
+            Preconditions.checkArgument(!enterOnString.isEmpty());
+            return new CommonParseMode(name, enterOnString, null);
+        }
+
+        /** parses anything starting with 'enterOnString', until 'exitOnString' is reached when it reverts to previous mode */
+        public static CommonParseMode transitionNested(String name, String enterOnString, String exitOnString) {
+            Preconditions.checkNotNull(exitOnString);
+            Preconditions.checkArgument(!exitOnString.isEmpty());
+            return new CommonParseMode(name, enterOnString, exitOnString);
+        }
+
+        public boolean allowedToTakeUnmatchedCharsAsLiteralValue() { return true; /** currently all non-top-level custom parse modes do this; but could be overridden */ }
+        public boolean allowedToExitBeforeExitStringEncountered() { return false; /** currently all non-top-level custom parse modes do not this; but could be overridden */ }
+
+        public InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> allowedTransitions, Collection<ParseMode> transitionsAllowedHereOverride) {
+            if (!input.substring(offset).startsWith(enterOnString)) return InternalParseResult.SKIP;
+
+            ParseMode currentLevelMode = this;
+            ParseNode result = new ParseNode(currentLevelMode, input);
+            result.contents = MutableList.of();
+            int i=offset;
+            if (!input.substring(i).startsWith(enterOnString))
+                return InternalParseResult.ofError("wrong start sequence for " + currentLevelMode + " at position " + i);
+            i+= enterOnString.length();
+
+            int last = i;
+            boolean exitStringEncountered = false;
+            boolean earlyTerminationRequested = false;
+            if (transitionsAllowedHereOverride==null) transitionsAllowedHereOverride = allowedTransitions.get(currentLevelMode);
+            if (transitionsAllowedHereOverride==null || transitionsAllowedHereOverride.isEmpty()) throw new IllegalStateException("Mode '"+currentLevelMode+"' is not configured with any transitions");
+            input: while (i<input.length()) {
+                if (exitOnString !=null && input.substring(i).startsWith(exitOnString)) {
+                    if (i>last) result.contents.add(new ParseValue(input.substring(last, i)));
+                    i+= exitOnString.length();
+                    last = i;
+                    exitStringEncountered = true;
+                    break;
+                }
+                Maybe<ParseNode> error = null;
+                for (ParseMode candidate: transitionsAllowedHereOverride) {
+                    InternalParseResult cpr = candidate.parse(input, i, allowedTransitions, null);
+                    if (cpr.skip) continue;
+                    if (cpr.resultOrError.isPresent()) {
+                        if (i>last) result.contents.add(new ParseValue(input.substring(last, i)));
+                        result.contents.add(cpr.resultOrError.get());
+                        i += cpr.resultOrError.get().source.length();
+                        last = i;
+                        if (cpr.earlyTerminationRequested) {
+                            earlyTerminationRequested = true;
+                            break input;
+                        }
+                        continue input;
+                    }
+                    if (error == null) {
+                        error = cpr.resultOrError;
+                    } else {
+                        // multiple possible modes, not used currently;
+                        // only take error from first mode
+                    }
+                }
+                if (!allowedToTakeUnmatchedCharsAsLiteralValue() && error==null) {
+                    if (allowedToExitBeforeExitStringEncountered()) break;
+                    error = Maybe.absent("Characters starting at " + i + " not permitted for " + currentLevelMode);
+                }
+                if (error!=null) return InternalParseResult.ofError(Maybe.Absent.getException(error));
+                i++;
+            }
+
+            if (!exitStringEncountered && !allowedToExitBeforeExitStringEncountered()) return InternalParseResult.ofError("Non-terminated "+currentLevelMode.name);
+            if (i>last) result.contents.add(new ParseValue(input.substring(last, i)));
+            last = i;
+            result.source = input.substring(offset, last);
+            InternalParseResult resultIPR = InternalParseResult.of(result);
+            Maybe<ParseNodeOrValue> lastPMR = result.getFinalContent();
+            if (earlyTerminationRequested) {
+                resultIPR.earlyTerminationRequested = true;
+            }
+            return resultIPR;
+        }
+    }
+
+    public static class BackslashParseMode extends ParseMode {
+        public static final Map<Character,String> COMMON_ESAPES = MutableMap.of(
+                'n', "\n",
+                'r', "\r",
+                't', "\t",
+                '0', "\0"
+                // these are supported because by default we support the same character
+//                '\'', "\'",
+//                '\"', "\""
+        ).asUnmodifiable();
+
+        public BackslashParseMode() { super(MODE); }
+        final static String MODE = "backslash_escape";
+        final static String START = "\\";
+        @Override
+        public InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> _allowedTransitions, Collection<ParseMode> _transitionsAllowedHereOverride) {
+            if (!input.substring(offset).startsWith(START)) return InternalParseResult.SKIP;
+            if (input.substring(offset).length()>=2) {
+                char c = input.charAt(offset+1);
+                return InternalParseResult.ofValue(this, input.substring(offset, offset+2), Maybe.ofDisallowingNull(COMMON_ESAPES.get(c)).or(() -> ""+c));
+            } else {
+                return InternalParseResult.ofError("Backslash escape character not permitted at end of string");
+            }
+        }
+    }
+
+    public static class CharactersCollectingParseMode extends ParseMode {
+        final Predicate<Character> charactersAcceptable;
+        public CharactersCollectingParseMode(String name, Predicate<Character> charactersAcceptable) {
+            super(name);
+            this.charactersAcceptable = charactersAcceptable;
+        }
+        public CharactersCollectingParseMode(String name, char c) {
+            this(name, cx -> Objects.equals(cx, c));
+        }
+        @Override
+        public InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> _allowedTransitions, Collection<ParseMode> _transitionsAllowedHereOverride) {
+            int i=offset;
+            while (i<input.length() && charactersAcceptable.test(input.charAt(i))) {
+                i++;
+            }
+            if (i>offset) {
+                String v = input.substring(offset, i);
+                return InternalParseResult.ofValue(this, v, v);
+            } else {
+                return InternalParseResult.SKIP;
+            }
+        }
+    }
+
+    public static class TopLevelParseMode extends CommonParseMode {
+        private final boolean allowsValues;
+        private final List<ParseMode> allowedTransitions = MutableList.of();
+        public List<String> mustEndWithOneOfTheseModes;
+
+        protected TopLevelParseMode(boolean allowsUnquotedLiteralValues) {
+            super("top-level", "", null);
+            this.allowsValues = allowsUnquotedLiteralValues;
+        }
+
+        @Override
+        public boolean allowedToTakeUnmatchedCharsAsLiteralValue() {
+            return allowsValues;
+        }
+
+        @Override
+        public boolean allowedToExitBeforeExitStringEncountered() {
+            return true;
+        }
+
+        @Override
+        public InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> allowedTransitions, Collection<ParseMode> transitionsAllowedHereOverride) {
+            InternalParseResult result = super.parse(input, offset, allowedTransitions, transitionsAllowedHereOverride);
+            if (mustEndWithOneOfTheseModes!=null && result.resultOrError.isPresent()) {
+                String error = result.resultOrError.get().getFinalContent().map(pn ->
+                        mustEndWithOneOfTheseModes.contains(pn.getParseNodeMode())
+                            ? null
+                            : "Expression ends with " + pn.getParseNodeMode() + " but should have ended with required token: " + mustEndWithOneOfTheseModes)
+                        .or("Expression is empty but was expected to end with required token: " + mustEndWithOneOfTheseModes);
+                if (error!=null) return InternalParseResult.ofError(error);
+            }
+            return result;
+        }
+    }
+
+    private final Multimap<ParseMode,ParseMode> allowedTransitions = Multimaps.newListMultimap(MutableMap.of(), MutableList::of);
+    private final TopLevelParseMode topLevel;
+
+    protected ExpressionParserImpl(TopLevelParseMode topLevel, List<ParseMode> allowedAtTopLevel, Multimap<ParseMode,ParseMode> allowedTransitions) {
+        this(topLevel, allowedAtTopLevel);
+        this.allowedTransitions.putAll(allowedTransitions);
+    }
+    protected ExpressionParserImpl(TopLevelParseMode topLevel, List<ParseMode> allowedAtTopLevel) {
+        this.topLevel = topLevel;
+        this.topLevel.allowedTransitions.addAll(allowedAtTopLevel);
+    }
+
+    public ExpressionParserImpl includeAllowedSubmodeTransition(ParseMode parent, ParseMode allowedSubmode, ParseMode ...allowedOtherSubmodes) {
+        allowedTransitions.put(parent, allowedSubmode);
+        for (ParseMode m: allowedOtherSubmodes) allowedTransitions.put(parent, m);
+        return this;
+    }
+    public ExpressionParserImpl includeGroupingBracketsAtUsualPlaces(ParseMode ...optionalExplicitBrackets) {
+        List<ParseMode> brackets = optionalExplicitBrackets==null ? MutableList.of() :
+                Arrays.asList(optionalExplicitBrackets).stream().filter(b -> b!=null).collect(Collectors.toList());
+        if (brackets.isEmpty()) brackets = MutableList.of(SQUARE_BRACKET, CURLY_BRACES, PARENTHESES);
+
+        brackets.forEach(b -> includeAllowedTopLevelTransition(b));
+        allowedTransitions.putAll(INTERPOLATED, brackets);
+        for (ParseMode b : brackets) {
+            allowedTransitions.putAll(b, brackets);
+            includeAllowedSubmodeTransition(b, INTERPOLATED);
+            includeAllowedSubmodeTransition(b, SINGLE_QUOTE);
+            includeAllowedSubmodeTransition(b, DOUBLE_QUOTE);
+            brackets.forEach(bb -> includeAllowedSubmodeTransition(b, bb));
+        }
+        return this;
+    }
+    public ExpressionParserImpl includeAllowedTopLevelTransition(ParseMode allowedAtTopLevel) {
+        topLevel.allowedTransitions.add(allowedAtTopLevel);
+        return this;
+    }
+    public ExpressionParserImpl removeAllowedSubmodeTransition(ParseMode parent, ParseMode disallowedSubmode) {
+        allowedTransitions.remove(parent, disallowedSubmode);
+        return this;
+    }
+    public ExpressionParserImpl removeAllowedTopLevelTransition(ParseMode disallowedSubmode) {
+        topLevel.allowedTransitions.remove(disallowedSubmode);
+        return this;
+    }
+
+    public Maybe<ParseNode> parse(String input) {
+        return topLevel.parse(input, 0, allowedTransitions, topLevel.allowedTransitions).resultOrError;
+    }
+    public Maybe<List<ParseNodeOrValue>> parseEverything(String input) {
+        return parse(input).mapMaybe(pr -> {
+            if (!Objects.equals(pr.source, input)) return Maybe.absent("Could not parse everything");
+            return Maybe.of(pr.contents);
+        });
+    }
+
+    public ExpressionParserImpl stoppingAt(String id, Predicate<String> earlyTermination, boolean requireTopLevelToEndWithThisOrAnotherRequiredMode) {
+        if (requireTopLevelToEndWithThisOrAnotherRequiredMode) {
+            if (topLevel.mustEndWithOneOfTheseModes == null) topLevel.mustEndWithOneOfTheseModes = MutableList.of();
+            topLevel.mustEndWithOneOfTheseModes.add(id);
+        }
+        return includeAllowedTopLevelTransition(new ParseMode(id) {
+            @Override
+            public InternalParseResult parse(String input, int offset, Multimap<ParseMode, ParseMode> allowedTransitions, @Nullable Collection<ParseMode> transitionsAllowedHereOverride) {
+                if (earlyTermination.test(input.substring(offset))) {
+                    InternalParseResult ipr = InternalParseResult.ofValue(this, "", "");
+                    ipr.earlyTerminationRequested = true;
+                    return ipr;
+                }
+                return InternalParseResult.SKIP;
+            }
+        });
+    }
+
+}

--- a/core/src/main/java/org/apache/brooklyn/core/workflow/utils/WorkflowSettingItemsUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/workflow/utils/WorkflowSettingItemsUtils.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow.utils;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.brooklyn.core.workflow.WorkflowExpressionResolution.WorkflowExpressionStage;
+import org.apache.brooklyn.core.workflow.WorkflowStepInstanceExecutionContext;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.CharactersCollectingParseMode;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNode;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNodeOrValue;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseValue;
+import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** convenience class for the complexities of setting values, especially nested values */
+public class WorkflowSettingItemsUtils {
+
+    /**
+     * variable indices are not obvious -- currently you should write x['${index}'] for maps and x[${index}] for lists.
+     * but the quotes on the former might suggest it should be a literal value.
+     * if you want a literal (unresolved) key of the form ${...}
+     * you have to put that into another variable, or use $brooklyn:literal.
+     *
+     * furthermore x[index] is also ambiguous -- probably that should be the way to imply using index as a variable.
+     * but currently (and historially) we have allowed it as a string literal "index".
+     * we now warn on that usage, but we might want to switch it, and respect its type as a string or integer (for map or list).
+     *
+     * this constant can be used to find usages.
+     */
+    public static final boolean TODO_ALLOW_VARIABLES_IN_INDICES = false;
+
+    public static final String VALUE_SET = "Value set";
+    public static final String PREVIOUS_VALUE = "Previous value";
+    public static final String PREVIOUS_VALUE_OUTER = "Previous value (outer)";
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowSettingItemsUtils.class);
+
+    public static Pair<String, List<Object>> resolveNameAndBracketedIndices(WorkflowStepInstanceExecutionContext context, String expression, boolean treatDotAsSubkeySeparator) {
+        if (TODO_ALLOW_VARIABLES_IN_INDICES) {
+            // this should be a more sophisicated resolution, using ExpressionParser
+            // values before a bracket should be taken as literals, interpolated expressions resolved, maybe quotes unquoted without resolving;
+            // and more importantly in the brackets unquoted values should be taken as expressions and resolved;
+            // not sure what to do for quotes, there is an argument to allow "count_${n}" but also to a quote as a literal.
+            throw new UnsupportedOperationException();
+        }
+        String resolved = context.resolve(WorkflowExpressionStage.STEP_INPUT, expression, String.class);
+        return expressionParseNameAndIndices(resolved, treatDotAsSubkeySeparator);
+    }
+
+    public static Pair<String, List<Object>> extractNameAndDotOrBracketedIndices(String nameFull) {
+        if (TODO_ALLOW_VARIABLES_IN_INDICES) {
+            // callers to this need to be updated
+            throw new UnsupportedOperationException();
+        }
+        return expressionParseNameAndIndices(nameFull, true);
+    }
+
+    public static Pair<String, List<Object>> expressionParseNameAndIndices(String nameFull, boolean treatDotAsSubkeySeparator) {
+        CharactersCollectingParseMode DOT = new CharactersCollectingParseMode("dot", '.');
+        ExpressionParserImpl ep = ExpressionParser
+                .newDefaultAllowingUnquotedLiteralValues()
+                .includeGroupingBracketsAtUsualPlaces(ExpressionParser.SQUARE_BRACKET);
+
+        if (treatDotAsSubkeySeparator) ep.includeAllowedTopLevelTransition(DOT);
+
+        ParseNode p = ep.parse(nameFull).get();
+        Iterator<ParseNodeOrValue> contents = p.getContents().iterator();
+        if (!contents.hasNext()) throw new IllegalArgumentException("Initial identifier is required");
+
+        ParseNodeOrValue nameBaseC = contents.next();
+        if (nameBaseC.isParseNodeMode(ExpressionParser.INTERPOLATED, ExpressionParser.SQUARE_BRACKET))
+            throw new IllegalArgumentException("Initial part of identifier cannot be an expression or reference");
+
+        String nameBase = ExpressionParser.getUnquoted(nameBaseC).trim();
+        List<Object> indices = MutableList.of();
+
+        while (contents.hasNext()) {
+            ParseNodeOrValue t = contents.next();
+            if (t.isParseNodeMode(DOT)) {
+                if (!contents.hasNext()) throw new IllegalArgumentException("Cannot end with a dot");
+                ParseNodeOrValue next = contents.next();
+                if (next.isParseNodeMode(ExpressionParser.SQUARE_BRACKET)) {
+                    // continue to next block; allow foo.['x'].[adfsads]
+                    t = next;
+                } else if (next.isParseNodeMode(ParseValue.MODE)) {
+                    // only a simple value is allowed
+                    indices.add(((ParseValue)next).getContents());
+                    t = null;
+
+                } else {
+                    throw new IllegalArgumentException("Cannot contain this type of object: "+next);
+                }
+            }
+            if (t!=null && t.isParseNodeMode(ExpressionParser.SQUARE_BRACKET)) {
+                List<ParseNodeOrValue> nest = ExpressionParser.trimWhitespace( ((ParseNode) t).getContents() );
+                Object index;
+                if (nest.size()>1) throw new IllegalArgumentException("Bracketed expression must contain a single string or number");
+                if (nest.isEmpty()) index = "";
+                else {
+                    ParseNodeOrValue n = nest.get(0);
+
+                    if (n instanceof ParseValue) {
+                        String v = ((ParseValue) n).getContents().trim();
+                        index = asInteger(v).asType(Object.class).or(() -> {
+                            if (TODO_ALLOW_VARIABLES_IN_INDICES) {
+                                // resolve?
+                                throw new UnsupportedOperationException();
+                            } else {
+                                log.warn("Index to " + nameFull + " should be quoted; allowing unquoted for legacy compatibility");
+                            }
+                            return v;
+                        });
+                    } else if (n.isParseNodeMode(ExpressionParser.SINGLE_QUOTE, ExpressionParser.DOUBLE_QUOTE)) {
+                        index = ExpressionParser.getUnquoted(n);
+                    } else {
+                        throw new IllegalArgumentException("Cannot contain this type of object bracketed: " + n);
+                    }
+                }
+                indices.add(index);
+            }
+        }
+
+        return Pair.of(nameBase, indices);
+    }
+
+    public static Maybe<Integer> asInteger(Object x) {
+        if (x instanceof Integer) return Maybe.of((Integer)x);
+        if (x instanceof String) {
+            if (((String)x).matches("-? *[0-9]+")) return Maybe.of(Integer.parseInt((String)x));
+        }
+        return Maybe.absent("Cannot make an integer out of: "+x);
+    }
+
+    public static <T> Maybe<T> ensureMutable(T x) {
+        return makeMutable(x, false);
+    }
+    public static <T> Maybe<T> makeMutableCopy(T x) {
+        return makeMutable(x, true);
+    }
+    private static <T> Maybe<T> makeMutable(T x, boolean alwaysCopyEvenIfMutable) {
+        Object result = makeMutable(x, alwaysCopyEvenIfMutable, () -> Maybe.absent("Cannot make a mutable object out of null"), (y) -> Maybe.absent("Cannot make a mutable object out of " + y.getClass()));
+        if (result instanceof Maybe) return (Maybe)result;
+        return Maybe.of((T)result);
+    }
+    public static Object makeMutableOrUnchangedDefaultingToMap(Object x) {
+        return makeMutable(x, false, () -> MutableMap.of(), v -> v);
+    }
+    public static Maybe<Object> makeMutableOrUnchangedForIndex(Object x, boolean alwaysCopyEvenIfMutable, Object index) {
+        return Maybe.ofDisallowingNull(makeMutable(x, alwaysCopyEvenIfMutable, () -> {
+            // number or empty string means list
+            if (index instanceof Integer || "".equals(index)) return MutableList.of();
+            // string is a map
+            if (index instanceof String) return MutableMap.of();
+            // other things not supported
+            return null;
+        }, v -> v));
+    }
+    public static Object makeMutable(@Nullable Object x, boolean alwaysCopyEvenIfMutable, @Nonnull Supplier<Object> ifNull, @Nonnull Function<Object,Object> ifNotIterableOrMap) {
+        if (x==null) {
+            return ifNull.get();
+        }
+
+        if (x instanceof Set) return (!alwaysCopyEvenIfMutable && x instanceof MutableSet) ? x : MutableSet.copyOf((Set) x);
+        if (x instanceof Map) return (!alwaysCopyEvenIfMutable && x instanceof MutableMap) ? x : MutableMap.copyOf((Map) x);
+        if (x instanceof Iterable) return (!alwaysCopyEvenIfMutable && x instanceof MutableList) ? x : MutableList.copyOf((Iterable) x);
+        return ifNotIterableOrMap.apply(x);
+    }
+
+    /** returns pair containing outermost updated object and innermost updated object.
+     * will be the same if there are no indices. */
+    public static Pair<Object,Object> setAtIndex(Pair<String,List<Object>> nameAndIndices, boolean allowToCreateIntermediate, Function<Object,Object> valueModifierOrSupplier, Function<String, Object> getter0, BiFunction<String, Object, Object> setter0) {
+
+        String name = nameAndIndices.getLeft();
+        List<Object> indices = nameAndIndices.getRight();
+
+        Object key = name;
+        List<Object> oldValuesReplacedOutermostFirst = MutableList.of();
+
+        if (indices!=null && !indices.isEmpty()) {
+            if ("output".equals(name))
+                throw new IllegalArgumentException("It is not permitted to set a subfield of the output");  // catch common error
+        }
+
+        String path = "";
+        Function<Object, Object> getter = (Function) getter0;
+        Function<Object,Consumer<Object>> setterCurried = k -> v -> {
+            oldValuesReplacedOutermostFirst.add(0, setter0.apply((String)k, v));
+        };
+        Consumer<Object> setter = null;
+
+        Object last = null;
+        for (Object index : MutableList.<Object>of(name).appendAll(indices)) {
+            path += (path.length()>0 ? "/" : "") + index;
+            setter = setterCurried.apply(index);
+            final String pathF = path;
+            final Consumer<Object> prevSetter = setter;
+            final Object next = getter.apply(index);
+            last = next;
+            if (next == null) {
+                if (!allowToCreateIntermediate) {
+                    throw new IllegalArgumentException("Cannot set index '" + index + "' at '" + pathF + "' because that is undefined");
+                } else {
+                    // create
+                    getter = k -> null;
+                    setterCurried = k -> v -> {
+                        Object target = makeMutableOrUnchangedForIndex(null, true, k).orThrow(
+                                () -> new IllegalArgumentException("Cannot set index '" + k + "' at '" + pathF + "' because that is undefined and key type unknown"));
+                        if (k instanceof Integer && (((Integer)k)<-1 || ((Integer)k)>0)) {
+                            throw new IllegalArgumentException("Cannot set index '" + k + "' at '" + pathF + "' because that is undefined and key type out of range");
+                        }
+                        Object oldV = target instanceof List ? ((List)target).add(v) : ((Map)target).put(k, v);
+                        oldValuesReplacedOutermostFirst.add(0, oldV);
+                        prevSetter.accept(target);
+                    };
+                }
+            } else if (next instanceof Map) {
+                getter = ((Map)next)::get;
+                setterCurried = k -> v -> {
+                    Map target = makeMutableCopy((Map)next).get();
+                    Object oldV = target.put(k, v);
+                    // we could be stricter and block this, in case they thought it was a list?
+//                    if (oldV==null) {
+//                        if (!(k instanceof String))
+//                            throw new IllegalArgumentException("Cannot set non-string index '" + k + "' in map at '" + pathF + "' unless it is replacing (map insertion only supported for string keys)");
+//                    }
+                    oldValuesReplacedOutermostFirst.add(0, oldV);
+                    prevSetter.accept(target);
+                };
+            } else if (next instanceof List) {
+                getter = k -> {
+                    k = asInteger(k).asType(Object.class).or(k);
+                    if ("".equals(k)) return null; // empty string means to append
+                    if (!(k instanceof Integer))
+                        throw new IllegalArgumentException("Cannot get index '" + k + "' at '" + pathF + "' because that is a list");
+                    Integer kn = (Integer) k;
+                    if (kn==-1 || kn==((List)next).size()) return null;  // -1 or N means to append
+                    return ((List) next).get((Integer) k);
+                };
+                setterCurried = k -> v -> {
+                    List target = makeMutableCopy((List)next).get();
+                    Integer kn = asInteger(k).or(() -> {
+                        if ("".equals(k)) return -1;
+                        throw new IllegalArgumentException("Cannot set index '" + k + "' at '" + pathF + "' because that is a list");
+                    });
+                    // -1 or size appends, or empty string
+
+                    // (might be nice for negative numbers to reference from the end also -
+                    // but the freemarker getter doesn't support that, so it would cause an odd asymmetry;
+                    // however use of the empty string, or size, to add gives easy ways to add that don't need this)
+                    oldValuesReplacedOutermostFirst.add(0, kn==-1 || kn==target.size() ? target.add(v) : target.set(kn, v));
+                    prevSetter.accept(target);
+                };
+            } else {
+                getter = k -> {
+                    throw new IllegalArgumentException("Cannot set sub-index at '" + k + "' at '" + pathF +"' because that is a " + next.getClass());
+                };
+                setterCurried = null;
+            }
+        }
+
+        setter.accept(valueModifierOrSupplier.apply(last));
+        return Pair.of(oldValuesReplacedOutermostFirst.get(0), oldValuesReplacedOutermostFirst.get(oldValuesReplacedOutermostFirst.size()-1));
+    }
+
+    public static void noteValueSetMetadata(WorkflowStepInstanceExecutionContext context, Object newValue, Object oldValue) {
+        context.noteOtherMetadata(WorkflowSettingItemsUtils.VALUE_SET, newValue);
+        if (oldValue!=null) {
+            context.noteOtherMetadata(WorkflowSettingItemsUtils.PREVIOUS_VALUE, oldValue);
+        }
+    }
+    public static void noteValueSetNestedMetadata(WorkflowStepInstanceExecutionContext context, Pair<String, List<Object>> nameAndIndices, Object newNestedValue, Pair<Object, Object> oldOuterAndInnerValues) {
+        noteValueSetMetadata(context, newNestedValue, oldOuterAndInnerValues.getRight());
+        if (!nameAndIndices.getRight().isEmpty()) {
+            Object oldValueOuter = oldOuterAndInnerValues.getLeft();
+            if (oldValueOuter != null) {
+                context.noteOtherMetadata(WorkflowSettingItemsUtils.PREVIOUS_VALUE_OUTER, oldValueOuter);
+            }
+        }
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/ExpressionParserTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/ExpressionParserTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.brooklyn.core.workflow.utils.ExpressionParser;
+import org.apache.brooklyn.core.workflow.utils.ExpressionParserImpl.ParseNodeOrValue;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.guava.Maybe;
+import org.testng.annotations.Test;
+
+public class ExpressionParserTest {
+
+    static String s(List<ParseNodeOrValue> pr) {
+        return pr.stream().map(ParseNodeOrValue::toString).collect(Collectors.joining(""));
+    }
+    static String parseFull(ExpressionParser ep, String expression) {
+        return getParseTreeString(ep.parseEverything(expression).get());
+    }
+    static String parseFull(String expression) {
+        return parseFull(ExpressionParser.newDefaultAllowingUnquotedLiteralValues(), expression);
+    }
+    static String parseFullWhitespace(String expression) {
+        return parseFull(ExpressionParser.newDefaultAllowingUnquotedAndSplittingOnWhitespace(), expression);
+    }
+    static String parsePartial(ExpressionParser ep, String expression) {
+        return getParseTreeString(ep.parse(expression).get().getContents());
+    }
+
+    static String getParseTreeString(List<ParseNodeOrValue> result) {
+        return result.stream().map(ParseNodeOrValue::toString).collect(Collectors.joining(""));
+    }
+
+    @Test
+    public void testCommon() {
+        Asserts.assertEquals(parseFull("hello"), "[hello]");
+        Asserts.assertEquals(parseFull("\"hello\""), "double_quote[hello]");
+        Asserts.assertEquals(parseFull("${a}"), "interpolated_expression[a]");
+
+        Asserts.assertEquals(parseFull("\"hello\"world"), "double_quote[hello][world]");
+        Asserts.assertEquals(parseFull("\"hello\" with 'sq \"'"), "double_quote[hello][ with ]single_quote[sq \"]");
+        Asserts.assertEquals(parseFullWhitespace("\"hello\" with 'sq \"'"), "double_quote[hello]whitespace[ ][with]whitespace[ ]single_quote[sq \"]");
+
+        Asserts.assertEquals(parseFull("\"hello ${a}\""), "double_quote[[hello ]interpolated_expression[a]]");
+        Asserts.assertEquals(parseFull("x[\"v\"] =1"), "[x[]double_quote[v][] =1]");
+    }
+
+    @Test
+    public void testError() {
+        Asserts.expectedFailureContains(Maybe.Absent.getException(ExpressionParser.newDefaultAllowingUnquotedLiteralValues().parseEverything("\"non-quoted string")),
+                "Non-terminated double_quote");
+    }
+
+    @Test
+    public void testPartial() {
+        ExpressionParser ep = ExpressionParser.newDefaultAllowingUnquotedLiteralValues().
+                stoppingAt("equals", s -> s.startsWith("="), true);
+        Asserts.assertEquals(parsePartial(ep, "x=1"), "[x]equals[]");
+        Asserts.assertEquals(parsePartial(ep, "x[\"v\"] =1"), "[x[]double_quote[v][] ]equals[]");
+        // equals not matched in expression
+        Asserts.assertFailsWith(() -> parsePartial(ep, "x[\"=\"] is 1"),
+                Asserts.expectedFailureContains("value", "should", "end", "with", "required", "equals"));
+    }
+
+    @Test
+    public void testBrackets() {
+        ExpressionParser ep1 = ExpressionParser.newDefaultAllowingUnquotedLiteralValues().
+                includeGroupingBracketsAtUsualPlaces();
+        Asserts.assertEquals(parseFull(ep1, "x[\"v\"] =1"), "[x]square_bracket[double_quote[v]][ =1]");
+
+        ExpressionParser ep2 = ExpressionParser.newDefaultAllowingUnquotedLiteralValues().
+                includeGroupingBracketsAtUsualPlaces().
+                stoppingAt("equals", s -> s.startsWith("="), true);
+        Asserts.assertEquals(parsePartial(ep2, "x[\"v\"] =1"), "[x]square_bracket[double_quote[v]][ ]equals[]");
+        Asserts.assertFailsWith(() -> parsePartial(ep2, "x[\"=\"] is 1"),
+                Asserts.expectedFailureContains("value", "should", "end", "with", "required", "equals"));
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/ShorthandProcessorQstTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/ShorthandProcessorQstTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.core.workflow;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.Test;
+
+public class ShorthandProcessorQstTest extends BrooklynMgmtUnitTestSupport {
+
+    void assertShorthandOfGives(String template, String input, Map<String,Object> expected) {
+        Asserts.assertEquals(new ShorthandProcessorQst(template).process(input).get(), expected);
+    }
+
+    void assertShorthandOfGivesError(String template, String input, Map<String,Object> expected) {
+        Asserts.assertEquals(new ShorthandProcessorQst(template).withFailOnMismatch(false).process(input).get(), expected);
+        Asserts.assertFails(() -> new ShorthandProcessorQst(template).withFailOnMismatch(true).process(input).get());
+    }
+
+    void assertShorthandFinalMatchRawOfGives(String template, String input, Map<String,Object> expected) {
+        Asserts.assertEquals(new ShorthandProcessorQst(template).withFinalMatchRaw(true).process(input).get(), expected);
+    }
+
+    void assertShorthandFailsWith(String template, String input, Consumer<Exception> check) {
+        try {
+            new ShorthandProcessorQst(template).process(input).get();
+            Asserts.shouldHaveFailedPreviously();
+        } catch (Exception e) {
+            check.accept(e);
+        }
+    }
+
+    @Test
+    public void testShorthandQuoted() {
+        assertShorthandOfGives("${x}", "hello world", MutableMap.of("x", "hello world"));
+
+        assertShorthandOfGives("${x} \" is \" ${y}", "a is b c", MutableMap.of("x", "a", "y", "b c"));
+        assertShorthandOfGives("${x} \" is \" ${y}", "a is b \"c\"", MutableMap.of("x", "a", "y", "b \"c\""));
+
+        // don't allow intermediate multi-token matching; we could add but not needed yet
+//        assertShorthandOfGives("${x} \" is \" ${y}", "a b is b c", MutableMap.of("x", "a b", "y", "b c"));
+
+        assertShorthandOfGives("${x} \" is \" ${y}", "this is b c", MutableMap.of("x", "this", "y", "b c"));
+        assertShorthandOfGives("${x} \"is\" ${y}", "this is b c", MutableMap.of("x", "th", "y", "is b c"));
+        assertShorthandOfGives("${x} \"is\" ${y}", "\"this\" is b c", MutableMap.of("x", "this", "y", "b c"));
+        assertShorthandOfGives("${x} \" is \" ${y}", "\"this is b\" is c", MutableMap.of("x", "this is b", "y", "c"));
+
+        // quotes with spaces before/after removed
+        assertShorthandOfGives("${x} \" is \" ${y}", "\"this is b\" is c is \"is quoted\"", MutableMap.of("x", "this is b", "y", "c is \"is quoted\""));
+        // if you want quotes, you have to wrap them in quotes
+        assertShorthandOfGives("${x} \" is \" ${y}", "\"this is b\" is \"\\\"c is is quoted\\\"\"", MutableMap.of("x", "this is b", "y", "\"c is is quoted\""));
+        // and only quotes at word end are considered, per below
+        assertShorthandOfGivesError("${x} \" is \" ${y}", "\"this is b\" is \"\\\"c is \"is  quoted\"\\\"\"", MutableMap.of("x", "this is b", "y", "\"c is \"is  quoted\"\""));
+        assertShorthandOfGivesError("${x} \" is \" ${y}", "\"this is b\" is \"\\\"c is \"is  quoted\"\\\"\"  too", MutableMap.of("x", "this is b", "y", "\"\\\"c is \"is  quoted\"\\\"\"  too"));
+
+        // preserve spaces in a word
+        assertShorthandOfGives("${x}", "\"  sp a  ces \"", MutableMap.of("x", "  sp a  ces "));
+        assertShorthandOfGives("${x}", "\"  sp a  ces \"  and  then  some", MutableMap.of("x", "\"  sp a  ces \"  and  then  some"));
+
+        // if you want quotes, you have to wrap them in quotes
+        assertShorthandOfGives("${x}", "\"\\\"c is is quoted\\\"\"", MutableMap.of("x", "\"c is is quoted\""));
+        // or use final match quoted
+        assertShorthandFinalMatchRawOfGives("${x}", "\"\\\"c is is quoted\\\"\"", MutableMap.of("x", "\"\\\"c is is quoted\\\"\""));
+        // a close quote must come at a word end to be considered
+        // so this gives an error
+        assertShorthandFailsWith("${x}", "\"c is  \"is", e -> Asserts.expectedFailureContainsIgnoreCase(e, "mismatched", "quot"));
+        // and this is treated as one quoted string
+        assertShorthandOfGivesError("${x}", "\"\\\"c  is \"is  quoted\"\\\"\"", MutableMap.of("x", "\"c  is \"is  quoted\"\""));
+    }
+
+    @Test
+    public void testShorthandWithOptionalPart() {
+        assertShorthandOfGives("[?${hello} \"hello\" ] ${x}", "hello world", MutableMap.of("hello", true, "x", "world"));
+
+        assertShorthandOfGives("[ \"hello\" ] ${x}", "hello world", MutableMap.of("x", "world"));
+        assertShorthandOfGives("[\"hello\"] ${x}", "hello world", MutableMap.of("x", "world"));
+        assertShorthandOfGives("[\"hello\"] ${x}", "hi world", MutableMap.of("x", "hi world"));
+        assertShorthandOfGives("[?${hello} \"hello\" ] ${x}", "hello world", MutableMap.of("hello", true, "x", "world"));
+        assertShorthandOfGives("[?${hello} \"hello\" ] ${x}", "hi world", MutableMap.of("hello", false, "x", "hi world"));
+
+        assertShorthandOfGives("[${type}] ${key}", "x", MutableMap.of("key", "x"));
+        assertShorthandOfGives("[${type}] ${key} \"=\" ${value}", "x = 1", MutableMap.of("key", "x", "value", "1"));
+        assertShorthandOfGives("[${type}] ${key} \"=\" ${value}", "x=1", MutableMap.of("key", "x", "value", "1"));
+        assertShorthandOfGives("[${type}] ${key} \"=\" ${value}", "integer x=1", MutableMap.of("type", "integer", "key", "x", "value", "1"));
+
+        // this matches -- more than one whitespace is not important
+        assertShorthandOfGives("[${type}] ${key} \"  =\" ${value}", "x =1", MutableMap.of("key", "x", "value", "1"));
+        // but this does not match
+        assertShorthandFailsWith("[${type}] ${key} \" =\" ${value}", "x=1", e -> Asserts.expectedFailureContainsIgnoreCase(e, " =", "end of input"));
+
+        assertShorthandOfGives("${x} [ ${y} ]", "hi world", MutableMap.of("x", "hi", "y", "world"));
+        assertShorthandOfGives("${x} [ ${y} ]", "hi world 1 and 2", MutableMap.of("x", "hi", "y", "world 1 and 2"));
+    }
+
+    @Test
+    public void testMultiWordShorthand() {
+        assertShorthandOfGives("${x...} \" is \" ${y}", "a b is c", MutableMap.of("x", "a b", "y", "c"));
+        assertShorthandOfGives("[${type}] ${key...} \"=\" ${value}", "integer a b x=1", MutableMap.of("type", "integer", "key", "a b x", "value", "1"));
+        assertShorthandOfGives("[${type}] ${key...} [\"=\" ${value}]", "integer a b x=1", MutableMap.of("type", "integer", "key", "a b x", "value", "1"));
+        assertShorthandOfGives("[${type}] ${key...} [\"=\" ${value}]", "integer a b x", MutableMap.of("type", "integer", "key", "a b x"));
+
+        assertShorthandFailsWith("[${type}] ${key} [\"=\" ${value}]", "integer a b x",
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "input", "trailing characters", "b x"));
+        assertShorthandFailsWith("[${type}] ${key%...} [\"=\" ${value}]", "integer a b x",
+                e -> Asserts.expectedFailureContainsIgnoreCase(e, "invalid", "key%"));
+
+        /*
+
+optional expressions are greedy -- ie if it can bind an optional expression it will do so
+
+but the ... multi-word match is *not* greedy -- if it can defer extra words until later it will do so
+
+for example given
+
+template [ ${word1...} ] [ ${word2...} ]
+to match against a b c
+
+there are 4 valid matches for word1 :  unset or a or a b or a b c  (with the complement being in word2).
+
+the logic will take the one which matches the optional word1 but as minimally as possible, is word1 is a and word2 is b c
+
+(but if our template were [ ${word1...} ] [ " and " ${word2...} ] then a b c would all have to go into word1 because it cannot match the " and " for word2)
+
+         */
+        assertShorthandOfGives("[ ${word1...} ] [ ${word2...} ]", "a b c", MutableMap.of("word1", "a", "word2" , "b c"));
+
+        assertShorthandOfGives("${word1} [ ${word2} ] \" and \" ${word3}", "a b and c", MutableMap.of("word1", "a", "word2", "b", "word3", "c"));
+        assertShorthandOfGives("${word1} [ ${word2} ] \" and \" ${word3}", "a and c", MutableMap.of("word1", "a", "word3", "c"));
+
+        assertShorthandOfGives("${word1} [ ${word2} ] \" and \" ${word3}", "a and b and c", MutableMap.of("word1", "a", "word3", "b and c"));
+        assertShorthandOfGives("${word1} [ ${word2...} ] \" and \" ${word3}", "a and b and c", MutableMap.of("word1", "a", "word2" , "and b", "word3", "c"));
+        assertShorthandOfGives("${word1} [ ${word2...} ] [ \" and \" ${word3} ]", "a and b and c", MutableMap.of("word1", "a", "word2" , "and b", "word3", "c"));
+        assertShorthandOfGives("${word1} [ ${word2...} ] [ \" and \" ${word3} ]", "a and b not c", MutableMap.of("word1", "a", "word2" , "and b not c"));
+        assertShorthandOfGives("${word1} [ ${word2...} ] [ \" and \" ${word3} ]", "a not b not c", MutableMap.of("word1", "a", "word2" , "not b not c"));
+    }
+
+    @Test
+    public void testShorthandWithNestedOptional() {
+        assertShorthandOfGives("[ [ ${a} ] ${b} [ \"=\" ${c...} ] ]", "b = c", MutableMap.of("b", "b", "c", "c"));
+        assertShorthandOfGives("[ [ ${a} ] ${b} [ \"=\" ${c...} ] ]", "a b = c", MutableMap.of("a", "a", "b", "b", "c", "c"));
+    }
+
+    @Test
+    public void testTokensVsWords() {
+        assertShorthandOfGives("[ [ ${type} ] ${var} [ \"=\" ${val...} ] ]",
+                "int foo['bar'] = baz", MutableMap.of("type", "int", "var", "foo['bar']", "val", "baz"));
+    }
+
+}

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowMapAndListTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowMapAndListTest.java
@@ -18,20 +18,31 @@
  */
 package org.apache.brooklyn.core.workflow;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.ImmutableMap;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Dumper;
+import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport;
+import org.apache.brooklyn.core.workflow.steps.appmodel.SetSensorWorkflowStep;
 import org.apache.brooklyn.entity.stock.BasicApplication;
 import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.util.collections.MutableList;
+import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
-import org.testng.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import java.util.List;
+public class WorkflowMapAndListTest extends BrooklynMgmtUnitTestSupport {
 
-public class WorkflowMapAndListTest  extends BrooklynMgmtUnitTestSupport {
+    private static final Logger log = LoggerFactory.getLogger(WorkflowMapAndListTest.class);
 
     private BasicApplication app;
 
@@ -49,7 +60,7 @@ public class WorkflowMapAndListTest  extends BrooklynMgmtUnitTestSupport {
     }
 
     @Test
-    public void testMapDirect() {
+    public void testSetWorkflowInMapWithDot() {
         Object result = runSteps(MutableList.of(
                 "let map myMap = {}",
                 "let myMap.a = 1",
@@ -57,62 +68,224 @@ public class WorkflowMapAndListTest  extends BrooklynMgmtUnitTestSupport {
         ));
         Asserts.assertEquals(result, "1");
     }
+    @Test
+    public void testSetWorkflowInMapWithBrackets() {
+        Object result = runSteps(MutableList.of(
+                "let map myMap = {}",
+                "let myMap['a'] = 1",
+                "return ${myMap.a}"
+        ));
+        Asserts.assertEquals(result, "1");
+    }
+    @Test
+    public void testSetWorkflowInListWithType() {
+        Object result = runSteps(MutableList.of(
+                "let list myList = []",
+                "let int myList[0] = 1",
+                "return ${myList[0]}"
+        ));
+        Asserts.assertEquals(result, 1);
+    }
 
     @Test
-    public void testSetSensorMap() {
+    public void testSetWorkflowCreateMapAndList() {
+        Object result = runSteps(MutableList.of(
+                "let myMap['a'] = 1",
+                "return ${myMap.a}"
+        ));
+        Asserts.assertEquals(result, "1");
+
+        result = runSteps(MutableList.of(
+                "let int myList[0] = 1",
+                "return ${myList}"
+        ));
+        Asserts.assertEquals(result, Arrays.asList(1));
+    }
+
+    @Test
+    public void testBasicSensorAndConfig() {
+        runSteps(MutableList.of(
+                "set-config my_config['a'] = 1",
+                "set-sensor int my_sensor['a'] = 1"
+        ));
+        EntityAsserts.assertConfigEquals(app, ConfigKeys.newConfigKey(Object.class, "my_config"), MutableMap.of("a", "1"));
+        EntityAsserts.assertAttributeEquals(app, Sensors.newSensor(Object.class, "my_sensor"), MutableMap.of("a", 1));
+    }
+
+    @Test
+    public void testMapBracketsMore() {
+        Object result = runSteps(MutableList.of(
+                "set-sensor service.problems['latency'] = \"too slow\"",
+                "let x = ${entity.sensor['service.problems']}",
+                "return ${x}"
+        ));
+        Asserts.assertEquals(result, ImmutableMap.of("latency", "too slow"));
+
+        result = runSteps(MutableList.of(
+                "let map myMap = {}",
+                "let myMap['a'] = 1",
+                "return ${myMap.a}"
+        ));
+        Asserts.assertEquals(result, "1");
+    }
+
+    @Test
+    public void testMapBracketsUnquotedSyntaxLegacy() {
+        // this will warn but will work, for legacy compatibility reasons
+
         Object result = runSteps(MutableList.of(
                 "set-sensor service.problems[latency] = \"too slow\"",
                 "let x = ${entity.sensor['service.problems']}",
                 "return ${x}"
         ));
         Asserts.assertEquals(result, ImmutableMap.of("latency", "too slow"));
+
+        result = runSteps(MutableList.of(
+                "let map myMap = {}",
+                "let myMap[a] = 1",
+                "return ${myMap.a}"
+        ));
+        Asserts.assertEquals(result, "1");
     }
 
     @Test
-    public void testListIndex() {
+    public void testMoreListByIndexInsertionCreationAndErrors() {
         Object result = runSteps(MutableList.of(
                 "let list mylist = [1, 2, 3]",
                 "let mylist[1] = 4",
                 "return ${mylist[1]}"
         ));
         Asserts.assertEquals(result, "4");
+
+        // 0 allowed to create (as does -1, further below)
+        result = runSteps(MutableList.of(
+                "let mylist[0] = 4",
+                "return ${mylist[0]}"
+        ));
+        Asserts.assertEquals(result, "4");
+
+        // other numbers not allowed to create
+        Asserts.assertFailsWith(() -> runSteps(MutableList.of(
+                "let mylist[123] = 4"
+        )), Asserts.expectedFailureContainsIgnoreCase("cannot set index", "123", "mylist", "undefined"));
+
+        // -1 puts at end
+        result = runSteps(MutableList.of(
+                "let list mylist = [1, 2, 3]",
+                "let mylist[-1] = 4",
+                "return ${mylist[3]}"
+        ));
+        Asserts.assertEquals(result, "4");
+
+        // also works if we insert
+        result = runSteps(MutableList.of(
+                "let list mylist = [1, 2, 3]",
+                "let mylist[-1]['a'][-1] = 4",
+                "return ${mylist[3]['a'][0]}"
+        ));
+        Asserts.assertEquals(result, "4");
+        // as does empty string
+        result = runSteps(MutableList.of(
+                "let list mylist = [1, 2, 3]",
+                "let mylist[]['a'][] = 4",
+                "return ${mylist[3]['a'][0]}"
+        ));
+        Asserts.assertEquals(result, "4");
+
+        // note: getting -1 is not supported
+        Asserts.assertFailsWith(() -> runSteps(MutableList.of(
+                "let list mylist = [1,2,3]",
+                "return ${mylist[-1]}"
+        )), Asserts.expectedFailureContainsIgnoreCase("invalid", "reference", "-1", "mylist"));
     }
 
     @Test
     public void testUndefinedList() {
-        Object result = null;
-        try {
-            result = runSteps(MutableList.of(
-                    "let list mylist = [1, 2, 3]",
-                    "let anotherList[1] = 4",
-                    "return ${anotherList[1]}"
-            ));
-        } catch (Exception e) {
-            // We can't use expectedExceptionsMessageRegExp as the error message is in the `Cause` exception
-            if (e.getCause() == null || !e.getCause().getMessage().contains("Cannot set anotherList[1] because anotherList is unset")) {
-                Assert.fail("Expected cause exception to contain 'Cannot set anotherList[1] because anotherList is unset'");
-            }
-            return;
-        }
-        Assert.fail("Expected IllegalArgumentException");
+        Asserts.assertFailsWith(() -> runSteps(MutableList.of(
+                    "let anotherList[123] = 4"
+            )),
+            e -> Asserts.expectedFailureContainsIgnoreCase(e.getCause(),
+                    "cannot", "index", "anotherList", "123", "undefined"));
     }
 
     @Test
     public void testInvalidListSpecifier() {
-        Object result = null;
-        try {
-            result = runSteps(MutableList.of(
-                    "let list mylist = [1, 2, 3]",
-                    "let mylist[1 = 4",
-                    "return ${mylist[1]}"
-            ));
-        } catch (Exception e) {
-            // We can't use expectedExceptionsMessageRegExp as the error message is in the `Cause` exception
-            if (e.getCause() == null || !e.getCause().getMessage().contains("Invalid list index specifier mylist[1")) {
-                Assert.fail("Expected cause exception to contain 'Invalid list index specifier mylist[1'");
-            }
-            return;
-        }
-        Assert.fail("Expected IllegalArgumentException");
+        Asserts.assertFailsWith(() -> runSteps(MutableList.of(
+                    "let list mylizt = [1, 2, 3]",
+                    "let mylizt['abc'] = 4",
+                    "return ${mylizt[1]}"
+            )),
+            e -> Asserts.expectedFailureContainsIgnoreCase(e.getCause(), "cannot", "mylizt", "abc", "list"));
     }
+
+    @Test(groups = "Integration", invocationCount = 20)
+    public void testBeefySensorRequireForAtomicityAndConfigCountsMapManyTimes() {
+        testBeefySensorRequireForAtomicityAndConfigCountsMap();
+    }
+
+    @Test
+    public void testBeefySensorRequireForAtomicityAndConfigCountsMap() {
+        runSteps(MutableList.of(
+                "set-sensor sum['total'] = 0", //needed for the 'last' check
+                "set-sensor map counts = {}", //needed for the 'last' check
+                MutableMap.of(
+                        "step", "foreach n in 1..20",
+                        "concurrency", 10,
+                        "steps", MutableList.of(
+                                "let last = ${entity.sensor['sum']['total']}",
+
+                                // keep counts using sensors and config - observe config might get mismatches but no errors,
+                                // and sensors update perfectly atomically
+
+                                "let ck = count_${n}",
+                                "let last_count = ${entity.sensor.counts[ck]} ?? 0",
+                                "let count = ${last_count} + 1",
+                                // races in setting config known; we might miss some here (see check)
+                                "set-config counts['${ck}'] = ${count}",
+                                // setting sensors however will be mutexed on the sensor (assuming it exists or is defined)
+                                "set-sensor counts['${ck}'] = ${count}",
+                                // append to a list
+                                "set-config ${ck}[] = ${count}",
+
+                                "let next = ${last} + ${n}",
+
+                                "log trying to set ${n} to ${next}, attempt ${count}",
+                                // also check require with retries
+                                MutableMap.of(
+                                        "step", "set-sensor sum['total']",
+                                        // reference so we can easily find this test
+                                        SetSensorWorkflowStep.REQUIRE.getName(), "${last}",
+                                        "value", "${next}",
+                                        "on-error", "retry from start"  // if condition not met, will replay
+                                ),
+                                "log succeeded setting ${n} to ${next}, attempt ${count}"
+                        )
+                )));
+
+        Dumper.dumpInfo(app);
+        EntityAsserts.assertAttributeEquals(app, Sensors.newSensor(Object.class, "sum"), MutableMap.of("total", 210));
+
+        Map counts;
+        counts = app.sensors().get(Sensors.newSensor(Map.class, "counts"));
+        Asserts.assertEquals(counts.size(), 20);
+        Asserts.assertThat(counts.get("count_15"), x -> ((Integer) x) >= 1);
+
+        counts = app.config().get(ConfigKeys.newConfigKey(Map.class, "counts"));
+        Asserts.assertThat(counts.size(), x -> x >= 15);  // we don't guarantee concurrency on config map writes, so might lose a few
+        if (counts.size()==20) {
+            log.warn("ODD!!! config for counts updated perfectly"); // doesn't usually happen, unless slow machine
+        }
+        int nn = 0;
+        for (int n=1; n<=20; n++) {
+            List count_n = app.config().get(ConfigKeys.newConfigKey(List.class, "count_"+n));
+            Asserts.assertThat(count_n.size(), x -> x >= 1);
+            for (int i = 0; i < count_n.size(); i++)
+                Asserts.assertEquals(count_n.get(i), i + 1);
+            nn += count_n.size();
+        }
+        if (nn<=20) {
+            log.warn("ODD!!! no retries");  // per odd comment above
+        }
+    }
+
 }

--- a/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/workflow/WorkflowNestedAndCustomExtensionTest.java
@@ -37,6 +37,7 @@ import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.core.test.entity.TestEntity;
 import org.apache.brooklyn.core.typereg.BasicTypeImplementationPlan;
+import org.apache.brooklyn.core.workflow.steps.appmodel.SetSensorWorkflowStep;
 import org.apache.brooklyn.core.workflow.steps.flow.LogWorkflowStep;
 import org.apache.brooklyn.core.workflow.store.WorkflowRetentionAndExpiration;
 import org.apache.brooklyn.core.workflow.store.WorkflowStatePersistenceViaSensors;
@@ -424,7 +425,7 @@ public class WorkflowNestedAndCustomExtensionTest extends RebindTestFixture<Test
                 "    - let count = ${entity.parent.sensor.count}",
                 "    - let inc = ${count} + 1",
                 "    - step: set-sensor count = ${inc}",
-                "      require: ${count}",
+                "      "+ SetSensorWorkflowStep.REQUIRE.getName()+": ${count}",
                 "      sensor:",
                 "        entity: ${entity.parent}",
                 "      on-error:",

--- a/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/test/Asserts.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Predicates;
@@ -1336,6 +1337,12 @@ public class Asserts {
             rethrowPreferredException(e, ee);
         }
         return true;
+    }
+    public static Predicate<Throwable> expectedFailureContains(String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
+        return e -> expectedFailureContains(e, phrase1ToContain, optionalOtherPhrasesToContain);
+    }
+    public static Predicate<Throwable> expectedFailureContainsIgnoreCase(String phrase1ToContain, String ...optionalOtherPhrasesToContain) {
+        return e -> expectedFailureContainsIgnoreCase(e, phrase1ToContain, optionalOtherPhrasesToContain);
     }
 
     /** As {@link #expectedFailureContains(Throwable, String, String...)} but case insensitive */

--- a/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
+++ b/utils/common/src/main/java/org/apache/brooklyn/util/guava/Maybe.java
@@ -238,6 +238,12 @@ public abstract class Maybe<T> implements Serializable, Supplier<T> {
         };
     }
 
+    public <T2> Maybe<T2> asType(Class<T2> requiredClass) {
+        if (isAbsent()) return Maybe.castAbsent(this);
+        if (requiredClass.isInstance(get())) return Maybe.<T2>cast((Maybe)this);
+        return Maybe.absent(() -> new IllegalArgumentException("Value is not of required type "+requiredClass));
+    }
+
     public static class MaybeGuavaOptional<T> extends Maybe<T> {
         private static final long serialVersionUID = -823731500051341455L;
         private final Optional<T> value;


### PR DESCRIPTION
Add an expression parser, and use it to improve shorthand parsing and workflow steps

`let x = ${"some long expression with spaces"}` no longer gets confused by the spaces inside the interpolated experssion

and you can do things like:

e.g. `set-sensor map_sensor["key value with space"] = xxx`

also brackets are now supported for config, map key support for `let`, and better atomicity guarantees for sensors, handling for lists (use `list_thing[] = ...` to add)

