### PR TITLE
fix: logbook search case insensitive

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/file/FileLogStore.java
@@ -191,14 +191,14 @@ public class FileLogStore implements LogStore {
                     if (!isSearchTaskIdMatch) return false;
                 }
 
-                // Check search phrases.
+                // Check search phrases. Case-insensitive to stay consistent with the OpenSearch backend.
                 if (Strings.isNonBlank(params.getSearchPhrase())) {
-                    if (Strings.isBlank(brooklynLogEntry.getMessage()) || !brooklynLogEntry.getMessage().contains(params.getSearchPhrase())) return false;
+                    if (Strings.isBlank(brooklynLogEntry.getMessage()) || !brooklynLogEntry.getMessage().toLowerCase(Locale.ROOT).contains(params.getSearchPhrase().toLowerCase(Locale.ROOT))) return false;
                 }
 
-                // Check logger/class name prefix.
+                // Check logger/class name prefix. Case-insensitive to stay consistent with the OpenSearch backend.
                 if (Strings.isNonBlank(params.getLoggerName())) {
-                    if (Strings.isBlank(brooklynLogEntry.getClazz()) || !brooklynLogEntry.getClazz().startsWith(params.getLoggerName())) return false;
+                    if (Strings.isBlank(brooklynLogEntry.getClazz()) || !brooklynLogEntry.getClazz().toLowerCase(Locale.ROOT).startsWith(params.getLoggerName().toLowerCase(Locale.ROOT))) return false;
                 }
 
                 return true;

--- a/core/src/main/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStore.java
+++ b/core/src/main/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStore.java
@@ -305,9 +305,11 @@ public class OpenSearchLogStore implements LogStore {
             queryBoolMustListBuilder.add(buildMatchPhraseOf("message", params.getSearchPhrase()));
         }
 
-        // Apply logger/class name prefix.
+        // Apply logger/class name prefix. Case-insensitive: the prefix query is a term-level query that is not
+        // analyzed, so without this flag it only matches the lowercased indexed terms of the analyzed "class" field.
         if (Strings.isNonBlank(params.getLoggerName())) {
-            queryBoolMustListBuilder.add(ImmutableMap.of("prefix", ImmutableMap.of("class", params.getLoggerName())));
+            queryBoolMustListBuilder.add(ImmutableMap.of("prefix", ImmutableMap.of("class",
+                    ImmutableMap.of("value", params.getLoggerName(), "case_insensitive", true))));
         }
 
         ImmutableList<Object> queryBoolMustList = queryBoolMustListBuilder.build();

--- a/core/src/test/java/org/apache/brooklyn/util/core/logbook/file/FileLogStoreTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/logbook/file/FileLogStoreTest.java
@@ -548,6 +548,40 @@ public class FileLogStoreTest extends BrooklynMgmtUnitTestSupport {
         assertEquals(0, brooklynLogEntries.size());
     }
 
+    @Test
+    public void testQueryLogSampleWithLoggerNameIsCaseInsensitive() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(1000);
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setLoggerName("I.C.B"); // upper case still matches the lower case "i.c.b" entries
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+
+        assertEquals(4, brooklynLogEntries.size());
+        assertTrue(brooklynLogEntries.stream().allMatch(e -> e.getClazz().startsWith("i.c.b")));
+    }
+
+    @Test
+    public void testQueryLogSampleWithSearchPhraseIsCaseInsensitive() {
+        File file = new File(Objects.requireNonNull(getClass().getClassLoader().getResource(JAVA_LOG_SAMPLE_PATH)).getFile());
+        mgmt = LocalManagementContextForTests.newInstance();
+        mgmt.getBrooklynProperties().put(LOGBOOK_LOG_STORE_PATH.getName(), file.getAbsolutePath());
+        LogBookQueryParams logBookQueryParams = new LogBookQueryParams();
+        logBookQueryParams.setNumberOfItems(1000);
+        logBookQueryParams.setTail(false);
+        logBookQueryParams.setLevels(ImmutableList.of());
+        logBookQueryParams.setSearchPhrase("TESTING"); // upper case still matches the lower case "testing" entries
+        FileLogStore fileLogStore = new FileLogStore(mgmt);
+        List<BrooklynLogEntry> brooklynLogEntries = fileLogStore.query(logBookQueryParams);
+
+        assertEquals(3, brooklynLogEntries.size());
+        assertTrue(brooklynLogEntries.stream().allMatch(e -> e.getMessage().toLowerCase(java.util.Locale.ROOT).contains("testing")));
+    }
+
     private LogBookQueryParams newQueryParams(boolean recursive) {
         LogBookQueryParams params = new LogBookQueryParams();
         params.setNumberOfItems(5); // Request first five only

--- a/core/src/test/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStoreTest.java
+++ b/core/src/test/java/org/apache/brooklyn/util/core/logbook/opensearch/OpenSearchLogStoreTest.java
@@ -179,7 +179,7 @@ public class OpenSearchLogStoreTest {
         p.setLevels(ImmutableList.of());
         p.setLoggerName("o.a.b.SSH");
         String query = cut.getJsonQuery(p);
-        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"prefix\":{\"class\":\"o.a.b.SSH\"}}]}}}");
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"prefix\":{\"class\":{\"value\":\"o.a.b.SSH\",\"case_insensitive\":true}}}]}}}");
     }
 
     @Test
@@ -192,7 +192,7 @@ public class OpenSearchLogStoreTest {
         p.setLoggerName("o.a.b.SSH");
         p.setSearchPhrase("some phrase");
         String query = cut.getJsonQuery(p);
-        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"match_phrase\":{\"message\":\"some phrase\"}},{\"prefix\":{\"class\":\"o.a.b.SSH\"}}]}}}");
+        assertEquals(query, "{\"sort\":{\"timestamp\":\"asc\"},\"size\":10,\"query\":{\"bool\":{\"must\":[{\"match_phrase\":{\"message\":\"some phrase\"}},{\"prefix\":{\"class\":{\"value\":\"o.a.b.SSH\",\"case_insensitive\":true}}}]}}}");
     }
 
     @Test


### PR DESCRIPTION
Make both the logger prefix and search phrase filters case-insensitive and consistent across the file and OpenSearch backends.

- FileLogStore: lowercase both sides of the clazz prefix and message search-phrase comparisons (Locale.ROOT).
- OpenSearchLogStore: add case_insensitive:true to the class prefix query, which is term-level and otherwise only matches the lowercased indexed terms of the analyzed "class" field.