### PR TITLE
Lookup user using BrooklynSecurityProviderFilterHelper

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/LoggingResourceFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/LoggingResourceFilter.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
+import org.slf4j.MDC;
 
 /**
  * Logs inbound REST api calls, and their responses.
@@ -96,7 +97,7 @@ public class LoggingResourceFilter implements ContainerRequestFilter, ContainerR
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         requestTimestamps.put(servletRequest, System.nanoTime());
-        
+
         String method = requestContext.getMethod();
         boolean isInteresting = !UNINTERESTING_METHODS.contains(method.toUpperCase());
         LogLevel logLevel = isInteresting ? LogLevel.DEBUG : LogLevel.TRACE;
@@ -143,6 +144,8 @@ public class LoggingResourceFilter implements ContainerRequestFilter, ContainerR
                 .append(remoteAddr);
 
         log(LOG, level, message.toString());
+
+        MDC.put("username", userName);
     }
 
     private String tryFindUserName(){
@@ -230,6 +233,7 @@ public class LoggingResourceFilter implements ContainerRequestFilter, ContainerR
         }
 
         log(LOG, level, message.toString());
+        MDC.clear();
     }
     
     private boolean isLogEnabled(Logger logger, LogLevel level) {

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/LoggingResourceFilter.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/filter/LoggingResourceFilter.java
@@ -176,7 +176,7 @@ public class LoggingResourceFilter implements ContainerRequestFilter, ContainerR
         
         SecurityContext securityContext = requestContext.getSecurityContext();
         Principal userPrincipal = (securityContext != null) ? requestContext.getSecurityContext().getUserPrincipal() : null;
-        String userName = (userPrincipal != null) ? userPrincipal.getName() : "<no-user>";
+        String userName = (userPrincipal != null) ? userPrincipal.getName() : tryFindUserName();
         String remoteAddr = servletRequest.getRemoteAddr();
         
         boolean includeHeaders = (responseContext.getStatus() / 100 == 5) || LOG.isTraceEnabled();


### PR DESCRIPTION
If not available in the context

This fixes a minor issue where the username is logged at the start of a rest request but at the end often fails because it doesn't look it up using BrooklynSecurityProviderFilterHelper.

Per @ahgittin 's suggestion it also adds the username to the logging context.  This means we can log the username with any activities that don't create a task.  This PR https://github.com/apache/brooklyn-dist/pull/186 will modify the log to do this.

It doesn't look like there are any unit tests here so I've just tested locally using the basicauth security provider - I assume this will work with other security providers but I think this will be specific to the provider.  It should at least do the same in both places now.