### PR TITLE
Fix authentication bypass bug

### DIFF
--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/BrooklynUserWithRandomPasswordSecurityProvider.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/security/provider/BrooklynUserWithRandomPasswordSecurityProvider.java
@@ -48,7 +48,7 @@ public class BrooklynUserWithRandomPasswordSecurityProvider extends AbstractSecu
 
     @Override
     public boolean authenticate(HttpServletRequest request, Supplier<HttpSession> sessionSupplierOnSuccess, String user, String pass) throws SecurityProviderDeniedAuthentication {
-        if ((USER.equals(user) && this.password.equals(password)) || isRemoteAddressLocalhost(request)) {
+        if ((USER.equals(user) && this.password.equals(pass)) || isRemoteAddressLocalhost(request)) {
             return allow(sessionSupplierOnSuccess.get(), user);
         } else {
             return false;


### PR DESCRIPTION
When using BrooklynUserWithRandomPasswordSecurityProvider as brooklyn.webconsole.security.provider, the password is never checked. Anyone can login as "brooklyn" user with arbitrary password.