### PR TITLE
suppressing of secrets in complex JSON serializable types

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -41,6 +41,7 @@ import org.apache.brooklyn.util.collections.MutableSet;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.core.flags.TypeCoercions;
 import org.apache.brooklyn.util.core.osgi.Osgis;
+import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.internal.StringSystemProperty;
 import org.apache.brooklyn.util.javalang.Boxing;
 import org.apache.brooklyn.util.stream.Streams;
@@ -59,12 +60,12 @@ public final class Sanitizer {
      * indicates that it may be private, so should not be logged etc.
      */
     public static final List<String> DEFAULT_SENSITIVE_FIELDS_TOKENS = ImmutableList.of(
-            "password", 
-            "passwd", 
-            "credential", 
-            "secret", 
+            "password",
+            "passwd",
+            "credential",
+            "secret",
             "private",
-            "access.cert", 
+            "access.cert",
             "access.key");
 
     /** @deprecated since 1.1 use {@link #DEFAULT_SENSITIVE_FIELDS_TOKENS} or {@link #getSensitiveFieldsTokens(Boolean)} */
@@ -208,6 +209,10 @@ public final class Sanitizer {
         }).collect(Collectors.joining("\n"));
     }
 
+    /// Takes a map and sanitizes it for the purposes of displaying (tags and logs);
+    /// this supports maps where the values have been JSON-converted such as for shell environments,
+    /// and will attempt a simple JSON parse (to maps and lists, not to types) if appropriate,
+    /// then format the output as for bash.
     public static void sanitizeMapToString(Map<?, ?> env, StringBuilder sb) {
         if (env!=null) {
             for (Map.Entry<?, ?> kv : env.entrySet()) {
@@ -217,9 +222,8 @@ public final class Sanitizer {
                         // key name is a secret token: suppress the entire value
                         stringValue = suppress(stringValue);
                     } else {
-                        // key is not a secret name, but the value might be JSON with nested secret fields
-                        stringValue = suppressNestedSecretsInJsonString(stringValue);
-                        stringValue = sanitizeMultilineString(stringValue);
+                        // key is not a secret name, but the value might be JSON with nested secret fields, or might be multi-line
+                        stringValue = suppressNestedSecretsInJsonStringOrMultiline(stringValue);
                     }
                     stringValue = BashStringEscapes.wrapBash(stringValue);
                 }
@@ -236,23 +240,30 @@ public final class Sanitizer {
      * This prevents nested passwords from leaking when a complex value is serialized to a JSON string
      * and stored as an environment variable whose top-level key name does not itself contain a secret token.
      */
-    static String suppressNestedSecretsInJsonString(String stringValue) {
-        if (stringValue == null || stringValue.isEmpty()) return stringValue;
+    static String suppressNestedSecretsInJsonStringOrMultiline(String stringValue) {
+        Maybe<Object> json = parseComplexJson(stringValue);
+        if (json.isAbsent()) {
+            return sanitizeMultilineString(stringValue);
+        } else {
+            Object suppressed = suppressNestedSecretsJson(json.get(), false);
+            // not sure why GSON defaults to HTML escaping, but without disabling that we get weird output
+            return new GsonBuilder().disableHtmlEscaping().create().toJson(suppressed);
+        }
+    }
+
+    static Maybe<Object> parseComplexJson(String stringValue) {
+        if (stringValue == null || stringValue.isEmpty()) return Maybe.absent("Empty or null");
         char first = stringValue.charAt(0);
         if (first != '{' && first != '[') {
             // fast path: not a JSON object/array, skip parsing
-            return stringValue;
+            return Maybe.absent("Does not start with { or [");
         }
         try {
-            Object parsed = new Gson().fromJson(stringValue, Object.class);
-            if (parsed instanceof Map || parsed instanceof Iterable) {
-                Object suppressed = suppressNestedSecretsJson(parsed, false);
-                return new GsonBuilder().disableHtmlEscaping().create().toJson(suppressed);
-            }
+            return Maybe.of(new Gson().fromJson(stringValue, Object.class));
         } catch (Exception e) {
             // not valid JSON or unexpected structure; return original
+            return Maybe.absent(e);
         }
-        return stringValue;
     }
 
     /** applies to strings, sets, lists, maps */
@@ -297,7 +308,7 @@ public final class Sanitizer {
 
     /**
      * Kept only in case this anonymous inner class has made it into any persisted state.
-     * 
+     *
      * @deprecated since 0.7.0
      */
     @Deprecated
@@ -318,7 +329,7 @@ public final class Sanitizer {
     public static Sanitizer newInstance(Predicate<Object> sanitizingNeededCheck) {
         return new Sanitizer(sanitizingNeededCheck);
     }
-    
+
     public static Sanitizer newInstance(){
         return newInstance(IS_SECRET_PREDICATE);
     }
@@ -334,7 +345,7 @@ public final class Sanitizer {
     static <K> Map<K, Object> sanitize(Map<K, ?> input, Set<Object> visited) {
         return (input == null) ? null : (Map) newInstance().apply(input, visited);
     }
-    
+
     private Predicate<Object> predicate;
 
     private Sanitizer(Predicate<Object> sanitizingNeededCheck) {
@@ -376,12 +387,12 @@ public final class Sanitizer {
             if (e.getKey() != null && predicate.apply(e.getKey())){
                 result.put(e.getKey(), suppress(e.getValue()));
                 continue;
-            } 
+            }
             result.put(e.getKey(), apply(e.getValue(), visited));
         }
         return result;
     }
-    
+
     private List<Object> applyIterable(Iterable<?> input, Set<Object> visited){
         List<Object> result = Lists.newArrayList();
         for(Object o : input){
@@ -404,11 +415,11 @@ public final class Sanitizer {
         }
         return result;
     }
-    
+
     private List<Object> applyList(List<?> input, Set<Object> visited) {
        return applyIterable(input, visited);
     }
-    
+
     private Set<Object> applySet(Set<?> input, Set<Object> visited) {
         return MutableSet.copyOf(applyIterable(input, visited));
     }

--- a/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
+++ b/core/src/main/java/org/apache/brooklyn/core/config/Sanitizer.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.server.BrooklynServerConfig;
@@ -212,13 +213,46 @@ public final class Sanitizer {
             for (Map.Entry<?, ?> kv : env.entrySet()) {
                 String stringValue = kv.getValue() != null ? kv.getValue().toString() : "";
                 if (!stringValue.isEmpty()) {
-                    stringValue = Sanitizer.suppressIfSecret(kv.getKey(), stringValue);
-                    stringValue = sanitizeMultilineString(stringValue);
+                    if (Sanitizer.IS_SECRET_PREDICATE.apply(kv.getKey())) {
+                        // key name is a secret token: suppress the entire value
+                        stringValue = suppress(stringValue);
+                    } else {
+                        // key is not a secret name, but the value might be JSON with nested secret fields
+                        stringValue = suppressNestedSecretsInJsonString(stringValue);
+                        stringValue = sanitizeMultilineString(stringValue);
+                    }
                     stringValue = BashStringEscapes.wrapBash(stringValue);
                 }
                 sb.append(kv.getKey()).append("=").append(stringValue).append("\n");
             }
         }
+    }
+
+    /**
+     * If the string is a JSON object or array, parses it and suppresses any nested secret fields
+     * (fields whose key names match {@link #IS_SECRET_PREDICATE}).
+     * If it is not a JSON object/array (or is malformed JSON), returns the original string unchanged.
+     * <p>
+     * This prevents nested passwords from leaking when a complex value is serialized to a JSON string
+     * and stored as an environment variable whose top-level key name does not itself contain a secret token.
+     */
+    static String suppressNestedSecretsInJsonString(String stringValue) {
+        if (stringValue == null || stringValue.isEmpty()) return stringValue;
+        char first = stringValue.charAt(0);
+        if (first != '{' && first != '[') {
+            // fast path: not a JSON object/array, skip parsing
+            return stringValue;
+        }
+        try {
+            Object parsed = new Gson().fromJson(stringValue, Object.class);
+            if (parsed instanceof Map || parsed instanceof Iterable) {
+                Object suppressed = suppressNestedSecretsJson(parsed, false);
+                return new GsonBuilder().disableHtmlEscaping().create().toJson(suppressed);
+            }
+        } catch (Exception e) {
+            // not valid JSON or unexpected structure; return original
+        }
+        return stringValue;
     }
 
     /** applies to strings, sets, lists, maps */

--- a/core/src/main/java/org/apache/brooklyn/util/core/json/ShellEnvironmentSerializer.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/json/ShellEnvironmentSerializer.java
@@ -17,6 +17,7 @@ package org.apache.brooklyn.util.core.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.collect.Maps;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.util.core.task.DeferredSupplier;
@@ -25,11 +26,14 @@ import org.apache.brooklyn.util.text.StringEscapes;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
 public class ShellEnvironmentSerializer {
+    private static final YAMLMapper YAML_MAPPER = new YAMLMapper();
+
     private ObjectMapper mapper;
     private final Function<Object, Object> resolver;
 
@@ -43,7 +47,20 @@ public class ShellEnvironmentSerializer {
 
     public String serialize(Object value) {
         if (value == null) return null;
-        if (value instanceof String) return (String)value;
+        if (value instanceof String) {
+            String str = (String) value;
+            // If the string is a YAML/JSON-serialized complex type (List or Map), normalize to JSON.
+            // This handles effector parameters submitted as YAML strings from the UI.
+            try {
+                Object parsed = YAML_MAPPER.readValue(str, Object.class);
+                if (parsed instanceof Map || parsed instanceof List) {
+                    return mapper.writeValueAsString(parsed);
+                }
+            } catch (Exception e) {
+                // not parseable as a YAML/JSON complex type; return as-is
+            }
+            return str;
+        }
         try {
             if (value instanceof DeferredSupplier) {
                 if (resolver!=null) {

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -27,6 +27,8 @@ import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.stream.Streams;
 import org.apache.brooklyn.util.text.Strings;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
 
 public class SanitizerTest {
@@ -68,6 +70,87 @@ public class SanitizerTest {
         assertEquals(Sanitizer.sanitize((ConfigBag)null), null);
         assertEquals(Sanitizer.sanitize((Map<?,?>)null), null);
         assertEquals(Sanitizer.newInstance().apply((Map<?,?>)null), null);
+    }
+
+    @Test
+    public void testSanitizeMapToString_nestedPasswordInJsonArray() {
+        // MY_DATA key doesn't contain a secret token, but its JSON value contains a "password" field
+        Map<String, Object> env = ImmutableMap.of(
+            "MY_DATA", "[{\"name\":\"element1\",\"password\":\"s3cr3t\",\"a_list\":[\"x\"]}]"
+        );
+        StringBuilder sb = new StringBuilder();
+        Sanitizer.sanitizeMapToString(env, sb);
+        String result = sb.toString();
+
+        assertFalse(result.contains("s3cr3t"), "Nested password should be suppressed, got: " + result);
+        assertTrue(result.contains("element1"), "Non-secret field should remain visible, got: " + result);
+        assertTrue(result.contains("suppressed"), "Should show suppressed marker, got: " + result);
+        assertFalse(result.contains("\\u003c"), "Suppressed marker should not be HTML-escaped, got: " + result);
+        assertTrue(result.contains("<suppressed>") || result.contains("<suppressed "), "Suppressed marker should use literal angle brackets, got: " + result);
+    }
+
+    @Test
+    public void testSanitizeMapToString_nestedPasswordInJsonObject() {
+        Map<String, Object> env = ImmutableMap.of(
+            "MY_DATA", "{\"name\":\"element1\",\"password\":\"s3cr3t\"}"
+        );
+        StringBuilder sb = new StringBuilder();
+        Sanitizer.sanitizeMapToString(env, sb);
+        String result = sb.toString();
+
+        assertFalse(result.contains("s3cr3t"), "Nested password in JSON object should be suppressed, got: " + result);
+        assertTrue(result.contains("element1"), "Non-secret field should remain visible, got: " + result);
+    }
+
+    @Test
+    public void testSanitizeMapToString_secretKeyStillSuppressesEntireValue() {
+        // When the key itself is a secret, the entire value is suppressed (existing behaviour)
+        Map<String, Object> env = ImmutableMap.of(
+            "SECRET_FIELD", "[{\"name\":\"toto\",\"password\":\"s3cr3t\"}]"
+        );
+        StringBuilder sb = new StringBuilder();
+        Sanitizer.sanitizeMapToString(env, sb);
+        String result = sb.toString();
+
+        assertFalse(result.contains("s3cr3t"), "Password should be suppressed, got: " + result);
+        assertFalse(result.contains("toto"), "Entire value should be suppressed for secret key, got: " + result);
+    }
+
+    @Test
+    public void testSanitizeMapToString_plainStringUnchanged() {
+        Map<String, Object> env = ImmutableMap.of("MY_VAR", "hello world");
+        StringBuilder sb = new StringBuilder();
+        Sanitizer.sanitizeMapToString(env, sb);
+        assertTrue(sb.toString().contains("hello world"), "Plain string should be unchanged");
+    }
+
+    @Test
+    public void testSanitizeMapToString_nonJsonStringStartingWithBrace() {
+        // A string that starts with { but is not valid JSON should be returned unchanged
+        Map<String, Object> env = ImmutableMap.of("MY_VAR", "{not valid json");
+        StringBuilder sb = new StringBuilder();
+        Sanitizer.sanitizeMapToString(env, sb);
+        assertTrue(sb.toString().contains("{not valid json"), "Invalid JSON should pass through unchanged");
+    }
+
+    @Test
+    public void testSuppressNestedSecretsInJsonString_jsonArray() {
+        String input = "[{\"name\":\"e1\",\"password\":\"secret123\"}]";
+        String result = Sanitizer.suppressNestedSecretsInJsonString(input);
+        assertFalse(result.contains("secret123"), "Password should be suppressed");
+        assertTrue(result.contains("e1"), "Non-secret field should remain");
+    }
+
+    @Test
+    public void testSuppressNestedSecretsInJsonString_nonJsonPassthrough() {
+        String input = "just a plain string";
+        assertEquals(Sanitizer.suppressNestedSecretsInJsonString(input), input);
+    }
+
+    @Test
+    public void testSuppressNestedSecretsInJsonString_malformedJsonPassthrough() {
+        String input = "[malformed";
+        assertEquals(Sanitizer.suppressNestedSecretsInJsonString(input), input);
     }
 
     @Test

--- a/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
+++ b/core/src/test/java/org/apache/brooklyn/core/config/SanitizerTest.java
@@ -50,21 +50,21 @@ public class SanitizerTest {
                 .putAll(Maps.transformValues(map, Sanitizer::suppress))
                 .put("mykey", "myval")
                 .build();
-        
+
         Map<String, Object> sanitized = Sanitizer.sanitize(ConfigBag.newInstance(map));
         assertEquals(sanitized, expected);
-        
+
         Map<String, Object> sanitized2 = Sanitizer.sanitize(map);
         assertEquals(sanitized2, expected);
     }
-    
+
     @Test
     public void testSanitizeWithNullKey() throws Exception {
         MutableMap<?, ?> map = MutableMap.of(null, null);
         Map<?, ?> sanitized = Sanitizer.sanitize(map);
         assertEquals(sanitized, map);
     }
-    
+
     @Test
     public void testSanitizeWithNull() throws Exception {
         assertEquals(Sanitizer.sanitize((ConfigBag)null), null);
@@ -136,7 +136,7 @@ public class SanitizerTest {
     @Test
     public void testSuppressNestedSecretsInJsonString_jsonArray() {
         String input = "[{\"name\":\"e1\",\"password\":\"secret123\"}]";
-        String result = Sanitizer.suppressNestedSecretsInJsonString(input);
+        String result = Sanitizer.suppressNestedSecretsInJsonStringOrMultiline(input);
         assertFalse(result.contains("secret123"), "Password should be suppressed");
         assertTrue(result.contains("e1"), "Non-secret field should remain");
     }
@@ -144,13 +144,13 @@ public class SanitizerTest {
     @Test
     public void testSuppressNestedSecretsInJsonString_nonJsonPassthrough() {
         String input = "just a plain string";
-        assertEquals(Sanitizer.suppressNestedSecretsInJsonString(input), input);
+        assertEquals(Sanitizer.suppressNestedSecretsInJsonStringOrMultiline(input), input);
     }
 
     @Test
     public void testSuppressNestedSecretsInJsonString_malformedJsonPassthrough() {
         String input = "[malformed";
-        assertEquals(Sanitizer.suppressNestedSecretsInJsonString(input), input);
+        assertEquals(Sanitizer.suppressNestedSecretsInJsonStringOrMultiline(input), input);
     }
 
     @Test

--- a/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
+++ b/software/base/src/test/java/org/apache/brooklyn/entity/software/base/ShellEnvironmentSerializerTest.java
@@ -16,6 +16,8 @@
 package org.apache.brooklyn.entity.software.base;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Date;
 
@@ -68,6 +70,24 @@ public class ShellEnvironmentSerializerTest extends BrooklynAppUnitTestSupport {
         // https://issues.apache.org/jira/browse/BROOKLYN-304
         assertSerialize(getClass().getClassLoader(), "{\"type\":\""+getClass().getClassLoader().getClass().getCanonicalName()+"\"}");
         assertSerialize(getClass(), getClass().getName());
+    }
+
+    @Test
+    public void testSerializeYamlStringNormalizedToJson() {
+        // YAML list → JSON array
+        assertEquals(ser.serialize("- item1\n- item2\n"), "[\"item1\",\"item2\"]");
+
+        // YAML list of maps → JSON array of objects
+        String yamlList = "- name: element1\n  password: s3cr3t\n";
+        String jsonResult = ser.serialize(yamlList);
+        assertTrue(jsonResult.startsWith("["), "Expected JSON array, got: " + jsonResult);
+        assertFalse(jsonResult.contains("- name:"), "Should not contain YAML list syntax: " + jsonResult);
+
+        // Plain string → unchanged
+        assertEquals(ser.serialize("plain string value"), "plain string value");
+
+        // JSON string → unchanged (already JSON, re-serialization produces same output)
+        assertEquals(ser.serialize("[\"a\",\"b\"]"), "[\"a\",\"b\"]");
     }
 
     private void assertSerialize(Object actual, String expected) {


### PR DESCRIPTION
Sanitizer.java
- add a method to parse a JSON object from JSON string and suppress the JSON data if needed
- maintains the current behavior otherwise
- added unit tests as needed

ShellEnvironmentSerializer.java
- handles JSON/YAML string passed in the effector invoked. Previously this would just return the string value as is, leaving the sensitive data unsuppressed
- added unit tests as needed